### PR TITLE
define the interface required for JuiceFS here.

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -29,9 +29,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/redis"
 	"github.com/juicedata/juicefs/pkg/utils"
-	"github.com/juicedata/juicesync/object"
+	obj "github.com/juicedata/juicesync/object"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -166,7 +167,7 @@ func format(c *cli.Context) error {
 		format.Bucket += "/"
 	}
 
-	object.UserAgent = "JuiceFS-" + Version()
+	obj.UserAgent = "JuiceFS-" + Version()
 
 	blob, err := createStorage(&format)
 	if err != nil {

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -1,16 +1,31 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package main
 
 import "testing"
 
 func TestFixObjectSize(t *testing.T) {
 	t.Run("Should make sure the size is in range", func(t *testing.T) {
-		cases := []struct{
+		cases := []struct {
 			input, expected int
 		}{
 			{30, 64},
 			{0, 64},
-			{2<<30, 16<<10},
-			{16<<11, 16<<10},
+			{2 << 30, 16 << 10},
+			{16 << 11, 16 << 10},
 		}
 		for _, c := range cases {
 			if size := fixObjectSize(c.input); size != c.expected {
@@ -19,7 +34,7 @@ func TestFixObjectSize(t *testing.T) {
 		}
 	})
 	t.Run("Should use powers of two", func(t *testing.T) {
-		cases := []struct{
+		cases := []struct {
 			input, expected int
 		}{
 			{150, 128},

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/juicedata/juicesync v0.6.3-0.20210105123925-2af95f8a8472
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+	github.com/yunify/qingstor-sdk-go v2.2.15+incompatible
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -28,9 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/utils"
-
-	"github.com/juicedata/juicesync/object"
 )
 
 const chunkSize = 1 << 26 // 64M

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juicedata/juicesync/object"
+	"github.com/juicedata/juicefs/pkg/object"
 )
 
 func BenchmarkCachedRead(b *testing.B) {

--- a/pkg/chunk/store_test.go
+++ b/pkg/chunk/store_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/utils"
-	"github.com/juicedata/juicesync/object"
 	"github.com/sirupsen/logrus"
 )
 
@@ -104,7 +104,7 @@ func TestAsyncStore(t *testing.T) {
 	conf.UploadLimit = 0
 	_ = NewCachedStore(mem, conf)
 	time.Sleep(time.Millisecond * 10) // wait for scan to finish
-	if _, err := mem.Head("chunks/0/0/123_0_4"); err != nil {
+	if _, err := mem.Get("chunks/0/0/123_0_4", 0, -1); err != nil {
 		t.Fatalf("staging object should be upload")
 	}
 }

--- a/pkg/object/interface.go
+++ b/pkg/object/interface.go
@@ -1,0 +1,58 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package object
+
+import (
+	"io"
+
+	obj "github.com/juicedata/juicesync/object"
+	"github.com/juicedata/juicesync/utils"
+)
+
+var logger = utils.GetLogger("juicefs")
+
+// ObjectStorage is the interface for object storage.
+// all of these API should be idempotent.
+type ObjectStorage interface {
+	// Description of the object storage.
+	String() string
+	// Create the bucket if not existed.
+	Create() error
+	// Get the data for the given object specified by key.
+	Get(key string, off, limit int64) (io.ReadCloser, error)
+	// Put data read from a reader to an object specified by key.
+	Put(key string, in io.Reader) error
+	// Delete a object.
+	Delete(key string) error
+}
+
+var storages = make(map[string]Creator)
+
+type Creator func(bucket, accessKey, secretKey string) (ObjectStorage, error)
+
+func register(name string, creator Creator) {
+	storages[name] = creator
+}
+
+func CreateStorage(name, endpoint, accessKey, secretKey string) (ObjectStorage, error) {
+	f, ok := storages[name]
+	if ok {
+		logger.Debugf("Creating %s storage at endpoint %s", name, endpoint)
+		return f(endpoint, accessKey, secretKey)
+	}
+	// look for implementation in juicesync
+	return obj.CreateStorage(name, endpoint, accessKey, secretKey)
+}

--- a/pkg/object/prefix.go
+++ b/pkg/object/prefix.go
@@ -1,0 +1,53 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package object
+
+import (
+	"fmt"
+	"io"
+)
+
+type withPrefix struct {
+	os     ObjectStorage
+	prefix string
+}
+
+// WithPrefix retuns a object storage that add a prefix to keys.
+func WithPrefix(os ObjectStorage, prefix string) (ObjectStorage, error) {
+	return &withPrefix{os, prefix}, nil
+}
+
+func (p *withPrefix) String() string {
+	return fmt.Sprintf("%s/%s", p.os, p.prefix)
+}
+
+func (p *withPrefix) Create() error {
+	return p.os.Create()
+}
+
+func (p *withPrefix) Get(key string, off, limit int64) (io.ReadCloser, error) {
+	return p.os.Get(p.prefix+key, off, limit)
+}
+
+func (p *withPrefix) Put(key string, in io.Reader) error {
+	return p.os.Put(p.prefix+key, in)
+}
+
+func (p *withPrefix) Delete(key string) error {
+	return p.os.Delete(p.prefix + key)
+}
+
+var _ ObjectStorage = &withPrefix{}


### PR DESCRIPTION
This PR clarify the API of object storage used by JuiceFS here, rather than use the wider interface used by Juicesync.

So we can add implementation here much easier.

Close #21 