### PR TITLE
Fix some errors reported by golangci-lint

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -89,7 +89,10 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 		return fmt.Errorf("Failed to get: %s", err)
 	}
 	data2, err := ioutil.ReadAll(p)
-	p.Close()
+	_ = p.Close()
+	if err != nil {
+		return err
+	}
 	if !bytes.Equal(data, data2) {
 		return fmt.Errorf("Read wrong data")
 	}

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -230,21 +230,6 @@ func (cache *cacheStore) stagePath(key string) string {
 	return filepath.Join(cache.dir, stagingDir, key)
 }
 
-// flush cached block into disk
-func (cache *cacheStore) flush() {
-	for {
-		w := <-cache.pending
-		path := cache.cachePath(w.key)
-		if cache.capacity > 0 && cache.flushPage(path, w.page.Data) == nil {
-			cache.add(w.key, int32(len(w.page.Data)), uint32(time.Now().Unix()))
-		}
-		cache.Lock()
-		delete(cache.pages, w.key)
-		cache.Unlock()
-		w.page.Release()
-	}
-}
-
 func (cache *cacheStore) add(key string, size int32, atime uint32) {
 	cache.Lock()
 	defer cache.Unlock()

--- a/pkg/chunk/page.go
+++ b/pkg/chunk/page.go
@@ -62,16 +62,6 @@ func (p *Page) Slice(off, len int) *Page {
 	return np
 }
 
-func (p *Page) isOffHeap() bool {
-	if p.offheap {
-		return true
-	}
-	if p.dep != nil {
-		return p.dep.isOffHeap()
-	}
-	return false
-}
-
 // Acquire increase the refcount
 func (p *Page) Acquire() {
 	atomic.AddInt32(&p.refs, 1)

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -230,23 +230,6 @@ func (s *sliceReader) run() {
 	}
 }
 
-func (s *sliceReader) invalidate() {
-	switch s.state {
-	case NEW:
-	case BUSY:
-		s.state = REFRESH
-		// TODO: interrupt reader
-	case READY:
-		if s.refs > 0 {
-			s.state = NEW
-			go s.run()
-		} else {
-			s.state = INVALID
-			s.delete() // nobody wants it anymore, so delete it
-		}
-	}
-}
-
 func (s *sliceReader) drop() {
 	if s.state <= BREAK {
 		if s.refs == 0 {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -78,7 +78,6 @@ func Lookup(ctx Context, parent Ino, name string) (entry *meta.Entry, err syscal
 	var attr = &Attr{}
 	if parent == rootID {
 		if nleng == 2 && name[0] == '.' && name[1] == '.' {
-			nleng = 1
 			name = name[:1]
 		}
 		n := getInternalNodeByName(name)

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -190,7 +190,7 @@ func (c *chunkWriter) commitThread() {
 		f.Unlock()
 
 		if err == 0 {
-			var ss = meta.Slice{s.id, s.length, s.soff, s.slen}
+			var ss = meta.Slice{Chunkid: s.id, Size: s.length, Off: s.soff, Len: s.slen}
 			err = f.w.m.Write(meta.Background, f.inode, c.indx, s.off, ss)
 		}
 
@@ -368,9 +368,7 @@ func (f *fileWriter) GetLength() uint64 {
 func (f *fileWriter) Truncate(length uint64) {
 	f.Lock()
 	defer f.Unlock()
-	if length < f.length {
-		// TODO: truncate write buffer
-	}
+	// TODO: truncate write buffer if length < f.length
 	f.length = length
 }
 


### PR DESCRIPTION
Some unused variables and functions are found by the linter, so they are deleted in this PR.