### PR TITLE
support static build for musl-gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ LDFLAGS = -s -w -X main.REVISION=$(REVISION) \
 			-X main.VERSION=$(VERSION)
 SHELL = /bin/sh
 
+ifdef STATIC
+	LDFLAGS += -linkmode external -extldflags '-static'
+	CC = /usr/bin/musl-gcc
+	export CC
+endif
+
 juicefs: Makefile cmd/*.go pkg/*/*.go
 	go build -ldflags="$(LDFLAGS)"  -o juicefs ./cmd
 


### PR DESCRIPTION
This PR add an environment variable `STATIC` for `Makefile`.
 When specified, the build for C code will use `musl-gcc`, and the output is static linked. This is good for container environment such as CSI driver container with no glibc required( may use musl-libc such as Alpine Linux).