### PR TITLE
logging INFO into syslog

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -86,8 +86,8 @@ func mount(c *cli.Context) error {
 		utils.SetLogLevel(logrus.DebugLevel)
 	} else if c.Bool("quiet") {
 		utils.SetLogLevel(logrus.ErrorLevel)
-		utils.InitLoggers(!c.Bool("nosyslog"))
 	}
+	utils.InitLoggers(!c.Bool("nosyslog") && !c.Bool("trace") && (c.Bool("background") || !c.Bool("debug")))
 	if c.Args().Len() < 1 {
 		logger.Fatalf("Redis URL and mountpoint are required")
 	}


### PR DESCRIPTION
logging INFO and above into syslog by default, also the DEBUG in daemon mode.

The tracing logs are two many for syslog, even in daemon mode.

Closes #65 