### PR TITLE
Optimized logging level by default only logging to syslog in daemon mode

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -31,9 +31,7 @@ import (
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/redis"
-	"github.com/juicedata/juicefs/pkg/utils"
 	obj "github.com/juicedata/juicesync/object"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -121,15 +119,7 @@ func test(store object.ObjectStorage) error {
 }
 
 func format(c *cli.Context) error {
-	if c.Bool("trace") {
-		utils.SetLogLevel(logrus.TraceLevel)
-	} else if c.Bool("debug") {
-		utils.SetLogLevel(logrus.DebugLevel)
-	} else if c.Bool("quiet") {
-		utils.SetLogLevel(logrus.ErrorLevel)
-		utils.InitLoggers(!c.Bool("nosyslog"))
-	}
-
+	setLoggerLevel(c)
 	if c.Args().Len() < 1 {
 		logger.Fatalf("Redis URL and name are required")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"log"
 	_ "net/http/pprof"
 	"os"
@@ -165,4 +166,14 @@ func stringContains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func setLoggerLevel(c *cli.Context) {
+	if c.Bool("trace") {
+		utils.SetLogLevel(logrus.TraceLevel)
+	} else if c.Bool("debug") {
+		utils.SetLogLevel(logrus.DebugLevel)
+	} else if c.Bool("quiet") {
+		utils.SetLogLevel(logrus.WarnLevel)
+	}
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -82,7 +82,7 @@ func mount(c *cli.Context) error {
 	setLoggerLevel(c)
 	if !c.Bool("nosyslog") {
 		// The default log to syslog is only in daemon mode.
-		utils.InitLoggers(c.Bool("b"))
+		utils.InitLoggers(c.Bool("d"))
 	}
 	if c.Args().Len() < 1 {
 		logger.Fatalf("Redis URL and mountpoint are required")

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juicedata/juicefs/pkg/redis"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juicedata/juicefs/pkg/vfs"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -80,14 +79,11 @@ func mount(c *cli.Context) error {
 			_ = agent.Listen(agent.Options{Addr: fmt.Sprintf("127.0.0.1:%d", port)})
 		}
 	}()
-	if c.Bool("trace") {
-		utils.SetLogLevel(logrus.TraceLevel)
-	} else if c.Bool("debug") {
-		utils.SetLogLevel(logrus.DebugLevel)
-	} else if c.Bool("quiet") {
-		utils.SetLogLevel(logrus.ErrorLevel)
+	setLoggerLevel(c)
+	if !c.Bool("nosyslog") {
+		// The default log to syslog is only in daemon mode.
+		utils.InitLoggers(c.Bool("b"))
 	}
-	utils.InitLoggers(!c.Bool("nosyslog") && !c.Bool("trace") && (c.Bool("background") || !c.Bool("debug")))
 	if c.Args().Len() < 1 {
 		logger.Fatalf("Redis URL and mountpoint are required")
 	}


### PR DESCRIPTION
This issue fixes three problems:

1. Even for output to Syslog, I think we need to record levels like trace, debug, etc., which is usually used for problem debug
2. Remove duplicate log level code in format and mount.
3. By `--quiet` definition, it should be able to log warnings so its log level should be `warning`, not `error`