### PR TITLE
change to use lower case for command line options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ all: juicefs
 REVISION := $(shell git rev-parse --short HEAD || unknown)
 REVISIONDATE := $(shell git log -1 --pretty=format:'%ad' --date short)
 VERSION := $(shell git describe --tags --match 'v*' | sed -e 's/^v//' -e 's/-g[0-9a-f]\{7,\}$$//')
-LDFLAGS = -s -w -X main.REVISION=$(REVISION) \
-		        -X main.REVISIONDATE=$(REVISIONDATE) \
-			-X main.VERSION=$(VERSION)
+LDFLAGS = -s -w -X main.revision=$(REVISION) \
+		        -X main.revisionDate=$(REVISIONDATE) \
+			-X main.version=$(VERSION)
 SHELL = /bin/sh
 
 ifdef STATIC

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Assume you have a Redis server running locally, we can create a volume called `t
 $ ./juicefs format localhost test
 ```
 
-It will create a volume with default settings. If there Redis server is not running locally, the address could be specifed using URL, for example, `redis://user:password@host:6379/1`.
+It will create a volume with default settings. If there Redis server is not running locally, the address could be specifed using URL, for example, `redis://user:password@host:6379/1`, the password can also be specified by environment variable `REDIS_PASSWORD` to hide it from command line options.
 
 As JuiceFS relies on object storage to store data, you can specify a object storage using `--storage`, `--bucket`, `--access-key` and `--secret-key`. By default, it uses a local directory to serve as an object store, for all the options, please see `./juicefs format -h`.
 

--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ Assume you have a Redis server running locally, we can create a volume called `t
 $ ./juicefs format localhost test
 ```
 
-It will create a volume with default settings. If there Redis server is not running locally, the address could be specifed using URL, for example, `redis://username:password@host:6379/1`.
+It will create a volume with default settings. If there Redis server is not running locally, the address could be specifed using URL, for example, `redis://user:password@host:6379/1`.
 
-As JuiceFS relies on object storage to store data, you can specify a object storage using `--storage`, `--bucket`, `--accesskey` and `--secretkey`. By default, it uses a local directory to serve as an object store, for all the options, please see `./juicefs format -h`.
+As JuiceFS relies on object storage to store data, you can specify a object storage using `--storage`, `--bucket`, `--access-key` and `--secret-key`. By default, it uses a local directory to serve as an object store, for all the options, please see `./juicefs format -h`.
 
 To use MinIO as object store, it could be specified as:
 
 ```bash
 $ ./juicefs format --storage minio \
    --bucket http://1.2.3.4:9000/mybucket \
-   --accesskey XXX \
-   --secretkey XXX \
+   --access-key XXX \
+   --secret-key XXX \
    localhost test
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,17 +66,17 @@ $ make
 $ ./juicefs format localhost test
 ```
 
-它会使用默认参数来格式化。如果 Redis 服务不在本地，你可以像这样完整填写它的地址：`redis://username:password@host:6379/1`。
+它会使用默认参数来格式化。如果 Redis 服务不在本地，你可以像这样完整填写它的地址：`redis://user:password@host:6379/1`。
 
-JuiceFS 还需要一个对象存储，可以通过参数 `--storage`、`--bucket`、`--accesskey` 和 `--secretkey` 来指定。它默认会使用本地目录来模拟一个对象存储用于测试，详细的参数请看 `./juicefs format -h`。
+JuiceFS 还需要一个对象存储，可以通过参数 `--storage`、`--bucket`、`--access-key` 和 `--secret-key` 来指定。它默认会使用本地目录来模拟一个对象存储用于测试，详细的参数请看 `./juicefs format -h`。
 
 如果使用 MinIO 来存数据，可以这么写：
 
 ```bash
 $ ./juicefs format --storage minio \
    --bucket http://1.2.3.4:9000/mybucket \
-   --accesskey XXX \
-   --secretkey XXX \
+   --access-key XXX \
+   --secret-key XXX \
    localhost test
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,7 +66,7 @@ $ make
 $ ./juicefs format localhost test
 ```
 
-它会使用默认参数来格式化。如果 Redis 服务不在本地，你可以像这样完整填写它的地址：`redis://user:password@host:6379/1`。
+它会使用默认参数来格式化。如果 Redis 服务不在本地，你可以像这样完整填写它的地址：`redis://user:password@host:6379/1`。Redis 密码可以通过环境变量 `REDIS_PASSWORD` 来指定，避免暴露在命令行选项中。
 
 JuiceFS 还需要一个对象存储，可以通过参数 `--storage`、`--bucket`、`--access-key` 和 `--secret-key` 来指定。它默认会使用本地目录来模拟一个对象存储用于测试，详细的参数请看 `./juicefs format -h`。
 

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -95,6 +95,7 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 	}
 	err = store.Delete(key)
 	if err != nil {
+		// it's OK to don't have delete permission
 		fmt.Printf("Failed to delete: %s", err)
 	}
 	return nil
@@ -141,9 +142,9 @@ func format(c *cli.Context) error {
 		UUID:        uuid.New().String(),
 		Storage:     c.String("storage"),
 		Bucket:      c.String("bucket"),
-		AccessKey:   c.String("accesskey"),
-		SecretKey:   c.String("secretkey"),
-		BlockSize:   fixObjectSize(c.Int("blockSize")),
+		AccessKey:   c.String("access-key"),
+		SecretKey:   c.String("secret-key"),
+		BlockSize:   fixObjectSize(c.Int("block-size")),
 		Compression: c.String("compress"),
 	}
 	if format.AccessKey == "" && os.Getenv("ACCESS_KEY") != "" {
@@ -168,13 +169,11 @@ func format(c *cli.Context) error {
 	logger.Infof("Data uses %s", blob)
 	if err := test(blob); err != nil {
 		logger.Fatalf("Storage %s is not configured correctly: %s", blob, err)
-		return err
 	}
 
 	err = m.Init(format, c.Bool("force"))
 	if err != nil {
 		logger.Fatalf("format: %s", err)
-		return err
 	}
 	if format.SecretKey != "" {
 		format.SecretKey = "removed"
@@ -189,7 +188,6 @@ func formatFlags() *cli.Command {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			logger.Fatalf("%v", err)
-			return nil
 		}
 		defaultBucket = path.Join(homeDir, ".juicefs", "local")
 	}
@@ -199,14 +197,14 @@ func formatFlags() *cli.Command {
 		ArgsUsage: "REDIS-URL NAME",
 		Flags: []cli.Flag{
 			&cli.IntFlag{
-				Name:  "blockSize",
+				Name:  "block-size",
 				Value: 4096,
 				Usage: "size of block in KiB",
 			},
 			&cli.StringFlag{
 				Name:  "compress",
 				Value: "lz4",
-				Usage: "compression algorithm",
+				Usage: "compression algorithm (lz4, zstd, none)",
 			},
 			&cli.StringFlag{
 				Name:  "storage",
@@ -219,12 +217,12 @@ func formatFlags() *cli.Command {
 				Usage: "A bucket URL to store data",
 			},
 			&cli.StringFlag{
-				Name:  "accesskey",
-				Usage: "Access key for object storage",
+				Name:  "access-key",
+				Usage: "Access key for object storage (env ACCESS_KEY)",
 			},
 			&cli.StringFlag{
-				Name:  "secretkey",
-				Usage: "Secret key for object storage",
+				Name:  "secret-key",
+				Usage: "Secret key for object storage (env SECRET_KEY)",
 			},
 
 			&cli.BoolFlag{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,13 +17,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"log"
 	_ "net/http/pprof"
 	"os"
 	"strings"
 
-	_ "github.com/juicedata/juicefs/pkg/object"
+	"github.com/sirupsen/logrus"
+
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/urfave/cli/v2"
 )
@@ -55,10 +55,6 @@ func main() {
 				Name:  "trace",
 				Usage: "enable trace log",
 			},
-			&cli.BoolFlag{
-				Name:  "nosyslog",
-				Usage: "disable syslog",
-			},
 		},
 		Commands: []*cli.Command{
 			formatFlags(),
@@ -83,21 +79,9 @@ func main() {
 
 func handleSysMountArgs() ([]string, error) {
 	optionToCmdFlag := map[string]string{
-		"attrcacheto":        "attrcacheto",
-		"entrycacheto":       "entrycacheto",
-		"direntrycacheto":    "direntrycacheto",
-		"get-timeout":        "getTimeout",
-		"put-timeout":        "putTimeout",
-		"ioretries":          "ioretries",
-		"max-uploads":        "maxUpload",
-		"buffer-size":        "bufferSize",
-		"prefetch":           "prefetch",
-		"writeback":          "writeback",
-		"cache-dir":          "cacheDir",
-		"cache-size":         "cacheSize",
-		"free-space-ratio":   "freeSpace",
-		"cache-partial-only": "partialOnly",
-		"no-usage-report":    "no-usage-report",
+		"attrcacheto":     "attr-cache",
+		"entrycacheto":    "entry-cache",
+		"direntrycacheto": "dir-entry-cache",
 	}
 	newArgs := []string{"juicefs", "mount", "-d"}
 	mountOptions := os.Args[3:]

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -32,12 +32,13 @@ import (
 
 	"github.com/VividCortex/godaemon"
 	"github.com/google/gops/agent"
+	"github.com/urfave/cli/v2"
+
 	"github.com/juicedata/juicefs/pkg/chunk"
 	"github.com/juicedata/juicefs/pkg/fuse"
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juicedata/juicefs/pkg/vfs"
-	"github.com/urfave/cli/v2"
 )
 
 func MakeDaemon() error {
@@ -118,16 +119,16 @@ func mount(c *cli.Context) error {
 
 		GetTimeout:  time.Second * time.Duration(c.Int("get-timeout")),
 		PutTimeout:  time.Second * time.Duration(c.Int("put-timeout")),
-		MaxUpload:   c.Int("max-upload"),
+		MaxUpload:   c.Int("max-uploads"),
 		AsyncUpload: c.Bool("writeback"),
 		Prefetch:    c.Int("prefetch"),
 		BufferSize:  c.Int("buffer-size") << 20,
 
 		CacheDir:       filepath.Join(c.String("cache-dir"), format.UUID),
 		CacheSize:      int64(c.Int("cache-size")),
-		FreeSpace:      float32(c.Float64("free-space")),
+		FreeSpace:      float32(c.Float64("free-space-ratio")),
 		CacheMode:      os.FileMode(0600),
-		CacheFullBlock: !c.Bool("partial-only"),
+		CacheFullBlock: !c.Bool("cache-partial-only"),
 		AutoCreate:     true,
 	}
 	blob, err := createStorage(format)
@@ -245,7 +246,7 @@ func mountFlags() *cli.Command {
 				Usage: "number of retries after network failure",
 			},
 			&cli.IntFlag{
-				Name:  "max-upload",
+				Name:  "max-uploads",
 				Value: 20,
 				Usage: "number of connections to upload",
 			},
@@ -275,12 +276,12 @@ func mountFlags() *cli.Command {
 				Usage: "size of cached objects in MiB",
 			},
 			&cli.Float64Flag{
-				Name:  "free-space",
+				Name:  "free-space-ratio",
 				Value: 0.1,
 				Usage: "min free space (ratio)",
 			},
 			&cli.BoolFlag{
-				Name:  "partial-only",
+				Name:  "cache-partial-only",
 				Usage: "cache only random/small read",
 			},
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -79,9 +80,9 @@ func mount(c *cli.Context) error {
 		}
 	}()
 	setLoggerLevel(c)
-	if !c.Bool("nosyslog") {
+	if !c.Bool("no-syslog") {
 		// The default log to syslog is only in daemon mode.
-		utils.InitLoggers(c.Bool("d"))
+		utils.InitLoggers(c.Bool("background"))
 	}
 	if c.Args().Len() < 1 {
 		logger.Fatalf("Redis URL and mountpoint are required")
@@ -115,18 +116,18 @@ func mount(c *cli.Context) error {
 		BlockSize: format.BlockSize * 1024,
 		Compress:  format.Compression,
 
-		GetTimeout:  time.Second * time.Duration(c.Int("getTimeout")),
-		PutTimeout:  time.Second * time.Duration(c.Int("putTimeout")),
-		MaxUpload:   c.Int("maxUpload"),
+		GetTimeout:  time.Second * time.Duration(c.Int("get-timeout")),
+		PutTimeout:  time.Second * time.Duration(c.Int("put-timeout")),
+		MaxUpload:   c.Int("max-upload"),
 		AsyncUpload: c.Bool("writeback"),
 		Prefetch:    c.Int("prefetch"),
-		BufferSize:  c.Int("bufferSize") << 20,
+		BufferSize:  c.Int("buffer-size") << 20,
 
-		CacheDir:       c.String("cacheDir"),
-		CacheSize:      int64(c.Int("cacheSize")),
-		FreeSpace:      float32(c.Float64("freeRatio")),
+		CacheDir:       filepath.Join(c.String("cache-dir"), format.UUID),
+		CacheSize:      int64(c.Int("cache-size")),
+		FreeSpace:      float32(c.Float64("free-space")),
 		CacheMode:      os.FileMode(0600),
-		CacheFullBlock: !c.Bool("partialOnly"),
+		CacheFullBlock: !c.Bool("partial-only"),
 		AutoCreate:     true,
 	}
 	blob, err := createStorage(format)
@@ -136,7 +137,7 @@ func mount(c *cli.Context) error {
 	logger.Infof("Data use %s", blob)
 	logger.Infof("mount volume %s at %s", format.Name, mp)
 
-	if c.Bool("d") {
+	if c.Bool("background") {
 		if err := MakeDaemon(); err != nil {
 			logger.Fatalf("Failed to make daemon: %s", err)
 		}
@@ -175,7 +176,7 @@ func mount(c *cli.Context) error {
 	if !c.Bool("no-usage-report") {
 		go reportUsage(m)
 	}
-	err = fuse.Main(conf, c.String("o"), c.Float64("attrcacheto"), c.Float64("entrycacheto"), c.Float64("direntrycacheto"))
+	err = fuse.Main(conf, c.String("o"), c.Float64("attr-cache"), c.Float64("entry-cache"), c.Float64("dir-entry-cache"))
 	if err != nil {
 		logger.Fatalf("fuse: %s", err)
 	}
@@ -199,51 +200,57 @@ func mountFlags() *cli.Command {
 		Action:    mount,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:  "d",
-				Usage: "run in background",
+				Name:    "d",
+				Aliases: []string{"background"},
+				Usage:   "run in background",
 			},
+			&cli.BoolFlag{
+				Name:  "no-syslog",
+				Usage: "disable syslog",
+			},
+
 			&cli.StringFlag{
 				Name:  "o",
 				Usage: "other fuse options",
 			},
 			&cli.Float64Flag{
-				Name:  "attrcacheto",
+				Name:  "attr-cache",
 				Value: 1.0,
 				Usage: "attributes cache timeout in seconds",
 			},
 			&cli.Float64Flag{
-				Name:  "entrycacheto",
+				Name:  "entry-cache",
 				Value: 1.0,
 				Usage: "file entry cache timeout in seconds",
 			},
 			&cli.Float64Flag{
-				Name:  "direntrycacheto",
+				Name:  "dir-entry-cache",
 				Value: 1.0,
 				Usage: "dir entry cache timeout in seconds",
 			},
 
 			&cli.IntFlag{
-				Name:  "getTimeout",
+				Name:  "get-timeout",
 				Value: 60,
 				Usage: "the max number of seconds to download an object",
 			},
 			&cli.IntFlag{
-				Name:  "putTimeout",
+				Name:  "put-timeout",
 				Value: 60,
 				Usage: "the max number of seconds to upload an object",
 			},
 			&cli.IntFlag{
-				Name:  "ioretries",
+				Name:  "io-retries",
 				Value: 30,
 				Usage: "number of retries after network failure",
 			},
 			&cli.IntFlag{
-				Name:  "maxUpload",
+				Name:  "max-upload",
 				Value: 20,
 				Usage: "number of connections to upload",
 			},
 			&cli.IntFlag{
-				Name:  "bufferSize",
+				Name:  "buffer-size",
 				Value: 300,
 				Usage: "total read/write buffering in MB",
 			},
@@ -258,28 +265,28 @@ func mountFlags() *cli.Command {
 				Usage: "Upload objects in background",
 			},
 			&cli.StringFlag{
-				Name:  "cacheDir",
+				Name:  "cache-dir",
 				Value: defaultCacheDir,
 				Usage: "directory to cache object",
 			},
 			&cli.IntFlag{
-				Name:  "cacheSize",
+				Name:  "cache-size",
 				Value: 1 << 10,
 				Usage: "size of cached objects in MiB",
 			},
 			&cli.Float64Flag{
-				Name:  "freeSpace",
+				Name:  "free-space",
 				Value: 0.1,
 				Usage: "min free space (ratio)",
 			},
 			&cli.BoolFlag{
-				Name:  "partialOnly",
+				Name:  "partial-only",
 				Usage: "cache only random/small read",
 			},
 
 			&cli.BoolFlag{
 				Name:  "no-usage-report",
-				Usage: "do not send usage report to juicefs.io",
+				Usage: "do not send usage report",
 			},
 		},
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,11 +18,11 @@ package main
 import "fmt"
 
 var (
-	VERSION      = "dev"
-	REVISION     = "HEAD"
-	REVISIONDATE = "now"
+	version      = "dev"
+	revision     = "HEAD"
+	revisionDate = "now"
 )
 
 func Version() string {
-	return fmt.Sprintf("%v (%v %v)", VERSION, REVISIONDATE, REVISION)
+	return fmt.Sprintf("%v (%v %v)", version, revisionDate, revision)
 }

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -85,8 +85,8 @@ func NewRedisMeta(url string, conf *RedisConfig) (Meta, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %s", url, err)
 	}
-	if opt.Password == "" && os.Getenv("REDIS_PASSWD") != "" {
-		opt.Password = os.Getenv("REDIS_PASSWD")
+	if opt.Password == "" && os.Getenv("REDIS_PASSWORD") != "" {
+		opt.Password = os.Getenv("REDIS_PASSWORD")
 	}
 	rdb := redis.NewClient(opt)
 	m := &redisMeta{


### PR DESCRIPTION
This PR change all command line options to use lower case for consistency.

This is a BREAKING change, we'd like to change it now rather than later.