### PR TITLE
use ENOATTR in darwin instead of ENODATA

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1523,7 +1523,7 @@ func (r *redisMeta) GetXattr(ctx Context, inode Ino, name string, vbuff *[]byte)
 	var err error
 	*vbuff, err = r.rdb.HGet(c, r.xattrKey(inode), name).Bytes()
 	if err == redis.Nil {
-		err = syscall.ENODATA
+		err = ENOATTR
 	}
 	return errno(err)
 }
@@ -1549,7 +1549,7 @@ func (r *redisMeta) SetXattr(ctx Context, inode Ino, name string, value []byte) 
 func (r *redisMeta) RemoveXattr(ctx Context, inode Ino, name string) syscall.Errno {
 	n, err := r.rdb.HDel(c, r.xattrKey(inode), name).Result()
 	if n == 0 {
-		err = syscall.ENODATA
+		err = ENOATTR
 	}
 	return errno(err)
 }

--- a/pkg/meta/utils_darwin.go
+++ b/pkg/meta/utils_darwin.go
@@ -1,0 +1,5 @@
+package meta
+
+import "syscall"
+
+const ENOATTR = syscall.ENOATTR

--- a/pkg/meta/utils_linux.go
+++ b/pkg/meta/utils_linux.go
@@ -1,0 +1,5 @@
+package meta
+
+import "syscall"
+
+const ENOATTR = syscall.ENODATA

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -744,7 +744,7 @@ func GetXattr(ctx Context, ino Ino, name string, size uint32) (value []byte, err
 	defer func() { logit(ctx, "getxattr (%d,%s,%d): %s (%d)", ino, name, size, strerr(err), len(value)) }()
 
 	if IsSpecialNode(ino) {
-		err = syscall.ENODATA
+		err = meta.ENOATTR
 		return
 	}
 	if len(name) > xattrMaxName {


### PR DESCRIPTION
In darwin, getxattr should return ENOATTR if extended attribute do not exists.

Closes #88 