### PR TITLE
Make slices parsing faster by pre-allocation

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1279,7 +1279,8 @@ func (r *redisMeta) Read(ctx Context, inode Ino, indx uint32, chunks *[]Slice) s
 	if err != nil {
 		return errno(err)
 	}
-	*chunks = readSlices(vals)
+	ss := readSlices(vals)
+	*chunks = buildSlice(ss)
 	if len(vals) >= 5 {
 		go r.compact(inode, indx)
 	}
@@ -1446,7 +1447,8 @@ func (r *redisMeta) compact(inode Ino, indx uint32) {
 		return
 	}
 
-	chunks := readSlices(vals)
+	ss := readSlices(vals)
+	chunks := buildSlice(ss)
 	var size uint32
 	for _, s := range chunks {
 		size += s.Len
@@ -1511,13 +1513,12 @@ func (r *redisMeta) compact(inode Ino, indx uint32) {
 	}
 }
 
-func readSlices(vals []string) []Slice {
+func readSlices(vals []string) []*slice {
 	ss := make([]*slice, len(vals))
 	for i, val := range vals {
 		ss[i] = parseSlice([]byte(val))
 	}
-	chunks := buildSlice(ss)
-	return chunks
+	return ss
 }
 
 func (r *redisMeta) GetXattr(ctx Context, inode Ino, name string, vbuff *[]byte) syscall.Errno {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1412,16 +1412,6 @@ func (r *redisMeta) deleteChunks(inode Ino, tracking string) {
 	r.rdb.ZRem(c, delchunks, tracking)
 }
 
-func parseSlice(buf []byte) *slice {
-	rb := utils.ReadBuffer(buf)
-	pos := rb.Get32()
-	chunkid := rb.Get64()
-	size := rb.Get32()
-	off := rb.Get32()
-	len := rb.Get32()
-	return newSlice(pos, chunkid, size, off, len)
-}
-
 func (r *redisMeta) compact(inode Ino, indx uint32) {
 	// avoid too many or duplicated compaction
 	r.Lock()
@@ -1514,9 +1504,12 @@ func (r *redisMeta) compact(inode Ino, indx uint32) {
 }
 
 func readSlices(vals []string) []*slice {
+	slices := make([]slice, len(vals))
 	ss := make([]*slice, len(vals))
 	for i, val := range vals {
-		ss[i] = parseSlice([]byte(val))
+		s := &slices[i]
+		s.read([]byte(val))
+		ss[i] = s
 	}
 	return ss
 }

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1281,7 +1281,7 @@ func (r *redisMeta) Read(ctx Context, inode Ino, indx uint32, chunks *[]Slice) s
 	}
 	ss := make([]*slice, len(vals))
 	for i, val := range vals {
-		ss[i] = r.parseSlice([]byte(val))
+		ss[i] = parseSlice([]byte(val))
 	}
 	*chunks = buildSlice(ss)
 	if len(vals) >= 5 {
@@ -1415,7 +1415,7 @@ func (r *redisMeta) deleteChunks(inode Ino, tracking string) {
 	r.rdb.ZRem(c, delchunks, tracking)
 }
 
-func (r *redisMeta) parseSlice(buf []byte) *slice {
+func parseSlice(buf []byte) *slice {
 	rb := utils.ReadBuffer(buf)
 	pos := rb.Get32()
 	chunkid := rb.Get64()
@@ -1452,9 +1452,10 @@ func (r *redisMeta) compact(inode Ino, indx uint32) {
 
 	ss := make([]*slice, len(vals))
 	for i, val := range vals {
-		ss[i] = r.parseSlice([]byte(val))
+		ss[i] = parseSlice([]byte(val))
 	}
 	chunks := buildSlice(ss)
+
 	var size uint32
 	for _, s := range chunks {
 		size += s.Len

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1251,7 +1251,7 @@ func (r *redisMeta) Close(ctx Context, inode Ino) syscall.Errno {
 	return 0
 }
 
-func (r *redisMeta) buildSlice(ss []*slice) []Slice {
+func buildSlice(ss []*slice) []Slice {
 	var root *slice
 	for _, s := range ss {
 		if root != nil {
@@ -1283,7 +1283,7 @@ func (r *redisMeta) Read(ctx Context, inode Ino, indx uint32, chunks *[]Slice) s
 	for i, val := range vals {
 		ss[i] = r.parseSlice([]byte(val))
 	}
-	*chunks = r.buildSlice(ss)
+	*chunks = buildSlice(ss)
 	if len(vals) >= 5 {
 		go r.compact(inode, indx)
 	}
@@ -1454,7 +1454,7 @@ func (r *redisMeta) compact(inode Ino, indx uint32) {
 	for i, val := range vals {
 		ss[i] = r.parseSlice([]byte(val))
 	}
-	chunks := r.buildSlice(ss)
+	chunks := buildSlice(ss)
 	var size uint32
 	for _, s := range chunks {
 		size += s.Len

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -21,7 +21,31 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/juicedata/juicefs/pkg/utils"
 )
+
+func BenchmarkReadSlices(b *testing.B) {
+	w := utils.NewBuffer(24)
+	w.Put32(0)
+	w.Put64(1014)
+	w.Put32(122)
+	w.Put32(0)
+	w.Put32(122)
+	v := string(w.Bytes())
+	var vals [128]string
+	for i := range vals {
+		vals[i] = v
+	}
+	b.ResetTimer()
+	var slices []*slice
+	for i := 0; i < b.N; i++ {
+		slices = readSlices(vals[:])
+	}
+	if len(slices) != len(vals) {
+		b.Fail()
+	}
+}
 
 // nolint:errcheck
 func TestRedisClient(t *testing.T) {

--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -15,6 +15,8 @@
 
 package meta
 
+import "github.com/juicedata/juicefs/pkg/utils"
+
 type slice struct {
 	chunkid uint64
 	size    uint32
@@ -38,6 +40,15 @@ func newSlice(pos uint32, chunkid uint64, cleng, off, len uint32) *slice {
 	s.left = nil
 	s.right = nil
 	return s
+}
+
+func (s *slice) read(buf []byte) {
+	rb := utils.ReadBuffer(buf)
+	s.pos = rb.Get32()
+	s.chunkid = rb.Get64()
+	s.size = rb.Get32()
+	s.off = rb.Get32()
+	s.len = rb.Get32()
 }
 
 func (s *slice) cut(pos uint32) (left, right *slice) {


### PR DESCRIPTION
## Before

```
BenchmarkReadSlices/small-16             3035296               400 ns/op             352 B/op          9 allocs/op
BenchmarkReadSlices/small-16             3063632               382 ns/op             352 B/op          9 allocs/op
BenchmarkReadSlices/small-16             3184216               383 ns/op             352 B/op          9 allocs/op
BenchmarkReadSlices/mid-16                227870              5467 ns/op            5632 B/op        129 allocs/op
BenchmarkReadSlices/mid-16                221240              5342 ns/op            5632 B/op        129 allocs/op
BenchmarkReadSlices/mid-16                220996              5185 ns/op            5632 B/op        129 allocs/op
BenchmarkReadSlices/large-16               14389             84043 ns/op           90112 B/op       2049 allocs/op
BenchmarkReadSlices/large-16               14252             83926 ns/op           90112 B/op       2049 allocs/op
BenchmarkReadSlices/large-16               13748             85014 ns/op           90112 B/op       2049 allocs/op
```

## After

```
BenchmarkReadSlices/small-16             3990091               301 ns/op             320 B/op          6 allocs/op
BenchmarkReadSlices/small-16             3838144               304 ns/op             320 B/op          6 allocs/op
BenchmarkReadSlices/small-16             3875310               325 ns/op             320 B/op          6 allocs/op
BenchmarkReadSlices/mid-16                301630              3684 ns/op            5248 B/op         66 allocs/op
BenchmarkReadSlices/mid-16                330322              3584 ns/op            5248 B/op         66 allocs/op
BenchmarkReadSlices/mid-16                326588              3623 ns/op            5248 B/op         66 allocs/op
BenchmarkReadSlices/large-16               21490             55500 ns/op           81920 B/op       1026 allocs/op
BenchmarkReadSlices/large-16               21813             56052 ns/op           81920 B/op       1026 allocs/op
BenchmarkReadSlices/large-16               21601             56190 ns/op           81920 B/op       1026 allocs/op
```