### PR TITLE
Avoid calling mget with massive number of keys in Readdir

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1167,10 +1167,6 @@ func (r *redisMeta) Readdir(ctx Context, inode Ino, plus uint8, entries *[]*Entr
 	if err := r.GetAttr(ctx, inode, &attr); err != 0 {
 		return err
 	}
-	vals, err := r.rdb.HGetAll(ctx, r.entryKey(inode)).Result()
-	if err != nil {
-		return errno(err)
-	}
 	*entries = []*Entry{
 		{
 			Inode: inode,
@@ -1185,26 +1181,47 @@ func (r *redisMeta) Readdir(ctx Context, inode Ino, plus uint8, entries *[]*Entr
 			Attr:  &Attr{Typ: TypeDirectory},
 		})
 	}
+	vals, err := r.rdb.HGetAll(ctx, r.entryKey(inode)).Result()
+	if err != nil {
+		return errno(err)
+	}
+	newEntries := make([]Entry, len(vals))
+	newAttrs := make([]Attr, len(newEntries))
+	var i int
 	for name, val := range vals {
 		typ, inode := r.parseEntry([]byte(val))
-		*entries = append(*entries, &Entry{
-			Inode: inode,
-			Name:  []byte(name),
-			Attr:  &Attr{Typ: typ},
-		})
+		ent := newEntries[i]
+		ent.Inode = inode
+		ent.Name = []byte(name)
+		attr := newAttrs[i]
+		attr.Typ = typ
+		ent.Attr = &attr
+		*entries = append(*entries, &ent)
+		i++
 	}
 	if plus != 0 {
-		var keys []string
-		for _, e := range *entries {
-			keys = append(keys, r.inodeKey(e.Inode))
+		batchSize := 4096
+		if batchSize > len(*entries) {
+			batchSize = len(*entries)
 		}
-		rs, _ := r.rdb.MGet(ctx, keys...).Result()
-		for i, re := range rs {
-			if re != nil {
-				if a, ok := re.(string); ok {
-					r.parseAttr([]byte(a), (*entries)[i].Attr)
+		keysBatch := make([]string, 0, batchSize)
+		for i := 0; i < len(*entries); i += batchSize {
+			end := i + batchSize
+			if end > len(*entries) {
+				end = len(*entries)
+			}
+			for _, e := range (*entries)[i:end] {
+				keysBatch = append(keysBatch, r.inodeKey(e.Inode))
+			}
+			rs, _ := r.rdb.MGet(ctx, keysBatch...).Result()
+			for j, re := range rs {
+				if re != nil {
+					if a, ok := re.(string); ok {
+						r.parseAttr([]byte(a), (*entries)[i+j].Attr)
+					}
 				}
 			}
+			keysBatch = keysBatch[:0]
 		}
 	}
 	return 0

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1200,7 +1200,7 @@ func (r *redisMeta) Readdir(ctx Context, inode Ino, plus uint8, entries *[]*Entr
 		i++
 	}
 	if plus != 0 {
-		batchSize := 4096
+		batchSize := 40960
 		if batchSize > len(*entries) {
 			batchSize = len(*entries)
 		}


### PR DESCRIPTION
This PR is related to #95 .

In the original implementation, `mget` is called once with all the keys which correspond to files in a directory. When there are many files in a directory, this call might block the Redis server process.

In this PR, I changed it to call `mget` in smaller fixed batch. The consequence is that we reduce the chance of blocking the Redis server, but `ReadDir` is made slower when the number of files in a directory exceeds the batch size (which is set to 4096 now).

For small directories, the latency difference is trivial:

* Before
```python
In [24]: %timeit os.listdir("/Users/satoru//jfs/some-files/")
1.26 ms ± 2.57 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

* After
```python
In [25]: %timeit os.listdir("/Users/satoru/jfs/some-files/")
1.27 ms ± 11.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

When I run the benchmark in a directory with more than 200,000 files, the new version is obviously slower:

* Before
```python
In [15]: %timeit os.listdir("/Users/satoru/jfs/many-files/")
446 ms ± 2.87 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

* After
```python
In [19]: %timeit os.listdir("/Users/satoru/jfs/many-files/")
488 ms ± 8.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```