### PR TITLE
Update command reference doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The highlighted features are:
 
 ---
 
-[Architecture](#architecture) | [Getting Started](#getting-started) | [POSIX Compatibility](#posix-compatibility) | [Performance Benchmark](#performance-benchmark) | [Supported Object Storage](#supported-object-storage) | [Command Reference](docs/command_reference.md) | [Status](#status) | [Roadmap](#roadmap) | [Reporting Issues](#reporting-issues) | [Contributing](#contributing) | [Community](#community) | [Usage Tracking](#usage-tracking) | [License](#license) | [Credits](#credits) | [FAQ](#faq)
+[Architecture](#architecture) | [Getting Started](#getting-started) | [POSIX Compatibility](#posix-compatibility) | [Performance Benchmark](#performance-benchmark) | [Supported Object Storage](#supported-object-storage) | [Status](#status) | [Roadmap](#roadmap) | [Reporting Issues](#reporting-issues) | [Contributing](#contributing) | [Community](#community) | [Usage Tracking](#usage-tracking) | [License](#license) | [Credits](#credits) | [FAQ](#faq)
 
 ---
 
@@ -178,7 +178,6 @@ It's considered as beta quality, the storage format is not stabilized yet. It's 
 ## Roadmap
 
 - Stabilize storage format
-- Hadoop SDK
 - S3 gateway
 - Windows client
 - Encryption at rest

--- a/README_CN.md
+++ b/README_CN.md
@@ -90,10 +90,13 @@ $ ./juicefs mount -d localhost ~/jfs
 
 挂载之后你可以像使用本地盘一样使用它，详细的挂载参数，请运行 `./juicefs mount -h`。
 
+### 命令索引
+
+请点击[这里](docs/command_reference.md)查看所有子命令以及命令行参数。
 
 ### Kubernetes
 
-JuiceFS 提供 [K8s CSI 驱动](https://github.com/juicedata/juicefs-csi-driver)来简化部署.
+JuiceFS 提供 [K8s CSI 驱动](https://github.com/juicedata/juicefs-csi-driver)来简化部署。
 
 ## POSIX 兼容性测试
 
@@ -174,7 +177,6 @@ JuiceFS 目前是 beta 状态，核心的存储格式还没有完全确定，还
 ## 产品路线图
 
 - 稳定存储格式
-- Hadoop 客户端
 - S3 兼容网关
 - Windows 客户端
 - 存储加密

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 	app := &cli.App{
 		Name:      "juicefs",
-		Usage:     "A POSIX filesystem built on redis and object storage.",
+		Usage:     "A POSIX file system built on Redis and object storage.",
 		Version:   Version(),
 		Copyright: "AGPLv3",
 		Flags: []cli.Flag{

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -230,7 +230,7 @@ func mountFlags() *cli.Command {
 
 			&cli.StringFlag{
 				Name:  "o",
-				Usage: "other fuse options",
+				Usage: "other FUSE options",
 			},
 			&cli.Float64Flag{
 				Name:  "attr-cache",
@@ -275,7 +275,7 @@ func mountFlags() *cli.Command {
 			&cli.IntFlag{
 				Name:  "buffer-size",
 				Value: 300,
-				Usage: "total read/write buffering in MB",
+				Usage: "total read/write buffering in MiB",
 			},
 			&cli.IntFlag{
 				Name:  "prefetch",

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -55,25 +55,25 @@ juicefs format [command options] REDIS-URL NAME
 
 ### Options
 
-`--block-size value`
+`--block-size value`\
 size of block in KiB (default: 4096)
 
-`--compress value`
+`--compress value`\
 compression algorithm (lz4, zstd, none) (default: "lz4")
 
-`--storage value`
+`--storage value`\
 Object storage type (e.g. s3, gcs, oss, cos) (default: "file")
 
-`--bucket value`
+`--bucket value`\
 A bucket URL to store data (default: `"$HOME/.juicefs/local"`)
 
-`--access-key value`
+`--access-key value`\
 Access key for object storage (env `ACCESS_KEY`)
 
-`--secret-key value`
+`--secret-key value`\
 Secret key for object storage (env `SECRET_KEY`)
 
-`--force`
+`--force`\
 overwrite existing format (default: false)
 
 ## juicefs mount
@@ -90,61 +90,61 @@ juicefs mount [command options] REDIS-URL MOUNTPOINT
 
 ### Options
 
-`-d, --background`
+`-d, --background`\
 run in background (default: false)
 
-`--no-syslog`
+`--no-syslog`\
 disable syslog (default: false)
 
-`-o value`
+`-o value`\
 other FUSE options
 
-`--attr-cache value`
+`--attr-cache value`\
 attributes cache timeout in seconds (default: 1)
 
-`--entry-cache value`
+`--entry-cache value`\
 file entry cache timeout in seconds (default: 1)
 
-`--dir-entry-cache value`
+`--dir-entry-cache value`\
 dir entry cache timeout in seconds (default: 1)
 
-`--enable-xattr`
+`--enable-xattr`\
 enable extended attributes (xattr) (default: false)
 
-`--get-timeout value`
+`--get-timeout value`\
 the max number of seconds to download an object (default: 60)
 
-`--put-timeout value`
+`--put-timeout value`\
 the max number of seconds to upload an object (default: 60)
 
-`--io-retries value`
+`--io-retries value`\
 number of retries after network failure (default: 30)
 
-`--max-uploads value`
+`--max-uploads value`\
 number of connections to upload (default: 20)
 
-`--buffer-size value`
+`--buffer-size value`\
 total read/write buffering in MiB (default: 300)
 
-`--prefetch value`
+`--prefetch value`\
 prefetch N blocks in parallel (default: 3)
 
-`--writeback`
+`--writeback`\
 Upload objects in background (default: false)
 
-`--cache-dir value`
+`--cache-dir value`\
 directory to cache object (default: `"$HOME/.juicefs/cache"`)
 
-`--cache-size value`
+`--cache-size value`\
 size of cached objects in MiB (default: 1024)
 
-`--free-space-ratio value`
+`--free-space-ratio value`\
 min free space (ratio) (default: 0.1)
 
-`--cache-partial-only`
+`--cache-partial-only`\
 cache only random/small read (default: false)
 
-`--no-usage-report`
+`--no-usage-report`\
 do not send usage report (default: false)
 
 ## juicefs benchmark
@@ -161,17 +161,17 @@ juicefs benchmark [command options] [arguments...]
 
 ### Options
 
-`--dest value`
+`--dest value`\
 path to run benchmark (default: `"/jfs/benchmark"`)
 
-`--block-size value`
+`--block-size value`\
 block size in MiB (default: 1)
 
-`--bigfile-file-size value`
+`--bigfile-file-size value`\
 size of big file in MiB (default: 1024)
 
-`--smallfile-file-size value`
+`--smallfile-file-size value`\
 size of small file in MiB (default: 0.1)
 
-`--smallfile-count value`
+`--smallfile-count value`\
 number of small files (default: 100)

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -1,6 +1,6 @@
 # Command Reference
 
-There are many commands to help you manage your filesystem. This page provides a detailed reference for these commands.
+There are many commands to help you manage your file system. This page provides a detailed reference for these commands.
 
 ## Overview
 
@@ -8,7 +8,7 @@ If you run `juicefs` by itself, it will print all available subcommands. In addi
 
 ```
 NAME:
-   juicefs - A POSIX filesystem built on redis and object storage.
+   juicefs - A POSIX file system built on Redis and object storage.
 
 USAGE:
    juicefs [global options] command [command options] [arguments...]
@@ -45,7 +45,7 @@ The documentation below gives you detailed information about each subcommand.
 
 ### Description
 
-Format a volume. It's the first step for initializing a new filesystem volume.
+Format a volume. It's the first step for initializing a new file system volume.
 
 ### Synopsis
 
@@ -55,32 +55,32 @@ juicefs format [command options] REDIS-URL NAME
 
 ### Options
 
-`--block-size value`  
+`--block-size value`
 size of block in KiB (default: 4096)
 
-`--compress value`   
+`--compress value`
 compression algorithm (lz4, zstd, none) (default: "lz4")
 
-`--storage value`    
+`--storage value`
 Object storage type (e.g. s3, gcs, oss, cos) (default: "file")
 
-`--bucket value`     
-A bucket URL to store data (default: `"/Users/surui/.juicefs/local"`)
+`--bucket value`
+A bucket URL to store data (default: `"$HOME/.juicefs/local"`)
 
-`--access-key value`  
-Access key for object storage (env ACCESS_KEY)
+`--access-key value`
+Access key for object storage (env `ACCESS_KEY`)
 
-`--secret-key value`  
-Secret key for object storage (env SECRET_KEY)
+`--secret-key value`
+Secret key for object storage (env `SECRET_KEY`)
 
-`--force`             
+`--force`
 overwrite existing format (default: false)
 
 ## juicefs mount
 
 ### Description
 
-Mount a volume. the volume shoud be formatted first.
+Mount a volume. The volume shoud be formatted first.
 
 ### Synopsis
 
@@ -90,61 +90,61 @@ juicefs mount [command options] REDIS-URL MOUNTPOINT
 
 ### Options
 
-`-d, --background`  
+`-d, --background`
 run in background (default: false)
 
-`--no-syslog`   
+`--no-syslog`
 disable syslog (default: false)
 
-`-o value`  
-other fuse options
+`-o value`
+other FUSE options
 
-`--attr-cache value`    
+`--attr-cache value`
 attributes cache timeout in seconds (default: 1)
 
-`--entry-cache value`   
+`--entry-cache value`
 file entry cache timeout in seconds (default: 1)
 
-`--dir-entry-cache value`   
+`--dir-entry-cache value`
 dir entry cache timeout in seconds (default: 1)
 
-`--enable-xattr`    
+`--enable-xattr`
 enable extended attributes (xattr) (default: false)
 
-`--get-timeout value`   
+`--get-timeout value`
 the max number of seconds to download an object (default: 60)
 
-`--put-timeout value`   
+`--put-timeout value`
 the max number of seconds to upload an object (default: 60)
 
-`--io-retries value`    
+`--io-retries value`
 number of retries after network failure (default: 30)
 
-`--max-uploads value`   
+`--max-uploads value`
 number of connections to upload (default: 20)
 
-`--buffer-size value`   
-total read/write buffering in MB (default: 300)
+`--buffer-size value`
+total read/write buffering in MiB (default: 300)
 
-`--prefetch value`       
+`--prefetch value`
 prefetch N blocks in parallel (default: 3)
 
-`--writeback`   
+`--writeback`
 Upload objects in background (default: false)
 
-`--cache-dir value`       
-directory to cache object (default: `"/Users/surui/.juicefs/cache"`)
+`--cache-dir value`
+directory to cache object (default: `"$HOME/.juicefs/cache"`)
 
-`--cache-size value`    
+`--cache-size value`
 size of cached objects in MiB (default: 1024)
 
-`--free-space-ratio value`      
+`--free-space-ratio value`
 min free space (ratio) (default: 0.1)
 
-`--cache-partial-only` 
+`--cache-partial-only`
 cache only random/small read (default: false)
 
-`--no-usage-report`  
+`--no-usage-report`
 do not send usage report (default: false)
 
 ## juicefs benchmark
@@ -161,17 +161,17 @@ juicefs benchmark [command options] [arguments...]
 
 ### Options
 
-`--dest value`  
+`--dest value`
 path to run benchmark (default: `"/jfs/benchmark"`)
 
-`--block-size value`    
+`--block-size value`
 block size in MiB (default: 1)
 
-`--bigfile-file-size value` 
+`--bigfile-file-size value`
 size of big file in MiB (default: 1024)
 
-`--smallfile-file-size value`   
+`--smallfile-file-size value`
 size of small file in MiB (default: 0.1)
 
-`--smallfile-count value`   
+`--smallfile-count value`
 number of small files (default: 100)


### PR DESCRIPTION
- Remove "Command Reference" from TOC
- Add "Command Reference" section to Chinese version README
- Fix spelling in "Command Reference"
- For a more visibility, use [backslash](https://github.github.com/gfm/#hard-line-breaks) to break line explicitly instead of multiple spaces (many editor also trim ending space automatically).
- Remove "Hadoop SDK" from roadmap

Ref to #96 