### PR TITLE
fix Makefile to pass revision when git- clone with --depth or --no-tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ ifneq ($(strip $(VERSION)),)
 	LDFLAGS += -X $(PKG).revision=$(REVISION) \
 		   -X $(PKG).revisionDate=$(REVISIONDATE) \
 		   -X $(PKG).version=$(VERSION)
+else ifneq ($(strip $(REVISION)),) # Use git clone with --depth or --no-tags
+	LDFLAGS += -X $(PKG).revision=$(REVISION) \
+		   -X $(PKG).revisionDate=$(REVISIONDATE)
 endif
 
 SHELL = /bin/sh

--- a/sdk/java/libjfs/Makefile
+++ b/sdk/java/libjfs/Makefile
@@ -3,6 +3,20 @@ LDFLAGS = -s -w
 
 all: target/libjfs.so.gz
 
+REVISION := $(shell git rev-parse --short HEAD 2>/dev/null)
+REVISIONDATE := $(shell git log -1 --pretty=format:'%ad' --date short 2>/dev/null)
+VERSION := $(shell git describe --tags --match 'v*' 2>/dev/null | sed -e 's/^v//' -e 's/-g[0-9a-f]\{7,\}$$//')
+PKG := github.com/juicedata/juicefs/pkg/version
+LDFLAGS = -s -w
+ifneq ($(strip $(VERSION)),)
+	LDFLAGS += -X $(PKG).revision=$(REVISION) \
+		   -X $(PKG).revisionDate=$(REVISIONDATE) \
+		   -X $(PKG).version=$(VERSION)
+else ifneq ($(strip $(REVISION)),) # Use git clone with --depth or --no-tags
+	LDFLAGS += -X $(PKG).revision=$(REVISION) \
+		   -X $(PKG).revisionDate=$(REVISIONDATE)
+endif
+
 target/libjfs.so.gz: libjfs.so
 	mkdir -p target
 	gzip -c libjfs.so > target/libjfs.so.gz


### PR DESCRIPTION
When use `git clone` with `--depth` or `--no-tags` option, we may not get the latest version tag, but the latest commit revision is there, we can pass the `revision` and `revisionDate`.