### PR TITLE
prometheus metrics: add namespace prefix

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -45,23 +45,23 @@ import (
 
 var (
 	cpu = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "cpu_usage",
+		Name: "juicefs_cpu_usage",
 		Help: "Accumulated CPU usage in seconds.",
 	})
 	memory = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "memory",
+		Name: "juicefs_memory",
 		Help: "Used memory in bytes.",
 	})
 	uptime = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "uptime",
+		Name: "juicefs_uptime",
 		Help: "Total running time in seconds.",
 	})
 	usedSpace = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "used_space",
+		Name: "juicefs_used_space",
 		Help: "Total used space in bytes.",
 	})
 	usedInodes = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "used_inodes",
+		Name: "juicefs_used_inodes",
 		Help: "Total number of inodes.",
 	})
 )

--- a/pkg/meta/redis_metrics.go
+++ b/pkg/meta/redis_metrics.go
@@ -19,12 +19,12 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	redisTxDist = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "redis_tx_durations_histogram_seconds",
+		Name:    "juicefs_redis_tx_durations_histogram_seconds",
 		Help:    "Redis transactions latency distributions.",
 		Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
 	})
 	redisTxRestart = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "redis_transaction_restart",
+		Name: "juicefs_redis_transaction_restart",
 		Help: "The number of times a Redis transaction is restarted.",
 	})
 )

--- a/pkg/object/metrics.go
+++ b/pkg/object/metrics.go
@@ -24,16 +24,16 @@ import (
 
 var (
 	reqsHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "object_request_durations_histogram_seconds",
+		Name:    "juicefs_object_request_durations_histogram_seconds",
 		Help:    "Object requests latency distributions.",
 		Buckets: prometheus.ExponentialBuckets(0.01, 1.5, 20),
 	}, []string{"method"})
 	reqErrors = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "object_request_errors",
+		Name: "juicefs_object_request_errors",
 		Help: "failed requests to object store",
 	})
 	dataBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "object_request_data_bytes",
+		Name: "juicefs_object_request_data_bytes",
 		Help: "Object requests size in bytes.",
 	}, []string{"method"})
 )

--- a/pkg/vfs/accesslog.go
+++ b/pkg/vfs/accesslog.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	opsDurationsHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "fuse_ops_durations_histogram_seconds",
+		Name:    "juicefs_fuse_ops_durations_histogram_seconds",
 		Help:    "Operations latency distributions.",
 		Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
 	})

--- a/pkg/vfs/handle.go
+++ b/pkg/vfs/handle.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	handlersGause = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "fuse_open_handlers",
+		Name: "juicefs_fuse_open_handlers",
 		Help: "number of open files and directories.",
 	}, func() float64 {
 		hanleLock.Lock()

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -54,12 +54,12 @@ var (
 
 var (
 	readSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "fuse_read_size_bytes",
+		Name:    "juicefs_fuse_read_size_bytes",
 		Help:    "size of read distributions.",
 		Buckets: prometheus.LinearBuckets(4096, 4096, 32),
 	})
 	writtenSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "fuse_written_size_bytes",
+		Name:    "juicefs_fuse_written_size_bytes",
 		Help:    "size of write distributions.",
 		Buckets: prometheus.LinearBuckets(4096, 4096, 32),
 	})


### PR DESCRIPTION
Prefix all prometheus metric names with `juicefs_` in order to set a namespace. Otherwise it's hard to know what a metric is referring to on a Prometheus instance with lots of metrics.

From https://prometheus.io/docs/practices/naming/:

> A metric name should have a (single-word) application prefix relevant to the domain the metric belongs to. The prefix is sometimes referred to as namespace by client libraries. For metrics specific to an application, the prefix is usually the application name itself.