### PR TITLE
support path-style URL for S3 (#134)

### DIFF
--- a/docs/en/how_to_setup_object_storage.md
+++ b/docs/en/how_to_setup_object_storage.md
@@ -55,9 +55,10 @@ The `<region>` should be replaced with specific region code, e.g. the region cod
 
 ***Note: For AWS China user, you need add `.cn` to the host, i.e. `amazonaws.com.cn`. And check [this document](https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-arns.html) to know your region code.***
 
-Currently, **JuiceFS only supports virtual hosted-style** and maybe support path-style in the future ([#134](https://github.com/juicedata/juicefs/issues/134)). So when you format a volume, the `--bucket` option should be virtual hosted-style URI. For example:
+JuiceFS supports both types of endpoint since v0.12 (before v0.12, only virtual hosted-style were supported). So when you format a volume, the `--bucket` option can be either virtual hosted-style URI or path-style URI. For example:
 
 ```bash
+# virtual hosted-style
 $ ./juicefs format \
     --storage s3 \
     --bucket https://<bucket>.s3.<region>.amazonaws.com \
@@ -65,15 +66,36 @@ $ ./juicefs format \
     localhost test
 ```
 
-You can also use S3 storage type to connect with S3-compatible storage. But beware that you still need use virtual hosted-style URI. For example:
+```bash
+# path-style
+$ ./juicefs format \
+    --storage s3 \
+    --bucket https://s3.<region>.amazonaws.com/<bucket> \
+    ... \
+    localhost test
+```
+
+You can also use S3 storage type to connect with S3-compatible storage. For example:
 
 ```bash
+# virtual hosted-style
 $ ./juicefs format \
     --storage s3 \
     --bucket https://<bucket>.<endpoint> \
     ... \
     localhost test
 ```
+
+```bash
+# path-style
+$ ./juicefs format \
+    --storage s3 \
+    --bucket https://<endpoint>/<bucket> \
+    ... \
+    localhost test
+```
+
+
 
 ## Google Cloud Storage
 

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -368,16 +368,16 @@ func newS3(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 
 	ssl := strings.ToLower(uri.Scheme) == "https"
 	awsConfig := &aws.Config{
-		Region:           aws.String(region),
-		DisableSSL:       aws.Bool(!ssl),
-		HTTPClient:       httpClient,
-		S3ForcePathStyle: aws.Bool(true),
+		Region:     aws.String(region),
+		DisableSSL: aws.Bool(!ssl),
+		HTTPClient: httpClient,
 	}
 	if accessKey != "" {
 		awsConfig.Credentials = credentials.NewStaticCredentials(accessKey, secretKey, "")
 	}
 	if ep != "" {
 		awsConfig.Endpoint = aws.String(ep)
+		awsConfig.S3ForcePathStyle = aws.Bool(true)
 	}
 
 	ses, err := session.NewSession(awsConfig)

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -293,6 +293,23 @@ func autoS3Region(bucketName, accessKey, secretKey string) (string, error) {
 	return "", err
 }
 
+func parseRegion(endpoint string) string {
+	if strings.HasPrefix(endpoint, "s3-") || strings.HasPrefix(endpoint, "s3.") {
+		endpoint = endpoint[3:]
+	}
+	if strings.HasPrefix(endpoint, "dualstack") {
+		endpoint = endpoint[len("dualstack."):]
+	}
+	if endpoint == "amazonaws.com" {
+		endpoint = awsDefaultRegion + "." + endpoint
+	}
+	region := strings.Split(endpoint, ".")[0]
+	if region == "external-1" {
+		region = awsDefaultRegion
+	}
+	return region
+}
+
 func newS3(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	uri, err := url.ParseRequestURI(endpoint)
 	if err != nil {
@@ -306,39 +323,46 @@ func newS3(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 		ep         string
 	)
 
-	if len(hostParts) == 1 { // take endpoint as bucketname
+	if len(hostParts) == 1 {
+		// take endpoint as bucketname
 		bucketName = hostParts[0]
 		if region, err = autoS3Region(bucketName, accessKey, secretKey); err != nil {
 			return nil, fmt.Errorf("Can't guess your region for bucket %s: %s", bucketName, err)
 		}
-	} else { // get region in endpoint
-		if strings.Contains(uri.Host, ".amazonaws.com") {
-			// standard s3
-			// [BUCKET].s3-[REGION].[REST_OF_ENDPOINT]
-			// [BUCKET].s3.[REGION].amazonaws.com[.cn]
-			hostParts = strings.SplitN(uri.Host, ".s3", 2)
-			bucketName = hostParts[0]
-			endpoint = "s3" + hostParts[1]
-			if strings.HasPrefix(endpoint, "s3-") || strings.HasPrefix(endpoint, "s3.") {
-				endpoint = endpoint[3:]
-			}
-			if strings.HasPrefix(endpoint, "dualstack") {
-				endpoint = endpoint[len("dualstack."):]
-			}
-			if endpoint == "amazonaws.com" {
-				endpoint = awsDefaultRegion + "." + endpoint
-			}
-			region = strings.Split(endpoint, ".")[0]
-			if region == "external-1" {
+	} else {
+		// get region or endpoint
+		if uri.Path != "" {
+			// [ENDPOINT]/[BUCKET]
+			pathParts := strings.Split(uri.Path, "/")
+			bucketName = pathParts[1]
+			if strings.Contains(uri.Host, ".amazonaws.com") {
+				// standard s3
+				// s3-[REGION].[REST_OF_ENDPOINT]/[BUCKET]
+				// s3.[REGION].amazonaws.com[.cn]/[BUCKET]
+				endpoint = uri.Host
+				region = parseRegion(endpoint)
+			} else {
+				// compatible s3
+				ep = uri.Host
 				region = awsDefaultRegion
 			}
 		} else {
-			// compatible s3
 			// [BUCKET].[ENDPOINT]
-			hostParts := strings.SplitN(uri.Host, ".", 2)
-			bucketName = hostParts[0]
-			ep = hostParts[1]
-			region = awsDefaultRegion
+			if strings.Contains(uri.Host, ".amazonaws.com") {
+				// standard s3
+				// [BUCKET].s3-[REGION].[REST_OF_ENDPOINT]
+				// [BUCKET].s3.[REGION].amazonaws.com[.cn]
+				hostParts = strings.SplitN(uri.Host, ".s3", 2)
+				bucketName = hostParts[0]
+				endpoint = "s3" + hostParts[1]
+				region = parseRegion(endpoint)
+			} else {
+				// compatible s3
+				hostParts := strings.SplitN(uri.Host, ".", 2)
+				bucketName = hostParts[0]
+				ep = hostParts[1]
+				region = awsDefaultRegion
+			}
 		}
 	}
 
@@ -353,6 +377,8 @@ func newS3(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	}
 	if ep != "" {
 		awsConfig.Endpoint = aws.String(ep)
+	}
+	if uri.Path != "" {
 		awsConfig.S3ForcePathStyle = aws.Bool(true)
 	}
 


### PR DESCRIPTION
When uri.Path is not empty, parse uri as path-style, otherwise parse uri as virtual hosted-style.

Passed [TestS3](https://github.com/juicedata/juicefs/blob/5a92bdfa6091042cc1fa21076b5069be1ce14af5/pkg/object/object_storage_test.go#L216) with following values:

```
juicefs-image.s3.ap-northeast-1.amazonaws.com
s3.ap-northeast-1.amazonaws.com/juicefs-image
play.minio.io:9000/juicefs
localhost:443/test
```

Closes #134 