### PR TITLE
add vol_name and mp labels for metrics

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -221,7 +221,7 @@ func mount(c *cli.Context) error {
 
 	mntLabels := prometheus.Labels{
 		"vol_name": format.Name,
-		"mp": mp,
+		"mp":       mp,
 	}
 	// Wrap the default registry, all prometheus.MustRegister() calls should be afterwards
 	prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(mntLabels, prometheus.DefaultRegisterer)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -218,6 +218,15 @@ func mount(c *cli.Context) error {
 		}
 	}()
 	installHandler(mp)
+
+	mntLabels := prometheus.Labels{
+		"vol_name": format.Name,
+		"mp": mp,
+	}
+	// Wrap the default registry, all prometheus.MustRegister() calls should be afterwards
+	prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(mntLabels, prometheus.DefaultRegisterer)
+	meta.InitMetrics()
+	vfs.InitMetrics()
 	go updateMetrics(m)
 	http.Handle("/metrics", promhttp.HandlerFor(
 		prometheus.DefaultGatherer,

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -144,6 +144,13 @@ func mount(c *cli.Context) error {
 		logger.Fatalf("load setting: %s", err)
 	}
 
+	mntLabels := prometheus.Labels{
+		"vol_name": format.Name,
+		"mp":       mp,
+	}
+	// Wrap the default registry, all prometheus.MustRegister() calls should be afterwards
+	prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(mntLabels, prometheus.DefaultRegisterer)
+
 	chunkConf := chunk.Config{
 		BlockSize: format.BlockSize * 1024,
 		Compress:  format.Compression,
@@ -219,12 +226,6 @@ func mount(c *cli.Context) error {
 	}()
 	installHandler(mp)
 
-	mntLabels := prometheus.Labels{
-		"vol_name": format.Name,
-		"mp":       mp,
-	}
-	// Wrap the default registry, all prometheus.MustRegister() calls should be afterwards
-	prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(mntLabels, prometheus.DefaultRegisterer)
 	meta.InitMetrics()
 	vfs.InitMetrics()
 	go updateMetrics(m)

--- a/pkg/meta/redis_metrics.go
+++ b/pkg/meta/redis_metrics.go
@@ -29,7 +29,7 @@ var (
 	})
 )
 
-func init() {
+func InitMetrics() {
 	prometheus.MustRegister(redisTxDist)
 	prometheus.MustRegister(redisTxRestart)
 }

--- a/pkg/object/metrics.go
+++ b/pkg/object/metrics.go
@@ -84,7 +84,7 @@ type withMetrics struct {
 	ObjectStorage
 }
 
-// WithMetrics retuns a object storage that exposes metrics of requests.
+// WithMetrics returns a object storage that exposes metrics of requests.
 func WithMetrics(os ObjectStorage) ObjectStorage {
 	_ = prometheus.Register(reqsHistogram)
 	_ = prometheus.Register(reqErrors)

--- a/pkg/vfs/accesslog.go
+++ b/pkg/vfs/accesslog.go
@@ -32,10 +32,6 @@ var (
 	})
 )
 
-func init() {
-	prometheus.MustRegister(opsDurationsHistogram)
-}
-
 type logReader struct {
 	sync.Mutex
 	buffer chan []byte

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -877,7 +877,11 @@ func Init(conf *Config, m_ meta.Meta, store chunk.ChunkStore) {
 	reader = NewDataReader(conf, m, store)
 	writer = NewDataWriter(conf, m, store)
 	handles = make(map[Ino][]*handle)
+}
+
+func InitMetrics() {
 	prometheus.MustRegister(readSizeHistogram)
 	prometheus.MustRegister(writtenSizeHistogram)
 	prometheus.MustRegister(handlersGause)
+	prometheus.MustRegister(opsDurationsHistogram)
 }


### PR DESCRIPTION
Add `vol_name` and `mp` labels for metrics.

As using [`prometheus`](https://github.com/prometheus/client_golang/blob/master/prometheus) package's wrap fuction [`WrapRegistererWith`](https://github.com/prometheus/client_golang/blob/babeb356a51b1277535260e0122ad8c46240ab96/prometheus/wrap.go#L46) to add labels to registry, all `prometheus.MustRegister()` call should be run after the wrap call.