### PR TITLE
fix object scs list

### DIFF
--- a/pkg/object/scs.go
+++ b/pkg/object/scs.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -89,6 +90,10 @@ func (s *scsClient) List(prefix, marker string, limit int64) ([]*Object, error) 
 	}
 	s.marker = list.NextMarker
 	n := len(list.Contents)
+	// Message from scs technical support, the api not guarantee contents is ordered, but marker is work.
+	// So we sort contents at here, can work both contents is ordered or not ordered.
+	// https://scs.sinacloud.com/doc/scs/api#get_bucket
+	sort.Slice(list.Contents, func(i, j int) bool { return list.Contents[i].Name < list.Contents[j].Name })
 	objs := make([]*Object, n)
 	for i := 0; i < n; i++ {
 		ob := list.Contents[i]


### PR DESCRIPTION
咨询了scs技术，一次list object操作返回的key列表顺序可能有问题，Arvintian在测试中也发现一个case导致无法sync。sync 使用marker翻页，接口保证下一页key一定大于marker，所以这里加一个sort，可以fix页内错误，没有错误情况下又不影响。
避免这个错误 [keys out of order error](https://github.com/juicedata/juicefs/blob/main/pkg/sync/sync.go#L129)。