### PR TITLE
use fusermount to unmount on linux

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -101,7 +101,7 @@ func installHandler(mp string) {
 			<-signalChan
 			go func() {
 				if runtime.GOOS == "linux" {
-					_ = exec.Command("umount", mp, "-l").Run()
+					_ = exec.Command("fusermount", "-uz", mp).Run()
 				} else if runtime.GOOS == "darwin" {
 					_ = exec.Command("diskutil", "umount", "force", mp).Run()
 				}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -101,7 +101,11 @@ func installHandler(mp string) {
 			<-signalChan
 			go func() {
 				if runtime.GOOS == "linux" {
-					_ = exec.Command("fusermount", "-uz", mp).Run()
+					if _, err := exec.LookPath("fusermount"); err == nil {
+						_ = exec.Command("fusermount", "-uz", mp).Run()
+					} else {
+						_ = exec.Command("umount", "-l", mp).Run()
+					}
 				} else if runtime.GOOS == "darwin" {
 					_ = exec.Command("diskutil", "umount", "force", mp).Run()
 				}

--- a/cmd/umount.go
+++ b/cmd/umount.go
@@ -58,10 +58,18 @@ func umount(ctx *cli.Context) error {
 			cmd = exec.Command("diskutil", "umount", mp)
 		}
 	case "linux":
-		if force {
-			cmd = exec.Command("fusermount", "-uz", mp)
+		if _, err := exec.LookPath("fusermount"); err == nil {
+			if force {
+				cmd = exec.Command("fusermount", "-uz", mp)
+			} else {
+				cmd = exec.Command("fusermount", "-u", mp)
+			}
 		} else {
-			cmd = exec.Command("fusermount", "-u", mp)
+			if force {
+				cmd = exec.Command("umount", "-l", mp)
+			} else {
+				cmd = exec.Command("umount", mp)
+			}
 		}
 	case "windows":
 		if !force {

--- a/cmd/umount.go
+++ b/cmd/umount.go
@@ -59,9 +59,9 @@ func umount(ctx *cli.Context) error {
 		}
 	case "linux":
 		if force {
-			cmd = exec.Command("umount", "-l", mp)
+			cmd = exec.Command("fusermount", "-uz", mp)
 		} else {
-			cmd = exec.Command("umount", mp)
+			cmd = exec.Command("fusermount", "-u", mp)
 		}
 	case "windows":
 		if !force {


### PR DESCRIPTION
#228  Early `umount` cannot unmount _fuse_ filesystem on Linux, and we need use `fusermount` which is in the fuse package. When unmount JuiceFS, try `fusermount` first, fallback to `umount` if fuse package doesn't installed.