### PR TITLE
obs: support proxy setting from environment variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8
 	github.com/yunify/qingstor-sdk-go v2.2.15+incompatible
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
+	golang.org/x/net v0.0.0-20201216054612-986b41b23924
 	golang.org/x/oauth2 v0.0.0-20190517181255-950ef44c6e07
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1


### PR DESCRIPTION
We've already define a http client for some object storage, the http client use [proxy setting from environment variables](https://github.com/juicedata/juicefs/blob/main/pkg/object/restful.go#L44), we use this http client to create object storage client if possible (such `s3`, `ks3`, `b2` etc.). 

This PR add support for `obs`.  