### PR TITLE
support IPv6 address for sftp

### DIFF
--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -383,7 +383,7 @@ func newSftp(endpoint, user, pass string) (ObjectStorage, error) {
 	var hostEnd int
 	// IPv6 address like [fe80::148a:d031:823a:fff]
 	if strings.HasPrefix(endpoint, "[") {
-		hostEnd = strings.Index(endpoint, "]") + 1
+		hostEnd = strings.Index(endpoint, "]:") + 1
 	} else { // IPv4 address or host name
 		hostEnd = strings.Index(endpoint, ":")
 	}

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -380,26 +380,18 @@ func (f *sftpStore) ListAll(prefix, marker string) (<-chan *Object, error) {
 }
 
 func newSftp(endpoint, user, pass string) (ObjectStorage, error) {
-	var hostEnd int
-	// IPv6 address like [fe80::148a:d031:823a:fff]
-	if strings.HasPrefix(endpoint, "[") {
-		hostEnd = strings.Index(endpoint, "]:") + 1
-	} else { // IPv4 address or host name
-		hostEnd = strings.Index(endpoint, ":")
+	idx := strings.LastIndex(endpoint, ":")
+	host, port, err := net.SplitHostPort(endpoint[:idx])
+	if err != nil && strings.Contains(err.Error(), "missing port") {
+		host, port, err = net.SplitHostPort(endpoint[:idx] + ":22")
 	}
-	if hostEnd <= 0 {
-		return nil, fmt.Errorf("unable to parse host from endpoint: %s", endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse host from endpoint (%s): %q", endpoint, err)
 	}
-	parts := strings.Split(endpoint[hostEnd:], ":")
-	root := filepath.Clean(parts[len(parts)-1])
-	port := "22"
-	// two ":" means endpoint contains custom port
-	if len(parts) > 2 {
-		port = parts[len(parts)-2]
-	}
+	root := filepath.Clean(endpoint[idx+1:])
 	// append suffix `/` removed by filepath.Clean()
 	// `.` is a directory, add `/`
-	if strings.HasSuffix(parts[len(parts)-1], dirSuffix) || root == "." {
+	if strings.HasSuffix(endpoint[idx+1:], dirSuffix) || root == "." {
 		root = root + dirSuffix
 	}
 
@@ -428,7 +420,7 @@ func newSftp(endpoint, user, pass string) (ObjectStorage, error) {
 	}
 
 	f := &sftpStore{
-		host:   strings.Trim(endpoint[:hostEnd], "[]"), // Trim bracket if it's IPv6 address
+		host:   host,
 		port:   port,
 		root:   root,
 		config: config,

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -394,7 +394,7 @@ func newSftp(endpoint, user, pass string) (ObjectStorage, error) {
 	root := filepath.Clean(parts[len(parts)-1])
 	port := "22"
 	// two ":" means endpoint contains custom port
-	if len(parts) > 1 {
+	if len(parts) > 2 {
 		port = parts[len(parts)-2]
 	}
 	// append suffix `/` removed by filepath.Clean()


### PR DESCRIPTION
Support IPv6 address for sftp server.

When we _sync_ files to IPv6 sftp server:
`./juicefs sync ./localdir/ user:pass@[IPv6 address]:/remotedir/`