### PR TITLE
use object.Object as interface

### DIFF
--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -92,7 +92,7 @@ func fsck(ctx *cli.Context) error {
 			continue
 		}
 
-		logger.Debugf("found block %s", obj.Key)
+		logger.Debugf("found block %s", obj.Key())
 		parts := strings.Split(obj.Key(), "/")
 		if len(parts) != 3 {
 			continue

--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -88,18 +88,18 @@ func fsck(ctx *cli.Context) error {
 		if obj == nil {
 			break // failed listing
 		}
-		if obj.IsDir {
+		if obj.IsDir() {
 			continue
 		}
 
 		logger.Debugf("found block %s", obj.Key)
-		parts := strings.Split(obj.Key, "/")
+		parts := strings.Split(obj.Key(), "/")
 		if len(parts) != 3 {
 			continue
 		}
 		name := parts[2]
-		blocks[name] = obj.Size
-		totalBlockBytes += obj.Size
+		blocks[name] = obj.Size()
+		totalBlockBytes += obj.Size()
 	}
 	logger.Infof("Found %d blocks (%d bytes)", len(blocks), totalBlockBytes)
 

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -178,29 +178,29 @@ func gc(ctx *cli.Context) error {
 		}()
 	}
 
-	foundLeaked := func(obj *object.Object) {
-		p.leakedBytes += obj.Size
+	foundLeaked := func(obj object.Object) {
+		p.leakedBytes += obj.Size()
 		p.leaked++
 		if ctx.Bool("delete") {
-			leakedObj <- obj.Key
+			leakedObj <- obj.Key()
 		}
 	}
 	for obj := range objs {
 		if obj == nil {
 			break // failed listing
 		}
-		if obj.IsDir {
+		if obj.IsDir() {
 			continue
 		}
-		if obj.Mtime.After(maxMtime) || obj.Mtime.Unix() == 0 {
+		if obj.Mtime().After(maxMtime) || obj.Mtime().Unix() == 0 {
 			logger.Debugf("ignore new block: %s %s", obj.Key, obj.Mtime)
-			skippedBytes += obj.Size
+			skippedBytes += obj.Size()
 			skipped++
 			continue
 		}
 
 		logger.Debugf("found block %s", obj.Key)
-		parts := strings.Split(obj.Key, "/")
+		parts := strings.Split(obj.Key(), "/")
 		if len(parts) != 3 {
 			continue
 		}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -193,13 +193,13 @@ func gc(ctx *cli.Context) error {
 			continue
 		}
 		if obj.Mtime().After(maxMtime) || obj.Mtime().Unix() == 0 {
-			logger.Debugf("ignore new block: %s %s", obj.Key, obj.Mtime)
+			logger.Debugf("ignore new block: %s %s", obj.Key(), obj.Mtime())
 			skippedBytes += obj.Size()
 			skipped++
 			continue
 		}
 
-		logger.Debugf("found block %s", obj.Key)
+		logger.Debugf("found block %s", obj.Key())
 		parts := strings.Split(obj.Key(), "/")
 		if len(parts) != 3 {
 			continue
@@ -212,7 +212,7 @@ func gc(ctx *cli.Context) error {
 		cid, _ := strconv.Atoi(parts[0])
 		size := keys[uint64(cid)]
 		if size == 0 {
-			logger.Debugf("find leaked object: %s, size: %d", obj.Key, obj.Size)
+			logger.Debugf("find leaked object: %s, size: %d", obj.Key(), obj.Size())
 			foundLeaked(obj)
 			continue
 		}

--- a/go.sum
+++ b/go.sum
@@ -355,7 +355,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236 h1:py4S1ZTRfz5hIvrhu83YSw7t0Z621+VrmmZBqSkQn5c=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236/go.mod h1:dlxKkLh3qAIPtgr2U/RVzsZJDuXA1ffg+Njikfmhvgw=
-github.com/juicedata/juicesync v0.7.0 h1:6Twooa5VNi39gfGfmuZwZCztkReLlSSZIET57bpJSh8=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4 h1:/Klbj2LgJnqWrVfK2RtsqNQm649uXi2diLc/2X3eis4=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4/go.mod h1:pQt7BggRNk3m4ZLGmtZ8ShrWe70RvyeXsHljoapikM0=
 github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236 h1:py4S1ZTRfz5hIvrhu83YSw7t0Z621+VrmmZBqSkQn5c=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236/go.mod h1:dlxKkLh3qAIPtgr2U/RVzsZJDuXA1ffg+Njikfmhvgw=
+github.com/juicedata/juicesync v0.7.0 h1:6Twooa5VNi39gfGfmuZwZCztkReLlSSZIET57bpJSh8=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4 h1:/Klbj2LgJnqWrVfK2RtsqNQm649uXi2diLc/2X3eis4=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4/go.mod h1:pQt7BggRNk3m4ZLGmtZ8ShrWe70RvyeXsHljoapikM0=
 github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -42,14 +42,14 @@ func (b *wasb) Create() error {
 	return err
 }
 
-func (b *wasb) Head(key string) (*Object, error) {
+func (b *wasb) Head(key string) (Object, error) {
 	blob := b.container.GetBlobReference(key)
 	err := blob.GetProperties(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Object{
+	return &obj{
 		blob.Name,
 		blob.Properties.ContentLength,
 		time.Time(blob.Properties.LastModified),
@@ -84,7 +84,7 @@ func (b *wasb) Delete(key string) error {
 	return b.container.GetBlobReference(key).Delete(nil)
 }
 
-func (b *wasb) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (b *wasb) List(prefix, marker string, limit int64) ([]Object, error) {
 	if marker != "" {
 		if b.marker == "" {
 			// last page
@@ -103,11 +103,11 @@ func (b *wasb) List(prefix, marker string, limit int64) ([]*Object, error) {
 	}
 	b.marker = resp.NextMarker
 	n := len(resp.Blobs)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		blob := resp.Blobs[i]
 		mtime := time.Time(blob.Properties.LastModified)
-		objs[i] = &Object{
+		objs[i] = &obj{
 			blob.Name,
 			int64(blob.Properties.ContentLength),
 			mtime,

--- a/pkg/object/b2.go
+++ b/pkg/object/b2.go
@@ -39,13 +39,13 @@ func (c *b2client) Create() error {
 	return nil
 }
 
-func (c *b2client) Head(key string) (*Object, error) {
+func (c *b2client) Head(key string) (Object, error) {
 	attr, err := c.bucket.Object(key).Attrs(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Object{
+	return &obj{
 		attr.Name,
 		attr.Size,
 		attr.UploadTimestamp,
@@ -85,7 +85,7 @@ func (c *b2client) Delete(key string) error {
 	return c.bucket.Object(key).Delete(ctx)
 }
 
-func (c *b2client) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (c *b2client) List(prefix, marker string, limit int64) ([]Object, error) {
 	if limit > 1000 {
 		limit = 1000
 	}
@@ -103,12 +103,12 @@ func (c *b2client) List(prefix, marker string, limit int64) ([]*Object, error) {
 	c.cursor = nc
 
 	n := len(objects)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		attr, err := objects[i].Attrs(ctx)
 		if err == nil {
 			// attr.LastModified is not correct
-			objs[i] = &Object{
+			objs[i] = &obj{
 				attr.Name,
 				attr.Size,
 				attr.UploadTimestamp,

--- a/pkg/object/bos.go
+++ b/pkg/object/bos.go
@@ -48,13 +48,13 @@ func (q *bosclient) Create() error {
 	return err
 }
 
-func (q *bosclient) Head(key string) (*Object, error) {
+func (q *bosclient) Head(key string) (Object, error) {
 	r, err := q.c.GetObjectMeta(q.bucket, key)
 	if err != nil {
 		return nil, err
 	}
 	mtime, _ := time.Parse(time.RFC1123, r.LastModified)
-	return &Object{
+	return &obj{
 		key,
 		r.ContentLength,
 		mtime,
@@ -100,7 +100,7 @@ func (q *bosclient) Delete(key string) error {
 	return q.c.DeleteObject(q.bucket, key)
 }
 
-func (q *bosclient) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (q *bosclient) List(prefix, marker string, limit int64) ([]Object, error) {
 	if limit > 1000 {
 		limit = 1000
 	}
@@ -110,11 +110,11 @@ func (q *bosclient) List(prefix, marker string, limit int64) ([]*Object, error) 
 		return nil, err
 	}
 	n := len(out.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		k := out.Contents[i]
 		mod, _ := time.Parse("2006-01-02T15:04:05Z", k.LastModified)
-		objs[i] = &Object{k.Key, int64(k.Size), mod, strings.HasSuffix(k.Key, "/")}
+		objs[i] = &obj{k.Key, int64(k.Size), mod, strings.HasSuffix(k.Key, "/")}
 	}
 	return objs, nil
 }

--- a/pkg/object/ceph.go
+++ b/pkg/object/ceph.go
@@ -163,8 +163,8 @@ func (c *ceph) Delete(key string) error {
 	})
 }
 
-func (c *ceph) ListAll(prefix, marker string) (<-chan *Object, error) {
-	var objs = make(chan *Object, 1000)
+func (c *ceph) ListAll(prefix, marker string) (<-chan Object, error) {
+	var objs = make(chan Object, 1000)
 	err := c.do(func(ctx *rados.IOContext) error {
 		defer close(objs)
 		iter, err := ctx.Iter()
@@ -190,7 +190,7 @@ func (c *ceph) ListAll(prefix, marker string) (<-chan *Object, error) {
 			if err != nil {
 				continue // FIXME
 			}
-			objs <- &Object{key, int64(st.Size), st.ModTime, strings.HasSuffix(key, "/")}
+			objs <- &obj{key, int64(st.Size), st.ModTime, strings.HasSuffix(key, "/")}
 		}
 		return nil
 	})

--- a/pkg/object/cos.go
+++ b/pkg/object/cos.go
@@ -50,7 +50,7 @@ func (c *COS) Create() error {
 	return err
 }
 
-func (c *COS) Head(key string) (*Object, error) {
+func (c *COS) Head(key string) (Object, error) {
 	resp, err := c.c.Object.Head(ctx, key, nil)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (c *COS) Head(key string) (*Object, error) {
 		mtime, _ = time.Parse(time.RFC1123, val[0])
 	}
 
-	return &Object{key, size, mtime, strings.HasSuffix(key, "/")}, nil
+	return &obj{key, size, mtime, strings.HasSuffix(key, "/")}, nil
 }
 
 func (c *COS) Get(key string, off, limit int64) (io.ReadCloser, error) {
@@ -115,7 +115,7 @@ func (c *COS) Delete(key string) error {
 	return err
 }
 
-func (c *COS) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (c *COS) List(prefix, marker string, limit int64) ([]Object, error) {
 	param := cos.BucketGetOptions{
 		Prefix:  prefix,
 		Marker:  marker,
@@ -130,16 +130,16 @@ func (c *COS) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(resp.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
 		t, _ := time.Parse(time.RFC3339, o.LastModified)
-		objs[i] = &Object{o.Key, int64(o.Size), t, strings.HasSuffix(o.Key, "/")}
+		objs[i] = &obj{o.Key, int64(o.Size), t, strings.HasSuffix(o.Key, "/")}
 	}
 	return objs, nil
 }
 
-func (c *COS) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (c *COS) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/filesystem_test.go
+++ b/pkg/object/filesystem_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 )
 
-func testKeysEqual(objs []*Object, expectedKeys []string) error {
+func testKeysEqual(objs []Object, expectedKeys []string) error {
 	gottenKeys := make([]string, len(objs))
 	for idx, obj := range objs {
-		gottenKeys[idx] = obj.Key
+		gottenKeys[idx] = obj.Key()
 	}
 	if len(gottenKeys) != len(expectedKeys) {
 		return fmt.Errorf("Expected {%s}, got {%s}", strings.Join(expectedKeys, ", "),

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -86,17 +86,17 @@ func (g *gs) Create() error {
 	return err
 }
 
-func (g *gs) Head(key string) (*Object, error) {
+func (g *gs) Head(key string) (Object, error) {
 	req := g.service.Objects.Get(g.bucket, key)
-	obj, err := req.Do()
+	o, err := req.Do()
 	if err != nil {
 		return nil, err
 	}
 
-	mtime, _ := time.Parse(time.RFC3339, obj.Updated)
-	return &Object{
+	mtime, _ := time.Parse(time.RFC3339, o.Updated)
+	return &obj{
 		key,
-		int64(obj.Size),
+		int64(o.Size),
 		mtime,
 		strings.HasSuffix(key, "/"),
 	}, nil
@@ -134,7 +134,7 @@ func (g *gs) Delete(key string) error {
 	return g.service.Objects.Delete(g.bucket, key).Do()
 }
 
-func (g *gs) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (g *gs) List(prefix, marker string, limit int64) ([]Object, error) {
 	call := g.service.Objects.List(g.bucket).Prefix(prefix).MaxResults(limit)
 	if marker != "" {
 		if g.pageToken == "" {
@@ -150,11 +150,11 @@ func (g *gs) List(prefix, marker string, limit int64) ([]*Object, error) {
 	}
 	g.pageToken = objects.NextPageToken
 	n := len(objects.Items)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		item := objects.Items[i]
 		mtime, _ := time.Parse(time.RFC3339, item.Updated)
-		objs[i] = &Object{item.Name, int64(item.Size), mtime, strings.HasSuffix(item.Name, "/")}
+		objs[i] = &obj{item.Name, int64(item.Size), mtime, strings.HasSuffix(item.Name, "/")}
 	}
 	return objs, nil
 }

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -103,7 +103,7 @@ func (s *ibmcos) Copy(dst, src string) error {
 	return err
 }
 
-func (s *ibmcos) Head(key string) (*Object, error) {
+func (s *ibmcos) Head(key string) (Object, error) {
 	param := s3.HeadObjectInput{
 		Bucket: &s.bucket,
 		Key:    &key,
@@ -112,7 +112,7 @@ func (s *ibmcos) Head(key string) (*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Object{
+	return &obj{
 		key,
 		*r.ContentLength,
 		*r.LastModified,
@@ -129,7 +129,7 @@ func (s *ibmcos) Delete(key string) error {
 	return err
 }
 
-func (s *ibmcos) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *ibmcos) List(prefix, marker string, limit int64) ([]Object, error) {
 	param := s3.ListObjectsInput{
 		Bucket:  &s.bucket,
 		Prefix:  &prefix,
@@ -141,15 +141,15 @@ func (s *ibmcos) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(resp.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		objs[i] = &Object{*o.Key, *o.Size, *o.LastModified, strings.HasSuffix(*o.Key, "/")}
+		objs[i] = &obj{*o.Key, *o.Size, *o.LastModified, strings.HasSuffix(*o.Key, "/")}
 	}
 	return objs, nil
 }
 
-func (s *ibmcos) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (s *ibmcos) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/interface.go
+++ b/pkg/object/interface.go
@@ -17,7 +17,6 @@ package object
 
 import (
 	"io"
-	"os"
 	"time"
 )
 
@@ -39,30 +38,6 @@ func (o *obj) Key() string      { return o.key }
 func (o *obj) Size() int64      { return o.size }
 func (o *obj) Mtime() time.Time { return o.mtime }
 func (o *obj) IsDir() bool      { return o.isDir }
-
-func MarshalObject(o Object) map[string]interface{} {
-	m := make(map[string]interface{})
-	m["key"] = o.Key()
-	m["size"] = o.Size()
-	m["mtime"] = o.Mtime().Unix()
-	m["isdir"] = o.IsDir()
-	if f, ok := o.(File); ok {
-		m["mode"] = f.Mode()
-		m["owner"] = f.Owner()
-		m["group"] = f.Group()
-	}
-	return m
-}
-
-func UnmarshalObject(m map[string]interface{}) Object {
-	mtime := time.Unix(int64(m["mtime"].(float64)), 0)
-	o := obj{m["key"].(string), int64(m["size"].(float64)), mtime, m["isdir"].(bool)}
-	if _, ok := m["mode"]; ok {
-		f := file{o, m["owner"].(string), m["group"].(string), m["mode"].(os.FileMode)}
-		return &f
-	}
-	return &o
-}
 
 type MultipartUpload struct {
 	MinPartSize int

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -55,7 +55,7 @@ func (s *ks3) Create() error {
 	return err
 }
 
-func (s *ks3) Head(key string) (*Object, error) {
+func (s *ks3) Head(key string) (Object, error) {
 	param := s3.HeadObjectInput{
 		Bucket: &s.bucket,
 		Key:    &key,
@@ -66,7 +66,7 @@ func (s *ks3) Head(key string) (*Object, error) {
 		return nil, err
 	}
 
-	return &Object{
+	return &obj{
 		key,
 		*r.ContentLength,
 		*r.LastModified,
@@ -131,7 +131,7 @@ func (s *ks3) Delete(key string) error {
 	return err
 }
 
-func (s *ks3) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *ks3) List(prefix, marker string, limit int64) ([]Object, error) {
 	param := s3.ListObjectsInput{
 		Bucket:  &s.bucket,
 		Prefix:  &prefix,
@@ -143,15 +143,15 @@ func (s *ks3) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(resp.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		objs[i] = &Object{*o.Key, *o.Size, *o.LastModified, strings.HasSuffix(*o.Key, "/")}
+		objs[i] = &obj{*o.Key, *o.Size, *o.LastModified, strings.HasSuffix(*o.Key, "/")}
 	}
 	return objs, nil
 }
 
-func (s *ks3) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (s *ks3) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/metrics.go
+++ b/pkg/object/metrics.go
@@ -103,7 +103,7 @@ func (p *withMetrics) track(method string, fn func() error) error {
 	return err
 }
 
-func (p *withMetrics) Head(key string) (obj *Object, err error) {
+func (p *withMetrics) Head(key string) (obj Object, err error) {
 	err = p.track("HEAD", func() error {
 		obj, err = p.ObjectStorage.Head(key)
 		return err

--- a/pkg/object/mss.go
+++ b/pkg/object/mss.go
@@ -97,7 +97,7 @@ func (c *mss) Copy(dst, src string) error {
 	return nil
 }
 
-func (c *mss) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (c *mss) List(prefix, marker string, limit int64) ([]Object, error) {
 	uri, _ := url.ParseRequestURI(c.endpoint)
 
 	query := url.Values{}
@@ -136,9 +136,9 @@ func (c *mss) List(prefix, marker string, limit int64) ([]*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	objs := make([]*Object, len(out.Contents))
+	objs := make([]Object, len(out.Contents))
 	for i, item := range out.Contents {
-		objs[i] = &Object{
+		objs[i] = &obj{
 			item.Key,
 			item.Size,
 			item.LastModified,

--- a/pkg/object/nos.go
+++ b/pkg/object/nos.go
@@ -40,7 +40,7 @@ func (s *nos) String() string {
 	return fmt.Sprintf("nos://%s", s.bucket)
 }
 
-func (s *nos) Head(key string) (*Object, error) {
+func (s *nos) Head(key string) (Object, error) {
 	objectRequest := &model.ObjectRequest{
 		Bucket: s.bucket,
 		Object: key,
@@ -54,7 +54,7 @@ func (s *nos) Head(key string) (*Object, error) {
 		return nil, fmt.Errorf("cannot get last modified time")
 	}
 	mtime, _ := time.Parse(time.RFC1123, lastModified)
-	return &Object{
+	return &obj{
 		key,
 		r.ContentLength,
 		mtime,
@@ -120,7 +120,7 @@ func (s *nos) Delete(key string) error {
 	return s.client.DeleteObject(&param)
 }
 
-func (s *nos) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *nos) List(prefix, marker string, limit int64) ([]Object, error) {
 	param := model.ListObjectsRequest{
 		Bucket:  s.bucket,
 		Prefix:  prefix,
@@ -132,14 +132,14 @@ func (s *nos) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(resp.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
 		mtime, err := time.Parse("2006-01-02T15:04:05 +0800", o.LastModified)
 		if err == nil {
 			mtime = mtime.Add(-8 * time.Hour)
 		}
-		objs[i] = &Object{o.Key, o.Size, mtime, strings.HasSuffix(o.Key, "/")}
+		objs[i] = &obj{o.Key, o.Size, mtime, strings.HasSuffix(o.Key, "/")}
 	}
 	return objs, nil
 }

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -32,12 +32,23 @@ var UserAgent = "JuiceFS"
 type MtimeChanger interface {
 	Chtimes(path string, mtime time.Time) error
 }
-type File struct {
+type File interface {
 	Object
-	Owner string
-	Group string
-	Mode  os.FileMode
+	Owner() string
+	Group() string
+	Mode() os.FileMode
 }
+
+type file struct {
+	obj
+	owner string
+	group string
+	mode  os.FileMode
+}
+
+func (f *file) Owner() string     { return f.owner }
+func (f *file) Group() string     { return f.group }
+func (f *file) Mode() os.FileMode { return f.mode }
 
 type FileSystem interface {
 	MtimeChanger
@@ -53,7 +64,7 @@ func (s DefaultObjectStorage) Create() error {
 	return nil
 }
 
-func (s DefaultObjectStorage) Head(key string) (*Object, error) {
+func (s DefaultObjectStorage) Head(key string) (Object, error) {
 	return nil, notSupported
 }
 
@@ -75,11 +86,11 @@ func (s DefaultObjectStorage) ListUploads(marker string) ([]*PendingPart, string
 	return nil, "", nil
 }
 
-func (s DefaultObjectStorage) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s DefaultObjectStorage) List(prefix, marker string, limit int64) ([]Object, error) {
 	return nil, notSupported
 }
 
-func (s DefaultObjectStorage) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (s DefaultObjectStorage) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -50,6 +50,30 @@ func (f *file) Owner() string     { return f.owner }
 func (f *file) Group() string     { return f.group }
 func (f *file) Mode() os.FileMode { return f.mode }
 
+func MarshalObject(o Object) map[string]interface{} {
+	m := make(map[string]interface{})
+	m["key"] = o.Key()
+	m["size"] = o.Size()
+	m["mtime"] = o.Mtime().UnixNano()
+	m["isdir"] = o.IsDir()
+	if f, ok := o.(File); ok {
+		m["mode"] = f.Mode()
+		m["owner"] = f.Owner()
+		m["group"] = f.Group()
+	}
+	return m
+}
+
+func UnmarshalObject(m map[string]interface{}) Object {
+	mtime := time.Unix(0, int64(m["mtime"].(float64)))
+	o := obj{m["key"].(string), int64(m["size"].(float64)), mtime, m["isdir"].(bool)}
+	if _, ok := m["mode"]; ok {
+		f := file{o, m["owner"].(string), m["group"].(string), os.FileMode(m["mode"].(float64))}
+		return &f
+	}
+	return &o
+}
+
 type FileSystem interface {
 	MtimeChanger
 	Chmod(path string, mode os.FileMode) error

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -39,14 +39,14 @@ func get(s ObjectStorage, k string, off, limit int64) (string, error) {
 	return string(data), nil
 }
 
-func listAll(s ObjectStorage, prefix, marker string, limit int64) ([]*Object, error) {
+func listAll(s ObjectStorage, prefix, marker string, limit int64) ([]Object, error) {
 	r, err := s.List(prefix, marker, limit)
 	if err == nil {
 		return r, nil
 	}
 	ch, err := s.ListAll(prefix, marker)
 	if err == nil {
-		objs := make([]*Object, 0)
+		objs := make([]Object, 0)
 		for obj := range ch {
 			if len(objs) < int(limit) {
 				objs = append(objs, obj)
@@ -96,14 +96,14 @@ func testStorage(t *testing.T, s ObjectStorage) {
 		if len(objs) != 1 {
 			t.Fatalf("List should return 1 keys, but got %d", len(objs))
 		}
-		if objs[0].Key != "/test" {
-			t.Fatalf("First key should be /test, but got %s", objs[0].Key)
+		if objs[0].Key() != "/test" {
+			t.Fatalf("First key should be /test, but got %s", objs[0].Key())
 		}
-		if !strings.Contains(s.String(), "encrypted") && objs[0].Size != 5 {
-			t.Fatalf("Size of first key shold be 5, but got %v", objs[0].Size)
+		if !strings.Contains(s.String(), "encrypted") && objs[0].Size() != 5 {
+			t.Fatalf("Size of first key shold be 5, but got %v", objs[0].Size())
 		}
 		now := time.Now()
-		if objs[0].Mtime.Before(now.Add(-10*time.Second)) || objs[0].Mtime.After(now.Add(time.Second*10)) {
+		if objs[0].Mtime().Before(now.Add(-10*time.Second)) || objs[0].Mtime().After(now.Add(time.Second*10)) {
 			t.Fatalf("Mtime of key should be within 10 seconds")
 		}
 	} else {

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -53,7 +53,7 @@ func (s *obsClient) Create() error {
 	return err
 }
 
-func (s *obsClient) Head(key string) (*Object, error) {
+func (s *obsClient) Head(key string) (Object, error) {
 	params := &obs.GetObjectMetadataInput{
 		Bucket: s.bucket,
 		Key:    key,
@@ -62,7 +62,7 @@ func (s *obsClient) Head(key string) (*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Object{
+	return &obj{
 		key,
 		r.ContentLength,
 		r.LastModified,
@@ -123,7 +123,7 @@ func (s *obsClient) Delete(key string) error {
 	return err
 }
 
-func (s *obsClient) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *obsClient) List(prefix, marker string, limit int64) ([]Object, error) {
 	input := &obs.ListObjectsInput{
 		Bucket: s.bucket,
 		Marker: marker,
@@ -135,15 +135,15 @@ func (s *obsClient) List(prefix, marker string, limit int64) ([]*Object, error) 
 		return nil, err
 	}
 	n := len(resp.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		objs[i] = &Object{o.Key, o.Size, o.LastModified, strings.HasSuffix(o.Key, "/")}
+		objs[i] = &obj{o.Key, o.Size, o.LastModified, strings.HasSuffix(o.Key, "/")}
 	}
 	return objs, nil
 }
 
-func (s *obsClient) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (s *obsClient) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/oos.go
+++ b/pkg/object/oos.go
@@ -42,12 +42,12 @@ func (s *oos) Create() error {
 	return err
 }
 
-func (s *oos) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *oos) List(prefix, marker string, limit int64) ([]Object, error) {
 	if limit > 1000 {
 		limit = 1000
 	}
 	objs, err := s.s3client.List(prefix, marker, limit)
-	if marker != "" && len(objs) > 0 && objs[0].Key == marker {
+	if marker != "" && len(objs) > 0 && objs[0].Key() == marker {
 		objs = objs[1:]
 	}
 	return objs, err

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -64,7 +64,7 @@ func (o *ossClient) checkError(err error) error {
 	return err
 }
 
-func (o *ossClient) Head(key string) (*Object, error) {
+func (o *ossClient) Head(key string) (Object, error) {
 	r, err := o.bucket.GetObjectMeta(key)
 	if o.checkError(err) != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (o *ossClient) Head(key string) (*Object, error) {
 	contentLength := r.Get("Content-Length")
 	mtime, _ := time.Parse(time.RFC1123, lastModified)
 	size, _ := strconv.ParseInt(contentLength, 10, 64)
-	return &Object{
+	return &obj{
 		key,
 		size,
 		mtime,
@@ -122,7 +122,7 @@ func (o *ossClient) Delete(key string) error {
 	return o.checkError(o.bucket.DeleteObject(key))
 }
 
-func (o *ossClient) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (o *ossClient) List(prefix, marker string, limit int64) ([]Object, error) {
 	if limit > 1000 {
 		limit = 1000
 	}
@@ -132,15 +132,15 @@ func (o *ossClient) List(prefix, marker string, limit int64) ([]*Object, error) 
 		return nil, err
 	}
 	n := len(result.Objects)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := result.Objects[i]
-		objs[i] = &Object{o.Key, o.Size, o.LastModified, strings.HasSuffix(o.Key, "/")}
+		objs[i] = &obj{o.Key, o.Size, o.LastModified, strings.HasSuffix(o.Key, "/")}
 	}
 	return objs, nil
 }
 
-func (o *ossClient) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (o *ossClient) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -45,13 +45,13 @@ func (q *qingstor) Create() error {
 	return err
 }
 
-func (q *qingstor) Head(key string) (*Object, error) {
+func (q *qingstor) Head(key string) (Object, error) {
 	r, err := q.bucket.HeadObject(key, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Object{
+	return &obj{
 		key,
 		*r.ContentLength,
 		*r.LastModified,
@@ -148,7 +148,7 @@ func (q *qingstor) Delete(key string) error {
 	return err
 }
 
-func (q *qingstor) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (q *qingstor) List(prefix, marker string, limit int64) ([]Object, error) {
 	if limit > 1000 {
 		limit = 1000
 	}
@@ -163,10 +163,10 @@ func (q *qingstor) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(out.Keys)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		k := out.Keys[i]
-		objs[i] = &Object{
+		objs[i] = &obj{
 			*k.Key,
 			*k.Size,
 			time.Unix(int64(*k.Modified), 0),
@@ -176,7 +176,7 @@ func (q *qingstor) List(prefix, marker string, limit int64) ([]*Object, error) {
 	return objs, nil
 }
 
-func (q *qingstor) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (q *qingstor) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -70,14 +70,14 @@ func (q *qiniu) download(key string, off, limit int64) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-func (q *qiniu) Head(key string) (*Object, error) {
+func (q *qiniu) Head(key string) (Object, error) {
 	r, err := q.bm.Stat(q.bucket, key)
 	if err != nil {
 		return nil, err
 	}
 
 	mtime := time.Unix(0, r.PutTime*100)
-	return &Object{
+	return &obj{
 		key,
 		r.Fsize,
 		mtime,
@@ -121,7 +121,7 @@ func (q *qiniu) Delete(key string) error {
 	return q.bm.Delete(q.bucket, key)
 }
 
-func (q *qiniu) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (q *qiniu) List(prefix, marker string, limit int64) ([]Object, error) {
 	if limit > 1000 {
 		limit = 1000
 	}
@@ -144,11 +144,11 @@ func (q *qiniu) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(entries)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		entry := entries[i]
 		mtime := entry.PutTime / 10000000
-		objs[i] = &Object{entry.Key, entry.Fsize, time.Unix(mtime, 0), strings.HasSuffix(entry.Key, "/")}
+		objs[i] = &obj{entry.Key, entry.Fsize, time.Unix(mtime, 0), strings.HasSuffix(entry.Key, "/")}
 	}
 	return objs, nil
 }

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -149,7 +149,7 @@ func parseError(resp *http.Response) error {
 	return fmt.Errorf("status: %v, message: %s", resp.StatusCode, string(data))
 }
 
-func (s *RestfulStorage) Head(key string) (*Object, error) {
+func (s *RestfulStorage) Head(key string) (Object, error) {
 	resp, err := s.request("HEAD", key, nil, nil)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (s *RestfulStorage) Head(key string) (*Object, error) {
 		return nil, fmt.Errorf("cannot get last modified time")
 	}
 	mtime, _ := time.Parse(time.RFC1123, lastModified)
-	return &Object{
+	return &obj{
 		key,
 		resp.ContentLength,
 		mtime,
@@ -228,7 +228,7 @@ func (s *RestfulStorage) Delete(key string) error {
 	return nil
 }
 
-func (s *RestfulStorage) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *RestfulStorage) List(prefix, marker string, limit int64) ([]Object, error) {
 	return nil, errors.New("Not implemented")
 }
 

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -58,7 +58,7 @@ func (s *s3client) Create() error {
 	return err
 }
 
-func (s *s3client) Head(key string) (*Object, error) {
+func (s *s3client) Head(key string) (Object, error) {
 	param := s3.HeadObjectInput{
 		Bucket: &s.bucket,
 		Key:    &key,
@@ -67,7 +67,7 @@ func (s *s3client) Head(key string) (*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Object{
+	return &obj{
 		key,
 		*r.ContentLength,
 		*r.LastModified,
@@ -141,7 +141,7 @@ func (s *s3client) Delete(key string) error {
 	return err
 }
 
-func (s *s3client) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *s3client) List(prefix, marker string, limit int64) ([]Object, error) {
 	param := s3.ListObjectsInput{
 		Bucket:  &s.bucket,
 		Prefix:  &prefix,
@@ -153,10 +153,10 @@ func (s *s3client) List(prefix, marker string, limit int64) ([]*Object, error) {
 		return nil, err
 	}
 	n := len(resp.Contents)
-	objs := make([]*Object, n)
+	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		objs[i] = &Object{
+		objs[i] = &obj{
 			*o.Key,
 			*o.Size,
 			*o.LastModified,
@@ -166,7 +166,7 @@ func (s *s3client) List(prefix, marker string, limit int64) ([]*Object, error) {
 	return objs, nil
 }
 
-func (s *s3client) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (s *s3client) ListAll(prefix, marker string) (<-chan Object, error) {
 	return nil, notSupported
 }
 

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -174,19 +174,7 @@ func (f *sftpStore) Head(key string) (Object, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	objKey, size := key, info.Size()
-	if info.IsDir() {
-		objKey, size = key+"/", 0
-	}
-	owner, group := getOwnerGroup(info)
-	o := &file{
-		obj{objKey, size, info.ModTime(), info.IsDir()},
-		owner,
-		group,
-		info.Mode(),
-	}
-	return o, nil
+	return fileInfo(key, info), nil
 }
 
 func (f *sftpStore) Get(key string, off, limit int64) (io.ReadCloser, error) {

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -163,7 +163,7 @@ func (f *sftpStore) path(key string) string {
 	return absPath
 }
 
-func (f *sftpStore) Head(key string) (*Object, error) {
+func (f *sftpStore) Head(key string) (Object, error) {
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return nil, err
@@ -179,12 +179,14 @@ func (f *sftpStore) Head(key string) (*Object, error) {
 	if info.IsDir() {
 		objKey, size = key+"/", 0
 	}
-	return &Object{
-		objKey,
-		size,
-		info.ModTime(),
-		info.IsDir(),
-	}, nil
+	owner, group := getOwnerGroup(info)
+	o := &file{
+		obj{objKey, size, info.ModTime(), info.IsDir()},
+		owner,
+		group,
+		info.Mode(),
+	}
+	return o, nil
 }
 
 func (f *sftpStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
@@ -321,7 +323,24 @@ func (s sortFI) Less(i, j int) bool {
 	return name1 < name2
 }
 
-func (f *sftpStore) doFind(c *sftp.Client, path, marker string, out chan *Object) {
+func fileInfo(key string, fi os.FileInfo) Object {
+	owner, group := getOwnerGroup(fi)
+	f := &file{
+		obj{key, fi.Size(), fi.ModTime(), fi.IsDir()},
+		owner,
+		group,
+		fi.Mode(),
+	}
+	if fi.IsDir() {
+		if key != "" {
+			f.key += "/"
+		}
+		f.size = 0
+	}
+	return f
+}
+
+func (f *sftpStore) doFind(c *sftp.Client, path, marker string, out chan Object) {
 	infos, err := c.ReadDir(path)
 	if err != nil {
 		logger.Errorf("readdir %s: %s", path, err)
@@ -333,11 +352,7 @@ func (f *sftpStore) doFind(c *sftp.Client, path, marker string, out chan *Object
 		p := path + fi.Name()
 		key := p[len(f.root):]
 		if key > marker {
-			if fi.IsDir() {
-				out <- &Object{key + "/", 0, fi.ModTime(), true}
-			} else {
-				out <- &Object{key, fi.Size(), fi.ModTime(), false}
-			}
+			out <- fileInfo(key, fi)
 		}
 		if fi.IsDir() && (key > marker || strings.HasPrefix(marker, key)) {
 			f.doFind(c, p+dirSuffix, marker, out)
@@ -345,7 +360,7 @@ func (f *sftpStore) doFind(c *sftp.Client, path, marker string, out chan *Object
 	}
 }
 
-func (f *sftpStore) find(c *sftp.Client, path, marker string, out chan *Object) {
+func (f *sftpStore) find(c *sftp.Client, path, marker string, out chan Object) {
 	if strings.HasSuffix(path, dirSuffix) {
 		fi, err := c.Stat(path)
 		if err != nil {
@@ -353,7 +368,7 @@ func (f *sftpStore) find(c *sftp.Client, path, marker string, out chan *Object) 
 			return
 		}
 		if marker == "" {
-			out <- &Object{"", 0, fi.ModTime(), true}
+			out <- fileInfo("", fi)
 		}
 		f.doFind(c, path, marker, out)
 	} else {
@@ -378,11 +393,7 @@ func (f *sftpStore) find(c *sftp.Client, path, marker string, out chan *Object) 
 
 			key := p[len(f.root):]
 			if key > marker || marker == "" {
-				if fi.IsDir() {
-					out <- &Object{key + "/", 0, fi.ModTime(), true}
-				} else {
-					out <- &Object{key, fi.Size(), fi.ModTime(), false}
-				}
+				out <- fileInfo(key, fi)
 			}
 			if fi.IsDir() && (key > marker || strings.HasPrefix(marker, key)) {
 				f.doFind(c, p+dirSuffix, marker, out)
@@ -391,16 +402,16 @@ func (f *sftpStore) find(c *sftp.Client, path, marker string, out chan *Object) 
 	}
 }
 
-func (f *sftpStore) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (f *sftpStore) List(prefix, marker string, limit int64) ([]Object, error) {
 	return nil, notSupported
 }
 
-func (f *sftpStore) ListAll(prefix, marker string) (<-chan *Object, error) {
+func (f *sftpStore) ListAll(prefix, marker string) (<-chan Object, error) {
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return nil, err
 	}
-	listed := make(chan *Object, 10240)
+	listed := make(chan Object, 10240)
 	go func() {
 		defer f.putSftpConnection(&c, nil)
 

--- a/pkg/object/speedy.go
+++ b/pkg/object/speedy.go
@@ -35,7 +35,7 @@ func (s *speedy) String() string {
 	return fmt.Sprintf("speedy://%s", uri.Host)
 }
 
-func (s *speedy) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (s *speedy) List(prefix, marker string, limit int64) ([]Object, error) {
 	uri, _ := url.ParseRequestURI(s.endpoint)
 
 	query := url.Values{}
@@ -74,12 +74,12 @@ func (s *speedy) List(prefix, marker string, limit int64) ([]*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	objs := make([]*Object, 0)
+	objs := make([]Object, 0)
 	for _, item := range out.Contents {
 		if strings.HasSuffix(item.Key, "/.speedycloud_dir_flag") {
 			continue
 		}
-		objs = append(objs, &Object{item.Key, item.Size, item.LastModified, strings.HasSuffix(item.Key, "/")})
+		objs = append(objs, &obj{item.Key, item.Size, item.LastModified, strings.HasSuffix(item.Key, "/")})
 	}
 	return objs, nil
 }

--- a/pkg/object/ufile.go
+++ b/pkg/object/ufile.go
@@ -183,7 +183,7 @@ type uFileListObjectsOutput struct {
 	DataSet []*DataItem `json:"DataSet,omitempty"`
 }
 
-func (u *ufile) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (u *ufile) List(prefix, marker string, limit int64) ([]Object, error) {
 	query := url.Values{}
 	query.Add("list", "")
 	query.Add("prefix", prefix)
@@ -201,9 +201,9 @@ func (u *ufile) List(prefix, marker string, limit int64) ([]*Object, error) {
 	if err := u.parseResp(resp, &out); err != nil {
 		return nil, err
 	}
-	objs := make([]*Object, len(out.DataSet))
+	objs := make([]Object, len(out.DataSet))
 	for i, item := range out.DataSet {
-		objs[i] = &Object{item.FileName, item.Size, time.Unix(int64(item.ModifyTime), 0), strings.HasSuffix(item.FileName, "/")}
+		objs[i] = &obj{item.FileName, item.Size, time.Unix(int64(item.ModifyTime), 0), strings.HasSuffix(item.FileName, "/")}
 	}
 	return objs, nil
 }

--- a/pkg/object/upyun.go
+++ b/pkg/object/upyun.go
@@ -41,12 +41,12 @@ func (u *up) Create() error {
 	return nil
 }
 
-func (u *up) Head(key string) (*Object, error) {
+func (u *up) Head(key string) (Object, error) {
 	info, err := u.c.GetInfo("/" + key)
 	if err != nil {
 		return nil, err
 	}
-	return &Object{
+	return &obj{
 		key,
 		info.Size,
 		info.Time,
@@ -90,7 +90,7 @@ func (u *up) Copy(dst, src string) error {
 	})
 }
 
-func (u *up) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (u *up) List(prefix, marker string, limit int64) ([]Object, error) {
 	if u.listing == nil {
 		listing := make(chan *upyun.FileInfo, limit)
 		go func() {
@@ -103,7 +103,7 @@ func (u *up) List(prefix, marker string, limit int64) ([]*Object, error) {
 		}()
 		u.listing = listing
 	}
-	objs := make([]*Object, 0, limit)
+	objs := make([]Object, 0, limit)
 	for len(objs) < int(limit) {
 		fi, ok := <-u.listing
 		if !ok {
@@ -111,7 +111,7 @@ func (u *up) List(prefix, marker string, limit int64) ([]*Object, error) {
 		}
 		key := prefix + "/" + fi.Name
 		if !fi.IsDir && key > marker {
-			objs = append(objs, &Object{key, fi.Size, fi.Time, strings.HasSuffix(key, "/")})
+			objs = append(objs, &obj{key, fi.Size, fi.Time, strings.HasSuffix(key, "/")})
 		}
 	}
 	if len(objs) > 0 {

--- a/pkg/object/yovole.go
+++ b/pkg/object/yovole.go
@@ -64,7 +64,7 @@ func (u *yovole) Create() error {
 
 // ListOutput presents output for ListObjects.
 type ListResult struct {
-	ObjectSummaries []*ObjectSummaries
+	ObjectSummaries []ObjectSummaries
 	BucketName      string
 	Prefix          string
 	MaxKeys         int
@@ -76,7 +76,7 @@ type ObjectSummaries struct {
 	LastModified int64
 }
 
-func (u *yovole) List(prefix, marker string, limit int64) ([]*Object, error) {
+func (u *yovole) List(prefix, marker string, limit int64) ([]Object, error) {
 	uri, _ := url.ParseRequestURI(u.endpoint)
 
 	query := url.Values{}
@@ -116,9 +116,9 @@ func (u *yovole) List(prefix, marker string, limit int64) ([]*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	objs := make([]*Object, 0)
+	objs := make([]Object, 0)
 	for _, item := range out.ObjectSummaries {
-		objs = append(objs, &Object{item.Key, item.Size, time.Unix(item.LastModified, 0), strings.HasSuffix(item.Key, "/")})
+		objs = append(objs, &obj{item.Key, item.Size, time.Unix(item.LastModified, 0), strings.HasSuffix(item.Key, "/")})
 	}
 	return objs, nil
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -72,11 +71,11 @@ func formatSize(bytes uint64) string {
 }
 
 // ListAll on all the keys that starts at marker from object storage.
-func ListAll(store object.ObjectStorage, start, end string) (<-chan *object.Object, error) {
+func ListAll(store object.ObjectStorage, start, end string) (<-chan object.Object, error) {
 	startTime := time.Now()
 	logger.Debugf("Iterating objects from %s start %q", store, start)
 
-	out := make(chan *object.Object, maxResults)
+	out := make(chan object.Object, maxResults)
 
 	// As the result of object storage's List method doesn't include the marker key,
 	// we try List the marker key separately.
@@ -100,7 +99,7 @@ func ListAll(store object.ObjectStorage, start, end string) (<-chan *object.Obje
 
 		go func() {
 			for obj := range ch {
-				if obj != nil && obj.Key > end {
+				if obj != nil && obj.Key() > end {
 					break
 				}
 				out <- obj
@@ -124,7 +123,7 @@ func ListAll(store object.ObjectStorage, start, end string) (<-chan *object.Obje
 	END:
 		for len(objs) > 0 {
 			for _, obj := range objs {
-				key := obj.Key
+				key := obj.Key()
 				if !first && key <= lastkey {
 					logger.Fatalf("The keys are out of order: marker %q, last %q current %q", marker, lastkey, key)
 				}
@@ -172,15 +171,15 @@ var bufPool = sync.Pool{
 	},
 }
 
-func copyObject(src, dst object.ObjectStorage, obj *object.Object) error {
+func copyObject(src, dst object.ObjectStorage, obj object.Object) error {
 	if limiter != nil {
-		limiter.Wait(obj.Size)
+		limiter.Wait(obj.Size())
 	}
 	concurrent <- 1
 	defer func() {
 		<-concurrent
 	}()
-	key := obj.Key
+	key := obj.Key()
 	if strings.HasPrefix(src.String(), "file://") || strings.HasPrefix(dst.String(), "file://") {
 		in, e := src.Get(key, 0, -1)
 		if e != nil {
@@ -193,7 +192,7 @@ func copyObject(src, dst object.ObjectStorage, obj *object.Object) error {
 		return dst.Put(key, in)
 	}
 	firstBlock := -1
-	if obj.Size > maxBlock {
+	if obj.Size() > maxBlock {
 		firstBlock = maxBlock
 	}
 	in, e := src.Get(key, 0, int64(firstBlock))
@@ -250,13 +249,13 @@ func try(n int, f func() error) (err error) {
 	return
 }
 
-func copyInParallel(src, dst object.ObjectStorage, obj *object.Object) error {
-	if obj.Size < maxBlock {
+func copyInParallel(src, dst object.ObjectStorage, obj object.Object) error {
+	if obj.Size() < maxBlock {
 		return try(3, func() error {
 			return copyObject(src, dst, obj)
 		})
 	}
-	upload, err := dst.CreateMultipartUpload(obj.Key)
+	upload, err := dst.CreateMultipartUpload(obj.Key())
 	if err != nil {
 		return try(3, func() error {
 			return copyObject(src, dst, obj)
@@ -266,12 +265,12 @@ func copyInParallel(src, dst object.ObjectStorage, obj *object.Object) error {
 	if partSize == 0 {
 		partSize = defaultPartSize
 	}
-	if obj.Size > partSize*int64(upload.MaxCount) {
-		partSize = obj.Size / int64(upload.MaxCount)
+	if obj.Size() > partSize*int64(upload.MaxCount) {
+		partSize = obj.Size() / int64(upload.MaxCount)
 		partSize = ((partSize-1)>>20 + 1) << 20 // align to MB
 	}
-	n := int((obj.Size-1)/partSize) + 1
-	key := obj.Key
+	n := int((obj.Size()-1)/partSize) + 1
+	key := obj.Key()
 	logger.Debugf("Copying object %s as %d parts (size: %d): %s", key, n, partSize, upload.UploadID)
 	parts := make([]*object.Part, n)
 	errs := make(chan error, n)
@@ -279,7 +278,7 @@ func copyInParallel(src, dst object.ObjectStorage, obj *object.Object) error {
 		go func(num int) {
 			sz := partSize
 			if num == n-1 {
-				sz = obj.Size - int64(num)*partSize
+				sz = obj.Size() - int64(num)*partSize
 			}
 			var err error
 			if limiter != nil {
@@ -331,7 +330,7 @@ func copyInParallel(src, dst object.ObjectStorage, obj *object.Object) error {
 	return nil
 }
 
-func worker(todo chan *object.Object, src, dst object.ObjectStorage, config *Config) {
+func worker(todo chan object.Object, src, dst object.ObjectStorage, config *Config) {
 	for {
 		obj, ok := <-todo
 		if !ok {
@@ -339,34 +338,34 @@ func worker(todo chan *object.Object, src, dst object.ObjectStorage, config *Con
 		}
 		start := time.Now()
 		var err error
-		if obj.Size == markDelete {
+		if obj.Size() == markDelete {
 			if config.DeleteSrc {
 				if config.Dry {
-					logger.Debugf("Will delete %s from %s", obj.Key, src)
+					logger.Debugf("Will delete %s from %s", obj.Key(), src)
 					continue
 				}
 				if err = try(3, func() error {
-					return src.Delete(obj.Key)
+					return src.Delete(obj.Key())
 				}); err == nil {
-					logger.Debugf("Deleted %s from %s", obj.Key, src)
+					logger.Debugf("Deleted %s from %s", obj.Key(), src)
 					atomic.AddInt64(&deleted, 1)
 				} else {
-					logger.Errorf("Failed to delete %s from %s: %s", obj.Key, src, err.Error())
+					logger.Errorf("Failed to delete %s from %s: %s", obj.Key(), src, err.Error())
 					atomic.AddInt64(&failed, 1)
 				}
 			}
 			if config.DeleteDst {
 				if config.Dry {
-					logger.Debugf("Will delete %s from %s", obj.Key, dst)
+					logger.Debugf("Will delete %s from %s", obj.Key(), dst)
 					continue
 				}
 				if err = try(3, func() error {
-					return dst.Delete(obj.Key)
+					return dst.Delete(obj.Key())
 				}); err == nil {
-					logger.Debugf("Deleted %s from %s", obj.Key, dst)
+					logger.Debugf("Deleted %s from %s", obj.Key(), dst)
 					atomic.AddInt64(&deleted, 1)
 				} else {
-					logger.Errorf("Failed to delete %s from %s: %s", obj.Key, dst, err.Error())
+					logger.Errorf("Failed to delete %s from %s: %s", obj.Key(), dst, err.Error())
 					atomic.AddInt64(&failed, 1)
 				}
 			}
@@ -374,56 +373,65 @@ func worker(todo chan *object.Object, src, dst object.ObjectStorage, config *Con
 		}
 
 		if config.Dry {
-			logger.Debugf("Will copy %s (%d bytes)", obj.Key, obj.Size)
+			logger.Debugf("Will copy %s (%d bytes)", obj.Key(), obj.Size())
 			continue
 		}
-		if config.Perms && obj.Size == markCopyPerms {
-			fi := (*object.File)(unsafe.Pointer(obj))
-			if err := dst.(object.FileSystem).Chmod(obj.Key, fi.Mode); err != nil {
-				logger.Warnf("Chmod %s to %d: %s", obj.Key, fi.Mode, err)
+		if config.Perms && obj.Size() == markCopyPerms {
+			fi := obj.(object.File)
+			if err := dst.(object.FileSystem).Chmod(obj.Key(), fi.Mode()); err != nil {
+				logger.Warnf("Chmod %s to %d: %s", obj.Key(), fi.Mode(), err)
 			}
-			if err := dst.(object.FileSystem).Chown(obj.Key, fi.Owner, fi.Group); err != nil {
-				logger.Warnf("Chown %s to (%s,%s): %s", obj.Key, fi.Owner, fi.Group, err)
+			if err := dst.(object.FileSystem).Chown(obj.Key(), fi.Owner(), fi.Group()); err != nil {
+				logger.Warnf("Chown %s to (%s,%s): %s", obj.Key(), fi.Owner(), fi.Group(), err)
 			}
 			atomic.AddInt64(&copied, 1)
-			logger.Debugf("Copied permissions (%s:%s:%s) for %s in %s", fi.Owner, fi.Group, fi.Mode, obj.Key, time.Since(start))
+			logger.Debugf("Copied permissions (%s:%s:%s) for %s in %s", fi.Owner(), fi.Group(), fi.Mode(), obj.Key(), time.Since(start))
 			continue
 		}
 		err = copyInParallel(src, dst, obj)
 		if err != nil {
 			atomic.AddInt64(&failed, 1)
-			logger.Errorf("Failed to copy %s: %s", obj.Key, err.Error())
+			logger.Errorf("Failed to copy %s: %s", obj.Key(), err.Error())
 		} else {
 			if mc, ok := dst.(object.MtimeChanger); ok {
-				err := mc.Chtimes(obj.Key, obj.Mtime)
+				err := mc.Chtimes(obj.Key(), obj.Mtime())
 				if err != nil {
-					logger.Warnf("Update mtime of %s: %s", obj.Key, err)
+					logger.Warnf("Update mtime of %s: %s", obj.Key(), err)
 				}
 			}
 			if config.Perms {
-				fi := (*object.File)(unsafe.Pointer(obj))
-				if err := dst.(object.FileSystem).Chmod(obj.Key, fi.Mode); err != nil {
-					logger.Warnf("Chmod %s to %o: %s", obj.Key, fi.Mode, err)
+				fi := obj.(object.File)
+				if err := dst.(object.FileSystem).Chmod(obj.Key(), fi.Mode()); err != nil {
+					logger.Warnf("Chmod %s to %o: %s", obj.Key(), fi.Mode(), err)
 				}
-				if err := dst.(object.FileSystem).Chown(obj.Key, fi.Owner, fi.Group); err != nil {
-					logger.Warnf("Chown %s to (%s,%s): %s", obj.Key, fi.Owner, fi.Group, err)
+				if err := dst.(object.FileSystem).Chown(obj.Key(), fi.Owner(), fi.Group()); err != nil {
+					logger.Warnf("Chown %s to (%s,%s): %s", obj.Key(), fi.Owner(), fi.Group(), err)
 				}
 			}
 			atomic.AddInt64(&copied, 1)
-			atomic.AddInt64(&copiedBytes, int64(obj.Size))
-			logger.Debugf("Copied %s (%d bytes) in %s", obj.Key, obj.Size, time.Since(start))
+			atomic.AddInt64(&copiedBytes, int64(obj.Size()))
+			logger.Debugf("Copied %s (%d bytes) in %s", obj.Key(), obj.Size(), time.Since(start))
 		}
 	}
 }
 
-func deleteFromDst(tasks chan *object.Object, dstobj *object.Object) {
-	dstobj.Size = markDelete
+type withSize struct {
+	object.Object
+	nsize int64
+}
+
+func (o *withSize) Size() int64 {
+	return o.nsize
+}
+
+func deleteFromDst(tasks chan object.Object, dstobj object.Object) {
+	dstobj = &withSize{dstobj, markDelete}
 	tasks <- dstobj
 	atomic.AddInt64(&found, 1)
 	atomic.AddInt64(&todo, 1)
 }
 
-func producer(tasks chan *object.Object, src, dst object.ObjectStorage, config *Config) {
+func producer(tasks chan object.Object, src, dst object.ObjectStorage, config *Config) {
 	start, end := config.Start, config.End
 	logger.Infof("Syncing from %s to %s", src, dst)
 	if start != "" {
@@ -448,7 +456,7 @@ func producer(tasks chan *object.Object, src, dst object.ObjectStorage, config *
 		dstkeys = filter(dstkeys, config.Include, config.Exclude)
 	}
 
-	var dstobj *object.Object
+	var dstobj object.Object
 	hasMore := true
 OUT:
 	for obj := range srckeys {
@@ -457,18 +465,18 @@ OUT:
 			hasMore = false
 			break
 		}
-		if !config.Dirs && obj.IsDir {
+		if !config.Dirs && obj.IsDir() {
 			// ignore directories
-			logger.Debug("Ignore directory ", obj.Key)
+			logger.Debug("Ignore directory ", obj.Key())
 			continue
 		}
 		atomic.AddInt64(&found, 1)
-		for hasMore && (dstobj == nil || obj.Key > dstobj.Key) {
+		for hasMore && (dstobj == nil || obj.Key() > dstobj.Key()) {
 			var ok bool
-			if config.DeleteDst && dstobj != nil && dstobj.Key < obj.Key {
-				if !config.Dirs && dstobj.IsDir {
+			if config.DeleteDst && dstobj != nil && dstobj.Key() < obj.Key() {
+				if !config.Dirs && dstobj.IsDir() {
 					// ignore
-					logger.Debug("Ignore deleting dst directory ", dstobj.Key)
+					logger.Debug("Ignore deleting dst directory ", dstobj.Key())
 				} else {
 					deleteFromDst(tasks, dstobj)
 				}
@@ -484,25 +492,27 @@ OUT:
 			}
 		}
 		// FIXME: there is a race when source is modified during coping
-		if !hasMore || obj.Key < dstobj.Key ||
-			obj.Key == dstobj.Key && (config.ForceUpdate || obj.Size != dstobj.Size ||
-				config.Update && obj.Mtime.Unix() > dstobj.Mtime.Unix()) {
+		if !hasMore || obj.Key() < dstobj.Key() ||
+			obj.Key() == dstobj.Key() && (config.ForceUpdate || obj.Size() != dstobj.Size() ||
+				config.Update && obj.Mtime().After(dstobj.Mtime())) {
+			if dstobj != nil {
+				// logger.Infof("%s size %+v %+v", obj.Key(), *obj, *dstobj)
+			}
 			tasks <- obj
 			atomic.AddInt64(&todo, 1)
-		} else if config.DeleteSrc && dstobj != nil && obj.Key == dstobj.Key && obj.Size == dstobj.Size {
-			obj.Size = markDelete
-			tasks <- obj
+		} else if config.DeleteSrc && dstobj != nil && obj.Key() == dstobj.Key() && obj.Size() == dstobj.Size() {
+			tasks <- &withSize{obj, markDelete}
 			atomic.AddInt64(&todo, 1)
 		} else if config.Perms {
-			f1 := (*object.File)(unsafe.Pointer(obj))
-			f2 := (*object.File)(unsafe.Pointer(dstobj))
-			if f2.Mode != f1.Mode || f2.Owner != f1.Owner || f2.Group != f1.Group {
-				obj.Size = markCopyPerms
-				tasks <- obj
+			f1 := obj.(object.File)
+			f2 := dstobj.(object.File)
+			if f2.Mode() != f1.Mode() || f2.Owner() != f1.Owner() || f2.Group() != f1.Group() {
+				logger.Infof("target %p %p %s %s %s %s", dstobj, f2, f2.Key(), f2.Mode(), f2.Owner(), f2.Group())
+				tasks <- &withSize{obj, markCopyPerms}
 				atomic.AddInt64(&todo, 1)
 			}
 		}
-		if dstobj != nil && dstobj.Key == obj.Key {
+		if dstobj != nil && dstobj.Key() == obj.Key() {
 			dstobj = nil
 		}
 	}
@@ -583,21 +593,21 @@ func findAny(s string, ps []*regexp.Regexp) bool {
 	return false
 }
 
-func filter(keys <-chan *object.Object, include, exclude []string) <-chan *object.Object {
+func filter(keys <-chan object.Object, include, exclude []string) <-chan object.Object {
 	inc := compileExp(include)
 	exc := compileExp(exclude)
-	r := make(chan *object.Object)
+	r := make(chan object.Object)
 	go func() {
 		for o := range keys {
 			if o == nil {
 				break
 			}
-			if findAny(o.Key, exc) {
-				logger.Debugf("exclude %s", o.Key)
+			if findAny(o.Key(), exc) {
+				logger.Debugf("exclude %s", o.Key())
 				continue
 			}
-			if len(inc) > 0 && !findAny(o.Key, inc) {
-				logger.Debugf("%s is not included", o.Key)
+			if len(inc) > 0 && !findAny(o.Key(), inc) {
+				logger.Debugf("%s is not included", o.Key())
 				continue
 			}
 			r <- o
@@ -613,7 +623,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 	if config.Manager != "" {
 		bufferSize = 100
 	}
-	todo := make(chan *object.Object, bufferSize)
+	todo := make(chan object.Object, bufferSize)
 	wg := sync.WaitGroup{}
 	concurrent = make(chan int, config.Threads)
 	if config.BWLimit > 0 {

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/juicedata/juicefs/pkg/object"
 )
 
-func collectAll(c <-chan *object.Object) []string {
+func collectAll(c <-chan object.Object) []string {
 	r := make([]string, 0)
 	for s := range c {
-		r = append(r, s.Key)
+		r = append(r, s.Key())
 	}
 	return r
 }


### PR DESCRIPTION
Object is common interface for File, it's better to use File as a wider interface for Object, rather than embed Object into File, the later will require to use unsafe to convert the pointer between them. It's actually UNSAFE.