### PR TITLE
skip first few large slices in compaction

### DIFF
--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -87,6 +87,16 @@ func (s *slice) visit(f func(*slice)) {
 	right.visit(f)
 }
 
+func marshalSlice(pos uint32, chunkid uint64, size, off, len uint32) []byte {
+	w := utils.NewBuffer(24)
+	w.Put32(pos)
+	w.Put64(chunkid)
+	w.Put32(size)
+	w.Put32(off)
+	w.Put32(len)
+	return w.Bytes()
+}
+
 func readSlices(vals []string) []*slice {
 	slices := make([]slice, len(vals))
 	ss := make([]*slice, len(vals))


### PR DESCRIPTION
For appended log files, there will be many small slices, and we always compact them into bigger one using FIFO, Then the first few slices will be compacted over and over again, even they are bigger than a block (4MB), this increase the get/put traffic.

This PR will skip the first few big slices to reduce traffic to object store during compaction.


Closes #261 