### PR TITLE
Show internal information for dir/files

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,95 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"bytes"
+	"encoding/gob"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func infoFlags() *cli.Command {
+	return &cli.Command{
+		Name:      "info",
+		Usage:     "info DIR or FILE",
+		ArgsUsage: "DIR or FILE",
+		Action:    info,
+	}
+}
+
+func info(ctx *cli.Context) error {
+	if runtime.GOOS == "windows" {
+		logger.Infof("Windows is not supported")
+		return nil
+	}
+	if ctx.Args().Len() < 1 {
+		logger.Infof("DIR or FILE is needed")
+		return nil
+	}
+
+	path := ctx.Args().Get(0)
+	p, err := filepath.Abs(path)
+	if err != nil {
+		logger.Errorf("abs of %s: %s", path, err)
+	}
+	d := filepath.Dir(p)
+	name := filepath.Base(p)
+	inode, err := utils.GetFileInode(d)
+	if err != nil {
+		return fmt.Errorf("lookup inode for %s: %s", d, err)
+	}
+
+	f := openControler(d)
+	if f == nil {
+		logger.Errorf("%s is not inside JuiceFS", path)
+	}
+
+	wb := utils.NewBuffer(8 + 8)
+	wb.Put32(meta.Info)
+	wb.Put32(8)
+	wb.Put64(inode)
+	_, err = f.Write(wb.Bytes())
+	if err != nil {
+		logger.Fatalf("write message: %s", err)
+	}
+
+	data := make([]byte, 100)
+	n, err := f.Read(data)
+	if err != nil {
+		logger.Fatalf("read message: %d %s", n, err)
+	}
+	_ = f.Close()
+	var summary meta.Summary
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	err = dec.Decode(&summary)
+	if err != nil {
+		logger.Fatalf("decode error: %s", err)
+	}
+
+	fmt.Printf("name:\t%s\n", name)
+	fmt.Printf("files:\t%d\n", summary.Files)
+	fmt.Printf("dirs:\t%d\n", summary.Dirs)
+	fmt.Printf("size:\t%d\n", summary.Size)
+	fmt.Printf("length:\t%d\n", summary.Length)
+
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,7 @@ func main() {
 			gatewayFlags(),
 			syncFlags(),
 			rmrFlags(),
+			infoFlags(),
 			benchmarkFlags(),
 			gcFlags(),
 			checkFlags(),

--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -23,6 +23,7 @@ COMMANDS:
    gateway    S3-compatible gateway
    sync       sync between two storage
    rmr        remove directories recursively
+   info       show internal information for paths or inodes
    benchmark  run benchmark, including read/write/stat big/small files
    gc         collect any leaked objects
    fsck       Check consistency of file system
@@ -305,6 +306,24 @@ Remove all files in directories recursively.
 ```
 juicefs rmr PATH ...
 ```
+
+## juicefs info
+
+### Description
+
+Show internal information for given paths or inodes.
+
+### Synopsis
+
+```
+juicefs info [command options] PATH or INODE
+```
+
+### Options
+
+`--inode, -i`\
+use inode instead of path (current dir should be inside JuiceFS) (default: `false`)
+
 
 ## juicefs benchmark
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -207,8 +207,6 @@ type Meta interface {
 	Summary(ctx Context, inode Ino, summary *Summary) syscall.Errno
 	// Rmr remove all the files and directories recursively.
 	Rmr(ctx Context, inode Ino, name string) syscall.Errno
-	// get internal info for  the file and directory.
-	Info(ctx Context, parent Ino, summary* Summary) syscall.Errno
 
 	// ListSlices returns all slices used by all files.
 	ListSlices(ctx Context, slices *[]Slice) syscall.Errno

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -28,6 +28,8 @@ const (
 	CompactChunk = 1001
 	// Rmr is a message to remove a directory recursively.
 	Rmr = 1002
+	// Info is a message to get the internal info for file or directory.
+	Info = 1003
 )
 
 const (
@@ -205,6 +207,8 @@ type Meta interface {
 	Summary(ctx Context, inode Ino, summary *Summary) syscall.Errno
 	// Rmr remove all the files and directories recursively.
 	Rmr(ctx Context, inode Ino, name string) syscall.Errno
+	// get internal info for  the file and directory.
+	Info(ctx Context, parent Ino, summary* Summary) syscall.Errno
 
 	// ListSlices returns all slices used by all files.
 	ListSlices(ctx Context, slices *[]Slice) syscall.Errno

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1149,6 +1149,18 @@ func (r *redisMeta) Rmr(ctx Context, parent Ino, name string) syscall.Errno {
 	return r.emptyEntry(ctx, parent, name, inode, concurrent)
 }
 
+func (r *redisMeta) Info(ctx Context, parent Ino, summary* Summary) syscall.Errno {
+	if st := r.Access(ctx, parent, 3, nil); st != 0 {
+		return st
+	}
+
+	if st := r.Summary(ctx, parent, summary); st != 0 {
+		return st
+	}
+
+	return 0
+}
+
 func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst Ino, nameDst string, inode *Ino, attr *Attr) syscall.Errno {
 	buf, err := r.rdb.HGet(ctx, r.entryKey(parentSrc), nameSrc).Bytes()
 	if err != nil {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1149,18 +1149,6 @@ func (r *redisMeta) Rmr(ctx Context, parent Ino, name string) syscall.Errno {
 	return r.emptyEntry(ctx, parent, name, inode, concurrent)
 }
 
-func (r *redisMeta) Info(ctx Context, parent Ino, summary* Summary) syscall.Errno {
-	if st := r.Access(ctx, parent, 3, nil); st != 0 {
-		return st
-	}
-
-	if st := r.Summary(ctx, parent, summary); st != 0 {
-		return st
-	}
-
-	return 0
-}
-
 func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst Ino, nameDst string, inode *Ino, attr *Attr) syscall.Errno {
 	buf, err := r.rdb.HGet(ctx, r.entryKey(parentSrc), nameSrc).Bytes()
 	if err != nil {


### PR DESCRIPTION
This PR is based on #284 

for example,
```bash
$ ./juicefs info /jfs /jfs/Makefile 
/jfs :
 inode: 1
 files: 2827
 dirs:  423
 length:        326090181
 size:  336531456

/jfs/Makefile :
 inode: 25
 files: 1
 dirs:  0
 length:        101
 size:  4096
 chunks:
        0:      7       101     0       101
```


Closes #205 