### PR TITLE
Remove redundant break

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -573,9 +573,6 @@ func (fs *FileSystem) lookup(ctx meta.Context, p string, followLastSymlink bool)
 			inode = fi.Inode()
 		}
 		parent = inode
-		if resolved {
-			break
-		}
 	}
 	if parent == 1 {
 		err = fs.m.GetAttr(ctx, parent, attr)


### PR DESCRIPTION
`resolved` is only set to `true` when `i == len(ss)-1`, but when this
condition holds the loop will terminate without `break`.