### PR TITLE
Use Lua script to speed up path resolving in `FileSystem.lookup`

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -530,9 +530,17 @@ func (fs *FileSystem) RemoveXattr(ctx meta.Context, p string, name string) (err 
 }
 
 func (fs *FileSystem) lookup(ctx meta.Context, p string, followLastSymlink bool) (fi *FileStat, err syscall.Errno) {
+	var inode Ino
+	var attr = &Attr{}
+
+	if err = fs.m.Resolve(ctx, p, followLastSymlink, &inode, attr); err != syscall.ENOTSUP {
+		return
+	}
+
+	// Fallback to the default implementation that calls `fs.m.Lookup` for each directory along the path.
+	// It might be slower for deep directories, but it works for every meta that implements `Lookup`.
 	parent := Ino(1)
 	ss := strings.Split(p, "/")
-	var attr = &Attr{}
 	for i, name := range ss {
 		if len(name) == 0 {
 			continue
@@ -551,7 +559,6 @@ func (fs *FileSystem) lookup(ctx meta.Context, p string, followLastSymlink bool)
 
 		var inode Ino
 		var resolved bool
-		// TODO: speed up by resolve the path in Redis
 		err = fs.m.Lookup(ctx, parent, name, &inode, attr)
 		if i == len(ss)-1 {
 			resolved = true

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -533,7 +533,15 @@ func (fs *FileSystem) lookup(ctx meta.Context, p string, followLastSymlink bool)
 	var inode Ino
 	var attr = &Attr{}
 
-	if err = fs.m.Resolve(ctx, p, followLastSymlink, &inode, attr); err != syscall.ENOTSUP {
+	err = fs.m.Resolve(ctx, p, &inode, attr)
+	if err == 0 {
+		fi = AttrToFileInfo(inode, attr)
+		p = strings.TrimRight(p, "/")
+		ss := strings.Split(p, "/")
+		fi.name = ss[len(ss)-1]
+		return
+	}
+	if err != syscall.ENOTSUP {
 		return
 	}
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -145,8 +145,9 @@ type Meta interface {
 	// Lookup returns the inode and attributes for the given entry in a directory.
 	Lookup(ctx Context, parent Ino, name string, inode *Ino, attr *Attr) syscall.Errno
 	// Resolve fetches the inode and attributes for an entry identified by the given path.
-	// ENOTSUP will be returned if there's no natural implementation for this operation.
-	Resolve(ctx Context, path string, followLastSymlink bool, inode *Ino, attr *Attr) syscall.Errno
+	// ENOTSUP will be returned if there's no natural implementation for this operation or
+	// if there are any symlink following involved.
+	Resolve(ctx Context, path string, inode *Ino, attr *Attr) syscall.Errno
 	// GetAttr returns the attributes for given node.
 	GetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno
 	// SetAttr updates the attributes for given node.

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -144,6 +144,9 @@ type Meta interface {
 	Access(ctx Context, inode Ino, modemask uint8, attr *Attr) syscall.Errno
 	// Lookup returns the inode and attributes for the given entry in a directory.
 	Lookup(ctx Context, parent Ino, name string, inode *Ino, attr *Attr) syscall.Errno
+	// Resolve fetches the inode and attributes for an entry identified by the given path.
+	// ENOTSUP will be returned if there's no natural implementation for this operation.
+	Resolve(ctx Context, path string, followLastSymlink bool, inode *Ino, attr *Attr) syscall.Errno
 	// GetAttr returns the attributes for given node.
 	GetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno
 	// SetAttr updates the attributes for given node.

--- a/pkg/meta/lua_scripts.go
+++ b/pkg/meta/lua_scripts.go
@@ -1,0 +1,50 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+const scriptLookup = `
+local buf = redis.call('HGET', KEYS[1], KEYS[2])
+if not buf then
+       return false
+end
+if string.len(buf) ~= 9 then
+       return {err=string.format("Invalid entry data: %s", buf)}
+end
+local ino = string.unpack(">I8", string.sub(buf, 2))
+return {ino, redis.call('GET', "i" .. tostring(ino))}
+`
+
+//nolint
+const scriptResolve = `
+local function parse_attr(buf)
+    local buf_len = string.len(buf)
+    local x = {}
+    if buf_len == 72 then
+        x.flags, x.mode, x.uid, x.gid,
+        x.atime, x.atime_nsec,
+        x.mtime, x.mtime_nsec,
+        x.ctime, x.ctime_nsec,
+        x.nlink, x.length, x.rdev, x.parent = string.unpack(">BHI4I4I8I4I8I4I8I4I4I8I4I8", buf)
+    elseif buf_len == 64 then
+        x.flags, x.mode, x.uid, x.gid,
+        x.atime, x.atime_nsec,
+        x.mtime, x.mtime_nsec,
+        x.ctime, x.ctime_nsec,
+        x.nlink, x.length, x.rdev = string.unpack(">BHI4I4I8I4I8I4I8I4I4I8I4", buf)
+    end
+    return x
+end
+`

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -530,7 +530,7 @@ func (r *redisMeta) Lookup(ctx Context, parent Ino, name string, inode *Ino, att
 	return errno(err)
 }
 
-func (r *redisMeta) Resolve(ctx Context, path string, followLastSymlink bool, inode *Ino, attr *Attr) syscall.Errno {
+func (r *redisMeta) Resolve(ctx Context, path string, inode *Ino, attr *Attr) syscall.Errno {
 	return syscall.ENOTSUP
 }
 

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -67,18 +67,6 @@ const delfiles = "delfiles"
 const allSessions = "sessions"
 const sliceRefs = "sliceRef"
 
-const scriptLookup = `
-local buf = redis.call('HGET', KEYS[1], KEYS[2])
-if not buf then
-       return false
-end
-if string.len(buf) ~= 9 then
-       return {err=string.format("Invalid entry data: %s", buf)}
-end
-local ino = string.unpack(">I8", string.sub(buf, 2))
-return {ino, redis.call('GET', "i" .. tostring(ino))}
-`
-
 // RedisConfig is config for Redis client.
 type RedisConfig struct {
 	Strict      bool // update ctime

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -530,6 +530,10 @@ func (r *redisMeta) Lookup(ctx Context, parent Ino, name string, inode *Ino, att
 	return errno(err)
 }
 
+func (r *redisMeta) Resolve(ctx Context, path string, followLastSymlink bool, inode *Ino, attr *Attr) syscall.Errno {
+	return syscall.ENOTSUP
+}
+
 func (r *redisMeta) accessMode(attr *Attr, uid uint32, gid uint32) uint8 {
 	if uid == 0 {
 		return 0x7


### PR DESCRIPTION
Fix #199 .

Per the discussion in #199 , we'll introduce this optimization by first adding a new method `Resolve` to the `Meta` interface.
If there's no way to implement a high performance `Resolve`, a `Meta` implementation can just return `syscall.ENOTSUP`. In this case, the current implementation will be used which only depends on `Meta.Lookup` being implemented.

With `redisMeta`, we can implement this with the help of Lua scripting do the resolving in one Redis request.