### PR TITLE
metrics(object): add more histogram buckets for latency distribution

### DIFF
--- a/pkg/object/metrics.go
+++ b/pkg/object/metrics.go
@@ -26,7 +26,7 @@ var (
 	reqsHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "object_request_durations_histogram_seconds",
 		Help:    "Object requests latency distributions.",
-		Buckets: prometheus.ExponentialBuckets(0.01, 1.5, 20),
+		Buckets: prometheus.ExponentialBuckets(0.01, 1.5, 25),
 	}, []string{"method"})
 	reqErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "object_request_errors",


### PR DESCRIPTION
After running with 35 buckets for some time, 25 seem to be the sweet number (despite the theoretical 60s timeout?)

![image](https://user-images.githubusercontent.com/11699655/115157897-e9e61380-a08b-11eb-834c-10b60fa02746.png)
