### PR TITLE
build a minimal binary with S3 only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ endif
 juicefs: Makefile cmd/*.go pkg/*/*.go
 	go build -ldflags="$(LDFLAGS)"  -o juicefs ./cmd
 
+juicefs.lite: Makefile cmd/*.go pkg/*/*.go
+	go build -tags nogateway,nocos,nobos,nohdfs,noibmcos,nobs,nooss,noqingstor,noscs,nosftp,noswift,noupyun,noazure,nogs \
+		-ldflags="$(LDFLAGS)" -o juicefs.lite ./cmd
+
 juicefs.ceph: Makefile cmd/*.go pkg/*/*.go
 	go build -tags ceph -ldflags="$(LDFLAGS)"  -o juicefs.ceph ./cmd
 

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -1,3 +1,5 @@
+//+build !nogateway
+
 /*
  * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
  *

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -1,3 +1,5 @@
+// +build !noazure
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/bos.go
+++ b/pkg/object/bos.go
@@ -1,3 +1,5 @@
+// +build !nobos
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/cos.go
+++ b/pkg/object/cos.go
@@ -1,3 +1,5 @@
+// +build !nocos
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/eos.go
+++ b/pkg/object/eos.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -1,3 +1,5 @@
+// +build !nogs
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *
@@ -30,8 +32,6 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/storage/v1"
 )
-
-var ctx = context.Background()
 
 type gs struct {
 	DefaultObjectStorage

--- a/pkg/object/hdfs.go
+++ b/pkg/object/hdfs.go
@@ -1,3 +1,5 @@
+// +build !nohdfs
+
 /*
  * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
  *

--- a/pkg/object/hdfs_kerberos.go
+++ b/pkg/object/hdfs_kerberos.go
@@ -1,3 +1,5 @@
+// +build !nohdfs
+
 // Copyright (c) 2014 Colin Marc (colinmarc@gmail.com)
 // borrowed from https://github.com/colinmarc/hdfs/blob/master/cmd/hdfs/kerberos.go
 

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -1,3 +1,5 @@
+// +build !noibmcos
+
 /*
  * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
  *

--- a/pkg/object/jss.go
+++ b/pkg/object/jss.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/nos.go
+++ b/pkg/object/nos.go
@@ -1,3 +1,5 @@
+// +build !nonos
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -16,6 +16,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -25,6 +26,7 @@ import (
 	"github.com/juicedata/juicefs/pkg/utils"
 )
 
+var ctx = context.Background()
 var logger = utils.GetLogger("juicefs")
 
 var UserAgent = "JuiceFS"

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -1,3 +1,5 @@
+// +build !noobs
+
 /*
  * JuiceFS, Copyright (C) 2019 Juicedata, Inc.
  *

--- a/pkg/object/oos.go
+++ b/pkg/object/oos.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -1,3 +1,5 @@
+// +build !nooss
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -1,3 +1,5 @@
+// +build !noqingstore
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -1,3 +1,5 @@
+// +build !noqiniu,!nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/scs.go
+++ b/pkg/object/scs.go
@@ -1,3 +1,5 @@
+// +build !noscs
+
 /*
  * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
  *

--- a/pkg/object/scw.go
+++ b/pkg/object/scw.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
  *

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -1,3 +1,5 @@
+// +build !nosftp
+
 // Part of this file is borrowed from Rclone under MIT license:
 // https://github.com/ncw/rclone/blob/master/backend/sftp/sftp.go
 

--- a/pkg/object/space.go
+++ b/pkg/object/space.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/swift.go
+++ b/pkg/object/swift.go
@@ -1,3 +1,5 @@
+// +build !noswift
+
 /*
  * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
  *

--- a/pkg/object/upyun.go
+++ b/pkg/object/upyun.go
@@ -1,3 +1,5 @@
+// +build !noupyun
+
 /*
  * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
  *

--- a/pkg/object/wasabi.go
+++ b/pkg/object/wasabi.go
@@ -1,3 +1,5 @@
+// +build !nos3
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *


### PR DESCRIPTION
Added build tags to exclude some of the features, to reduce the size of binary.

Added a rule to build a minimal binary only support file and S3 as object store, reduce the size to 1/3.

```
$ make juicefs.lite
$ ls -l juicefs*
-rwxr-xr-x  1 davies  staff  74564020 Apr 19 15:11 juicefs
-rwxr-xr-x  1 davies  staff  27690572 Apr 19 15:37 juicefs.lite
```

Close #318