### PR TITLE
push metrics to prometheous gateway from Java SDK

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -158,13 +158,14 @@ func NewFileSystem(conf *vfs.Config, m meta.Meta, d chunk.ChunkStore) (*FileSyst
 }
 
 func (fs *FileSystem) log(ctx LogContext, format string, args ...interface{}) {
+	used := ctx.Duration()
+	opsDurationsHistogram.Observe(used.Seconds())
 	if fs.logBuffer == nil {
 		return
 	}
 	now := utils.Now()
 	cmd := fmt.Sprintf(format, args...)
 	ts := now.Format("2006.01.02 15:04:05.000000")
-	used := ctx.Duration()
 	cmd += fmt.Sprintf(" <%.6f>", used.Seconds())
 	line := fmt.Sprintf("%s [uid:%d,gid:%d,pid:%d] %s\n", ts, ctx.Uid(), ctx.Gid(), ctx.Pid(), cmd)
 	select {
@@ -771,6 +772,7 @@ func (f *File) pread(ctx meta.Context, b []byte, offset int64) (n int, err error
 	if got == 0 {
 		return 0, io.EOF
 	}
+	writtenSizeHistogram.Observe(float64(got))
 	return got, nil
 }
 
@@ -805,6 +807,7 @@ func (f *File) pwrite(ctx meta.Context, b []byte, offset int64) (n int, err sysc
 		f.wdata = nil
 		return
 	}
+	writtenSizeHistogram.Observe(float64(len(b)))
 	return len(b), 0
 }
 

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -772,7 +772,7 @@ func (f *File) pread(ctx meta.Context, b []byte, offset int64) (n int, err error
 	if got == 0 {
 		return 0, io.EOF
 	}
-	writtenSizeHistogram.Observe(float64(got))
+	readSizeHistogram.Observe(float64(got))
 	return got, nil
 }
 

--- a/pkg/fs/metrics.go
+++ b/pkg/fs/metrics.go
@@ -1,3 +1,18 @@
+/*
+ * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package fs
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/fs/metrics.go
+++ b/pkg/fs/metrics.go
@@ -1,0 +1,21 @@
+package fs
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	readSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "sdk_read_size_bytes",
+		Help:    "size of read distributions.",
+		Buckets: prometheus.LinearBuckets(4096, 4096, 32),
+	})
+	writtenSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "sdk_written_size_bytes",
+		Help:    "size of write distributions.",
+		Buckets: prometheus.LinearBuckets(4096, 4096, 32),
+	})
+	opsDurationsHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "sdk_ops_durations_histogram_seconds",
+		Help:    "Operations latency distributions.",
+		Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
+	})
+)

--- a/pkg/metric/metrics.go
+++ b/pkg/metric/metrics.go
@@ -1,0 +1,75 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package metric
+
+import (
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	start = time.Now()
+	cpu   = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "cpu_usage",
+		Help: "Accumulated CPU usage in seconds.",
+	}, func() float64 {
+		ru := utils.GetRusage()
+		return ru.GetStime() + ru.GetUtime()
+	})
+	memory = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "memory",
+		Help: "Used memory in bytes.",
+	}, func() float64 {
+		_, rss := utils.MemoryUsage()
+		return float64(rss)
+	})
+	uptime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "uptime",
+		Help: "Total running time in seconds.",
+	}, func() float64 {
+		return time.Since(start).Seconds()
+	})
+	usedSpace = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "used_space",
+		Help: "Total used space in bytes.",
+	})
+	usedInodes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "used_inodes",
+		Help: "Total number of inodes.",
+	})
+)
+
+func UpdateMetrics(m meta.Meta) {
+	prometheus.MustRegister(cpu)
+	prometheus.MustRegister(memory)
+	prometheus.MustRegister(uptime)
+	prometheus.MustRegister(usedSpace)
+	prometheus.MustRegister(usedInodes)
+
+	ctx := meta.Background
+	for {
+		var totalSpace, availSpace, iused, iavail uint64
+		err := m.StatFS(ctx, &totalSpace, &availSpace, &iused, &iavail)
+		if err == 0 {
+			usedSpace.Set(float64(totalSpace - availSpace))
+			usedInodes.Set(float64(iused))
+		}
+		time.Sleep(time.Second * 10)
+	}
+}

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -74,6 +74,7 @@ func ReportUsage(m meta.Meta, version string) {
 		u.VolumeID = format.UUID
 	}
 	u.SessionID = int64(rand.Uint32())
+	println("sessionid", u.SessionID)
 	u.Version = version
 	var start = time.Now()
 	for {

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -74,7 +74,6 @@ func ReportUsage(m meta.Meta, version string) {
 		u.VolumeID = format.UUID
 	}
 	u.SessionID = int64(rand.Uint32())
-	println("sessionid", u.SessionID)
 	u.Version = version
 	var start = time.Now()
 	for {

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -289,7 +289,9 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 			go func() {
 				for {
 					time.Sleep(interval)
-					pusher.Push()
+					if err := pusher.Push(); err != nil {
+						logger.Warnf("push metrics to %s: %s", jConf.PushGateway, err)
+					}
 				}
 			}()
 			meta.InitMetrics()
@@ -418,7 +420,9 @@ func jfs_term(pid int, h uintptr) int {
 		}
 	}
 	if pusher != nil {
-		pusher.Push()
+		if err := pusher.Push(); err != nil {
+			logger.Warnf("push metrics: %s", err)
+		}
 	}
 	return 0
 }

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -327,6 +327,9 @@ public class JuiceFileSystemImpl extends FileSystem {
     obj.put("putTimeout", Integer.valueOf(getConf(conf, "put-timeout", getConf(conf, "object-timeout", "60"))));
     obj.put("memorySize", Integer.valueOf(getConf(conf, "memory-size", "300")));
     obj.put("readahead", Integer.valueOf(getConf(conf, "max-readahead", "0")));
+    obj.put("pushGateway", getConf(conf, "push-gateway", ""));
+    obj.put("pushInterval", Integer.valueOf(getConf(conf, "push-interval", "10")));
+    obj.put("pushAuth", getConf(conf, "push-auth", ""));
     obj.put("noUsageReport", Boolean.valueOf(getConf(conf, "no-usage-report", "false")));
     obj.put("freeSpace", getConf(conf, "free-space", ""));
     obj.put("accessLog", getConf(conf, "access-log", ""));


### PR DESCRIPTION
This PR added the configuration to enable pushing metrics to Promethous Push Gateway [1]

```
juicefs.push-gateway = host:port
juicefs.push-interval = 10
juicefs.push-auth = name:password
```

Since the Push Gateway will not forget any pushed serials, they should be wiped periodically (for example, every hour), otherwise there will be too many serials in Promethous.

[1] https://github.com/prometheus/pushgateway

Closes #312 