### PR TITLE
Speed up SetAttr

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -840,6 +840,7 @@ func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode u
 			changed = true
 		}
 		if !changed {
+			*attr = cur
 			return nil
 		}
 		cur.Ctime = now.Unix()

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -803,7 +803,7 @@ func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode u
 			cur.Uid = attr.Uid
 			changed = true
 		}
-		if set&SetAttrGID != 0 && cur.Uid != attr.Uid {
+		if set&SetAttrGID != 0 && cur.Gid != attr.Gid {
 			cur.Gid = attr.Gid
 			changed = true
 		}

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -122,7 +122,9 @@ func setattrStr(set int, mode, uid, gid uint32, atime, mtime int64, size uint64)
 	} else if set&meta.SetAttrAtime != 0 {
 		atimeStr = strconv.FormatInt(atime, 10)
 	}
-	sb.WriteString("atime=" + atimeStr + ";")
+	if atimeStr != "" {
+		sb.WriteString("atime=" + atimeStr + ";")
+	}
 
 	var mtimeStr string
 	if (set&meta.SetAttrMtime) != 0 && mtime < 0 {
@@ -130,7 +132,9 @@ func setattrStr(set int, mode, uid, gid uint32, atime, mtime int64, size uint64)
 	} else if set&meta.SetAttrMtime != 0 {
 		mtimeStr = strconv.FormatInt(mtime, 10)
 	}
-	sb.WriteString("mtime=" + mtimeStr + ";")
+	if mtimeStr != "" {
+		sb.WriteString("mtime=" + mtimeStr + ";")
+	}
 
 	if (set & meta.SetAttrSize) != 0 {
 		sizeStr := strconv.FormatUint(size, 10)


### PR DESCRIPTION
For setattr, if there is nothing actually changed, we don't to update the attribute in Redis to save a RPC call.

For a directory with 44K files, this PR could decrease the time of `chown -R` from 18 seconds to 14 seconds.