### PR TITLE
store blocks into multiple bucket

### DIFF
--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -69,6 +69,9 @@ size of block in KiB (default: 4096)
 `--compress value`\
 compression algorithm (lz4, zstd, none) (default: "none")
 
+`--shards value`\
+store the blocks into N buckets by hash of key (default: 0)
+
 `--storage value`\
 Object storage type (e.g. s3, gcs, oss, cos) (default: "file")
 

--- a/go.sum
+++ b/go.sum
@@ -355,7 +355,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236 h1:py4S1ZTRfz5hIvrhu83YSw7t0Z621+VrmmZBqSkQn5c=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236/go.mod h1:dlxKkLh3qAIPtgr2U/RVzsZJDuXA1ffg+Njikfmhvgw=
-github.com/juicedata/juicesync v0.7.0 h1:6Twooa5VNi39gfGfmuZwZCztkReLlSSZIET57bpJSh8=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4 h1:/Klbj2LgJnqWrVfK2RtsqNQm649uXi2diLc/2X3eis4=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4/go.mod h1:pQt7BggRNk3m4ZLGmtZ8ShrWe70RvyeXsHljoapikM0=
 github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236 h1:py4S1ZTRfz5hIvrhu83YSw7t0Z621+VrmmZBqSkQn5c=
 github.com/juicedata/godaemon v0.0.0-20210118074000-659b6681b236/go.mod h1:dlxKkLh3qAIPtgr2U/RVzsZJDuXA1ffg+Njikfmhvgw=
+github.com/juicedata/juicesync v0.7.0 h1:6Twooa5VNi39gfGfmuZwZCztkReLlSSZIET57bpJSh8=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4 h1:/Klbj2LgJnqWrVfK2RtsqNQm649uXi2diLc/2X3eis4=
 github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4/go.mod h1:pQt7BggRNk3m4ZLGmtZ8ShrWe70RvyeXsHljoapikM0=
 github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -30,6 +30,7 @@ type Format struct {
 	SecretKey   string
 	BlockSize   int
 	Compression string
+	Shards      int
 	Partitions  int
 	EncryptKey  string
 }

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -454,6 +454,6 @@ func TestMarsharl(t *testing.T) {
 }
 
 func TestSharding(t *testing.T) {
-	s, _ := NewSharded("mem", "", "", "", 10)
+	s, _ := NewSharded("mem", "%d", "", "", 10)
 	testStorage(t, s)
 }

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -452,3 +452,8 @@ func TestMarsharl(t *testing.T) {
 		t.Fatalf("%+v != %+v", o2, o)
 	}
 }
+
+func TestSharding(t *testing.T) {
+	s, _ := NewSharded("mem", "", "", "", 10)
+	testStorage(t, s)
+}

--- a/pkg/object/sharding.go
+++ b/pkg/object/sharding.go
@@ -43,7 +43,7 @@ func (s *sharded) Create() error {
 
 func (s *sharded) pick(key string) ObjectStorage {
 	h := fnv.New32a()
-	h.Write([]byte(key))
+	_, _ = h.Write([]byte(key))
 	i := h.Sum32() % uint32(len(s.stores))
 	return s.stores[i]
 }

--- a/pkg/object/sharding.go
+++ b/pkg/object/sharding.go
@@ -1,0 +1,198 @@
+/*
+ * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package object
+
+import (
+	"container/heap"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"time"
+)
+
+type sharded struct {
+	DefaultObjectStorage
+	stores []ObjectStorage
+}
+
+func (s *sharded) String() string {
+	return fmt.Sprintf("shard%d://%s", len(s.stores), s.stores[0])
+}
+
+func (s *sharded) Create() error {
+	for _, o := range s.stores {
+		if err := o.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *sharded) pick(key string) ObjectStorage {
+	h := fnv.New32a()
+	h.Write([]byte(key))
+	i := h.Sum32() % uint32(len(s.stores))
+	return s.stores[i]
+}
+
+func (s *sharded) Head(key string) (Object, error) {
+	return s.pick(key).Head(key)
+}
+
+func (s *sharded) Get(key string, off, limit int64) (io.ReadCloser, error) {
+	return s.pick(key).Get(key, off, limit)
+}
+
+func (s *sharded) Put(key string, body io.Reader) error {
+	return s.pick(key).Put(key, body)
+}
+
+func (s *sharded) Delete(key string) error {
+	return s.pick(key).Delete(key)
+}
+
+const maxResults = 10000
+
+// ListAll on all the keys that starts at marker from object storage.
+func ListAll(store ObjectStorage, prefix, marker string) (<-chan Object, error) {
+	if ch, err := store.ListAll(prefix, marker); err == nil {
+		return ch, nil
+	}
+
+	startTime := time.Now()
+	out := make(chan Object, maxResults)
+	logger.Debugf("Listing objects from %s marker %q", store, marker)
+	objs, err := store.List("", marker, maxResults)
+	if err != nil {
+		logger.Errorf("Can't list %s: %s", store, err.Error())
+		return nil, err
+	}
+	logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Since(startTime))
+	go func() {
+		lastkey := ""
+		first := true
+	END:
+		for len(objs) > 0 {
+			for _, obj := range objs {
+				key := obj.Key()
+				if !first && key <= lastkey {
+					logger.Fatalf("The keys are out of order: marker %q, last %q current %q", marker, lastkey, key)
+				}
+				lastkey = key
+				// logger.Debugf("found key: %s", key)
+				out <- obj
+				first = false
+			}
+			// Corner case: the func parameter `marker` is an empty string("") and exactly
+			// one object which key is an empty string("") returned by the List() method.
+			if lastkey == "" {
+				break END
+			}
+
+			marker = lastkey
+			startTime = time.Now()
+			logger.Debugf("Continue listing objects from %s marker %q", store, marker)
+			objs, err = store.List(prefix, marker, maxResults)
+			for err != nil {
+				logger.Warnf("Fail to list: %s, retry again", err.Error())
+				// slow down
+				time.Sleep(time.Millisecond * 100)
+				objs, err = store.List(prefix, marker, maxResults)
+			}
+			logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Since(startTime))
+		}
+		close(out)
+	}()
+	return out, nil
+}
+
+type nextKey struct {
+	o  Object
+	ch <-chan Object
+}
+
+type nextObjects struct {
+	os []nextKey
+}
+
+func (s *nextObjects) Len() int           { return len(s.os) }
+func (s *nextObjects) Less(i, j int) bool { return s.os[i].o.Key() < s.os[j].o.Key() }
+func (s *nextObjects) Swap(i, j int)      { s.os[i], s.os[j] = s.os[j], s.os[i] }
+func (s *nextObjects) Push(o interface{}) { s.os = append(s.os, o.(nextKey)) }
+func (s *nextObjects) Pop() interface{} {
+	o := s.os[len(s.os)-1]
+	s.os = s.os[:len(s.os)-1]
+	return o
+}
+
+func (s *sharded) ListAll(prefix, marker string) (<-chan Object, error) {
+	heads := &nextObjects{make([]nextKey, 0)}
+	for i := range s.stores {
+		ch, err := ListAll(s.stores[i], prefix, marker)
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %s", s.stores[i], err)
+		}
+		if err == nil {
+			first := <-ch
+			if first != nil {
+				heads.Push(nextKey{first, ch})
+			}
+		}
+	}
+	heap.Init(heads)
+
+	out := make(chan Object, 1000)
+	go func() {
+		for heads.Len() > 0 {
+			n := heap.Pop(heads).(nextKey)
+			out <- n.o
+			o := <-n.ch
+			if o != nil {
+				heap.Push(heads, nextKey{o, n.ch})
+			}
+		}
+		close(out)
+	}()
+	return out, nil
+}
+
+func (s *sharded) CreateMultipartUpload(key string) (*MultipartUpload, error) {
+	return s.pick(key).CreateMultipartUpload(key)
+}
+
+func (s *sharded) UploadPart(key string, uploadID string, num int, body []byte) (*Part, error) {
+	return s.pick(key).UploadPart(key, uploadID, num, body)
+}
+
+func (s *sharded) AbortUpload(key string, uploadID string) {
+	s.pick(key).AbortUpload(key, uploadID)
+}
+
+func (s *sharded) CompleteUpload(key string, uploadID string, parts []*Part) error {
+	return s.pick(key).CompleteUpload(key, uploadID, parts)
+}
+
+func NewSharded(name, endpoint, ak, sk string, shards int) (ObjectStorage, error) {
+	stores := make([]ObjectStorage, shards)
+	var err error
+	for i := range stores {
+		stores[i], err = CreateStorage(name, fmt.Sprintf(endpoint, i), ak, sk)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &sharded{stores: stores}, nil
+}

--- a/pkg/object/sharding.go
+++ b/pkg/object/sharding.go
@@ -146,11 +146,9 @@ func (s *sharded) ListAll(prefix, marker string) (<-chan Object, error) {
 		if err != nil {
 			return nil, fmt.Errorf("list %s: %s", s.stores[i], err)
 		}
-		if err == nil {
-			first := <-ch
-			if first != nil {
-				heads.Push(nextKey{first, ch})
-			}
+		first := <-ch
+		if first != nil {
+			heads.Push(nextKey{first, ch})
 		}
 	}
 	heap.Init(heads)

--- a/pkg/object/sharding.go
+++ b/pkg/object/sharding.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -189,7 +190,11 @@ func NewSharded(name, endpoint, ak, sk string, shards int) (ObjectStorage, error
 	stores := make([]ObjectStorage, shards)
 	var err error
 	for i := range stores {
-		stores[i], err = CreateStorage(name, fmt.Sprintf(endpoint, i), ak, sk)
+		ep := fmt.Sprintf(endpoint, i)
+		if strings.HasSuffix(ep, "%!(EXTRA int=0)") {
+			return nil, fmt.Errorf("can not generate different endpoint using %s", endpoint)
+		}
+		stores[i], err = CreateStorage(name, ep, ak, sk)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -214,7 +214,13 @@ func getOrCreate(name, user, group, superuser, supergroup string, f func() *fs.F
 }
 
 func createStorage(format *meta.Format) (object.ObjectStorage, error) {
-	blob, err := object.CreateStorage(strings.ToLower(format.Storage), format.Bucket, format.AccessKey, format.SecretKey)
+	var blob object.ObjectStorage
+	var err error
+	if format.Shards > 1 {
+		blob, err = object.NewSharded(strings.ToLower(format.Storage), format.Bucket, format.AccessKey, format.SecretKey, format.Shards)
+	} else {
+		blob, err = object.CreateStorage(strings.ToLower(format.Storage), format.Bucket, format.AccessKey, format.SecretKey)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To enable this, a volume should be formatted with `--shards  N` and `--bucket TEMPLATE`, N means the number of buckets and TEMPLATE is used to generated different bucket names, for example, `test%d`.

Then all the blocks will be stored into different buckets based on the hash of object keys.