### PR TITLE
show internal metrics at end of benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,25 @@ Besides the things covered by pjdfstest, JuiceFS provides:
 
 ## Performance Benchmark
 
+### Basic benchmark
+
+JuiceFS provides a subcommand to run a few basic benchmarks to understand how it works in your enviroment:
+
+```bash
+$ ./juicefs bench /jfs
+Written a big file (1024.00 MiB): (113.67 MiB/s)
+Read a big file (1024.00 MiB): (127.12 MiB/s)
+Written 100 small files (102.40 KiB): 151.7 files/s, 6.6 ms for each file
+Read 100 small files (102.40 KiB): 692.1 files/s, 1.4 ms for each file
+Stated 100 files: 584.2 files/s, 1.7 ms for each file
+FUSE operation: 19333, avg: 0.3 ms
+Update meta: 436, avg: 1.4 ms
+Put object: 356, avg: 4.8 ms
+Get object first byte: 308, avg: 0.2 ms
+Delete object: 356, avg: 0.2 ms
+Used: 23.4s, CPU: 69.1%, MEM: 147.0 MiB
+```
+
 ### Throughput
 
 Performed a sequential read/write benchmark on JuiceFS, [EFS](https://aws.amazon.com/efs) and [S3FS](https://github.com/s3fs-fuse/s3fs-fuse) by [fio](https://github.com/axboe/fio), here is the result:

--- a/README_CN.md
+++ b/README_CN.md
@@ -146,6 +146,25 @@ Result: PASS
 
 ## 性能测试
 
+### 基础性能测试
+
+JuiceFS 提供一个性能测试的子命令来帮助你了解它在你的环境中的性能表现：
+
+```bash
+$ ./juicefs bench /jfs
+Written a big file (1024.00 MiB): (113.67 MiB/s)
+Read a big file (1024.00 MiB): (127.12 MiB/s)
+Written 100 small files (102.40 KiB): 151.7 files/s, 6.6 ms for each file
+Read 100 small files (102.40 KiB): 692.1 files/s, 1.4 ms for each file
+Stated 100 files: 584.2 files/s, 1.7 ms for each file
+FUSE operation: 19333, avg: 0.3 ms
+Update meta: 436, avg: 1.4 ms
+Put object: 356, avg: 4.8 ms
+Get object first byte: 308, avg: 0.2 ms
+Delete object: 356, avg: 0.2 ms
+Used: 23.4s, CPU: 69.1%, MEM: 147.0 MiB
+```
+
 ### 顺序读写性能
 
 使用 [fio](https://github.com/axboe/fio) 测试了 JuiceFS、[EFS](https://aws.amazon.com/efs) 和 [S3FS](https://github.com/s3fs-fuse/s3fs-fuse) 的顺序读写性能，结果如下：

--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -332,7 +332,7 @@ juicefs info [command options] PATH or INODE
 use inode instead of path (current dir should be inside JuiceFS) (default: false)
 
 
-## juicefs benchmark
+## juicefs bench
 
 ### Description
 
@@ -341,24 +341,21 @@ Run benchmark, include read/write/stat big and small files.
 ### Synopsis
 
 ```
-juicefs benchmark [options] DIR
+juicefs bench [options] [PATH]
 ```
 
 ### Options
 
-`--dest value`\
-path to run benchmark (default: `"/jfs/benchmark"`)
-
 `--block-size value`\
 block size in MiB (default: 1)
 
-`--bigfile-file-size value`\
+`--big-file-size value`\
 size of big file in MiB (default: 1024)
 
-`--smallfile-file-size value`\
+`--small-file-size value`\
 size of small file in MiB (default: 0.1)
 
-`--smallfile-count value`\
+`--small-file-count value`\
 number of small files (default: 100)
 
 ## juicefs gc

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -121,14 +121,20 @@ func collectMetrics() []byte {
 	}
 	for _, mf := range mfs {
 		for _, m := range mf.Metric {
+			var name string = *mf.Name
+			for _, l := range m.Label {
+				if *l.Name != "mp" && *l.Name != "vol_name" {
+					name += "_" + *l.Value
+				}
+			}
 			switch *mf.Type {
 			case io_prometheus_client.MetricType_GAUGE:
-				_, _ = fmt.Fprintf(w, "%s %s\n", *mf.Name, format(*m.Gauge.Value))
+				_, _ = fmt.Fprintf(w, "%s %s\n", name, format(*m.Gauge.Value))
 			case io_prometheus_client.MetricType_COUNTER:
-				_, _ = fmt.Fprintf(w, "%s %s\n", *mf.Name, format(*m.Counter.Value))
+				_, _ = fmt.Fprintf(w, "%s %s\n", name, format(*m.Counter.Value))
 			case io_prometheus_client.MetricType_HISTOGRAM:
-				_, _ = fmt.Fprintf(w, "%s_total %d\n", *mf.Name, *m.Histogram.SampleCount)
-				_, _ = fmt.Fprintf(w, "%s_sum %s\n", *mf.Name, format(*m.Histogram.SampleSum))
+				_, _ = fmt.Fprintf(w, "%s_total %d\n", name, *m.Histogram.SampleCount)
+				_, _ = fmt.Fprintf(w, "%s_sum %s\n", name, format(*m.Histogram.SampleSum))
 			case io_prometheus_client.MetricType_SUMMARY:
 			}
 		}


### PR DESCRIPTION
This Added the following metrics at the end of benchmark:

```
FUSE operation: 19333, avg: 0.3 ms
Update meta: 436, avg: 1.4 ms
Put object: 356, avg: 4.8 ms
Get object first byte: 308, avg: 0.2 ms
Delete object: 356, avg: 0.2 ms
Used: 23.4s, CPU: 69.1%, MEM: 147.0 MiB
```

close #315