### PR TITLE
Add more logs and upgrade log level in `disk_cache.go`

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -414,7 +414,7 @@ func (cache *cacheStore) scanStaging() map[string]string {
 
 	stagingBlocks := make(map[string]string)
 	stagingPrefix := filepath.Join(cache.dir, stagingDir)
-	logger.Infof("Scan %s to find staging blocks", stagingPrefix)
+	logger.Debugf("Scan %s to find staging blocks", stagingPrefix)
 	_ = filepath.Walk(stagingPrefix, func(path string, fi os.FileInfo, err error) error {
 		if fi != nil {
 			if fi.IsDir() || strings.HasSuffix(path, ".tmp") {
@@ -436,7 +436,7 @@ func (cache *cacheStore) scanStaging() map[string]string {
 		return nil
 	})
 	if len(stagingBlocks) > 0 {
-		logger.Infof("Found %d staging blocks (%d bytes) in %s with %s", len(stagingBlocks), cache.used, cache.dir, time.Since(start))
+		logger.Debugf("Found %d staging blocks (%d bytes) in %s with %s", len(stagingBlocks), cache.used, cache.dir, time.Since(start))
 	}
 	return stagingBlocks
 }

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -436,7 +436,7 @@ func (cache *cacheStore) scanStaging() map[string]string {
 		return nil
 	})
 	if len(stagingBlocks) > 0 {
-		logger.Debugf("Found %d staging blocks (%d bytes) in %s with %s", len(stagingBlocks), cache.used, cache.dir, time.Since(start))
+		logger.Infof("Found %d staging blocks (%d bytes) in %s with %s", len(stagingBlocks), cache.used, cache.dir, time.Since(start))
 	}
 	return stagingBlocks
 }

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -21,6 +21,13 @@ import (
 	"time"
 )
 
+func TestNewCacheStore(t *testing.T) {
+	s := newCacheStore("/tmp/diskCache", 1<<30, 1<<10, 1, &defaultConf)
+	if s == nil {
+		t.Fatalf("Create new cache store failed")
+	}
+}
+
 func TestExpand(t *testing.T) {
 	rs := expandDir("/not/exists/jfsCache")
 	if len(rs) != 1 || rs[0] != "/not/exists/jfsCache" {


### PR DESCRIPTION
- Add cache directory path to every log of `cacheStore` to help distinguish different directory when use multiple cache directories
- Add log before execute `cacheStore.cleanup()` to know more context
- Upgrade some logs level (INFO → WARNING)