### PR TITLE
Use SQL database as meta store

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -291,7 +291,7 @@ func benchmark(c *cli.Context) error {
 				st(name+"_sum")/st(name+"_total")*1000)
 		}
 		show("FUSE operation", "fuse_ops_durations_histogram_seconds")
-		show("Update meta", "redis_tx_durations_histogram_seconds")
+		show("Update meta", "transaction_durations_histogram_seconds")
 		show("Put object", "object_request_durations_histogram_seconds_PUT")
 		show("Get object first byte", "object_request_durations_histogram_seconds_GET")
 		show("Delete object", "object_request_durations_histogram_seconds_DELETE")

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -143,16 +143,7 @@ func format(c *cli.Context) error {
 	if c.Args().Len() < 1 {
 		logger.Fatalf("Redis URL and name are required")
 	}
-	addr := c.Args().Get(0)
-	if !strings.Contains(addr, "://") {
-		addr = "redis://" + addr
-	}
-	logger.Infof("Meta address: %s", addr)
-	var rc = meta.RedisConfig{Retries: 2}
-	m, err := meta.NewRedisMeta(addr, &rc)
-	if err != nil {
-		logger.Fatalf("Meta is not available: %s", err)
-	}
+	m := meta.NewClient(c.Args().Get(0), &meta.Config{Retries: 2})
 
 	if c.Args().Len() < 2 {
 		logger.Fatalf("Please give it a name")

--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -41,17 +41,7 @@ func fsck(ctx *cli.Context) error {
 	if ctx.Args().Len() < 1 {
 		return fmt.Errorf("REDIS-URL is needed")
 	}
-	addr := ctx.Args().Get(0)
-	if !strings.Contains(addr, "://") {
-		addr = "redis://" + addr
-	}
-
-	logger.Infof("Meta address: %s", addr)
-	var rc = meta.RedisConfig{Retries: 10, Strict: true}
-	m, err := meta.NewRedisMeta(addr, &rc)
-	if err != nil {
-		logger.Fatalf("Meta: %s", err)
-	}
+	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
 	format, err := m.Load()
 	if err != nil {
 		logger.Fatalf("load setting: %s", err)

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -141,16 +141,11 @@ func (g *GateWay) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, er
 	mctx = meta.NewContext(uint32(os.Getpid()), uint32(os.Getuid()), []uint32{uint32(os.Getgid())})
 
 	c := g.ctx
-	redisAddr := c.Args().Get(0)
-	if !strings.Contains(redisAddr, "://") {
-		redisAddr = "redis://" + redisAddr
-	}
-	logger.Infof("Meta address: %s", redisAddr)
-	var rc = meta.RedisConfig{Retries: 10, Strict: true}
-	m, err := meta.NewRedisMeta(redisAddr, &rc)
-	if err != nil {
-		logger.Fatalf("Meta: %s", err)
-	}
+	addr := c.Args().Get(0)
+	m := meta.NewClient(addr, &meta.Config{
+		Retries: 10,
+		Strict:  true,
+	})
 	format, err := m.Load()
 	if err != nil {
 		logger.Fatalf("load setting: %s", err)
@@ -206,7 +201,7 @@ func (g *GateWay) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, er
 
 	conf := &vfs.Config{
 		Meta: &meta.Config{
-			IORetries: 10,
+			Retries: 10,
 		},
 		Format:    format,
 		Version:   version.Version(),

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -106,17 +106,7 @@ func gc(ctx *cli.Context) error {
 	if ctx.Args().Len() < 1 {
 		return fmt.Errorf("REDIS-URL is needed")
 	}
-	addr := ctx.Args().Get(0)
-	if !strings.Contains(addr, "://") {
-		addr = "redis://" + addr
-	}
-
-	logger.Infof("Meta address: %s", addr)
-	var rc = meta.RedisConfig{Retries: 10, Strict: true}
-	m, err := meta.NewRedisMeta(addr, &rc)
-	if err != nil {
-		logger.Fatalf("Meta: %s", err)
-	}
+	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
 	format, err := m.Load()
 	if err != nil {
 		logger.Fatalf("load setting: %s", err)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -18,7 +18,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/urfave/cli/v2"
@@ -29,17 +28,7 @@ func status(ctx *cli.Context) error {
 	if ctx.Args().Len() < 1 {
 		return fmt.Errorf("REDIS-URL is needed")
 	}
-	addr := ctx.Args().Get(0)
-	if !strings.Contains(addr, "://") {
-		addr = "redis://" + addr
-	}
-
-	logger.Infof("Meta address: %s", addr)
-	var rc = meta.RedisConfig{Retries: 10, Strict: true}
-	m, err := meta.NewRedisMeta(addr, &rc)
-	if err != nil {
-		logger.Fatalf("Meta: %s", err)
-	}
+	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
 	format, err := m.Load()
 	if err != nil {
 		logger.Fatalf("load setting: %s", err)

--- a/docs/en/k8s_grafana_template.json
+++ b/docs/en/k8s_grafana_template.json
@@ -685,7 +685,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(juicefs_redis_tx_durations_histogram_seconds_count{vol_name=\"$name\"}[1m])) by  (node)",
+          "expr": "sum(rate(juicefs_transaction_durations_histogram_seconds_count{vol_name=\"$name\"}[1m])) by  (node)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -697,7 +697,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Redis Transcations",
+      "title": "Transcations",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -783,7 +783,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(juicefs_redis_tx_durations_histogram_seconds_sum{vol_name=\"$name\"}[1m])) by  (node,mp) * 1000000 / sum(rate(juicefs_redis_tx_durations_histogram_seconds_count{vol_name=\"$name\"}[1m])) by  (node,mp)",
+          "expr": "sum(rate(juicefs_transaction_durations_histogram_seconds_sum{vol_name=\"$name\"}[1m])) by  (node,mp) * 1000000 / sum(rate(juicefs_transaction_durations_histogram_seconds_count{vol_name=\"$name\"}[1m])) by  (node,mp)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -795,7 +795,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Redis Transcation Latency",
+      "title": "Transcation Latency",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -869,7 +869,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(juicefs_redis_transaction_restart{vol_name=~\"$name\"}[1m])) by (node)",
+          "expr": "sum(rate(juicefs_transaction_restart{vol_name=~\"$name\"}[1m])) by (node)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Restarts {{node}}",
@@ -879,7 +879,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Redis Transaction Restarts",
+      "title": "Transaction Restarts",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/colinmarc/hdfs/v2 v2.2.0
 	github.com/go-ini/ini v1.62.0 // indirect
 	github.com/go-redis/redis/v8 v8.4.0
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gonutz/w32/v2 v2.2.0
 	github.com/google/gops v0.3.13
 	github.com/google/uuid v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ks3sdklib/aws-sdk-go v0.0.0-20180820074416-dafab05ad142
 	github.com/kurin/blazer v0.2.1
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c
 	github.com/minio/minio-go v6.0.14+incompatible

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	google.golang.org/api v0.5.0
+	xorm.io/xorm v1.0.7
 )
 
 replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20210222051636-e7cabdf948f4

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/QA=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.39.0 h1:UgQP9na6OTfp4dsAiz/eFpFA1C6tPdH5wiRdi19tuMw=
 cloud.google.com/go v0.39.0/go.mod h1:rVLT6fkc8chs9sfPtFc1SBH6em7n+ZoXaG+87tDISts=
 git.apache.org/thrift.git v0.13.0 h1:/3bz5WZ+sqYArk7MBBBbDufMxKKOA56/6JO6psDpUDY=
 git.apache.org/thrift.git v0.13.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a/go.mod h1:EXuID2Zs0pAQhH8yz+DNjUbjppKQzKFAn28TMYPB6IU=
 github.com/Arvintian/scs-go-sdk v1.0.0 h1:2Hll7bcEc8co8v5/2Ibzo410fW4QnTnhkq1NOASd8vc=
 github.com/Arvintian/scs-go-sdk v1.0.0/go.mod h1:DMIkwn27iuTIo9o7INj3L/bcA7bW6QwljWC3ZpxjkXw=
 github.com/Arvintian/scs-go-sdk v1.1.0 h1:vqVOfoMD6XSr7eG1a2M9oSiQwhDZYKKdH2rrZRPx6So=
@@ -50,6 +51,7 @@ github.com/IBM/ibm-cos-sdk-go v1.6.0/go.mod h1:Pa7XzoyngeWPnqGol8ZF+gwUeLEAyDHkk
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20171031020902-cc8892cb2b05 h1:NEPjpPSOSDDmnix+VANw/CfUs1fAorLIaz/IFz2eQ2o=
 github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20171031020902-cc8892cb2b05/go.mod h1:0N5CbwYI/8V1T6YOEwkgMvLmiGDNn661vLutBZQrC2c=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.27.2/go.mod h1:g5s5osgELxgM+Md9Qni9rzo7Rbt+vvFQI4bt/Mc93II=
@@ -67,6 +69,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/aliyun-oss-go-sdk v2.1.0+incompatible h1:90Z2Cp7EqcbaYfVwVjmQoK8kgoFPz+doQlujcwe1BRg=
 github.com/aliyun/aliyun-oss-go-sdk v2.1.0+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -128,6 +131,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/siphash v1.2.1 h1:4cLinnzVJDKxTCl9B01807Yiy+W7ZzVHj/KIroQRvT4=
 github.com/dchest/siphash v1.2.1/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
+github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
@@ -197,6 +201,7 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
@@ -395,6 +400,7 @@ github.com/ks3sdklib/aws-sdk-go v0.0.0-20180820074416-dafab05ad142/go.mod h1:WKP
 github.com/kurin/blazer v0.2.1 h1:lUhpcdTHl3foU5IcjgzM5Hbv9hQX7ce7PugSGIi+ztU=
 github.com/kurin/blazer v0.2.1/go.mod h1:4FCXMUWo9DllR2Do4TtBd377ezyAJ51vB5uTBjt0pGU=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
@@ -418,6 +424,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -632,6 +639,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
+github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.8 h1:BeqN3uNCyYgoujWqZDbpQMhNmPf5xIypjzbT2AMMZUs=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.8/go.mod h1:wQBO5HdAkLjj2q6XQiIfDSP8DXDNrppDRw2Kp/1BODA=
 github.com/tidwall/gjson v1.6.7 h1:Mb1M9HZCRWEcXQ8ieJo7auYyyiSux6w9XN3AdTpxJrE=
@@ -673,6 +682,7 @@ github.com/xlab/treeprint v1.0.0/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cim
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yunify/qingstor-sdk-go v2.2.15+incompatible h1:/Z0q3/eSMoPYAuRmhjWtuGSmVVciFC6hfm3yfCKuvz0=
 github.com/yunify/qingstor-sdk-go v2.2.15+incompatible/go.mod h1:w6wqLDQ5bBTzxGJ55581UrSwLrsTAsdo9N6yX/8d9RY=
+github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -700,6 +710,7 @@ golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff/go.mod h1:flIaEI6LNU6xOCD5P
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -726,6 +737,7 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -927,3 +939,7 @@ rsc.io/goversion v1.2.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
+xorm.io/builder v0.3.7 h1:2pETdKRK+2QG4mLX4oODHEhn5Z8j1m8sXa7jfu+/SZI=
+xorm.io/builder v0.3.7/go.mod h1:aUW0S9eb9VCaPohFCH3j7czOx1PMW3i1HrSzbLYGBSE=
+xorm.io/xorm v1.0.7 h1:26yBTDVI+CfQpVz2Y88fISh+aiJXIPP4eNoTJlwzsC4=
+xorm.io/xorm v1.0.7/go.mod h1:uF9EtbhODq5kNWxMbnBEj8hRRZnlcNSz2t2N7HW/+A4=

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -352,7 +352,7 @@ func (fs *FileSystem) Rmr(ctx meta.Context, p string) (err syscall.Errno) {
 	if err != 0 {
 		return
 	}
-	err = fs.m.Rmr(ctx, parent.inode, path.Base(p))
+	err = meta.Remove(fs.m, ctx, parent.inode, path.Base(p))
 	return
 }
 
@@ -929,6 +929,6 @@ func (f *File) Summary(ctx meta.Context, depth uint8, maxentries uint32) (s *met
 		f.fs.log(l, "Summary (%s): %s (%d,%d,%d,%d)", f.path, errstr(err), s.Length, s.Size, s.Files, s.Dirs)
 	}()
 	s = &meta.Summary{}
-	err = f.fs.m.Summary(ctx, f.inode, s)
+	err = meta.GetSummary(f.fs.m, ctx, f.inode, s)
 	return
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -25,7 +25,7 @@ import (
 
 // nolint:errcheck
 func TestFileSystem(t *testing.T) {
-	m, err := meta.NewRedisMeta("redis://127.0.0.1:6379/10", &meta.RedisConfig{})
+	m, err := meta.newRedisMeta("redis://127.0.0.1:6379/10", &meta.RedisConfig{})
 	if err != nil {
 		t.Logf("redis is not available: %s", err)
 		t.Skip()

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -25,11 +25,7 @@ import (
 
 // nolint:errcheck
 func TestFileSystem(t *testing.T) {
-	m, err := meta.newRedisMeta("redis://127.0.0.1:6379/10", &meta.RedisConfig{})
-	if err != nil {
-		t.Logf("redis is not available: %s", err)
-		t.Skip()
-	}
+	m := meta.NewClient("redis://127.0.0.1:6379/10", &meta.Config{})
 	format := meta.Format{
 		Name:      "test",
 		BlockSize: 4096,

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -15,11 +15,12 @@
 
 package meta
 
-// type Config struct {
-// 	Addr      string
-// 	Password  string
-// 	IORetries int
-// }
+// Config for clients.
+type Config struct {
+	Strict      bool // update ctime
+	Retries     int
+	CaseInsensi bool
+}
 
 type Format struct {
 	Name        string

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -15,11 +15,11 @@
 
 package meta
 
-type Config struct {
-	Addr      string
-	Password  string
-	IORetries int
-}
+// type Config struct {
+// 	Addr      string
+// 	Password  string
+// 	IORetries int
+// }
 
 type Format struct {
 	Name        string

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -213,12 +213,7 @@ type Meta interface {
 	OnMsg(mtype uint32, cb MsgCallback)
 }
 
-type Config struct {
-	Strict      bool // update ctime
-	Retries     int
-	CaseInsensi bool
-}
-
+// NewClient creates a Meta client for given uri.
 func NewClient(uri string, conf *Config) Meta {
 	if !strings.Contains(uri, "://") {
 		uri = "redis://" + uri

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -203,11 +203,6 @@ type Meta interface {
 	// Setlk sets a file range lock on given file.
 	Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype uint32, start, end uint64, pid uint32) syscall.Errno
 
-	// Summary returns the summary for given file or directory.
-	Summary(ctx Context, inode Ino, summary *Summary) syscall.Errno
-	// Rmr remove all the files and directories recursively.
-	Rmr(ctx Context, inode Ino, name string) syscall.Errno
-
 	// Compact all the chunks by merge small slices together
 	CompactAll(ctx Context) syscall.Errno
 	// ListSlices returns all slices used by all files.

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -79,16 +79,9 @@ local ino = struct.unpack(">I8", string.sub(buf, 2))
 return {ino, redis.call('GET', "i" .. tostring(ino))}
 `
 
-// RedisConfig is config for Redis client.
-type RedisConfig struct {
-	Strict      bool // update ctime
-	Retries     int
-	CaseInsensi bool
-}
-
 type redisMeta struct {
 	sync.Mutex
-	conf    *RedisConfig
+	conf    *Config
 	rdb     *redis.Client
 	txlocks [1024]sync.Mutex // Pessimistic locks to reduce conflict on Redis
 
@@ -110,8 +103,8 @@ type msgCallbacks struct {
 	callbacks map[uint32]MsgCallback
 }
 
-// NewRedisMeta return a meta store using Redis.
-func NewRedisMeta(url string, conf *RedisConfig) (Meta, error) {
+// newRedisMeta return a meta store using Redis.
+func newRedisMeta(url string, conf *Config) (Meta, error) {
 	opt, err := redis.ParseURL(url)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %s", url, err)

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -597,6 +597,7 @@ func errno(err error) syscall.Errno {
 	if err == redis.Nil {
 		return syscall.ENOENT
 	}
+	// debug.PrintStack()
 	logger.Errorf("error: %s", err)
 	return syscall.EIO
 }

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -597,7 +598,7 @@ func errno(err error) syscall.Errno {
 	if err == redis.Nil {
 		return syscall.ENOENT
 	}
-	// debug.PrintStack()
+	debug.PrintStack()
 	logger.Errorf("error: %s", err)
 	return syscall.EIO
 }

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -598,7 +597,6 @@ func errno(err error) syscall.Errno {
 	if err == redis.Nil {
 		return syscall.ENOENT
 	}
-	debug.PrintStack()
 	logger.Errorf("error: %s", err)
 	return syscall.EIO
 }

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -533,7 +533,7 @@ func (r *redisMeta) Lookup(ctx Context, parent Ino, name string, inode *Ino, att
 	return errno(err)
 }
 
-func (r *redisMeta) accessMode(attr *Attr, uid uint32, gid uint32) uint8 {
+func accessMode(attr *Attr, uid uint32, gid uint32) uint8 {
 	if uid == 0 {
 		return 0x7
 	}
@@ -562,7 +562,7 @@ func (r *redisMeta) Access(ctx Context, inode Ino, mmask uint8, attr *Attr) sysc
 		}
 	}
 
-	mode := r.accessMode(attr, ctx.Uid(), ctx.Gid())
+	mode := accessMode(attr, ctx.Uid(), ctx.Gid())
 	if mode&mmask != mmask {
 		logger.Debugf("Access inode %d %o, mode %o, request mode %o", inode, attr.Mode, mode, mmask)
 		return syscall.EACCES

--- a/pkg/meta/redis_metrics.go
+++ b/pkg/meta/redis_metrics.go
@@ -19,7 +19,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	txDist = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "tx_durations_histogram_seconds",
+		Name:    "transaction_durations_histogram_seconds",
 		Help:    "Transactions latency distributions.",
 		Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
 	})

--- a/pkg/meta/redis_metrics.go
+++ b/pkg/meta/redis_metrics.go
@@ -18,18 +18,18 @@ package meta
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	redisTxDist = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "redis_tx_durations_histogram_seconds",
-		Help:    "Redis transactions latency distributions.",
+	txDist = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "tx_durations_histogram_seconds",
+		Help:    "Transactions latency distributions.",
 		Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
 	})
-	redisTxRestart = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "redis_transaction_restart",
-		Help: "The number of times a Redis transaction is restarted.",
+	txRestart = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "transaction_restart",
+		Help: "The number of times a transaction is restarted.",
 	})
 )
 
 func InitMetrics() {
-	prometheus.MustRegister(redisTxDist)
-	prometheus.MustRegister(redisTxRestart)
+	prometheus.MustRegister(txDist)
+	prometheus.MustRegister(txRestart)
 }

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -68,12 +68,12 @@ func BenchmarkReadSlices(b *testing.B) {
 }
 
 func TestRedisClient(t *testing.T) {
-	var conf RedisConfig
-	_, err := NewRedisMeta("http://127.0.0.1:6379/7", &conf)
+	var conf Config
+	_, err := newRedisMeta("http://127.0.0.1:6379/7", &conf)
 	if err == nil {
 		t.Fatal("meta created with invalid url")
 	}
-	m, err := NewRedisMeta("redis://127.0.0.1:6379/7", &conf)
+	m, err := newRedisMeta("redis://127.0.0.1:6379/7", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -309,8 +309,8 @@ func testMetaClient(t *testing.T, m Meta) {
 }
 
 func TestLocksRedis(t *testing.T) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1:6379/5", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1:6379/5", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -410,8 +410,8 @@ func TestLocksRedis(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1:6379/5", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1:6379/5", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -444,8 +444,8 @@ func testRemove(t *testing.T, m Meta) {
 }
 
 func TestCaseIncensi(t *testing.T) {
-	var conf = RedisConfig{CaseInsensi: true}
-	m, err := NewRedisMeta("redis://127.0.0.1:6379/6", &conf)
+	var conf = Config{CaseInsensi: true}
+	m, err := newRedisMeta("redis://127.0.0.1:6379/6", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -482,8 +482,8 @@ func testCaseIncensi(t *testing.T, m Meta) {
 }
 
 func TestCompaction(t *testing.T) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1:6379/8", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1:6379/8", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -593,8 +593,8 @@ func testCompaction(t *testing.T, m Meta) {
 }
 
 func TestConcurrentWrite(t *testing.T) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1/9", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1/9", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -618,7 +618,6 @@ func testConcurrentWrite(t *testing.T, m Meta) {
 	if st := m.Create(ctx, 1, "f", 0650, 022, &inode, attr); st != 0 {
 		t.Fatalf("create file %s", st)
 	}
-	// nolint:errcheck
 	defer m.Unlink(ctx, 1, "f")
 
 	var errno syscall.Errno
@@ -644,8 +643,8 @@ func testConcurrentWrite(t *testing.T, m Meta) {
 }
 
 func TestTruncateAndDelete(t *testing.T) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1/10", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1/10", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -703,8 +702,8 @@ func testTruncateAndDelete(t *testing.T, m Meta) {
 }
 
 func TestCopyFileRange(t *testing.T) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1/10", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1/10", &conf)
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
@@ -767,8 +766,8 @@ func testCopyFileRange(t *testing.T, m Meta) {
 }
 
 func benchmarkReaddir(b *testing.B, n int) {
-	var conf RedisConfig
-	m, err := NewRedisMeta("redis://127.0.0.1/10", &conf)
+	var conf Config
+	m, err := newRedisMeta("redis://127.0.0.1/10", &conf)
 	if err != nil {
 		b.Skipf("redis is not available: %s", err)
 	}

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -95,9 +95,9 @@ func testMetaClient(t *testing.T, m Meta) {
 		t.Fatalf("load got volume name %s, expected %s", format.Name, "test")
 	}
 	_ = m.NewSession()
-	switch m.(type) {
+	switch r := m.(type) {
 	case *redisMeta:
-		go m.(*redisMeta).cleanStaleSessions()
+		go r.cleanStaleSessions()
 	}
 	ctx := Background
 	var parent, inode, dummyInode Ino
@@ -530,11 +530,11 @@ func testCompaction(t *testing.T, m Meta) {
 	if len(cs1) != 5 {
 		t.Fatalf("expect 5 slices, but got %+v", cs1)
 	}
-	switch m.(type) {
+	switch r := m.(type) {
 	case *redisMeta:
-		m.(*redisMeta).compactChunk(inode, 1)
+		r.compactChunk(inode, 1)
 	case *dbMeta:
-		m.(*dbMeta).compactChunk(inode, 1)
+		r.compactChunk(inode, 1)
 	}
 	var cs []Slice
 	_ = m.Read(ctx, inode, 1, &cs)
@@ -623,7 +623,7 @@ func testConcurrentWrite(t *testing.T, m Meta) {
 
 	var errno syscall.Errno
 	var g sync.WaitGroup
-	for i := 0; i <= 20; i++ {
+	for i := 0; i <= 10; i++ {
 		g.Add(1)
 		go func(indx uint32) {
 			defer g.Done()
@@ -649,7 +649,7 @@ func TestTruncateAndDelete(t *testing.T) {
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
-	m.(*redisMeta).rdb.FlushAll(context.Background())
+	m.(*redisMeta).rdb.FlushDB(context.Background())
 	testTruncateAndDelete(t, m)
 }
 
@@ -708,7 +708,7 @@ func TestCopyFileRange(t *testing.T) {
 	if err != nil {
 		t.Skipf("redis is not available: %s", err)
 	}
-	m.(*redisMeta).rdb.FlushAll(context.Background())
+	m.(*redisMeta).rdb.FlushDB(context.Background())
 	testCopyFileRange(t, m)
 }
 

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -532,9 +532,9 @@ func testCompaction(t *testing.T, m Meta) {
 	}
 	switch r := m.(type) {
 	case *redisMeta:
-		r.compactChunk(inode, 1)
+		r.compactChunk(inode, 1, true)
 	case *dbMeta:
-		r.compactChunk(inode, 1)
+		r.compactChunk(inode, 1, true)
 	}
 	var cs []Slice
 	_ = m.Read(ctx, inode, 1, &cs)

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -623,7 +623,7 @@ func testConcurrentWrite(t *testing.T, m Meta) {
 
 	var errno syscall.Errno
 	var g sync.WaitGroup
-	for i := 0; i <= 1; i++ {
+	for i := 0; i <= 20; i++ {
 		g.Add(1)
 		go func(indx uint32) {
 			defer g.Done()

--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -109,3 +109,13 @@ func readSlices(vals []string) []*slice {
 	}
 	return ss
 }
+
+func readSliceBuf(buf []byte) []*slice {
+	var ss []*slice
+	for i := 0; i < len(buf); i += sliceBytes {
+		s := new(slice)
+		s.read(buf[i:])
+		ss = append(ss, s)
+	}
+	return ss
+}

--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -87,8 +87,10 @@ func (s *slice) visit(f func(*slice)) {
 	right.visit(f)
 }
 
+const sliceBytes = 24
+
 func marshalSlice(pos uint32, chunkid uint64, size, off, len uint32) []byte {
-	w := utils.NewBuffer(24)
+	w := utils.NewBuffer(sliceBytes)
 	w.Put32(pos)
 	w.Put64(chunkid)
 	w.Put32(size)

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1007,7 +1007,7 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 					return errno(err)
 				}
 				if !ok {
-
+					return syscall.ENOENT
 				}
 				dn.Nlink--
 				if dn.Nlink > 0 {
@@ -1253,7 +1253,7 @@ func (r *dbMeta) cleanStaleSession(sid uint64) {
 			logger.Errorf("Failed to delete inode %d: %s", s.Inode, err)
 			done = false
 		} else {
-			r.engine.Delete(&s)
+			_, _ = r.engine.Delete(&s)
 		}
 	}
 	if done {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -16,18 +16,23 @@
 package meta
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"xorm.io/xorm"
 )
 
 // DBConfig is config for Redis client.
 type DBConfig struct {
-	Strict  bool // update ctime
-	Retries int
+	Strict      bool // update ctime
+	Retries     int
+	CaseInsensi bool
 }
 
 type setting struct {
@@ -59,7 +64,7 @@ type node struct {
 	Ctime  time.Time
 	Nlink  uint32
 	Length uint64
-	Rdev   uint64
+	Rdev   uint32
 	Parent uint64
 }
 
@@ -78,12 +83,6 @@ type symlink struct {
 	Target string `xorm:"varchar(4096)"`
 }
 
-type xattr struct {
-	Inode uint64
-	Name  string `xorm:"varchar(256)"`
-	Value []byte `xorm:"varchar(4096)"`
-}
-
 type session struct {
 	sid       uint64
 	heartbeta time.Time
@@ -97,23 +96,6 @@ type delchunk struct {
 	expire time.Time
 }
 
-type flock struct {
-	inode uint64
-	sid   uint64
-	owner uint64
-	ltype uint8
-}
-
-type Plock struct {
-	inode uint64
-	sid   uint64
-	owner uint64
-	pid   uint32
-	ltype uint8
-	start uint64
-	end   uint64
-}
-
 type dbMeta struct {
 	sync.Mutex
 	conf   *DBConfig
@@ -123,6 +105,8 @@ type dbMeta struct {
 	openFiles    map[Ino]int
 	removedFiles map[Ino]bool
 	compacting   map[uint64]bool
+	deleting     chan int
+	symlinks     *sync.Map
 	msgCallbacks *msgCallbacks
 }
 
@@ -133,15 +117,17 @@ func NewSQLMeta(driver, dsn string) (*dbMeta, error) {
 	}
 
 	m := &dbMeta{
+		conf:         &DBConfig{},
 		engine:       engine,
 		openFiles:    make(map[Ino]int),
 		removedFiles: make(map[Ino]bool),
 		compacting:   make(map[uint64]bool),
+		deleting:     make(chan int, 2),
+		symlinks:     &sync.Map{},
 		msgCallbacks: &msgCallbacks{
 			callbacks: make(map[uint32]MsgCallback),
 		},
 	}
-	// TODO sid
 	return m, nil
 }
 
@@ -149,62 +135,75 @@ func (m *dbMeta) Init(format Format, force bool) error {
 	_ = m.engine.Sync2(new(setting))
 	_ = m.engine.Sync2(new(counter))
 	_ = m.engine.Sync2(new(node))
-	_ = m.engine.Sync2(new(node))
 	_ = m.engine.Sync2(new(edge))
 	_ = m.engine.Sync2(new(symlink))
-	_ = m.engine.Sync2(new(xattr))
-	_ = m.engine.Sync2(new(flock))
-	_ = m.engine.Sync2(new(plock))
+	_ = m.engine.Sync2(new(chunk))
 
-	// values, err := m.engine.QueryString("select * from setting")
+	f, err := m.Load()
+	if err != nil {
+		return err
+	}
+	if f != nil {
+		// TODO: update
+		return nil
+	}
+	data, err := json.MarshalIndent(format, "", "")
+	if err != nil {
+		logger.Fatalf("json: %s", err)
+	}
+	_, err = m.engine.Insert(&setting{"format", string(data)})
+	if err != nil {
+		return err
+	}
 
-	// body, err := m.rdb.Get(c, "setting").Bytes()
-	// if err != nil && err != redis.Nil {
-	// 	return err
-	// }
-
-	// data, err := json.MarshalIndent(format, "", "")
-	// if err != nil {
-	// 	loggem.Fatalf("json: %s", err)
-	// }
-	// err = m.rdb.Set(c, "setting", data, 0).Err()
-	// if err != nil {
-	// 	return err
-	// }
-
-	// root inode
-	// var attr Attr
-	// attm.Flags = 0
-	// attm.Typ = TypeDirectory
-	// attm.Mode = 0777
-	// attm.Uid = 0
-	// attm.Uid = 0
-	// ts := time.Now().Unix()
-	// attm.Atime = ts
-	// attm.Mtime = ts
-	// attm.Ctime = ts
-	// attm.Nlink = 2
-	// attm.Length = 4 << 10
-	// attm.Rdev = 0
-	// attm.Parent = 1
-	// m.rdb.Set(c, m.inodeKey(1), m.marshal(&attr), 0)
-	return nil
+	now := time.Now()
+	_, err = m.engine.Insert(&node{
+		Inode:  1,
+		Type:   TypeDirectory,
+		Mode:   0777,
+		Atime:  now,
+		Mtime:  now,
+		Ctime:  now,
+		Nlink:  2,
+		Length: 4 << 10,
+		Parent: 1,
+	})
+	_, _ = m.engine.Insert(
+		counter{"nextinode", 2},
+		counter{"nextchunkid", 1},
+		counter{"nextsession", 1},
+		counter{"usedSpace", 0},
+		counter{"totalInodes", 0})
+	return err
 }
 
 func (m *dbMeta) Load() (*Format, error) {
-	// body, err := m.rdb.Get(c, "setting").Bytes()
-	// if err == redis.Nil {
-	// 	return nil, fmt.Errorf("no volume found")
-	// }
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// var format Format
-	// err = json.Unmarshal(body, &format)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("json: %s", err)
-	// }
-	// return &format, nil
+	var s setting
+	has, err := m.engine.Where("name = ?", "format").Get(&s)
+	if err != nil || !has {
+		return nil, err
+	}
+
+	var format Format
+	err = json.Unmarshal([]byte(s.Value), &format)
+	if err != nil {
+		return nil, fmt.Errorf("json: %s", err)
+	}
+	return &format, nil
+}
+
+func (m *dbMeta) NewSession() error {
+	v, err := m.incr("nextsession")
+	if err != nil {
+		return fmt.Errorf("create session: %s", err)
+	}
+	m.sid = int64(v)
+	logger.Debugf("session is %d", m.sid)
+
+	// go r.refreshSession()
+	// go r.cleanupDeletedFiles()
+	// go r.cleanupSlices()
+	return nil
 }
 
 func (m *dbMeta) OnMsg(mtype uint32, cb MsgCallback) {
@@ -223,47 +222,243 @@ func (m *dbMeta) newMsg(mid uint32, args ...interface{}) error {
 	return fmt.Errorf("message %d is not supported", mid)
 }
 
+func (m *dbMeta) incr(name string) (uint64, error) {
+	r, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var c counter
+		_, err := s.Where("name = ?", name).Get(&c)
+		if err != nil {
+			return nil, err
+		}
+		c.Value++
+		_, err = s.Cols("value").Update(&c)
+		if err != nil {
+			return nil, err
+		}
+		return c.Value - 1, nil
+	})
+	return r.(uint64), err
+}
+
 func (m *dbMeta) nextInode() (Ino, error) {
-	m.engine.Exec("update counter set nextinode=nextinode+1")
-	return Ino(0), nil
+	v, err := m.incr("nextinode")
+	return Ino(v), err
 }
 
 func (m *dbMeta) StatFS(ctx Context, totalspace, availspace, iused, iavail *uint64) syscall.Errno {
-	// *totalspace = 1 << 50
-	// used, _ := m.rdb.IncrBy(c, usedSpace, 0).Result()
-	// used = ((used >> 16) + 1) << 16 // aligned to 64K
-	// *availspace = *totalspace - uint64(used)
-	// inodes, _ := m.rdb.IncrBy(c, totalInodes, 0).Result()
-	// *iused = uint64(inodes)
-	// *iavail = 10 << 20
+	var c counter
+	m.engine.Where("name='usedSpace'").Get(&c)
+	*totalspace = 1 << 50
+	for *totalspace < c.Value {
+		*totalspace *= 2
+	}
+	*availspace = *totalspace - c.Value
+	m.engine.Where("name='totalInodes'").Get(&c)
+	*iused = c.Value
+	*iavail = 10 << 20
 	return 0
 }
 
 func (m *dbMeta) Lookup(ctx Context, parent Ino, name string, inode *Ino, attr *Attr) syscall.Errno {
+	var e edge
+	has, err := m.engine.Where("Parent = ? and Name = ?", parent, name).Get(&e)
+	if err != nil {
+		return errno(err)
+	}
+	if !has {
+		return syscall.ENOENT
+	}
+	if attr == nil {
+		*inode = Ino(e.Inode)
+		return 0
+	}
+	var n node
+	has, err = m.engine.Where("inode = ?", e.Inode).Get(&n)
+	if err != nil {
+		return errno(err)
+	}
+	if !has {
+		return syscall.ENOENT
+	}
+	*inode = Ino(e.Inode)
+	m.parseAttr(&n, attr)
 	return 0
 }
 
-func (m *dbMeta) Access(ctx Context, inode Ino, modemask uint16) syscall.Errno {
-	return 0 // handled by kernel
+func (m *dbMeta) parseAttr(n *node, attr *Attr) {
+	if attr == nil {
+		return
+	}
+	attr.Typ = n.Type
+	attr.Mode = n.Mode
+	attr.Flags = n.Flags
+	attr.Uid = n.Uid
+	attr.Gid = n.Gid
+	attr.Atime = n.Atime.Unix()
+	attr.Atimensec = uint32(n.Atime.Nanosecond())
+	attr.Mtime = n.Mtime.Unix()
+	attr.Mtimensec = uint32(n.Mtime.Nanosecond())
+	attr.Ctime = n.Ctime.Unix()
+	attr.Ctimensec = uint32(n.Ctime.Nanosecond())
+	attr.Nlink = n.Nlink
+	attr.Length = n.Length
+	attr.Rdev = uint32(n.Rdev)
+	attr.Parent = Ino(n.Parent)
+	attr.Full = true
+}
+
+func (m *dbMeta) Access(ctx Context, inode Ino, mmask uint8, attr *Attr) syscall.Errno {
+	if ctx.Uid() == 0 {
+		return 0
+	}
+
+	if attr == nil || !attr.Full {
+		if attr == nil {
+			attr = &Attr{}
+		}
+		err := m.GetAttr(ctx, inode, attr)
+		if err != 0 {
+			return err
+		}
+	}
+
+	mode := accessMode(attr, ctx.Uid(), ctx.Gid())
+	if mode&mmask != mmask {
+		logger.Debugf("Access inode %d %o, mode %o, request mode %o", inode, attr.Mode, mode, mmask)
+		return syscall.EACCES
+	}
+	return 0
 }
 
 func (m *dbMeta) GetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno {
-	return 0
-}
-
-func (m *dbMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, attr *Attr) syscall.Errno {
-	return 0
-}
-
-func (m *dbMeta) Fallocate(ctx Context, inode Ino, mode uint8, off uint64, size uint64) syscall.Errno {
+	var n node
+	ok, err := m.engine.Where("Inode = ?", inode).Get(&n)
+	if err != nil && inode == 1 {
+		err = nil
+		n.Type = TypeDirectory
+		n.Mode = 0777
+		n.Nlink = 2
+		n.Length = 4 << 10
+	}
+	if err != nil {
+		return errno(err)
+	}
+	if !ok {
+		return syscall.ENOENT
+	}
+	m.parseAttr(&n, attr)
 	return 0
 }
 
 func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint8, attr *Attr) syscall.Errno {
-	return 0
+	_, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var cur node
+		ok, err := s.Where("Inode = ?", inode).Get(&cur)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if (set&(SetAttrUID|SetAttrGID)) != 0 && (set&SetAttrMode) != 0 {
+			attr.Mode |= (cur.Mode & 06000)
+		}
+		var changed bool
+		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
+			if cur.Mode&01777 != cur.Mode {
+				cur.Mode &= 01777
+				changed = true
+			}
+			attr.Mode &= 01777
+		}
+		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {
+			cur.Uid = attr.Uid
+			changed = true
+		}
+		if set&SetAttrGID != 0 && cur.Gid != attr.Gid {
+			cur.Gid = attr.Gid
+			changed = true
+		}
+		if set&SetAttrMode != 0 {
+			if ctx.Uid() != 0 && (attr.Mode&02000) != 0 {
+				if ctx.Gid() != cur.Gid {
+					attr.Mode &= 05777
+				}
+			}
+			if attr.Mode != cur.Mode {
+				cur.Mode = attr.Mode
+				changed = true
+			}
+		}
+		now := time.Now()
+		if set&SetAttrAtime != 0 && (cur.Atime.Unix() != attr.Atime || uint32(cur.Atime.Nanosecond()) != attr.Atimensec) {
+			cur.Atime = time.Unix(attr.Atime, int64(attr.Atimensec))
+			changed = true
+		}
+		if set&SetAttrAtimeNow != 0 {
+			cur.Atime = now
+			changed = true
+		}
+		if set&SetAttrMtime != 0 && (cur.Mtime.Unix() != attr.Mtime || uint32(cur.Mtime.Nanosecond()) != attr.Mtimensec) {
+			cur.Mtime = time.Unix(attr.Mtime, int64(attr.Mtimensec))
+			changed = true
+		}
+		if set&SetAttrMtimeNow != 0 {
+			cur.Mtime = now
+			changed = true
+		}
+		m.parseAttr(&cur, attr)
+		if !changed {
+			return nil, nil
+		}
+		cur.Ctime = now
+		_, err = s.Where("inode = ?", inode).Update(&cur)
+		return &cur, err
+	})
+	return errno(err)
+}
+
+func (m *dbMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, attr *Attr) syscall.Errno {
+	n, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var n node
+		ok, err := s.Where("Inode = ?", inode).Get(&n)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		n.Length = length
+		_, err = s.Cols("length").Update(&n)
+		if err != nil {
+			return nil, err
+		}
+		return &n, nil
+	})
+	if err == nil && attr != nil {
+		m.parseAttr(n.(*node), attr)
+	}
+	return errno(err)
+}
+
+func (m *dbMeta) Fallocate(ctx Context, inode Ino, mode uint8, off uint64, size uint64) syscall.Errno {
+	return syscall.ENOTSUP
 }
 
 func (m *dbMeta) ReadLink(ctx Context, inode Ino, path *[]byte) syscall.Errno {
+	if target, ok := m.symlinks.Load(inode); ok {
+		*path = target.([]byte)
+		return 0
+	}
+	var l symlink
+	ok, err := m.engine.Where("inode = ?", inode).Get(&l)
+	if err != nil {
+		return errno(err)
+	}
+	if !ok {
+		return syscall.ENOENT
+	}
+	*path = []byte(l.Target)
+	m.symlinks.Store(inode, []byte(l.Target))
 	return 0
 }
 
@@ -275,8 +470,109 @@ func (m *dbMeta) Mknod(ctx Context, parent Ino, name string, _type uint8, mode, 
 	return m.mknod(ctx, parent, name, _type, mode, cumask, rdev, "", inode, attr)
 }
 
+func (m *dbMeta) resolveCase(ctx Context, parent Ino, name string) *Entry {
+	// TODO in SQL
+	var entries []*Entry
+	_ = m.Readdir(ctx, parent, 0, &entries)
+	for _, e := range entries {
+		n := string(e.Name)
+		if strings.EqualFold(name, n) {
+			return e
+		}
+	}
+	return nil
+}
+
 func (m *dbMeta) mknod(ctx Context, parent Ino, name string, _type uint8, mode, cumask uint16, rdev uint32, path string, inode *Ino, attr *Attr) syscall.Errno {
-	return 0
+	ino, err := m.nextInode()
+	if err != nil {
+		return errno(err)
+	}
+	var n node
+	n.Inode = uint64(ino)
+	n.Type = _type
+	n.Mode = mode & ^cumask
+	n.Uid = ctx.Uid()
+	n.Gid = ctx.Gid()
+	if _type == TypeDirectory {
+		n.Nlink = 2
+		n.Length = 4 << 10
+	} else {
+		n.Nlink = 1
+		if _type == TypeSymlink {
+			n.Length = uint64(len(path))
+		} else {
+			n.Length = 0
+			n.Rdev = rdev
+		}
+	}
+	n.Parent = uint64(parent)
+	if inode != nil {
+		*inode = ino
+	}
+
+	_, err = m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var pn node
+		ok, err := s.Where("Inode = ?", parent).Get(&pn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if pn.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		var e edge
+		ok, err = s.Where("parent=? and name=?", parent, name).Get(&e)
+		if err != nil {
+			return nil, err
+		}
+		if ok || !ok && m.conf.CaseInsensi && m.resolveCase(ctx, parent, name) != nil {
+			return nil, syscall.EEXIST
+		}
+
+		now := time.Now()
+		if _type == TypeDirectory {
+			pn.Nlink++
+		}
+		pn.Mtime = now
+		pn.Ctime = now
+		n.Atime = now
+		n.Mtime = now
+		n.Ctime = now
+		if ctx.Value(CtxKey("behavior")) == "Hadoop" {
+			n.Gid = pn.Gid
+		}
+
+		e.Inode = uint64(ino)
+		e.Parent = uint64(parent)
+		e.Name = name
+		e.Type = _type
+		_, err = s.Insert(&e)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := s.Update(&pn, &node{Inode: pn.Inode}); err != nil {
+			return nil, err
+		}
+		if _, err := s.Insert(&n); err != nil {
+			return nil, err
+		}
+		if _type == TypeSymlink {
+			if _, err := s.Insert(&symlink{Inode: uint64(ino), Target: path}); err != nil {
+				return nil, err
+			}
+		} else if _type == TypeFile {
+			s.Exec("update counter set value=value+? where key='usedSpace'", align4K(0))
+		}
+		s.Exec("update counter set value=value+1 where key='totalInodes'")
+		return nil, err
+	})
+	if err != nil {
+		m.parseAttr(&n, attr)
+	}
+	return errno(err)
 }
 
 func (m *dbMeta) Mkdir(ctx Context, parent Ino, name string, mode uint16, cumask uint16, copysgid uint8, inode *Ino, attr *Attr) syscall.Errno {
@@ -284,22 +580,440 @@ func (m *dbMeta) Mkdir(ctx Context, parent Ino, name string, mode uint16, cumask
 }
 
 func (m *dbMeta) Create(ctx Context, parent Ino, name string, mode uint16, cumask uint16, inode *Ino, attr *Attr) syscall.Errno {
-	return 0
+	err := m.Mknod(ctx, parent, name, TypeFile, mode, cumask, 0, inode, attr)
+	if err == 0 && inode != nil {
+		m.Lock()
+		m.openFiles[*inode] = 1
+		m.Unlock()
+	}
+	return err
+}
+
+func (m *dbMeta) Unlink(ctx Context, parent Ino, name string) syscall.Errno {
+	_, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var pn node
+		ok, err := s.Where("Inode = ?", parent).Get(&pn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if pn.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		var e edge
+		ok, err = s.Where("parent=? and name=?", parent, name).Get(&e)
+		if err != nil {
+			return nil, err
+		}
+		if !ok && (!m.conf.CaseInsensi || m.resolveCase(ctx, parent, name) == nil) {
+			return nil, syscall.ENOENT
+		}
+		if e.Type == TypeDirectory {
+			return nil, syscall.EPERM
+		}
+
+		var n node
+		ok, err = s.Where("Inode = ?", e.Inode).Get(&n)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+
+		now := time.Now()
+		pn.Mtime = now
+		pn.Ctime = time.Now()
+		n.Ctime = now
+		n.Nlink--
+		var opened bool
+		if e.Type == TypeFile && n.Nlink == 0 {
+			m.Lock()
+			opened = m.openFiles[Ino(e.Inode)] > 0
+			m.Unlock()
+		}
+
+		if _, err := s.Delete(&edge{Parent: uint64(parent), Name: name}); err != nil {
+			return nil, err
+		}
+		// s.Delete(&xattr{Inode: e.Inode})
+		if _, err := s.Update(&pn, &node{Inode: pn.Inode}); err != nil {
+			return nil, err
+		}
+		s.Exec("update counter set value=value-1 where key='totalInodes'")
+
+		if n.Nlink > 0 {
+			if _, err := s.Update(&n, &node{Inode: e.Inode}); err != nil {
+				return nil, err
+			}
+		} else {
+			switch e.Type {
+			case TypeSymlink:
+				if _, err := s.Delete(&symlink{Inode: e.Inode}); err != nil {
+					return nil, err
+				}
+				if _, err := s.Delete(&node{Inode: e.Inode}); err != nil {
+					return nil, err
+				}
+			case TypeFile:
+				if opened {
+					if _, err := s.Update(&n, &node{Inode: e.Inode}); err != nil {
+						return nil, err
+					}
+					// pipe.SAdd(ctx, r.sustained(r.sid), strconv.Itoa(int(inode)))
+				} else {
+					// pipe.ZAdd(ctx, delfiles, &redis.Z{Score: float64(now.Unix()), Member: r.toDelete(inode, attr.Length)})
+					if _, err := s.Delete(&node{Inode: e.Inode}); err != nil {
+						return nil, err
+					}
+					s.Exec("update counter set value=value-? where key='usedSpace'", align4K(n.Length))
+				}
+			}
+		}
+		if err == nil && e.Type == TypeFile && n.Nlink == 0 {
+			if opened {
+				m.Lock()
+				m.removedFiles[Ino(e.Inode)] = true
+				m.Unlock()
+			} else {
+				// go m.deleteFile(inode, attr.Length, "")
+			}
+		}
+		return nil, err
+	})
+	return errno(err)
 }
 
 func (m *dbMeta) Rmdir(ctx Context, parent Ino, name string) syscall.Errno {
-	return 0
+	if name == "." {
+		return syscall.EINVAL
+	}
+	if name == ".." {
+		return syscall.ENOTEMPTY
+	}
+
+	_, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var pn node
+		ok, err := s.Where("Inode = ?", parent).Get(&pn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if pn.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		var e edge
+		ok, err = s.Where("parent=? and name=?", parent, name).Get(&e)
+		if err != nil {
+			return nil, err
+		}
+		if !ok && (!m.conf.CaseInsensi || m.resolveCase(ctx, parent, name) == nil) {
+			return nil, syscall.ENOENT
+		}
+		if e.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		cnt, err := s.Where("parent = ?", e.Inode).Count(&edge{})
+		if err != nil {
+			return nil, err
+		}
+		if cnt != 0 {
+			return nil, syscall.ENOTEMPTY
+		}
+
+		now := time.Now()
+		pn.Nlink--
+		pn.Mtime = now
+		pn.Ctime = now
+		if _, err := s.Delete(&edge{Parent: uint64(parent), Name: name}); err != nil {
+			return nil, err
+		}
+		if _, err := s.Delete(&node{Inode: e.Inode}); err != nil {
+			return nil, err
+		}
+		// s.Delete(&xattr{Inode: e.Inode})
+		if _, err := s.Update(&pn, &node{Inode: pn.Inode}); err != nil {
+			return nil, err
+		}
+		s.Exec("update counter set value=value-1 where key='totalInodes'")
+		return nil, err
+	})
+	return errno(err)
 }
 
 func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst Ino, nameDst string, inode *Ino, attr *Attr) syscall.Errno {
-	return 0
+	_, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var spn node
+		ok, err := s.Where("Inode = ?", parentSrc).Get(&spn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if spn.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		var se edge
+		ok, err = s.Where("parent=? and name=?", parentSrc, nameSrc).Get(&se)
+		if err != nil {
+			return nil, err
+		}
+		if !ok && (!m.conf.CaseInsensi || m.resolveCase(ctx, parentSrc, nameSrc) == nil) {
+			return nil, syscall.ENOENT
+		}
+
+		if parentSrc == parentDst && nameSrc == nameDst {
+			if inode != nil {
+				*inode = Ino(se.Inode)
+			}
+			return nil, nil
+		}
+
+		var sn node
+		ok, err = s.Where("Inode = ?", se.Inode).Get(&sn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+
+		var dpn node
+		ok, err = s.Where("Inode = ?", parentDst).Get(&dpn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if dpn.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		var de edge
+		ok, err = s.Where("parent=? and name=?", parentDst, nameDst).Get(&de)
+		if err != nil {
+			return nil, err
+		}
+		var opened bool
+		var dino Ino
+		var dn node
+		if ok {
+			dino = Ino(de.Inode)
+			if ctx.Value(CtxKey("behavior")) == "Hadoop" {
+				return nil, syscall.EEXIST
+			}
+			if de.Type == TypeDirectory {
+				cnt, err := s.Where("parent = ?", de.Inode).Count(&edge{})
+				if err != nil {
+					return nil, err
+				}
+				if cnt != 0 {
+					return nil, syscall.ENOTEMPTY
+				}
+			} else {
+				ok, err := s.Where("Inode = ?", de.Inode).Get(&dn)
+				if err != nil {
+					return nil, errno(err)
+				}
+				if !ok {
+
+				}
+				dn.Nlink--
+				if dn.Nlink > 0 {
+					dn.Ctime = time.Now()
+				} else if dn.Type == TypeFile {
+					m.Lock()
+					opened = m.openFiles[Ino(dn.Inode)] > 0
+					m.Unlock()
+				}
+			}
+		}
+
+		now := time.Now()
+		spn.Mtime = now
+		spn.Ctime = now
+		dpn.Mtime = now
+		dpn.Ctime = now
+		sn.Parent = uint64(parentDst)
+		sn.Ctime = now
+		if sn.Type == TypeDirectory && parentSrc != parentDst {
+			spn.Nlink--
+			dpn.Nlink++
+		}
+		if attr != nil {
+			m.parseAttr(&sn, attr)
+		}
+
+		s.Delete(&edge{Parent: uint64(parentSrc), Name: nameSrc})
+		s.Update(&spn, &node{Inode: uint64(parentSrc)})
+		if dino > 0 {
+			if dn.Type != TypeDirectory && dn.Nlink > 0 {
+				s.Update(dn, &node{Inode: dn.Inode})
+			} else {
+				if dn.Type == TypeDirectory {
+					s.Delete(&node{Inode: dn.Inode})
+					dn.Nlink--
+				} else if dn.Type == TypeSymlink {
+					s.Delete(&symlink{Inode: dn.Inode})
+					s.Delete(&node{Inode: dn.Inode})
+				} else if dn.Type == TypeFile {
+					if opened {
+						s.Update(&dn, &node{Inode: dn.Inode})
+						// pipe.SAdd(ctx, r.sustained(r.sid), strconv.Itoa(int(dino)))
+					} else {
+						// pipe.ZAdd(ctx, delfiles, &redis.Z{Score: float64(now.Unix()), Member: r.toDelete(dino, dattr.Length)})
+						s.Delete(&node{Inode: dn.Inode})
+						s.Exec("update counter set value=value-? where key='usedSpace'", align4K(dn.Length))
+					}
+				}
+				s.Exec("update counter set value=value-1 where key='totalInodes'")
+				// pipe.Del(ctx, r.xattrKey(dino))
+			}
+			s.Delete(&edge{Parent: uint64(parentDst), Name: nameDst})
+		}
+		s.Insert(&edge{uint64(parentDst), nameDst, sn.Inode, sn.Type})
+		if parentDst != parentSrc {
+			s.Update(&dpn, &node{Inode: uint64(parentDst)})
+		}
+		s.Update(&sn, &node{Inode: sn.Inode})
+		if err == nil && dino > 0 && dn.Type == TypeFile {
+			if opened {
+				m.Lock()
+				m.removedFiles[dino] = true
+				m.Unlock()
+			} else {
+				// go r.deleteFile(dino, dattr.Length, "")
+			}
+		}
+		return nil, err
+	})
+	return errno(err)
 }
 
 func (m *dbMeta) Link(ctx Context, inode, parent Ino, name string, attr *Attr) syscall.Errno {
-	return 0
+	_, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var pn node
+		ok, err := s.Where("Inode = ?", parent).Get(&pn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if pn.Type != TypeDirectory {
+			return nil, syscall.ENOTDIR
+		}
+		var e edge
+		ok, err = s.Where("parent=? and name=?", parent, name).Get(&e)
+		if err != nil {
+			return nil, err
+		}
+		if ok || !ok && m.conf.CaseInsensi && m.resolveCase(ctx, parent, name) != nil {
+			return nil, syscall.EEXIST
+		}
+
+		var n node
+		ok, err = s.Where("Inode = ?", inode).Get(&n)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if n.Type == TypeDirectory {
+			return nil, syscall.EPERM
+		}
+
+		now := time.Now()
+		pn.Mtime = now
+		pn.Ctime = now
+		n.Nlink++
+		n.Ctime = now
+
+		if ok, err := s.Insert(&edge{Parent: uint64(parent), Name: name, Inode: uint64(inode), Type: n.Type}); err != nil || ok == 0 {
+			return nil, err
+		}
+		if _, err := s.Update(&pn, &node{Inode: uint64(parent)}); err != nil {
+			return nil, err
+		}
+		if _, err := s.Cols("ctime", "nlink").Update(&n, node{Inode: uint64(inode)}); err != nil {
+			return nil, err
+		}
+		if err == nil && attr != nil {
+			m.parseAttr(&n, attr)
+		}
+		return nil, err
+	})
+	return errno(err)
 }
 
 func (m *dbMeta) Readdir(ctx Context, inode Ino, plus uint8, entries *[]*Entry) syscall.Errno {
+	var attr Attr
+	eno := m.GetAttr(ctx, inode, &attr)
+	if eno != 0 {
+		return eno
+	}
+	*entries = nil
+	*entries = append(*entries, &Entry{
+		Inode: inode,
+		Name:  []byte("."),
+		Attr:  &attr,
+	})
+	var pattr Attr
+	eno = m.GetAttr(ctx, attr.Parent, &pattr)
+	if eno != 0 {
+		return eno
+	}
+	*entries = append(*entries, &Entry{
+		Inode: attr.Parent,
+		Name:  []byte(".."),
+		Attr:  &pattr,
+	})
+
+	e := new(edge)
+	rows, err := m.engine.Where("parent=? ", inode).Rows(e)
+	if err != nil {
+		return errno(err)
+	}
+	names := make(map[uint64][]byte)
+	var inodes []string
+	for rows.Next() {
+		err = rows.Scan(e)
+		if err != nil {
+			return errno(err)
+		}
+		names[e.Inode] = []byte(e.Name)
+		inodes = append(inodes, strconv.FormatUint(e.Inode, 10))
+	}
+	rows.Close()
+	if len(inodes) == 0 {
+		return 0
+	}
+
+	var n node
+	nodes, err := m.engine.Where("inode IN (?)", strings.Join(inodes, ",")).Rows(&n)
+	if err != nil {
+		return errno(err)
+	}
+	defer nodes.Close()
+	for nodes.Next() {
+		err = nodes.Scan(&n)
+		if err != nil {
+			return errno(err)
+		}
+		attr := new(Attr)
+		m.parseAttr(&n, attr)
+		*entries = append(*entries, &Entry{
+			Inode: Ino(n.Inode),
+			Name:  names[n.Inode],
+			Attr:  attr,
+		})
+	}
 	return 0
 }
 
@@ -317,24 +1031,94 @@ func (m *dbMeta) Open(ctx Context, inode Ino, flags uint8, attr *Attr) syscall.E
 }
 
 func (m *dbMeta) Close(ctx Context, inode Ino) syscall.Errno {
+	m.Lock()
+	defer m.Unlock()
+	refs := m.openFiles[inode]
+	if refs <= 1 {
+		delete(m.openFiles, inode)
+		if m.removedFiles[inode] {
+			delete(m.removedFiles, inode)
+			go func() {
+				// if err := m.deleteInode(inode); err == nil {
+				// 	m.rdb.SRem(ctx, m.sustained(m.sid), strconv.Itoa(int(inode)))
+				// }
+			}()
+		}
+	} else {
+		m.openFiles[inode] = refs - 1
+	}
 	return 0
 }
 
 func (m *dbMeta) Read(ctx Context, inode Ino, indx uint32, chunks *[]Slice) syscall.Errno {
+	var c chunk
+	rows, err := m.engine.Where("inode=? and indx=?", inode, indx).Rows(&c)
+	if err != nil {
+		return errno(err)
+	}
+	defer rows.Close()
+	var vals []*slice
+	for rows.Next() {
+		err := rows.Scan(&c)
+		if err != nil {
+			return errno(err)
+		}
+		vals = append(vals, &slice{c.Chunkid, c.Size, c.Off, c.Size, c.Pos, nil, nil})
+	}
+	*chunks = buildSlice(vals)
+	if len(vals) >= 5 || len(*chunks) >= 5 {
+		// go r.compactChunk(inode, indx)
+	}
 	return 0
 }
 
 func (m *dbMeta) NewChunk(ctx Context, inode Ino, indx uint32, offset uint32, chunkid *uint64) syscall.Errno {
-	// cid, err := m.rdb.Incr(c, "nextchunk").Uint64()
-	// if err == nil {
-	// 	*chunkid = cid
-	// }
-	// return errno(err)
-	return 0
+	v, err := m.incr("nextchunk")
+	if err == nil {
+		*chunkid = v
+	}
+	return errno(err)
 }
 
 func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
-	return syscall.ENOTSUP
+	_, err := m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+		var n node
+		ok, err := s.Where("Inode = ?", inode).Get(&n)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, syscall.ENOENT
+		}
+		if n.Type != TypeFile {
+			return nil, syscall.EPERM
+		}
+		newleng := uint64(indx)*ChunkSize + uint64(off) + uint64(slice.Len)
+		var added int64
+		if newleng > n.Length {
+			added = align4K(newleng) - align4K(n.Length)
+			n.Length = newleng
+		}
+		now := time.Now()
+		n.Mtime = now
+		n.Ctime = now
+
+		if _, err := s.Insert(&chunk{uint64(inode), indx, off, slice.Chunkid, slice.Size, slice.Off, slice.Len}); err != nil {
+			return nil, err
+		}
+		if _, err := s.Update(&n, &node{Inode: uint64(inode)}); err != nil {
+			return nil, err
+		}
+		// most of chunk are used by single inode, so use that as the default (1 == not exists)
+		if added > 0 {
+			s.Exec("update counter set value=value+1 where key='usedSpace'")
+		}
+		if n, _ := s.Count(&chunk{Inode: uint64(inode), Indx: indx}); n%20 == 19 {
+			// 	go r.compactChunk(inode, indx)
+		}
+		return nil, nil
+	})
+	return errno(err)
 }
 
 func (m *dbMeta) GetXattr(ctx Context, inode Ino, name string, vbuff *[]byte) syscall.Errno {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1,0 +1,366 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+	"time"
+
+	"xorm.io/xorm"
+)
+
+// DBConfig is config for Redis client.
+type DBConfig struct {
+	Strict  bool // update ctime
+	Retries int
+}
+
+type setting struct {
+	Name  string
+	Value string `xorm:"varchar(4096)"`
+}
+
+type counter struct {
+	Name  string
+	Value uint64
+}
+
+type edge struct {
+	Parent uint64
+	Name   string
+	Inode  uint64
+	Type   uint8
+}
+
+type node struct {
+	Inode  uint64
+	Type   uint8
+	Flags  uint8
+	Mode   uint16
+	Uid    uint32
+	Gid    uint32
+	Atime  time.Time
+	Mtime  time.Time
+	Ctime  time.Time
+	Nlink  uint32
+	Length uint64
+	Rdev   uint64
+	Parent uint64
+}
+
+type chunk struct {
+	Inode   uint64
+	Indx    uint32
+	Pos     uint32
+	Chunkid uint64
+	Size    uint32
+	Off     uint32
+	Len     uint32
+}
+
+type symlink struct {
+	Inode  uint64
+	Target string `xorm:"varchar(4096)"`
+}
+
+type xattr struct {
+	Inode uint64
+	Name  string `xorm:"varchar(256)"`
+	Value []byte `xorm:"varchar(4096)"`
+}
+
+type session struct {
+	sid       uint64
+	heartbeta time.Time
+}
+
+type delchunk struct {
+	inode  uint64
+	start  uint64
+	end    uint64
+	maxid  uint64
+	expire time.Time
+}
+
+type flock struct {
+	inode uint64
+	sid   uint64
+	owner uint64
+	ltype uint8
+}
+
+type Plock struct {
+	inode uint64
+	sid   uint64
+	owner uint64
+	pid   uint32
+	ltype uint8
+	start uint64
+	end   uint64
+}
+
+type dbMeta struct {
+	sync.Mutex
+	conf   *DBConfig
+	engine *xorm.Engine
+
+	sid          int64
+	openFiles    map[Ino]int
+	removedFiles map[Ino]bool
+	compacting   map[uint64]bool
+	msgCallbacks *msgCallbacks
+}
+
+func NewSQLMeta(driver, dsn string) (*dbMeta, error) {
+	engine, err := xorm.NewEngine(driver, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use data source %s: %s", driver, err)
+	}
+
+	m := &dbMeta{
+		engine:       engine,
+		openFiles:    make(map[Ino]int),
+		removedFiles: make(map[Ino]bool),
+		compacting:   make(map[uint64]bool),
+		msgCallbacks: &msgCallbacks{
+			callbacks: make(map[uint32]MsgCallback),
+		},
+	}
+	// TODO sid
+	return m, nil
+}
+
+func (m *dbMeta) Init(format Format, force bool) error {
+	_ = m.engine.Sync2(new(setting))
+	_ = m.engine.Sync2(new(counter))
+	_ = m.engine.Sync2(new(node))
+	_ = m.engine.Sync2(new(node))
+	_ = m.engine.Sync2(new(edge))
+	_ = m.engine.Sync2(new(symlink))
+	_ = m.engine.Sync2(new(xattr))
+	_ = m.engine.Sync2(new(flock))
+	_ = m.engine.Sync2(new(plock))
+
+	// values, err := m.engine.QueryString("select * from setting")
+
+	// body, err := m.rdb.Get(c, "setting").Bytes()
+	// if err != nil && err != redis.Nil {
+	// 	return err
+	// }
+
+	// data, err := json.MarshalIndent(format, "", "")
+	// if err != nil {
+	// 	loggem.Fatalf("json: %s", err)
+	// }
+	// err = m.rdb.Set(c, "setting", data, 0).Err()
+	// if err != nil {
+	// 	return err
+	// }
+
+	// root inode
+	// var attr Attr
+	// attm.Flags = 0
+	// attm.Typ = TypeDirectory
+	// attm.Mode = 0777
+	// attm.Uid = 0
+	// attm.Uid = 0
+	// ts := time.Now().Unix()
+	// attm.Atime = ts
+	// attm.Mtime = ts
+	// attm.Ctime = ts
+	// attm.Nlink = 2
+	// attm.Length = 4 << 10
+	// attm.Rdev = 0
+	// attm.Parent = 1
+	// m.rdb.Set(c, m.inodeKey(1), m.marshal(&attr), 0)
+	return nil
+}
+
+func (m *dbMeta) Load() (*Format, error) {
+	// body, err := m.rdb.Get(c, "setting").Bytes()
+	// if err == redis.Nil {
+	// 	return nil, fmt.Errorf("no volume found")
+	// }
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// var format Format
+	// err = json.Unmarshal(body, &format)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("json: %s", err)
+	// }
+	// return &format, nil
+}
+
+func (m *dbMeta) OnMsg(mtype uint32, cb MsgCallback) {
+	m.msgCallbacks.Lock()
+	defer m.msgCallbacks.Unlock()
+	m.msgCallbacks.callbacks[mtype] = cb
+}
+
+func (m *dbMeta) newMsg(mid uint32, args ...interface{}) error {
+	m.msgCallbacks.Lock()
+	cb, ok := m.msgCallbacks.callbacks[mid]
+	m.msgCallbacks.Unlock()
+	if ok {
+		return cb(args...)
+	}
+	return fmt.Errorf("message %d is not supported", mid)
+}
+
+func (m *dbMeta) nextInode() (Ino, error) {
+	m.engine.Exec("update counter set nextinode=nextinode+1")
+	return Ino(0), nil
+}
+
+func (m *dbMeta) StatFS(ctx Context, totalspace, availspace, iused, iavail *uint64) syscall.Errno {
+	// *totalspace = 1 << 50
+	// used, _ := m.rdb.IncrBy(c, usedSpace, 0).Result()
+	// used = ((used >> 16) + 1) << 16 // aligned to 64K
+	// *availspace = *totalspace - uint64(used)
+	// inodes, _ := m.rdb.IncrBy(c, totalInodes, 0).Result()
+	// *iused = uint64(inodes)
+	// *iavail = 10 << 20
+	return 0
+}
+
+func (m *dbMeta) Lookup(ctx Context, parent Ino, name string, inode *Ino, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Access(ctx Context, inode Ino, modemask uint16) syscall.Errno {
+	return 0 // handled by kernel
+}
+
+func (m *dbMeta) GetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Fallocate(ctx Context, inode Ino, mode uint8, off uint64, size uint64) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint8, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) ReadLink(ctx Context, inode Ino, path *[]byte) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Symlink(ctx Context, parent Ino, name string, path string, inode *Ino, attr *Attr) syscall.Errno {
+	return m.mknod(ctx, parent, name, TypeSymlink, 0644, 022, 0, path, inode, attr)
+}
+
+func (m *dbMeta) Mknod(ctx Context, parent Ino, name string, _type uint8, mode, cumask uint16, rdev uint32, inode *Ino, attr *Attr) syscall.Errno {
+	return m.mknod(ctx, parent, name, _type, mode, cumask, rdev, "", inode, attr)
+}
+
+func (m *dbMeta) mknod(ctx Context, parent Ino, name string, _type uint8, mode, cumask uint16, rdev uint32, path string, inode *Ino, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Mkdir(ctx Context, parent Ino, name string, mode uint16, cumask uint16, copysgid uint8, inode *Ino, attr *Attr) syscall.Errno {
+	return m.Mknod(ctx, parent, name, TypeDirectory, mode, cumask, 0, inode, attr)
+}
+
+func (m *dbMeta) Create(ctx Context, parent Ino, name string, mode uint16, cumask uint16, inode *Ino, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Rmdir(ctx Context, parent Ino, name string) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst Ino, nameDst string, inode *Ino, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Link(ctx Context, inode, parent Ino, name string, attr *Attr) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Readdir(ctx Context, inode Ino, plus uint8, entries *[]*Entry) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Open(ctx Context, inode Ino, flags uint8, attr *Attr) syscall.Errno {
+	var err syscall.Errno
+	if attr != nil {
+		err = m.GetAttr(ctx, inode, attr)
+	}
+	if err == 0 {
+		m.Lock()
+		m.openFiles[inode] = m.openFiles[inode] + 1
+		m.Unlock()
+	}
+	return 0
+}
+
+func (m *dbMeta) Close(ctx Context, inode Ino) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) Read(ctx Context, inode Ino, indx uint32, chunks *[]Slice) syscall.Errno {
+	return 0
+}
+
+func (m *dbMeta) NewChunk(ctx Context, inode Ino, indx uint32, offset uint32, chunkid *uint64) syscall.Errno {
+	// cid, err := m.rdb.Incr(c, "nextchunk").Uint64()
+	// if err == nil {
+	// 	*chunkid = cid
+	// }
+	// return errno(err)
+	return 0
+}
+
+func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
+	return syscall.ENOTSUP
+}
+
+func (m *dbMeta) GetXattr(ctx Context, inode Ino, name string, vbuff *[]byte) syscall.Errno {
+	return syscall.ENOSYS
+}
+
+func (m *dbMeta) ListXattr(ctx Context, inode Ino, names *[]byte) syscall.Errno {
+	return syscall.ENOSYS
+}
+
+func (m *dbMeta) SetXattr(ctx Context, inode Ino, name string, value []byte) syscall.Errno {
+	return syscall.ENOSYS
+}
+
+func (m *dbMeta) RemoveXattr(ctx Context, inode Ino, name string) syscall.Errno {
+	return syscall.ENOSYS
+}
+
+func (m *dbMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, block bool) syscall.Errno {
+	return syscall.ENOSYS
+}
+
+func (m *dbMeta) Getlk(ctx Context, inode Ino, owner uint64, ltype *uint32, start, end *uint64, pid *uint32) syscall.Errno {
+	return syscall.ENOSYS
+}
+
+func (m *dbMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype uint32, start, end uint64, pid uint32) syscall.Errno {
+	return syscall.ENOSYS
+}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -99,8 +99,8 @@ type sustained struct {
 }
 
 type delfile struct {
-	Inode  Ino       `xorm:"unique(delfile) notnull"`
-	Length uint64    `xorm:"unique(delfile) notnull"`
+	Inode  Ino       `xorm:"pk notnull"`
+	Length uint64    `xorm:"notnull"`
 	Expire time.Time `xorm:"notnull"`
 }
 
@@ -221,7 +221,7 @@ func (m *dbMeta) Init(format Format, force bool) error {
 		logger.Fatalf("json: %s", err)
 	}
 
-	return errno(m.txn(func(s *xorm.Session) error {
+	return m.txn(func(s *xorm.Session) error {
 		_, err = s.Insert(&setting{"format", string(data)})
 		if err != nil {
 			return err
@@ -251,7 +251,7 @@ func (m *dbMeta) Init(format Format, force bool) error {
 			counter{"nextCleanupSlices", 0},
 		)
 		return err
-	}))
+	})
 }
 
 func (m *dbMeta) Load() (*Format, error) {
@@ -331,7 +331,7 @@ func (m *dbMeta) nextInode() (Ino, error) {
 	v, err := m.incrCounter("nextInode", 100)
 	if err == nil {
 		m.freeInodes.next = v + 1
-		m.freeInodes.maxid = v + 1000
+		m.freeInodes.maxid = v + 100
 	}
 	return Ino(v), err
 }
@@ -1104,7 +1104,7 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 			} else {
 				ok, err := s.Where("Inode = ?", de.Inode).Get(&dn)
 				if err != nil {
-					return errno(err)
+					return err
 				}
 				if !ok {
 					return syscall.ENOENT
@@ -1374,7 +1374,7 @@ func (m *dbMeta) cleanStaleSession(sid uint64) {
 func (m *dbMeta) cleanStaleSessions() {
 	// TODO: once per minute
 	var s session
-	rows, err := m.engine.Where("Heartbeat > ?", time.Now().Add(time.Minute*-5)).Rows(&s)
+	rows, err := m.engine.Where("Heartbeat < ?", time.Now().Add(time.Minute*-5)).Rows(&s)
 	if err != nil {
 		logger.Warnf("scan stale sessions: %s", err)
 		return
@@ -1401,8 +1401,8 @@ func (m *dbMeta) refreshSession() {
 	for {
 		time.Sleep(time.Minute)
 		_ = m.txn(func(ses *xorm.Session) error {
-			_, err := ses.Cols("Heartbeat").Update(&session{Heartbeat: time.Now()}, &session{Sid: m.sid})
-			if err != nil {
+			n, err := ses.Cols("Heartbeat").Update(&session{Heartbeat: time.Now()}, &session{Sid: m.sid})
+			if err != nil || n == 0 {
 				logger.Errorf("update session: %s", err)
 			}
 			return err
@@ -1802,6 +1802,7 @@ func (m *dbMeta) deleteFile(inode Ino, length uint64) {
 			return
 		}
 	}
+	_, _ = m.engine.Delete(delfile{Inode: inode})
 }
 
 func (m *dbMeta) compactChunk(inode Ino, indx uint32, force bool) {
@@ -1928,7 +1929,7 @@ func (m *dbMeta) compactChunk(inode Ino, indx uint32, force bool) {
 			}
 		}
 	} else {
-		logger.Warnf("compact %d %d: %s", inode, indx, errno)
+		logger.Warnf("compact %d %d: %s", inode, indx, err)
 	}
 	go func() {
 		// wait for the current compaction to finish

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -36,74 +36,72 @@ import (
 
 type setting struct {
 	Name  string `xorm:"pk"`
-	Value string `xorm:"varchar(4096)"`
+	Value string `xorm:"varchar(4096) notnull"`
 }
 
 type counter struct {
 	Name  string `xorm:"pk"`
-	Value uint64
+	Value uint64 `xorm:"notnull"`
 }
 
 type edge struct {
-	Parent Ino    `xorm:"unique(edge)"`
-	Name   string `xorm:"unique(edge)"`
-	Inode  Ino
-	Type   uint8
+	Parent Ino    `xorm:"unique(edge) notnull"`
+	Name   string `xorm:"unique(edge) notnull"`
+	Inode  Ino    `xorm:"notnull"`
+	Type   uint8  `xorm:"notnull"`
 }
 
 type node struct {
-	Inode  Ino `xorm:"pk"`
-	Type   uint8
-	Flags  uint8
-	Mode   uint16
-	Uid    uint32
-	Gid    uint32
-	Atime  time.Time
-	Mtime  time.Time
+	Inode  Ino       `xorm:"pk"`
+	Type   uint8     `xorm:"notnull"`
+	Flags  uint8     `xorm:"notnull"`
+	Mode   uint16    `xorm:"notnull"`
+	Uid    uint32    `xorm:"notnull"`
+	Gid    uint32    `xorm:"notnull"`
+	Atime  time.Time `xorm:"notnull"`
+	Mtime  time.Time `xorm:"notnull"`
 	Ctime  time.Time `xorm:"updated"`
-	Nlink  uint32
-	Length uint64
+	Nlink  uint32    `xorm:"notnull"`
+	Length uint64    `xorm:"notnull"`
 	Rdev   uint32
 	Parent Ino
 }
 
 type chunk struct {
-	Inode  Ino    `xorm:"unique(chunk)"`
-	Indx   uint32 `xorm:"unique(chunk)"`
-	Slices []byte `xorm:"blob"`
+	Inode  Ino    `xorm:"unique(chunk) notnull"`
+	Indx   uint32 `xorm:"unique(chunk) notnull"`
+	Slices []byte `xorm:"blob notnull"`
 }
-
+type sliceRef struct {
+	Chunkid uint64 `xorm:"pk"`
+	Size    uint32 `xorm:"notnull"`
+	Refs    int    `xorm:"notnull"`
+}
 type symlink struct {
 	Inode  Ino    `xorm:"pk"`
-	Target string `xorm:"varchar(4096)"`
+	Target string `xorm:"varchar(4096) notnull"`
 }
 
 type xattr struct {
-	Inode Ino    `xorm:"unique(name)"`
-	Name  string `xorm:"unique(name)"`
-	Value []byte `xorm:"blob"`
+	Inode Ino    `xorm:"unique(name) notnull"`
+	Name  string `xorm:"unique(name) notnull"`
+	Value []byte `xorm:"blob notnull"`
 }
 
 type session struct {
-	Sid       uint64 `xorm:"pk"`
-	Heartbeat time.Time
+	Sid       uint64    `xorm:"pk"`
+	Heartbeat time.Time `xorm:"notnull"`
 }
 
 type sustained struct {
-	Sid   uint64 `xorm:"unique(sustained)"`
-	Inode Ino    `xorm:"unique(sustained)"`
+	Sid   uint64 `xorm:"unique(sustained) notnull"`
+	Inode Ino    `xorm:"unique(sustained) notnull"`
 }
 
 type delfile struct {
-	Inode  Ino    `xorm:"unique(delfile)"`
-	Length uint64 `xorm:"unique(delfile)"`
-	Expire time.Time
-}
-
-type sliceRef struct {
-	Chunkid uint64
-	Size    uint32
-	Refs    int
+	Inode  Ino       `xorm:"unique(delfile) notnull"`
+	Length uint64    `xorm:"unique(delfile) notnull"`
+	Expire time.Time `xorm:"notnull"`
 }
 
 type freeID struct {

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -51,7 +51,7 @@ func TestMySQLClient(t *testing.T) {
 
 func TestConcurrentWriteSQL(t *testing.T) {
 	os.Remove("test1.db")
-	m, err := newSQLMeta("mysql", "root:mysql123@/dev", &Config{})
+	m, err := newSQLMeta("sqlite3", "test1.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -60,9 +60,7 @@ func TestConcurrentWriteSQL(t *testing.T) {
 
 func TestCompactionSQL(t *testing.T) {
 	os.Remove("test2.db")
-	// m, err := newSQLMeta("sqlite3", "test2.db", &Config{})
-	m, err := newSQLMeta("mysql", "root:mysql123@/dev", &Config{})
-
+	m, err := newSQLMeta("sqlite3", "test2.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -13,6 +13,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+//nolint:errcheck
 package meta
 
 import (

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -1,0 +1,185 @@
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+import (
+	"bytes"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestSQLClient(t *testing.T) {
+	os.Remove("test.db")
+	m, err := NewSQLMeta("sqlite3", "test.db")
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
+	}
+	m.OnMsg(DeleteChunk, func(args ...interface{}) error { return nil })
+	_ = m.Init(Format{Name: "test"}, true)
+	err = m.Init(Format{Name: "test"}, false) // changes nothing
+	if err != nil {
+		t.Fatalf("initialize failed: %s", err)
+	}
+	format, err := m.Load()
+	if err != nil {
+		t.Fatalf("load failed after initialization: %s", err)
+	}
+	if format.Name != "test" {
+		t.Fatalf("load got volume name %s, expected %s", format.Name, "test")
+	}
+	_ = m.NewSession()
+	// go m.(*sqlM).cleanStaleSessions()
+	ctx := Background
+	var parent, inode, dummyInode Ino
+	var attr = &Attr{}
+	if st := m.Mkdir(ctx, 1, "d", 0640, 022, 0, &parent, attr); st != 0 {
+		t.Fatalf("mkdir d: %s", st)
+	}
+	defer m.Rmdir(ctx, 1, "d")
+	if st := m.Unlink(ctx, 1, "d"); st != syscall.EPERM {
+		t.Fatalf("unlink d: %s", st)
+	}
+	if st := m.Rmdir(ctx, parent, "."); st != syscall.EINVAL {
+		t.Fatalf("Rmdir d.: %s", st)
+	}
+	if st := m.Rmdir(ctx, parent, ".."); st != syscall.ENOTEMPTY {
+		t.Fatalf("Rmdir d..: %s", st)
+	}
+	if st := m.Lookup(ctx, 1, "d", &parent, attr); st != 0 {
+		t.Fatalf("lookup d: %s", st)
+	}
+	if st := m.Access(ctx, parent, 4, attr); st != 0 {
+		t.Fatalf("access d: %s", st)
+	}
+	if st := m.Create(ctx, parent, "f", 0650, 022, &inode, attr); st != 0 {
+		t.Fatalf("create f: %s", st)
+	}
+	defer m.Unlink(ctx, parent, "f")
+	if st := m.Rmdir(ctx, parent, "f"); st != syscall.ENOTDIR {
+		t.Fatalf("rmdir f: %s", st)
+	}
+	if st := m.Rmdir(ctx, 1, "d"); st != syscall.ENOTEMPTY {
+		t.Fatalf("rmdir d: %s", st)
+	}
+	if st := m.Mknod(ctx, inode, "df", TypeFile, 0650, 022, 0, &dummyInode, nil); st != syscall.ENOTDIR {
+		t.Fatalf("create fd: %s", st)
+	}
+	if st := m.Mknod(ctx, parent, "f", TypeFile, 0650, 022, 0, &inode, attr); st != syscall.EEXIST {
+		t.Fatalf("create f: %s", st)
+	}
+	if st := m.Lookup(ctx, parent, "f", &inode, attr); st != 0 {
+		t.Fatalf("lookup f: %s", st)
+	}
+	attr.Atime = 2
+	attr.Mtime = 2
+	attr.Uid = 1
+	attr.Gid = 1
+	attr.Mode = 0644
+	if st := m.SetAttr(ctx, inode, SetAttrAtime|SetAttrMtime|SetAttrUID|SetAttrGID|SetAttrMode, 0, attr); st != 0 {
+		t.Fatalf("setattr f: %s", st)
+	}
+	if st := m.SetAttr(ctx, inode, 0, 0, attr); st != 0 { // changes nothing
+		t.Fatalf("setattr f: %s", st)
+	}
+	if st := m.GetAttr(ctx, inode, attr); st != 0 {
+		t.Fatalf("getattr f: %s", st)
+	}
+	if attr.Atime != 2 || attr.Mtime != 2 || attr.Uid != 1 || attr.Gid != 1 || attr.Mode != 0644 {
+		t.Fatalf("atime:%d mtime:%d uid:%d gid:%d mode:%o", attr.Atime, attr.Mtime, attr.Uid, attr.Gid, attr.Mode)
+	}
+	if st := m.SetAttr(ctx, inode, SetAttrAtimeNow|SetAttrMtimeNow, 0, attr); st != 0 {
+		t.Fatalf("setattr f: %s", st)
+	}
+	fakeCtx := NewContext(100, 1, []uint32{1})
+	if st := m.Access(fakeCtx, parent, 4, nil); st != syscall.EACCES {
+		t.Fatalf("access d: %s", st)
+	}
+	if st := m.Access(fakeCtx, inode, 4, nil); st != 0 {
+		t.Fatalf("access f: %s", st)
+	}
+	var entries []*Entry
+	if st := m.Readdir(ctx, parent, 0, &entries); st != 0 {
+		t.Fatalf("readdir: %s", st)
+	} else if len(entries) != 3 {
+		t.Fatalf("entries: %d", len(entries))
+	} else if string(entries[0].Name) != "." || string(entries[1].Name) != ".." || string(entries[2].Name) != "f" {
+		t.Fatalf("entries: %+v", entries)
+	}
+	if st := m.Rename(ctx, parent, "f", 1, "f2", &inode, attr); st != 0 {
+		t.Fatalf("rename d/f -> f2: %s", st)
+	}
+	defer func() {
+		_ = m.Unlink(ctx, 1, "f2")
+	}()
+	if st := m.Rename(ctx, 1, "f2", 1, "f2", &inode, attr); st != 0 {
+		t.Fatalf("rename f2 -> f2: %s", st)
+	}
+	if st := m.Create(ctx, 1, "f", 0644, 022, &inode, attr); st != 0 {
+		t.Fatalf("create f: %s", st)
+	}
+	defer m.Unlink(ctx, 1, "f")
+	if st := m.Rename(ctx, 1, "f2", 1, "f", &inode, attr); st != 0 {
+		t.Fatalf("rename f2 -> f: %s", st)
+	}
+	if st := m.Link(ctx, inode, 1, "f3", attr); st != 0 {
+		t.Fatalf("link f3 -> f: %s", st)
+	}
+	defer m.Unlink(ctx, 1, "f3")
+	if st := m.Link(ctx, parent, 1, "d2", attr); st != syscall.EPERM {
+		t.Fatalf("link d2 -> d: %s", st)
+	}
+	if st := m.Symlink(ctx, 1, "s", "/f", &inode, attr); st != 0 {
+		t.Fatalf("symlink s -> /f: %s", st)
+	}
+	defer m.Unlink(ctx, 1, "s")
+	var target1, target2 []byte
+	if st := m.ReadLink(ctx, inode, &target1); st != 0 {
+		t.Fatalf("readlink s: %s", st)
+	}
+	if st := m.ReadLink(ctx, inode, &target2); st != 0 { // cached
+		t.Fatalf("readlink s: %s", st)
+	}
+	if !bytes.Equal(target1, target2) || !bytes.Equal(target1, []byte("/f")) {
+		t.Fatalf("readlink got %s %s, expected %s", target1, target2, "/f")
+	}
+	if st := m.ReadLink(ctx, parent, &target1); st != syscall.ENOENT {
+		t.Fatalf("readlink d: %s", st)
+	}
+	if st := m.Lookup(ctx, 1, "f", &inode, attr); st != 0 {
+		t.Fatalf("lookup f: %s", st)
+	}
+
+	// data
+	var chunkid uint64
+	if st := m.Open(ctx, inode, 2, attr); st != 0 {
+		t.Fatalf("open f: %s", st)
+	}
+	if st := m.NewChunk(ctx, inode, 0, 0, &chunkid); st != 0 {
+		t.Fatalf("write chunk: %s", st)
+	}
+	var s = Slice{Chunkid: chunkid, Size: 100, Len: 100}
+	if st := m.Write(ctx, inode, 0, 100, s); st != 0 {
+		t.Fatalf("write end: %s", st)
+	}
+	var chunks []Slice
+	if st := m.Read(ctx, inode, 0, &chunks); st != 0 {
+		t.Fatalf("read chunk: %s", st)
+	}
+	if len(chunks) != 2 || chunks[0].Chunkid != 0 || chunks[0].Size != 100 || chunks[1].Chunkid != chunkid || chunks[1].Size != 100 {
+		t.Fatalf("chunks: %v", chunks)
+	}
+}

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSQLClient(t *testing.T) {
 	os.Remove("test.db")
-	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -30,8 +30,8 @@ func TestSQLClient(t *testing.T) {
 }
 
 func TestConcurrentWriteSQL(t *testing.T) {
-	os.Remove("test2.db")
-	m, err := NewSQLMeta("sqlite3", "test2.db", &DBConfig{})
+	os.Remove("test.db")
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -40,7 +40,7 @@ func TestConcurrentWriteSQL(t *testing.T) {
 
 func TestCompactionSQL(t *testing.T) {
 	os.Remove("test.db")
-	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -49,7 +49,7 @@ func TestCompactionSQL(t *testing.T) {
 
 func TestTruncateAndDeleteSQL(t *testing.T) {
 	os.Remove("test.db")
-	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -58,7 +58,7 @@ func TestTruncateAndDeleteSQL(t *testing.T) {
 
 func TestCopyFileRangeSQL(t *testing.T) {
 	os.Remove("test.db")
-	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -67,7 +67,7 @@ func TestCopyFileRangeSQL(t *testing.T) {
 
 func TestCaseIncensiSQL(t *testing.T) {
 	os.Remove("test.db")
-	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{CaseInsensi: true})
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{CaseInsensi: true})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -182,4 +182,19 @@ func TestSQLClient(t *testing.T) {
 	if len(chunks) != 2 || chunks[0].Chunkid != 0 || chunks[0].Size != 100 || chunks[1].Chunkid != chunkid || chunks[1].Size != 100 {
 		t.Fatalf("chunks: %v", chunks)
 	}
+
+	// xattr
+	if st := m.SetXattr(ctx, inode, "a", []byte("v")); st != 0 {
+		t.Fatalf("setxattr: %s", st)
+	}
+	var value []byte
+	if st := m.GetXattr(ctx, inode, "a", &value); st != 0 || string(value) != "v" {
+		t.Fatalf("getxattr: %s %v", st, value)
+	}
+	if st := m.ListXattr(ctx, inode, &value); st != 0 || string(value) != "a\000" {
+		t.Fatalf("listxattr: %s %v", st, value)
+	}
+	if st := m.RemoveXattr(ctx, inode, "a"); st != 0 {
+		t.Fatalf("setxattr: %s", st)
+	}
 }

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -51,7 +51,7 @@ func TestMySQLClient(t *testing.T) {
 
 func TestConcurrentWriteSQL(t *testing.T) {
 	os.Remove("test1.db")
-	m, err := newSQLMeta("sqlite3", "test1.db", &Config{})
+	m, err := newSQLMeta("mysql", "root:mysql123@/dev", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -60,7 +60,9 @@ func TestConcurrentWriteSQL(t *testing.T) {
 
 func TestCompactionSQL(t *testing.T) {
 	os.Remove("test2.db")
-	m, err := newSQLMeta("sqlite3", "test2.db", &Config{})
+	// m, err := newSQLMeta("sqlite3", "test2.db", &Config{})
+	m, err := newSQLMeta("mysql", "root:mysql123@/dev", &Config{})
+
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -16,185 +16,60 @@
 package meta
 
 import (
-	"bytes"
 	"os"
-	"syscall"
 	"testing"
 )
 
 func TestSQLClient(t *testing.T) {
 	os.Remove("test.db")
-	m, err := NewSQLMeta("sqlite3", "test.db")
+	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
-	m.OnMsg(DeleteChunk, func(args ...interface{}) error { return nil })
-	_ = m.Init(Format{Name: "test"}, true)
-	err = m.Init(Format{Name: "test"}, false) // changes nothing
-	if err != nil {
-		t.Fatalf("initialize failed: %s", err)
-	}
-	format, err := m.Load()
-	if err != nil {
-		t.Fatalf("load failed after initialization: %s", err)
-	}
-	if format.Name != "test" {
-		t.Fatalf("load got volume name %s, expected %s", format.Name, "test")
-	}
-	_ = m.NewSession()
-	// go m.(*sqlM).cleanStaleSessions()
-	ctx := Background
-	var parent, inode, dummyInode Ino
-	var attr = &Attr{}
-	if st := m.Mkdir(ctx, 1, "d", 0640, 022, 0, &parent, attr); st != 0 {
-		t.Fatalf("mkdir d: %s", st)
-	}
-	defer m.Rmdir(ctx, 1, "d")
-	if st := m.Unlink(ctx, 1, "d"); st != syscall.EPERM {
-		t.Fatalf("unlink d: %s", st)
-	}
-	if st := m.Rmdir(ctx, parent, "."); st != syscall.EINVAL {
-		t.Fatalf("Rmdir d.: %s", st)
-	}
-	if st := m.Rmdir(ctx, parent, ".."); st != syscall.ENOTEMPTY {
-		t.Fatalf("Rmdir d..: %s", st)
-	}
-	if st := m.Lookup(ctx, 1, "d", &parent, attr); st != 0 {
-		t.Fatalf("lookup d: %s", st)
-	}
-	if st := m.Access(ctx, parent, 4, attr); st != 0 {
-		t.Fatalf("access d: %s", st)
-	}
-	if st := m.Create(ctx, parent, "f", 0650, 022, &inode, attr); st != 0 {
-		t.Fatalf("create f: %s", st)
-	}
-	defer m.Unlink(ctx, parent, "f")
-	if st := m.Rmdir(ctx, parent, "f"); st != syscall.ENOTDIR {
-		t.Fatalf("rmdir f: %s", st)
-	}
-	if st := m.Rmdir(ctx, 1, "d"); st != syscall.ENOTEMPTY {
-		t.Fatalf("rmdir d: %s", st)
-	}
-	if st := m.Mknod(ctx, inode, "df", TypeFile, 0650, 022, 0, &dummyInode, nil); st != syscall.ENOTDIR {
-		t.Fatalf("create fd: %s", st)
-	}
-	if st := m.Mknod(ctx, parent, "f", TypeFile, 0650, 022, 0, &inode, attr); st != syscall.EEXIST {
-		t.Fatalf("create f: %s", st)
-	}
-	if st := m.Lookup(ctx, parent, "f", &inode, attr); st != 0 {
-		t.Fatalf("lookup f: %s", st)
-	}
-	attr.Atime = 2
-	attr.Mtime = 2
-	attr.Uid = 1
-	attr.Gid = 1
-	attr.Mode = 0644
-	if st := m.SetAttr(ctx, inode, SetAttrAtime|SetAttrMtime|SetAttrUID|SetAttrGID|SetAttrMode, 0, attr); st != 0 {
-		t.Fatalf("setattr f: %s", st)
-	}
-	if st := m.SetAttr(ctx, inode, 0, 0, attr); st != 0 { // changes nothing
-		t.Fatalf("setattr f: %s", st)
-	}
-	if st := m.GetAttr(ctx, inode, attr); st != 0 {
-		t.Fatalf("getattr f: %s", st)
-	}
-	if attr.Atime != 2 || attr.Mtime != 2 || attr.Uid != 1 || attr.Gid != 1 || attr.Mode != 0644 {
-		t.Fatalf("atime:%d mtime:%d uid:%d gid:%d mode:%o", attr.Atime, attr.Mtime, attr.Uid, attr.Gid, attr.Mode)
-	}
-	if st := m.SetAttr(ctx, inode, SetAttrAtimeNow|SetAttrMtimeNow, 0, attr); st != 0 {
-		t.Fatalf("setattr f: %s", st)
-	}
-	fakeCtx := NewContext(100, 1, []uint32{1})
-	if st := m.Access(fakeCtx, parent, 4, nil); st != syscall.EACCES {
-		t.Fatalf("access d: %s", st)
-	}
-	if st := m.Access(fakeCtx, inode, 4, nil); st != 0 {
-		t.Fatalf("access f: %s", st)
-	}
-	var entries []*Entry
-	if st := m.Readdir(ctx, parent, 0, &entries); st != 0 {
-		t.Fatalf("readdir: %s", st)
-	} else if len(entries) != 3 {
-		t.Fatalf("entries: %d", len(entries))
-	} else if string(entries[0].Name) != "." || string(entries[1].Name) != ".." || string(entries[2].Name) != "f" {
-		t.Fatalf("entries: %+v", entries)
-	}
-	if st := m.Rename(ctx, parent, "f", 1, "f2", &inode, attr); st != 0 {
-		t.Fatalf("rename d/f -> f2: %s", st)
-	}
-	defer func() {
-		_ = m.Unlink(ctx, 1, "f2")
-	}()
-	if st := m.Rename(ctx, 1, "f2", 1, "f2", &inode, attr); st != 0 {
-		t.Fatalf("rename f2 -> f2: %s", st)
-	}
-	if st := m.Create(ctx, 1, "f", 0644, 022, &inode, attr); st != 0 {
-		t.Fatalf("create f: %s", st)
-	}
-	defer m.Unlink(ctx, 1, "f")
-	if st := m.Rename(ctx, 1, "f2", 1, "f", &inode, attr); st != 0 {
-		t.Fatalf("rename f2 -> f: %s", st)
-	}
-	if st := m.Link(ctx, inode, 1, "f3", attr); st != 0 {
-		t.Fatalf("link f3 -> f: %s", st)
-	}
-	defer m.Unlink(ctx, 1, "f3")
-	if st := m.Link(ctx, parent, 1, "d2", attr); st != syscall.EPERM {
-		t.Fatalf("link d2 -> d: %s", st)
-	}
-	if st := m.Symlink(ctx, 1, "s", "/f", &inode, attr); st != 0 {
-		t.Fatalf("symlink s -> /f: %s", st)
-	}
-	defer m.Unlink(ctx, 1, "s")
-	var target1, target2 []byte
-	if st := m.ReadLink(ctx, inode, &target1); st != 0 {
-		t.Fatalf("readlink s: %s", st)
-	}
-	if st := m.ReadLink(ctx, inode, &target2); st != 0 { // cached
-		t.Fatalf("readlink s: %s", st)
-	}
-	if !bytes.Equal(target1, target2) || !bytes.Equal(target1, []byte("/f")) {
-		t.Fatalf("readlink got %s %s, expected %s", target1, target2, "/f")
-	}
-	if st := m.ReadLink(ctx, parent, &target1); st != syscall.ENOENT {
-		t.Fatalf("readlink d: %s", st)
-	}
-	if st := m.Lookup(ctx, 1, "f", &inode, attr); st != 0 {
-		t.Fatalf("lookup f: %s", st)
-	}
+	testMetaClient(t, m)
+}
 
-	// data
-	var chunkid uint64
-	if st := m.Open(ctx, inode, 2, attr); st != 0 {
-		t.Fatalf("open f: %s", st)
+func TestConcurrentWriteSQL(t *testing.T) {
+	os.Remove("test2.db")
+	m, err := NewSQLMeta("sqlite3", "test2.db", &DBConfig{})
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
 	}
-	if st := m.NewChunk(ctx, inode, 0, 0, &chunkid); st != 0 {
-		t.Fatalf("write chunk: %s", st)
-	}
-	var s = Slice{Chunkid: chunkid, Size: 100, Len: 100}
-	if st := m.Write(ctx, inode, 0, 100, s); st != 0 {
-		t.Fatalf("write end: %s", st)
-	}
-	var chunks []Slice
-	if st := m.Read(ctx, inode, 0, &chunks); st != 0 {
-		t.Fatalf("read chunk: %s", st)
-	}
-	if len(chunks) != 2 || chunks[0].Chunkid != 0 || chunks[0].Size != 100 || chunks[1].Chunkid != chunkid || chunks[1].Size != 100 {
-		t.Fatalf("chunks: %v", chunks)
-	}
+	testConcurrentWrite(t, m)
+}
 
-	// xattr
-	if st := m.SetXattr(ctx, inode, "a", []byte("v")); st != 0 {
-		t.Fatalf("setxattr: %s", st)
+func TestCompactionSQL(t *testing.T) {
+	os.Remove("test.db")
+	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
 	}
-	var value []byte
-	if st := m.GetXattr(ctx, inode, "a", &value); st != 0 || string(value) != "v" {
-		t.Fatalf("getxattr: %s %v", st, value)
+	testCompaction(t, m)
+}
+
+func TestTruncateAndDeleteSQL(t *testing.T) {
+	os.Remove("test.db")
+	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
 	}
-	if st := m.ListXattr(ctx, inode, &value); st != 0 || string(value) != "a\000" {
-		t.Fatalf("listxattr: %s %v", st, value)
+	testTruncateAndDelete(t, m)
+}
+
+func TestCopyFileRangeSQL(t *testing.T) {
+	os.Remove("test.db")
+	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{})
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
 	}
-	if st := m.RemoveXattr(ctx, inode, "a"); st != 0 {
-		t.Fatalf("setxattr: %s", st)
+	testCopyFileRange(t, m)
+}
+
+func TestCaseIncensiSQL(t *testing.T) {
+	os.Remove("test.db")
+	m, err := NewSQLMeta("sqlite3", "test.db", &DBConfig{CaseInsensi: true})
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
 	}
+	testCaseIncensi(t, m)
 }

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -31,7 +31,7 @@ func TestSQLClient(t *testing.T) {
 }
 
 func TestMySQLClient(t *testing.T) {
-	m, err := newSQLMeta("mysql", "root:mysql123@/dev", &Config{})
+	m, err := newSQLMeta("mysql", "root:@/dev", &Config{})
 	if err != nil {
 		t.Skipf("create meta: %s", err)
 	}

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -29,9 +29,28 @@ func TestSQLClient(t *testing.T) {
 	testMetaClient(t, m)
 }
 
+func TestMySQLClient(t *testing.T) {
+	m, err := newSQLMeta("mysql", "root:@/dev", &Config{})
+	if err != nil {
+		t.Skipf("create meta: %s", err)
+	}
+	m.engine.DropTables(&setting{})
+	m.engine.DropTables(&counter{})
+	m.engine.DropTables(&node{})
+	m.engine.DropTables(&edge{})
+	m.engine.DropTables(&symlink{})
+	m.engine.DropTables(&chunk{})
+	m.engine.DropTables(&sliceRef{})
+	m.engine.DropTables(&session{})
+	m.engine.DropTables(&sustained{})
+	m.engine.DropTables(&xattr{})
+	m.engine.DropTables(&delfile{})
+	testMetaClient(t, m)
+}
+
 func TestConcurrentWriteSQL(t *testing.T) {
-	os.Remove("test.db")
-	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
+	os.Remove("test1.db")
+	m, err := newSQLMeta("sqlite3", "test1.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}
@@ -39,8 +58,8 @@ func TestConcurrentWriteSQL(t *testing.T) {
 }
 
 func TestCompactionSQL(t *testing.T) {
-	os.Remove("test.db")
-	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
+	os.Remove("test2.db")
+	m, err := newSQLMeta("sqlite3", "test2.db", &Config{})
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -31,7 +31,7 @@ func TestSQLClient(t *testing.T) {
 }
 
 func TestMySQLClient(t *testing.T) {
-	m, err := newSQLMeta("mysql", "root:@/dev", &Config{})
+	m, err := newSQLMeta("mysql", "root:mysql123@/dev", &Config{})
 	if err != nil {
 		t.Skipf("create meta: %s", err)
 	}

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -154,14 +154,14 @@ func handleInternalMsg(ctx Context, msg []byte) []byte {
 	case meta.Rmr:
 		inode := Ino(r.Get64())
 		name := string(r.Get(int(r.Get8())))
-		r := m.Rmr(ctx, inode, name)
+		r := meta.Remove(m, ctx, inode, name)
 		return []byte{uint8(r)}
 	case meta.Info:
 		var summary meta.Summary
 		inode := Ino(r.Get64())
 
 		wb := utils.NewBuffer(4)
-		r := m.Summary(ctx, inode, &summary)
+		r := meta.GetSummary(m, ctx, inode, &summary)
 		if r != 0 {
 			msg := r.Error()
 			wb.Put32(uint32(len(msg)))

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -769,6 +769,11 @@ func (r *dataReader) visit(inode Ino, fn func(*fileReader)) {
 
 func (r *dataReader) Truncate(inode Ino, length uint64) {
 	r.visit(inode, func(f *fileReader) {
+		f.visit(func(s *sliceReader) {
+			if s.block.off+s.block.len > length {
+				s.invalidate()
+			}
+		})
 		f.length = length
 	})
 }

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -712,7 +712,7 @@ func NewDataReader(conf *Config, m meta.Meta, store chunk.ChunkStore) DataReader
 		readAheadTotal: uint64(readAheadTotal),
 		readAheadMax:   uint64(readAheadMax),
 		maxRequests:    readAheadMax/conf.Chunk.BlockSize*readSessions + 1,
-		maxRetries:     uint32(conf.Meta.IORetries),
+		maxRetries:     uint32(conf.Meta.Retries),
 	}
 	go r.checkReadBuffer()
 	return r

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -422,7 +422,7 @@ func Open(ctx Context, ino Ino, flags uint32) (entry *meta.Entry, fh uint64, err
 }
 
 func Truncate(ctx Context, ino Ino, size int64, opened uint8, attr *Attr) (err syscall.Errno) {
-	defer func() { logit(ctx, "truncate (%d,%d): %s", ino, size, strerr(err)) }()
+	// defer func() { logit(ctx, "truncate (%d,%d): %s", ino, size, strerr(err)) }()
 	if IsSpecialNode(ino) {
 		err = syscall.EPERM
 		return

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -402,7 +402,7 @@ func NewDataWriter(conf *Config, m meta.Meta, store chunk.ChunkStore) DataWriter
 		blockSize:  conf.Chunk.BlockSize,
 		bufferSize: int64(conf.Chunk.BufferSize),
 		files:      make(map[Ino]*fileWriter),
-		maxRetries: uint32(conf.Meta.IORetries),
+		maxRetries: uint32(conf.Meta.Retries),
 	}
 	go w.flushAll()
 	return w

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -310,10 +310,7 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 		utils.InitLoggers(false)
 
 		addr := jConf.MetaURL
-		m := meta.NewClient(addr, &meta.Config{
-			Retries: 10,
-			Strict:  true,
-		})
+		m := meta.NewClient(addr, &meta.Config{Retries: 10, Strict: true})
 		format, err := m.Load()
 		if err != nil {
 			logger.Fatalf("load setting: %s", err)
@@ -401,7 +398,7 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 
 		conf := &vfs.Config{
 			Meta: &meta.Config{
-				IORetries: 10,
+				Retries: 10,
 			},
 			Format:    format,
 			Chunk:     &chunkConf,

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -310,15 +310,10 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 		utils.InitLoggers(false)
 
 		addr := jConf.MetaURL
-		if !strings.Contains(addr, "://") {
-			addr = "redis://" + addr
-		}
-		logger.Infof("Meta address: %s", addr)
-		var rc = meta.RedisConfig{Retries: 10, Strict: true}
-		m, err := meta.NewRedisMeta(addr, &rc)
-		if err != nil {
-			logger.Fatalf("Meta: %s", err)
-		}
+		m := meta.NewClient(addr, &meta.Config{
+			Retries: 10,
+			Strict:  true,
+		})
 		format, err := m.Load()
 		if err != nil {
 			logger.Fatalf("load setting: %s", err)


### PR DESCRIPTION
SQL is a popular interface to talk to database, this PR enable JuiceFS to use SQL databases as meta store. Currently, SQLite and MySQL are supported, other database will be added later.

To use MySQL as meta store:

```
./juicefs format mysql://user:pass@host:port/db  name
```

Or SQLite 

```
./juicefs format sqlite3:///path/to/db  name
```

Except file locks, other POSIX features are supported.

Closes #183  #359