### PR TITLE
Fix `juicefs profile` panic when parse invalid log line

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -71,6 +71,10 @@ func parseLine(line string) *logEntry {
 		return nil
 	}
 	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		logger.Warnf("Log line is invalid: %s", line)
+		return nil
+	}
 	ts, err := time.Parse("2006.01.02 15:04:05.000000", strings.Join([]string{fields[0], fields[1]}, " "))
 	if err != nil {
 		logger.Warnf("Failed to parse log line: %s: %s", line, err)


### PR DESCRIPTION
Fix panic when parse invalid log line, e.g. `2021.05.^C` (the last line of access log).

```
panic: runtime error: index out of range [1] with length 1

goroutine 71 [running]:
main.parseLine(0xc001625a40, 0xa, 0xa)
	/go/src/github.com/juicedata/juicefs/cmd/profile.go:74 +0x659
main.(*profiler).reader(0xc000a8fef0)
	/go/src/github.com/juicedata/juicefs/cmd/profile.go:99 +0xb6
created by main.profile
	/go/src/github.com/juicedata/juicefs/cmd/profile.go:290 +0x605
```