### PR TITLE
Optimize readSliceBuf

### DIFF
--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -111,11 +111,13 @@ func readSlices(vals []string) []*slice {
 }
 
 func readSliceBuf(buf []byte) []*slice {
-	var ss []*slice
+	nSlices := len(buf) / sliceBytes
+	slices := make([]slice, nSlices)
+	ss := make([]*slice, nSlices)
 	for i := 0; i < len(buf); i += sliceBytes {
-		s := new(slice)
+		s := &slices[i/sliceBytes]
 		s.read(buf[i:])
-		ss = append(ss, s)
+		ss[i/sliceBytes] = s
 	}
 	return ss
 }


### PR DESCRIPTION
Before:
```
BenchmarkReadSliceBuf
BenchmarkReadSliceBuf/small
BenchmarkReadSliceBuf/small-16         	 3337833	       380.6 ns/op
BenchmarkReadSliceBuf/mid
BenchmarkReadSliceBuf/mid-16           	  297603	      4010 ns/op
BenchmarkReadSliceBuf/large
BenchmarkReadSliceBuf/large-16         	   20037	     60182 ns/op
```

After:
```
BenchmarkReadSliceBuf
BenchmarkReadSliceBuf/small
BenchmarkReadSliceBuf/small-16         	 5951392	       201.1 ns/op
BenchmarkReadSliceBuf/mid
BenchmarkReadSliceBuf/mid-16           	  590236	      2038 ns/op
BenchmarkReadSliceBuf/large
BenchmarkReadSliceBuf/large-16         	   40591	     29739 ns/op
```