### PR TITLE
fix juicefs sync launch worker args

### DIFF
--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -234,20 +234,16 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 				logger.Errorf("copy itself to %s: %s", host, err)
 				return
 			}
-			// launch itself with --worker argument replaced with --manager
+			// launch itself
 			var args = []string{host, rpath}
-			args = append(args, os.Args[1:]...)
-			for i := range args {
-				if strings.HasPrefix(args[i], "--worker") {
-					if len(args[i]) > len("--worker") {
-						args[i] = fmt.Sprintf("--manager=%s", address)
-					} else {
-						args[i] = "--manager"
-						args[i+1] = address
-					}
-					break
-				}
+			if strings.HasSuffix(path, "juicefs") {
+				args = append(args, os.Args[1:]...)
+				args = append(args, "--manager", address)
+			} else {
+				args = append(args, "--manager", address)
+				args = append(args, os.Args[1:]...)
 			}
+
 			logger.Debugf("launch worker command args: [ssh, %s]\n", strings.Join(args, ", "))
 			cmd = exec.Command("ssh", args...)
 			stderr, err := cmd.StderrPipe()


### PR DESCRIPTION
Currently the concat  launch worker command is: `/tmp/juicefs sync -manager {{managerAddress}} sync ... `, which has a unnecessary `sync` arg.
This PR fix this problem.