### PR TITLE
fix permession check in lua script

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -534,15 +534,17 @@ func (fs *FileSystem) lookup(ctx meta.Context, p string, followLastSymlink bool)
 	var inode Ino
 	var attr = &Attr{}
 
-	err = fs.m.Resolve(ctx, 1, p, &inode, attr)
-	if err == 0 {
-		fi = AttrToFileInfo(inode, attr)
-		p = strings.TrimRight(p, "/")
-		ss := strings.Split(p, "/")
-		fi.name = ss[len(ss)-1]
-	}
-	if err != syscall.ENOTSUP {
-		return
+	if fs.conf.FastResolve {
+		err = fs.m.Resolve(ctx, 1, p, &inode, attr)
+		if err == 0 {
+			fi = AttrToFileInfo(inode, attr)
+			p = strings.TrimRight(p, "/")
+			ss := strings.Split(p, "/")
+			fi.name = ss[len(ss)-1]
+		}
+		if err != syscall.ENOTSUP {
+			return
+		}
 	}
 
 	// Fallback to the default implementation that calls `fs.m.Lookup` for each directory along the path.

--- a/pkg/meta/lua_scripts.go
+++ b/pkg/meta/lua_scripts.go
@@ -29,7 +29,7 @@ const scriptResolve = `
 local function unpack_attr(buf)
     local x = {}
     x.flags, x.mode, x.uid, x.gid = struct.unpack(">BHI4I4", string.sub(buf, 0, 11))
-    x.type = (x.mode / 4096) % 8
+    x.type = math.floor(x.mode / 4096) % 8
     x.mode = x.mode % 4096
     return x
 end
@@ -58,9 +58,9 @@ local function can_access(ino, uid, gid)
     local attr = get_attr(ino)
     local mode = 0
     if attr.uid == uid then
-        mode = (attr.mode / 64) % 8
+        mode = math.floor(attr.mode / 64) % 8
     elseif attr.gid == gid then
-        mode = (attr.mode / 8) % 8
+        mode = math.floor(attr.mode / 8) % 8
     else
         mode = attr.mode % 8
     end

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -555,6 +555,7 @@ func (r *redisMeta) Resolve(ctx Context, parent Ino, path string, inode *Ino, at
 			return syscall.ENOTSUP
 		default:
 			logger.Warnf("resolve %d %s: %s", parent, path, err)
+			r.shaResolve = ""
 			return syscall.ENOTSUP
 		}
 	}

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -115,6 +115,20 @@ func testMetaClient(t *testing.T, m Meta) {
 	if st := m.Resolve(ctx, parent, "/f2", &inode, attr); st != syscall.ENOENT && st != syscall.ENOTSUP {
 		t.Fatalf("resolve f2: %s", st)
 	}
+	// check owner permission
+	var p1, c1 Ino
+	if st := m.Mkdir(ctx2, 1, "d1", 0777, 022, 0, &p1, attr); st != 0 {
+		t.Fatalf("mkdir d1: %s", st)
+	}
+	if st := m.Mkdir(ctx2, p1, "d2", 0777, 022, 0, &c1, attr); st != 0 {
+		t.Fatalf("mkdir d2: %s", st)
+	}
+	if st := m.Resolve(ctx2, 1, "/d1/d2", nil, nil); st != 0 && st != syscall.ENOTSUP {
+		t.Fatalf("resolve /d1/d2: %s", st)
+	}
+	m.Rmdir(ctx2, p1, "d2")
+	m.Rmdir(ctx2, 1, "d1")
+
 	attr.Atime = 2
 	attr.Mtime = 2
 	attr.Uid = 1

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -38,12 +38,13 @@ const (
 )
 
 type Config struct {
-	Meta       *meta.Config
-	Format     *meta.Format
-	Chunk      *chunk.Config
-	Version    string
-	Mountpoint string
-	AccessLog  string
+	Meta        *meta.Config
+	Format      *meta.Format
+	Chunk       *chunk.Config
+	Version     string
+	Mountpoint  string
+	FastResolve bool
+	AccessLog   string
 }
 
 var (

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -226,6 +226,7 @@ type javaConf struct {
 	MaxUploads     int    `json:"maxUploads"`
 	GetTimeout     int    `json:"getTimeout"`
 	PutTimeout     int    `json:"putTimeout"`
+	FastResolve    bool   `json:"fastResolve"`
 	Debug          bool   `json:"debug"`
 	NoUsageReport  bool   `json:"noUsageReport"`
 	AccessLog      string `json:"accessLog"`
@@ -400,9 +401,10 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 			Meta: &meta.Config{
 				Retries: 10,
 			},
-			Format:    format,
-			Chunk:     &chunkConf,
-			AccessLog: jConf.AccessLog,
+			Format:      format,
+			Chunk:       &chunkConf,
+			AccessLog:   jConf.AccessLog,
+			FastResolve: jConf.FastResolve,
 		}
 		if !jConf.NoUsageReport {
 			go usage.ReportUsage(m, "java-sdk "+version.Version())

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -333,6 +333,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     obj.put("pushGateway", getConf(conf, "push-gateway", ""));
     obj.put("pushInterval", Integer.valueOf(getConf(conf, "push-interval", "10")));
     obj.put("pushAuth", getConf(conf, "push-auth", ""));
+    obj.put("fastResolve", Boolean.valueOf(getConf(conf, "fast-resolve", "true")));
     obj.put("noUsageReport", Boolean.valueOf(getConf(conf, "no-usage-report", "false")));
     obj.put("freeSpace", getConf(conf, "free-space", ""));
     obj.put("accessLog", getConf(conf, "access-log", ""));


### PR DESCRIPTION
The division return a float rather than a integer, so we need to use math.floor() to convert the result into a integer.

Added a configuration to disable resolve using Lua script.