### PR TITLE
lock read rows during transactions

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -350,6 +350,7 @@ func (m *dbMeta) txn(f func(s *xorm.Session) error) error {
 	var err error
 	for i := 0; i < 50; i++ {
 		_, err = m.engine.Transaction(func(s *xorm.Session) (interface{}, error) {
+			s.ForUpdate()
 			return nil, f(s)
 		})
 		// TODO: add other retryable errors here

--- a/pkg/meta/sql_unix.go
+++ b/pkg/meta/sql_unix.go
@@ -35,11 +35,7 @@ func (m *dbMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, block
 	var err syscall.Errno
 	for {
 		err = errno(m.txn(func(s *xorm.Session) error {
-			var suffix string
-			if m.engine.DriverName() != "sqlite3" {
-				suffix = " for update"
-			}
-			rows, err := s.SQL("select * from jfs_flock where inode=?"+suffix, inode).Rows(&flock{Inode: inode})
+			rows, err := s.Rows(&flock{Inode: inode})
 			if err != nil {
 				return err
 			}
@@ -168,11 +164,7 @@ func (m *dbMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype u
 				}
 				return err
 			}
-			var suffix string
-			if m.engine.DriverName() != "sqlite3" {
-				suffix = " for update"
-			}
-			rows, err := s.SQL("select * from jfs_plock where inode=?"+suffix, inode).Rows(&plock{Inode: inode})
+			rows, err := s.Rows(&plock{Inode: inode})
 			if err != nil {
 				return errno(err)
 			}


### PR DESCRIPTION
Under repeatable read isolation level, the transaction will commit successfully even some queried rows is changed by other transactions, which is different from the optimistic transaction in Redis.

This PR will add a lock for all queried rows during a transaction to fix the conflict.