### PR TITLE
donot try to override version from tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,9 @@ all: juicefs
 
 REVISION := $(shell git rev-parse --short HEAD 2>/dev/null)
 REVISIONDATE := $(shell git log -1 --pretty=format:'%ad' --date short 2>/dev/null)
-VERSION := $(shell git describe --tags --match 'v*' 2>/dev/null | sed -e 's/^v//' -e 's/-g[0-9a-f]\{7,\}$$//')
 PKG := github.com/juicedata/juicefs/pkg/version
 LDFLAGS = -s -w
-ifneq ($(strip $(VERSION)),)
-	LDFLAGS += -X $(PKG).revision=$(REVISION) \
-		   -X $(PKG).revisionDate=$(REVISIONDATE) \
-		   -X $(PKG).version=$(VERSION)
-else ifneq ($(strip $(REVISION)),) # Use git clone with --depth or --no-tags
+ifneq ($(strip $(REVISION)),) # Use git clone
 	LDFLAGS += -X $(PKG).revision=$(REVISION) \
 		   -X $(PKG).revisionDate=$(REVISIONDATE)
 endif


### PR DESCRIPTION
We should hold a branch for each stable version, and use version from code.