### PR TITLE
Support sticky bit in Java SDK

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1412,7 +1412,7 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 					r.Unlock()
 				}
 			}
-			if ctx.Uid() != 0 && sattr.Mode&01000 != 0 && ctx.Uid() != sattr.Uid && ctx.Uid() != tattr.Uid {
+			if ctx.Uid() != 0 && dattr.Mode&01000 != 0 && ctx.Uid() != dattr.Uid && ctx.Uid() != tattr.Uid {
 				return syscall.EACCES
 			}
 		} else {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1109,6 +1109,9 @@ func (r *redisMeta) Unlink(ctx Context, parent Ino, name string) syscall.Errno {
 		r.parseAttr([]byte(rs[1].(string)), &attr)
 		attr.Ctime = now.Unix()
 		attr.Ctimensec = uint32(now.Nanosecond())
+		if ctx.Uid() != 0 && pattr.Mode&01000 != 0 && ctx.Uid() != pattr.Uid && ctx.Uid() != attr.Uid {
+			return syscall.EACCES
+		}
 
 		buf, err := tx.HGet(ctx, r.entryKey(parent), name).Bytes()
 		if err != nil {
@@ -1193,12 +1196,13 @@ func (r *redisMeta) Rmdir(ctx Context, parent Ino, name string) syscall.Errno {
 	}
 
 	return r.txn(ctx, func(tx *redis.Tx) error {
-		a, err := tx.Get(ctx, r.inodeKey(parent)).Bytes()
-		if err != nil {
-			return err
+		rs, _ := tx.MGet(ctx, r.inodeKey(parent), r.inodeKey(inode)).Result()
+		if rs[0] == nil || rs[1] == nil {
+			return redis.Nil
 		}
-		var pattr Attr
-		r.parseAttr(a, &pattr)
+		var pattr, attr Attr
+		r.parseAttr([]byte(rs[0].(string)), &pattr)
+		r.parseAttr([]byte(rs[1].(string)), &attr)
 		if pattr.Typ != TypeDirectory {
 			return syscall.ENOTDIR
 		}
@@ -1225,6 +1229,10 @@ func (r *redisMeta) Rmdir(ctx Context, parent Ino, name string) syscall.Errno {
 		if cnt > 0 {
 			return syscall.ENOTEMPTY
 		}
+		if ctx.Uid() != 0 && pattr.Mode&01000 != 0 && ctx.Uid() != pattr.Uid && ctx.Uid() != attr.Uid {
+			return syscall.EACCES
+		}
+
 		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 			pipe.HDel(ctx, r.entryKey(parent), name)
 			pipe.Set(ctx, r.inodeKey(parent), r.marshal(&pattr), 0)
@@ -1350,6 +1358,21 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 	}
 
 	return r.txn(ctx, func(tx *redis.Tx) error {
+		rs, _ := tx.MGet(ctx, r.inodeKey(parentSrc), r.inodeKey(parentDst), r.inodeKey(ino)).Result()
+		if rs[0] == nil || rs[1] == nil || rs[2] == nil {
+			return redis.Nil
+		}
+		var sattr, dattr, iattr Attr
+		r.parseAttr([]byte(rs[0].(string)), &sattr)
+		if sattr.Typ != TypeDirectory {
+			return syscall.ENOTDIR
+		}
+		r.parseAttr([]byte(rs[1].(string)), &dattr)
+		if dattr.Typ != TypeDirectory {
+			return syscall.ENOTDIR
+		}
+		r.parseAttr([]byte(rs[2].(string)), &iattr)
+
 		buf, err = tx.HGet(ctx, r.entryKey(parentDst), nameDst).Bytes()
 		if err != nil && err != redis.Nil {
 			return err
@@ -1364,6 +1387,11 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 			if dino1 != dino || typ1 != dtyp {
 				return syscall.EAGAIN
 			}
+			a, err := tx.Get(ctx, r.inodeKey(dino)).Bytes()
+			if err != nil {
+				return err
+			}
+			r.parseAttr(a, &tattr)
 			if typ1 == TypeDirectory {
 				cnt, err := tx.HLen(ctx, r.entryKey(dino)).Result()
 				if err != nil {
@@ -1373,11 +1401,6 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 					return syscall.ENOTEMPTY
 				}
 			} else {
-				a, err := tx.Get(ctx, r.inodeKey(dino)).Bytes()
-				if err != nil {
-					return err
-				}
-				r.parseAttr(a, &tattr)
 				tattr.Nlink--
 				if tattr.Nlink > 0 {
 					now := time.Now()
@@ -1388,6 +1411,9 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 					opened = r.openFiles[dino] > 0
 					r.Unlock()
 				}
+			}
+			if ctx.Uid() != 0 && sattr.Mode&01000 != 0 && ctx.Uid() != sattr.Uid && ctx.Uid() != tattr.Uid {
+				return syscall.EACCES
 			}
 		} else {
 			dino = 0
@@ -1401,30 +1427,19 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 		if ino != ino1 {
 			return syscall.EAGAIN
 		}
+		if ctx.Uid() != 0 && sattr.Mode&01000 != 0 && ctx.Uid() != sattr.Uid && ctx.Uid() != iattr.Uid {
+			return syscall.EACCES
+		}
 
-		rs, _ := tx.MGet(ctx, r.inodeKey(parentSrc), r.inodeKey(parentDst), r.inodeKey(ino)).Result()
-		if rs[0] == nil || rs[1] == nil || rs[2] == nil {
-			return redis.Nil
-		}
-		var sattr, dattr, iattr Attr
-		r.parseAttr([]byte(rs[0].(string)), &sattr)
-		if sattr.Typ != TypeDirectory {
-			return syscall.ENOTDIR
-		}
 		now := time.Now()
 		sattr.Mtime = now.Unix()
 		sattr.Mtimensec = uint32(now.Nanosecond())
 		sattr.Ctime = now.Unix()
 		sattr.Ctimensec = uint32(now.Nanosecond())
-		r.parseAttr([]byte(rs[1].(string)), &dattr)
-		if dattr.Typ != TypeDirectory {
-			return syscall.ENOTDIR
-		}
 		dattr.Mtime = now.Unix()
 		dattr.Mtimensec = uint32(now.Nanosecond())
 		dattr.Ctime = now.Unix()
 		dattr.Ctimensec = uint32(now.Nanosecond())
-		r.parseAttr([]byte(rs[2].(string)), &iattr)
 		iattr.Parent = parentDst
 		iattr.Ctime = now.Unix()
 		iattr.Ctimensec = uint32(now.Nanosecond())

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1213,7 +1213,7 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 					m.Unlock()
 				}
 			}
-			if ctx.Uid() != 0 && spn.Mode&01000 != 0 && ctx.Uid() != spn.Uid && ctx.Uid() != dn.Uid {
+			if ctx.Uid() != 0 && dpn.Mode&01000 != 0 && ctx.Uid() != dpn.Uid && ctx.Uid() != dn.Uid {
 				return syscall.EACCES
 			}
 		}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -951,6 +951,9 @@ func (m *dbMeta) Unlink(ctx Context, parent Ino, name string) syscall.Errno {
 		if !ok {
 			return syscall.ENOENT
 		}
+		if ctx.Uid() != 0 && pn.Mode&01000 != 0 && ctx.Uid() != pn.Uid && ctx.Uid() != n.Uid {
+			return syscall.EACCES
+		}
 
 		now := time.Now().UnixNano() / 1e3
 		pn.Mtime = now
@@ -1064,6 +1067,19 @@ func (m *dbMeta) Rmdir(ctx Context, parent Ino, name string) syscall.Errno {
 		if e.Type != TypeDirectory {
 			return syscall.ENOTDIR
 		}
+		if ctx.Uid() != 0 && pn.Mode&01000 != 0 && ctx.Uid() != pn.Uid {
+			var n = node{Inode: e.Inode}
+			ok, err = s.Get(&n)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return syscall.ENOENT
+			}
+			if ctx.Uid() != n.Uid {
+				return syscall.EACCES
+			}
+		}
 		exist, err := s.Exist(&edge{Parent: e.Inode})
 		if err != nil {
 			return err
@@ -1172,6 +1188,13 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 			if ctx.Value(CtxKey("behavior")) == "Hadoop" {
 				return syscall.EEXIST
 			}
+			ok, err := s.Get(&dn)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return syscall.ENOENT
+			}
 			if de.Type == TypeDirectory {
 				exist, err := s.Exist(&edge{Parent: de.Inode})
 				if err != nil {
@@ -1181,13 +1204,6 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 					return syscall.ENOTEMPTY
 				}
 			} else {
-				ok, err := s.Get(&dn)
-				if err != nil {
-					return err
-				}
-				if !ok {
-					return syscall.ENOENT
-				}
 				dn.Nlink--
 				if dn.Nlink > 0 {
 					dn.Ctime = time.Now().UnixNano() / 1e3
@@ -1197,6 +1213,12 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 					m.Unlock()
 				}
 			}
+			if ctx.Uid() != 0 && spn.Mode&01000 != 0 && ctx.Uid() != spn.Uid && ctx.Uid() != dn.Uid {
+				return syscall.EACCES
+			}
+		}
+		if ctx.Uid() != 0 && spn.Mode&01000 != 0 && ctx.Uid() != spn.Uid && ctx.Uid() != sn.Uid {
+			return syscall.EACCES
 		}
 
 		now := time.Now().UnixNano() / 1e3

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -49,6 +49,15 @@ func TestMySQLClient(t *testing.T) {
 	testMetaClient(t, m)
 }
 
+func TestStickyBitSQL(t *testing.T) {
+	os.Remove("test.db")
+	m, err := newSQLMeta("sqlite3", "test.db", &Config{})
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
+	}
+	testStickyBit(t, m)
+}
+
 func TestLocksSQL(t *testing.T) {
 	os.Remove("test1.db")
 	m, err := newSQLMeta("sqlite3", "test1.db", &Config{})


### PR DESCRIPTION
When default permission is enabled on FUSE, the kernel will check for sticky bit, and JuiceFS don't need to do anything rather than storing the sticky bit.

For Java SDK and S3 gateway, JuiceFS need to check permission, so we added the permission check for all meta engines, so they will be active for Java SDK and S3 gateway.

Closes #472 