### PR TITLE
Cleanup leaked inodes in Redis from earlier version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,4 @@ release:
 		juicedata/golang-cross:latest release --rm-dist
 
 test:
-	go test -v -cover ./pkg/... ./cmd/... || cat pkg/meta/bench-test.log
+	go test -v -cover ./pkg/... ./cmd/...

--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -96,7 +96,7 @@ func fsck(ctx *cli.Context) error {
 	logger.Infof("Listing all slices ...")
 	var c = meta.NewContext(0, 0, []uint32{0})
 	var slices []meta.Slice
-	r := m.ListSlices(c, &slices)
+	r := m.ListSlices(c, &slices, false)
 	if r != 0 {
 		logger.Fatalf("list all slices: %s", r)
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -172,7 +172,7 @@ func gc(ctx *cli.Context) error {
 
 	var c = meta.NewContext(0, 0, []uint32{0})
 	var slices []meta.Slice
-	r := m.ListSlices(c, &slices)
+	r := m.ListSlices(c, &slices, ctx.Bool("delete"))
 	if r != 0 {
 		logger.Fatalf("list all slices: %s", r)
 	}

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -214,7 +214,7 @@ type Meta interface {
 	// Compact all the chunks by merge small slices together
 	CompactAll(ctx Context) syscall.Errno
 	// ListSlices returns all slices used by all files.
-	ListSlices(ctx Context, slices *[]Slice) syscall.Errno
+	ListSlices(ctx Context, slices *[]Slice, delete bool) syscall.Errno
 
 	// OnMsg add a callback for the given message type.
 	OnMsg(mtype uint32, cb MsgCallback)

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2424,7 +2424,7 @@ func (r *redisMeta) cleanupLeakedInodes(delete bool) {
 				var entries []*Entry
 				eno := r.Readdir(ctx, Ino(ino), 0, &entries)
 				if eno != syscall.ENOENT && eno != 0 {
-					logger.Errorf("readdir %d: %s", eno)
+					logger.Errorf("readdir %d: %s", ino, eno)
 					return
 				}
 				for _, e := range entries {
@@ -2470,7 +2470,6 @@ func (r *redisMeta) cleanupLeakedInodes(delete bool) {
 			break
 		}
 	}
-	return
 }
 
 func (r *redisMeta) ListSlices(ctx Context, slices *[]Slice, delete bool) syscall.Errno {

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -653,7 +653,7 @@ func testCompaction(t *testing.T, m Meta) {
 		logger.Fatalf("compactall: %s", st)
 	}
 	var slices []Slice
-	if st := m.ListSlices(ctx, &slices); st != 0 {
+	if st := m.ListSlices(ctx, &slices, false); st != 0 {
 		logger.Fatalf("list all slices: %s", st)
 	}
 
@@ -757,7 +757,7 @@ func testTruncateAndDelete(t *testing.T, m Meta) {
 	}
 
 	var ss []Slice
-	m.ListSlices(ctx, &ss)
+	m.ListSlices(ctx, &ss, false)
 	if len(ss) != 1 {
 		t.Fatalf("number of chunks: %d != 3, %+v", len(ss), ss)
 	}
@@ -767,7 +767,7 @@ func testTruncateAndDelete(t *testing.T, m Meta) {
 	}
 
 	time.Sleep(time.Millisecond * 100)
-	m.ListSlices(ctx, &ss)
+	m.ListSlices(ctx, &ss, false)
 	// the last chunk could be found and deleted
 	if len(ss) > 1 {
 		t.Fatalf("number of chunks: %d > 1, %+v", len(ss), ss)

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2058,7 +2058,7 @@ func (m *dbMeta) CompactAll(ctx Context) syscall.Errno {
 	return 0
 }
 
-func (m *dbMeta) ListSlices(ctx Context, slices *[]Slice) syscall.Errno {
+func (m *dbMeta) ListSlices(ctx Context, slices *[]Slice, delete bool) syscall.Errno {
 	var c chunk
 	rows, err := m.engine.Rows(&c)
 	if err != nil {


### PR DESCRIPTION
For earlier version, there are leaked inodes in Redis, the PR will cleanup them in `juicefs gc --delete`