### PR TITLE
Fix the wrong organizational structure of the Cache directories when using Hadoop SDK

### DIFF
--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -381,7 +381,11 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 			Readahead:      jConf.Readahead << 20,
 		}
 		if chunkConf.CacheDir != "memory" {
-			chunkConf.CacheDir = filepath.Join(chunkConf.CacheDir, format.UUID)
+			ds := utils.SplitDir(chunkConf.CacheDir)
+			for i := range ds {
+				ds[i] = filepath.Join(ds[i], format.UUID)
+			}
+			chunkConf.CacheDir = strings.Join(ds, string(os.PathListSeparator))
 		}
 		store := chunk.NewCachedStore(blob, chunkConf)
 		m.OnMsg(meta.DeleteChunk, meta.MsgCallback(func(args ...interface{}) error {


### PR DESCRIPTION
Config in core-site.xml is :
```
<property>
        <name>juicefs.juicefstest.cache-dir</name>
        <value>/ssd/juicefs-cache:/juicefs-cache1</value>
    </property>
```

When creating cache dirs, it only adds the key after the last dir:
```
ls cache dirs:
ssd/juicefs-cache/juicefstest/raw/
ssd/juicefs-cache1/juicefstest/eb22c013-ea4e-4a42-9c3f-3ade6a3d7d81/raw
```

Closes #514 