### PR TITLE
cache attribute and chunks for open files

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -146,7 +146,7 @@ func (g *GateWay) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, er
 		Retries:   10,
 		Strict:    true,
 		ReadOnly:  c.Bool("read-only"),
-		OpenCache: time.Duration(time.Duration(c.Float64("open-cache") * 1e9)),
+		OpenCache: time.Duration(c.Float64("open-cache") * 1e9),
 	})
 	format, err := m.Load()
 	if err != nil {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -95,6 +95,7 @@ func mount(c *cli.Context) error {
 		Strict:      true,
 		CaseInsensi: strings.HasSuffix(mp, ":") && runtime.GOOS == "windows",
 		ReadOnly:    readOnly,
+		OpenCache:   time.Duration(time.Duration(c.Float64("open-cache") * 1e9)),
 		MountPoint:  mp,
 	})
 	format, err := m.Load()
@@ -300,6 +301,12 @@ func clientFlags() []cli.Flag {
 		&cli.BoolFlag{
 			Name:  "cache-partial-only",
 			Usage: "cache only random/small read",
+		},
+
+		&cli.Float64Flag{
+			Name:  "open-cache",
+			Value: 0.0,
+			Usage: "open files cache timeout in seconds",
 		},
 	}
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -95,7 +95,7 @@ func mount(c *cli.Context) error {
 		Strict:      true,
 		CaseInsensi: strings.HasSuffix(mp, ":") && runtime.GOOS == "windows",
 		ReadOnly:    readOnly,
-		OpenCache:   time.Duration(time.Duration(c.Float64("open-cache") * 1e9)),
+		OpenCache:   time.Duration(c.Float64("open-cache") * 1e9),
 		MountPoint:  mp,
 	})
 	format, err := m.Load()

--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -142,6 +142,9 @@ file entry cache timeout in seconds (default: 1)
 `--dir-entry-cache value`\
 dir entry cache timeout in seconds (default: 1)
 
+`--open-cache value`\
+open file cache timeout in seconds (default: 0)
+
 `--enable-xattr`\
 enable extended attributes (xattr) (default: false)
 

--- a/docs/zh_cn/command_reference.md
+++ b/docs/zh_cn/command_reference.md
@@ -142,6 +142,9 @@ juicefs mount [command options] REDIS-URL MOUNTPOINT
 `--dir-entry-cache value`\
 目录项缓存过期时间；单位为秒 (默认: 1)
 
+`--open-cache value`\
+打开的文件的缓存过期时间；单位为秒 (默认: 0)
+
 `--enable-xattr`\
 启用扩展属性 (xattr) 功能 (默认: false)
 

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -629,6 +629,7 @@ func (fs *FileSystem) Create(ctx meta.Context, p string, mode uint16) (f *File, 
 		fi = AttrToFileInfo(inode, attr)
 		fi.name = path.Base(p)
 		f = &File{}
+		f.flags = vfs.MODE_MASK_W
 		f.path = p
 		f.inode = fi.inode
 		f.info = fi

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -259,7 +259,7 @@ func (fs *FileSystem) Open(ctx meta.Context, path string, flags uint32) (f *File
 	}
 
 	if flags != 0 && !fi.IsDir() {
-		err = fs.m.Access(ctx, fi.inode, uint8(flags), nil)
+		err = fs.m.Access(ctx, fi.inode, uint8(flags), fi.attr)
 		if err != 0 {
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func (fs *FileSystem) Open(ctx meta.Context, path string, flags uint32) (f *File
 		} else if flags&vfs.MODE_MASK_W != 0 {
 			oflags = syscall.O_RDWR
 		}
-		err = fs.m.Open(ctx, fi.inode, oflags, nil)
+		err = fs.m.Open(ctx, fi.inode, oflags, fi.attr)
 		if err != 0 {
 			return
 		}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -130,6 +130,7 @@ type File struct {
 	fs    *FileSystem
 
 	sync.Mutex
+	flags    uint32
 	offset   int64
 	rdata    vfs.FileReader
 	wdata    vfs.FileWriter
@@ -258,21 +259,19 @@ func (fs *FileSystem) Open(ctx meta.Context, path string, flags uint32) (f *File
 	}
 
 	if flags != 0 && !fi.IsDir() {
-		if ctx.Uid() != 0 {
-			err = fs.m.Access(ctx, fi.inode, uint8(flags), nil)
-			if err != 0 {
-				return nil, err
-			}
-			var oflags uint32 = syscall.O_RDONLY
-			if flags == vfs.MODE_MASK_W {
-				oflags = syscall.O_WRONLY
-			} else if flags&vfs.MODE_MASK_W != 0 {
-				oflags = syscall.O_RDWR
-			}
-			err = fs.m.Open(ctx, fi.inode, oflags, nil)
-			if err != 0 {
-				return
-			}
+		err = fs.m.Access(ctx, fi.inode, uint8(flags), nil)
+		if err != 0 {
+			return nil, err
+		}
+		var oflags uint32 = syscall.O_RDONLY
+		if flags == vfs.MODE_MASK_W {
+			oflags = syscall.O_WRONLY
+		} else if flags&vfs.MODE_MASK_W != 0 {
+			oflags = syscall.O_RDWR
+		}
+		err = fs.m.Open(ctx, fi.inode, oflags, nil)
+		if err != 0 {
+			return
 		}
 	}
 
@@ -281,6 +280,7 @@ func (fs *FileSystem) Open(ctx meta.Context, path string, flags uint32) (f *File
 	f.inode = fi.inode
 	f.info = fi
 	f.fs = fs
+	f.flags = flags
 	return
 }
 
@@ -875,17 +875,20 @@ func (f *File) Close(ctx meta.Context) (err syscall.Errno) {
 	defer func() { f.fs.log(l, "Close (%s): %s", f.path, errstr(err)) }()
 	f.Lock()
 	defer f.Unlock()
-	f.offset = 0
-	if f.rdata != nil {
-		rdata := f.rdata
-		f.rdata = nil
-		time.AfterFunc(time.Second, func() {
-			rdata.Close(meta.Background)
-		})
-	}
-	if f.wdata != nil {
-		err = f.wdata.Close(meta.Background)
-		f.wdata = nil
+	if f.flags != 0 && !f.info.IsDir() {
+		f.offset = 0
+		if f.rdata != nil {
+			rdata := f.rdata
+			f.rdata = nil
+			time.AfterFunc(time.Second, func() {
+				rdata.Close(meta.Background)
+			})
+		}
+		if f.wdata != nil {
+			err = f.wdata.Close(meta.Background)
+			f.wdata = nil
+		}
+		f.fs.m.Close(ctx, f.inode)
 	}
 	return
 }

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -235,13 +235,15 @@ func (fs *fileSystem) Create(cancel <-chan struct{}, in *fuse.CreateIn, name str
 func (fs *fileSystem) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.OpenOut) (status fuse.Status) {
 	ctx := newContext(cancel, &in.InHeader)
 	defer releaseContext(ctx)
-	_, fh, err := vfs.Open(ctx, Ino(in.NodeId), in.Flags)
+	entry, fh, err := vfs.Open(ctx, Ino(in.NodeId), in.Flags)
 	if err != 0 {
 		return fuse.Status(err)
 	}
 	out.Fh = fh
 	if vfs.IsSpecialNode(Ino(in.NodeId)) {
 		out.OpenFlags |= fuse.FOPEN_DIRECT_IO
+	} else if entry.Attr.KeepCache {
+		out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
 	}
 	return 0
 }

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -15,12 +15,15 @@
 
 package meta
 
+import "time"
+
 // Config for clients.
 type Config struct {
 	Strict      bool // update ctime
 	Retries     int
 	CaseInsensi bool
 	ReadOnly    bool
+	OpenCache   time.Duration
 	MountPoint  string
 }
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -82,8 +82,10 @@ type Attr struct {
 	Nlink     uint32 // number of links (sub-directories or hardlinks)
 	Length    uint64 // length of regular file
 	Rdev      uint32 // device number
-	Parent    Ino    // inode of parent, only for Directory
-	Full      bool   // the attributes are completed or not
+
+	Parent    Ino  // inode of parent, only for Directory
+	Full      bool // the attributes are completed or not
+	KeepCache bool // whether the file is modified since last open
 }
 
 func typeToStatType(_type uint8) uint32 {

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -85,7 +85,7 @@ type Attr struct {
 
 	Parent    Ino  // inode of parent, only for Directory
 	Full      bool // the attributes are completed or not
-	KeepCache bool // whether the file is modified since last open
+	KeepCache bool // whether to keep the cached page or not
 }
 
 func typeToStatType(_type uint8) uint32 {

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -19,10 +19,12 @@ type openfiles struct {
 }
 
 func newOpenFiles(expire time.Duration) *openfiles {
-	return &openfiles{
+	of := &openfiles{
 		expire: expire,
 		files:  make(map[Ino]*openFile),
 	}
+	go of.cleanup()
+	return of
 }
 
 func (o *openfiles) cleanup() {
@@ -80,9 +82,6 @@ func (o *openfiles) Close(ino Ino) bool {
 	of, ok := o.files[ino]
 	if ok {
 		of.refs--
-		if of.refs <= 0 && of.lastCheck.Add(o.expire).Before(time.Now()) {
-			delete(o.files, ino)
-		}
 		return of.refs <= 0
 	}
 	return true

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -88,6 +88,9 @@ func (o *openfiles) Close(ino Ino) bool {
 }
 
 func (o *openfiles) Check(ino Ino, attr *Attr) bool {
+	if attr == nil {
+		panic("attr is nil")
+	}
 	o.Lock()
 	defer o.Unlock()
 	of, ok := o.files[ino]
@@ -99,6 +102,9 @@ func (o *openfiles) Check(ino Ino, attr *Attr) bool {
 }
 
 func (o *openfiles) Update(ino Ino, attr *Attr) bool {
+	if attr == nil {
+		panic("attr is nil")
+	}
 	o.Lock()
 	defer o.Unlock()
 	of, ok := o.files[ino]

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -64,10 +64,8 @@ func (o *openfiles) Open(ino Ino, attr *Attr) {
 		of = &openFile{}
 		of.chunks = make(map[uint32][]Slice)
 		o.files[ino] = of
-	} else if attr.Mtime == of.attr.Mtime && attr.Mtimensec == of.attr.Mtimensec {
-		if attr != nil {
-			attr.KeepCache = true
-		}
+	} else if attr != nil && attr.Mtime == of.attr.Mtime && attr.Mtimensec == of.attr.Mtimensec {
+		attr.KeepCache = true
 	} else {
 		of.chunks = make(map[uint32][]Slice)
 	}

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -1,0 +1,158 @@
+package meta
+
+import (
+	"sync"
+	"time"
+)
+
+type openFile struct {
+	attr      Attr
+	lastCheck time.Time
+	refs      int
+	chunks    map[uint32][]Slice
+}
+
+type openfiles struct {
+	sync.Mutex
+	expire time.Duration
+	files  map[Ino]*openFile
+}
+
+func newOpenFiles(expire time.Duration) *openfiles {
+	return &openfiles{
+		expire: expire,
+		files:  make(map[Ino]*openFile),
+	}
+}
+
+func (o *openfiles) cleanup() {
+	for {
+		o.Lock()
+		cutoff := time.Now().Add(-time.Hour)
+		for ino, of := range o.files {
+			if of.refs == 0 && of.lastCheck.Before(cutoff) {
+				delete(o.files, ino)
+			}
+		}
+		o.Unlock()
+		time.Sleep(time.Second)
+	}
+}
+
+func (o *openfiles) OpenCheck(ino Ino, attr *Attr) bool {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if ok && time.Since(of.lastCheck) < o.expire {
+		if attr != nil {
+			*attr = of.attr
+			attr.KeepCache = true
+		}
+		of.refs++
+		return true
+	}
+	return false
+}
+
+func (o *openfiles) Open(ino Ino, attr *Attr) {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if !ok {
+		of = &openFile{}
+		of.chunks = make(map[uint32][]Slice)
+		o.files[ino] = of
+	} else if attr != nil && attr.Mtime == of.attr.Mtime && attr.Mtimensec == of.attr.Mtimensec {
+		attr.KeepCache = true
+	} else {
+		of.chunks = make(map[uint32][]Slice)
+	}
+	if attr != nil {
+		of.attr = *attr
+	}
+	of.refs++
+	of.lastCheck = time.Now()
+}
+
+func (o *openfiles) Close(ino Ino) bool {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if ok {
+		of.refs--
+		if of.refs <= 0 && of.lastCheck.Add(o.expire).Before(time.Now()) {
+			delete(o.files, ino)
+		}
+		return of.refs <= 0
+	}
+	return true
+}
+
+func (o *openfiles) Check(ino Ino, attr *Attr) bool {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if ok && time.Since(of.lastCheck) < o.expire {
+		*attr = of.attr
+		return true
+	}
+	return false
+}
+
+func (o *openfiles) Update(ino Ino, attr *Attr) bool {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if ok {
+		if attr.Mtime != of.attr.Mtime || attr.Mtimensec != of.attr.Mtimensec {
+			of.chunks = make(map[uint32][]Slice)
+		} else {
+			attr.KeepCache = true
+		}
+		of.attr = *attr
+		of.lastCheck = time.Now()
+		return true
+	}
+	return false
+}
+
+func (o *openfiles) IsOpen(ino Ino) bool {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	return ok && of.refs > 0
+}
+
+func (o *openfiles) ReadChunk(ino Ino, indx uint32) ([]Slice, bool) {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if !ok {
+		return nil, false
+	}
+	cs, ok := of.chunks[indx]
+	return cs, ok
+}
+
+func (o *openfiles) CacheChunk(ino Ino, indx uint32, cs []Slice) {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if ok {
+		of.chunks[indx] = cs
+	}
+}
+
+func (o *openfiles) InvalidateChunk(ino Ino, indx uint32) {
+	o.Lock()
+	defer o.Unlock()
+	of, ok := o.files[ino]
+	if ok {
+		if indx == 0xFFFFFFFF {
+			of.chunks = make(map[uint32][]Slice)
+		} else {
+			delete(of.chunks, indx)
+		}
+		of.lastCheck = time.Unix(0, 0)
+	}
+}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1918,7 +1918,7 @@ func (r *redisMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) sysca
 		return 0
 	}
 	var err syscall.Errno
-	if attr != nil {
+	if attr != nil && !attr.Full {
 		err = r.GetAttr(ctx, inode, attr)
 	}
 	if err == 0 {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1573,7 +1573,7 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 					tattr.Ctime = now.Unix()
 					tattr.Ctimensec = uint32(now.Nanosecond())
 				} else if dtyp == TypeFile {
-					opened = r.of.IsOpen(*inode)
+					opened = r.of.IsOpen(dino)
 				}
 			}
 			if ctx.Uid() != 0 && dattr.Mode&01000 != 0 && ctx.Uid() != dattr.Uid && ctx.Uid() != tattr.Uid {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -81,7 +81,7 @@ type redisMeta struct {
 	sid          int64
 	usedSpace    uint64
 	usedInodes   uint64
-	openFiles    map[Ino]int
+	of           *openfiles
 	removedFiles map[Ino]bool
 	compacting   map[uint64]bool
 	deleting     chan int
@@ -153,7 +153,7 @@ func newRedisMeta(url string, conf *Config) (Meta, error) {
 	m := &redisMeta{
 		conf:         conf,
 		rdb:          rdb,
-		openFiles:    make(map[Ino]int),
+		of:           newOpenFiles(conf.OpenCache),
 		removedFiles: make(map[Ino]bool),
 		compacting:   make(map[uint64]bool),
 		deleting:     make(chan int, 2),
@@ -775,9 +775,15 @@ func (r *redisMeta) GetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno {
 		c, cancel = context.WithTimeout(ctx, time.Millisecond*300)
 		defer cancel()
 	}
+	if r.conf.OpenCache > 0 && r.of.Check(inode, attr) {
+		return 0
+	}
 	a, err := r.rdb.Get(c, r.inodeKey(inode)).Bytes()
 	if err == nil {
 		r.parseAttr(a, attr)
+		if r.conf.OpenCache > 0 {
+			r.of.Update(inode, attr)
+		}
 	}
 	if err != nil && inode == 1 {
 		err = nil
@@ -881,6 +887,7 @@ func (r *redisMeta) txn(ctx Context, txf func(tx *redis.Tx) error, keys ...strin
 }
 
 func (r *redisMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, attr *Attr) syscall.Errno {
+	defer func() { r.of.InvalidateChunk(inode, 0xFFFFFFFF) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		var t Attr
 		a, err := tx.Get(ctx, r.inodeKey(inode)).Bytes()
@@ -987,6 +994,7 @@ func (r *redisMeta) Fallocate(ctx Context, inode Ino, mode uint8, off uint64, si
 	if size == 0 {
 		return syscall.EINVAL
 	}
+	defer func() { r.of.InvalidateChunk(inode, 0xFFFFFFFF) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		var t Attr
 		a, err := tx.Get(ctx, r.inodeKey(inode)).Bytes()
@@ -1229,9 +1237,7 @@ func (r *redisMeta) Mkdir(ctx Context, parent Ino, name string, mode uint16, cum
 func (r *redisMeta) Create(ctx Context, parent Ino, name string, mode uint16, cumask uint16, inode *Ino, attr *Attr) syscall.Errno {
 	err := r.Mknod(ctx, parent, name, TypeFile, mode, cumask, 0, inode, attr)
 	if err == 0 && inode != nil {
-		r.Lock()
-		r.openFiles[*inode] = 1
-		r.Unlock()
+		r.of.Open(*inode, attr)
 	}
 	return err
 }
@@ -1287,9 +1293,7 @@ func (r *redisMeta) Unlink(ctx Context, parent Ino, name string) syscall.Errno {
 		attr.Nlink--
 		var opened bool
 		if _type == TypeFile && attr.Nlink == 0 {
-			r.Lock()
-			opened = r.openFiles[inode] > 0
-			r.Unlock()
+			opened = r.of.IsOpen(inode)
 		}
 
 		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
@@ -1569,9 +1573,7 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 					tattr.Ctime = now.Unix()
 					tattr.Ctimensec = uint32(now.Nanosecond())
 				} else if dtyp == TypeFile {
-					r.Lock()
-					opened = r.openFiles[dino] > 0
-					r.Unlock()
+					opened = r.of.IsOpen(*inode)
 				}
 			}
 			if ctx.Uid() != 0 && dattr.Mode&01000 != 0 && ctx.Uid() != dattr.Uid && ctx.Uid() != tattr.Uid {
@@ -1909,27 +1911,27 @@ func (r *redisMeta) deleteInode(inode Ino) error {
 }
 
 func (r *redisMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) syscall.Errno {
+	if r.conf.ReadOnly && flags&(syscall.O_WRONLY|syscall.O_RDWR|syscall.O_TRUNC|syscall.O_APPEND) != 0 {
+		return syscall.EROFS
+	}
+	if r.conf.OpenCache > 0 && r.of.OpenCheck(inode, attr) {
+		return 0
+	}
 	var err syscall.Errno
 	if attr != nil {
 		err = r.GetAttr(ctx, inode, attr)
 	}
-	if r.conf.ReadOnly && flags&(syscall.O_WRONLY|syscall.O_RDWR|syscall.O_TRUNC|syscall.O_APPEND) != 0 {
-		return syscall.EROFS
-	}
 	if err == 0 {
-		r.Lock()
-		r.openFiles[inode] = r.openFiles[inode] + 1
-		r.Unlock()
+		// TODO: tracking update in Redis
+		r.of.Open(inode, attr)
 	}
 	return 0
 }
 
 func (r *redisMeta) Close(ctx Context, inode Ino) syscall.Errno {
-	r.Lock()
-	defer r.Unlock()
-	refs := r.openFiles[inode]
-	if refs <= 1 {
-		delete(r.openFiles, inode)
+	if r.of.Close(inode) {
+		r.Lock()
+		defer r.Unlock()
 		if r.removedFiles[inode] {
 			delete(r.removedFiles, inode)
 			go func() {
@@ -1938,8 +1940,6 @@ func (r *redisMeta) Close(ctx Context, inode Ino) syscall.Errno {
 				}
 			}()
 		}
-	} else {
-		r.openFiles[inode] = refs - 1
 	}
 	return 0
 }
@@ -1968,12 +1968,17 @@ func buildSlice(ss []*slice) []Slice {
 }
 
 func (r *redisMeta) Read(ctx Context, inode Ino, indx uint32, chunks *[]Slice) syscall.Errno {
+	if cs, ok := r.of.ReadChunk(inode, indx); ok {
+		*chunks = cs
+		return 0
+	}
 	vals, err := r.rdb.LRange(ctx, r.chunkKey(inode, indx), 0, 1000000).Result()
 	if err != nil {
 		return errno(err)
 	}
 	ss := readSlices(vals)
 	*chunks = buildSlice(ss)
+	r.of.CacheChunk(inode, indx, *chunks)
 	if !r.conf.ReadOnly && (len(vals) >= 5 || len(*chunks) >= 5) {
 		go r.compactChunk(inode, indx, false)
 	}
@@ -1989,6 +1994,7 @@ func (r *redisMeta) NewChunk(ctx Context, inode Ino, indx uint32, offset uint32,
 }
 
 func (r *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
+	defer func() { r.of.InvalidateChunk(inode, indx) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		var attr Attr
 		a, err := tx.Get(ctx, r.inodeKey(inode)).Bytes()
@@ -2030,6 +2036,7 @@ func (r *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice
 }
 
 func (r *redisMeta) CopyFileRange(ctx Context, fin Ino, offIn uint64, fout Ino, offOut uint64, size uint64, flags uint32, copied *uint64) syscall.Errno {
+	defer func() { r.of.InvalidateChunk(fout, 0xFFFFFFFF) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		rs, err := tx.MGet(ctx, r.inodeKey(fin), r.inodeKey(fout)).Result()
 		if err != nil {
@@ -2523,6 +2530,7 @@ func (r *redisMeta) compactChunk(inode Ino, indx uint32, force bool) {
 		logger.Infof("compaction for %d:%d is wasted, delete slice %d (%d bytes)", inode, indx, chunkid, size)
 		r.deleteSlice(ctx, chunkid, size)
 	} else if errno == 0 {
+		r.of.InvalidateChunk(inode, indx)
 		// reset it to zero
 		r.rdb.HIncrBy(ctx, sliceRefs, r.sliceKey(chunkid, size), -1)
 		r.cleanupZeroRef(r.sliceKey(chunkid, size))

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -263,11 +263,6 @@ func (j *juice) Open(path string, flags int) (e int, fh uint64) {
 	return
 }
 
-func cache_mode(mattr uint8) (bool, bool) {
-	var direct_io, keep_cache bool
-	return direct_io, keep_cache
-}
-
 // Open opens a file.
 // The flags are a combination of the fuse.O_* constants.
 func (j *juice) OpenEx(path string, fi *fuse.FileInfo_t) (e int) {
@@ -281,11 +276,11 @@ func (j *juice) OpenEx(path string, fi *fuse.FileInfo_t) (e int) {
 	entry, fh, errno := vfs.Open(ctx, f.Inode(), uint32(fi.Flags))
 	if errno == 0 {
 		fi.Fh = fh
-		fi.DirectIo, fi.KeepCache = cache_mode(entry.Attr.Flags)
 		if vfs.IsSpecialNode(f.Inode()) {
 			fi.DirectIo = true
+		} else {
+			fi.KeepCache = entry.Attr.KeepCache
 		}
-		fi.NonSeekable = false
 		j.Lock()
 		j.handlers[fh] = f.Inode()
 		j.Unlock()

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -840,7 +840,7 @@ func jfs_setOwner(pid int, h uintptr, cpath *C.char, owner *C.char, group *C.cha
 	if err != 0 {
 		return errno(err)
 	}
-	defer f.Close()
+	defer f.Close(w.withPid(pid))
 	st, _ := f.Stat()
 	uid := uint32(st.(*fs.FileStat).Uid())
 	gid := uint32(st.(*fs.FileStat).Gid())

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -222,7 +222,6 @@ type javaConf struct {
 	AutoCreate     bool    `json:"autoCreate"`
 	CacheFullBlock bool    `json:"cacheFullBlock"`
 	Writeback      bool    `json:"writeback"`
-	OpenCache      bool    `json:"opencache"`
 	MemorySize     int     `json:"memorySize"`
 	Prefetch       int     `json:"prefetch"`
 	Readahead      int     `json:"readahead"`
@@ -736,7 +735,7 @@ func jfs_stat1(pid int, h uintptr, cpath *C.char, buf uintptr) int {
 	if err != 0 {
 		return errno(err)
 	}
-	return fill_stat(w, utils.NewNativeBuffer(toBuf(buf, 130)), info.(*fs.FileStat))
+	return fill_stat(w, utils.NewNativeBuffer(toBuf(buf, 130)), info)
 }
 
 //export jfs_lstat1
@@ -826,7 +825,7 @@ func jfs_utime(pid int, h uintptr, cpath *C.char, mtime, atime int64) int {
 	if err != 0 {
 		return errno(err)
 	}
-	defer f.Close(ctx)
+	defer f.Close(w.withPid(pid))
 	return errno(f.Utime(w.withPid(pid), atime, mtime))
 }
 

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -318,7 +318,7 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 			Retries:   10,
 			Strict:    true,
 			ReadOnly:  jConf.ReadOnly,
-			OpenCache: time.Duration(time.Duration(jConf.OpenCache * 1e9)),
+			OpenCache: time.Duration(jConf.OpenCache * 1e9),
 		})
 		format, err := m.Load()
 		if err != nil {

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -313,6 +313,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     obj.put("readOnly", Boolean.valueOf(getConf(conf, "read-only", "false")));
     obj.put("cacheDir", getConf(conf, "cache-dir", "memory"));
     obj.put("cacheSize", Integer.valueOf(getConf(conf, "cache-size", "100")));
+    obj.put("openCache", Float.valueOf(getConf(conf, "open-cache", "0.0")));
     obj.put("cacheFullBlock", Boolean.valueOf(getConf(conf, "cache-full-block", "true")));
     obj.put("metacache", Boolean.valueOf(getConf(conf, "metacache", "true")));
     obj.put("autoCreate", Boolean.valueOf(getConf(conf, "auto-create-cache-dir", "true")));

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -306,7 +306,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     for (String key : keys) {
       obj.put(key, getConf(conf, key, ""));
     }
-    String[] bkeys = new String[]{"debug", "writeback", "opencache"};
+    String[] bkeys = new String[]{"debug", "writeback"};
     for (String key : bkeys) {
       obj.put(key, Boolean.valueOf(getConf(conf, key, "false")));
     }


### PR DESCRIPTION
For not-modified files, we should keep the page cache in kernel, also cache the chunks to speed up read.

For any changes to the data, the mtime of file will be updated in microseconds, so we can check the mtime to know whether the file is changed or not. If not, we will keep the cache for chunks and pages in kernel, otherwise invalidate them.

And, we introduce a new option called `OpenCache`, which tell the client to don't check the mtime of a file before that, then JuiceFS will not know any change in the past period. So `OpenCache` should be set based on the change interval of files.

TODO: add command option for OpenCache

Closes #454 