### PR TITLE
cmd: add auto completion for bash & zsh

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete juicefs

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,0 +1,22 @@
+#compdef juicefs
+
+_cli_zsh_autocomplete() {
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+
+  return
+}
+
+compdef _cli_zsh_autocomplete juicefs

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -238,6 +238,9 @@ func reorderOptions(app *cli.App, args []string) []string {
 				newArgs = append(newArgs, args[i])
 			}
 		} else {
+			if strings.HasPrefix(option, "-") && !stringContains(args, "--generate-bash-completion") {
+				logger.Fatalf("unknown option: %s", option)
+			}
 			others = append(others, option)
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,11 +62,12 @@ func main() {
 		Usage: "print only the version",
 	}
 	app := &cli.App{
-		Name:      "juicefs",
-		Usage:     "A POSIX file system built on Redis and object storage.",
-		Version:   version.Version(),
-		Copyright: "AGPLv3",
-		Flags:     globalFlags(),
+		Name:                 "juicefs",
+		Usage:                "A POSIX file system built on Redis and object storage.",
+		Version:              version.Version(),
+		Copyright:            "AGPLv3",
+		EnableBashCompletion: true,
+		Flags:                globalFlags(),
 		Commands: []*cli.Command{
 			formatFlags(),
 			mountFlags(),
@@ -237,10 +238,6 @@ func reorderOptions(app *cli.App, args []string) []string {
 				newArgs = append(newArgs, args[i])
 			}
 		} else {
-			if strings.HasPrefix(option, "-") {
-				logger.Errorf("unknown option: %s", option)
-				os.Exit(1)
-			}
 			others = append(others, option)
 		}
 	}


### PR DESCRIPTION
close #503 

Run `source bash_autocomplete` or `source zsh_autocomplete` based on the shell to make auto-completion work. We may need a specific doc for this.