### PR TITLE
invalidate cache fo open files

### DIFF
--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -276,6 +276,8 @@ type Meta interface {
 	NewChunk(ctx Context, inode Ino, indx uint32, offset uint32, chunkid *uint64) syscall.Errno
 	// Write put a slice of data on top of the given chunk.
 	Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno
+	// InvalidateChunkCache invalidate chunk cache
+	InvalidateChunkCache(ctx Context, inode Ino, indx uint32) syscall.Errno
 	// CopyFileRange copies part of a file to another one.
 	CopyFileRange(ctx Context, fin Ino, offIn uint64, fout Ino, offOut uint64, size uint64, flags uint32, copied *uint64) syscall.Errno
 

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -112,7 +112,8 @@ func (o *openfiles) Update(ino Ino, attr *Attr) bool {
 	if ok {
 		if attr.Mtime != of.attr.Mtime || attr.Mtimensec != of.attr.Mtimensec {
 			of.chunks = make(map[uint32][]Slice)
-			of.attr.KeepCache = false
+		} else {
+			attr.KeepCache = of.attr.KeepCache
 		}
 		of.attr = *attr
 		of.lastCheck = time.Now()

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1996,6 +1996,11 @@ func (r *redisMeta) NewChunk(ctx Context, inode Ino, indx uint32, offset uint32,
 	return errno(err)
 }
 
+func (r *redisMeta) InvalidateChunkCache(ctx Context, inode Ino, indx uint32) syscall.Errno {
+	r.of.InvalidateChunk(inode, indx)
+	return 0
+}
+
 func (r *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
 	defer func() { r.of.InvalidateChunk(inode, indx) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1049,6 +1049,7 @@ func (r *redisMeta) Fallocate(ctx Context, inode Ino, mode uint8, off uint64, si
 }
 
 func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint8, attr *Attr) syscall.Errno {
+	defer func() { r.of.InvalidateChunk(inode, 0xFFFFFFFE) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		var cur Attr
 		a, err := tx.Get(ctx, r.inodeKey(inode)).Bytes()
@@ -1173,6 +1174,7 @@ func (r *redisMeta) mknod(ctx Context, parent Ino, name string, _type uint8, mod
 		}
 	}
 	attr.Parent = parent
+	attr.Full = true
 	if inode != nil {
 		*inode = ino
 	}
@@ -1258,7 +1260,7 @@ func (r *redisMeta) Unlink(ctx Context, parent Ino, name string) syscall.Errno {
 	if _type == TypeDirectory {
 		return syscall.EPERM
 	}
-
+	defer func() { r.of.InvalidateChunk(inode, 0xFFFFFFFE) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		rs, _ := tx.MGet(ctx, r.inodeKey(parent), r.inodeKey(inode)).Result()
 		if rs[0] == nil || rs[1] == nil {
@@ -1667,6 +1669,7 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 }
 
 func (r *redisMeta) Link(ctx Context, inode, parent Ino, name string, attr *Attr) syscall.Errno {
+	defer func() { r.of.InvalidateChunk(inode, 0xFFFFFFFE) }()
 	return r.txn(ctx, func(tx *redis.Tx) error {
 		rs, err := tx.MGet(ctx, r.inodeKey(parent), r.inodeKey(inode)).Result()
 		if err != nil {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1752,6 +1752,11 @@ func (m *dbMeta) NewChunk(ctx Context, inode Ino, indx uint32, offset uint32, ch
 	return errno(err)
 }
 
+func (m *dbMeta) InvalidateChunkCache(ctx Context, inode Ino, indx uint32) syscall.Errno {
+	m.of.InvalidateChunk(inode, indx)
+	return 0
+}
+
 func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
 	defer func() { m.of.InvalidateChunk(inode, indx) }()
 	var newSpace int64

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -222,7 +222,7 @@ func (s *sliceReader) run() {
 		s.currentPos = 0 // start again from beginning
 		err = syscall.EIO
 		f.tried++
-		f.r.m.InvalidateChunkCache(meta.Background, inode, indx)
+		_ = f.r.m.InvalidateChunkCache(meta.Background, inode, indx)
 		if f.tried >= f.r.maxRetries {
 			s.done(err, 0)
 		} else {

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -222,7 +222,7 @@ func (s *sliceReader) run() {
 		s.currentPos = 0 // start again from beginning
 		err = syscall.EIO
 		f.tried++
-		// ind.r.m.InvalidateChunkCache(inode, chindx)
+		f.r.m.InvalidateChunkCache(meta.Background, inode, indx)
 		if f.tried >= f.r.maxRetries {
 			s.done(err, 0)
 		} else {


### PR DESCRIPTION
1. Invadate the cached attribute for open files after some fields changed.

2. When the cached mtime is updated by GetAttr(), future Open() will assume the mtime is consistent with page cache, but not, so we should mark the cached attribute so that future Open() will not keep the cache.

3. When a file is compacted by other clients, the chunk was deleted, so we should invalidate the chunk cache after a temporary read failure.