### PR TITLE
cmd/dump: dump metadata into STDOUT

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/juicedata/juicefs/pkg/meta"
@@ -25,16 +26,21 @@ import (
 
 func dump(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
-	if ctx.Args().Len() < 2 {
-		return fmt.Errorf("META-ADDR and FILE are needed")
+	if ctx.Args().Len() < 1 {
+		return fmt.Errorf("META-ADDR is needed")
+	}
+	var fp io.WriteCloser
+	if ctx.Args().Len() == 1 || ctx.Args().Get(1) == "--" {
+		fp = os.Stdout
+	} else {
+		var err error
+		fp, err = os.OpenFile(ctx.Args().Get(1), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer fp.Close()
 	}
 	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true, Subdir: ctx.String("subdir")})
-	fname := ctx.Args().Get(1)
-	fp, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer fp.Close()
 	return m.DumpMeta(fp)
 }
 
@@ -42,7 +48,7 @@ func dumpFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "dump",
 		Usage:     "dump metadata into a JSON file",
-		ArgsUsage: "META-ADDR FILE",
+		ArgsUsage: "META-ADDR [FILE]",
 		Action:    dump,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -30,7 +30,7 @@ func dump(ctx *cli.Context) error {
 		return fmt.Errorf("META-ADDR is needed")
 	}
 	var fp io.WriteCloser
-	if ctx.Args().Len() == 1 || ctx.Args().Get(1) == "--" {
+	if ctx.Args().Len() == 1 {
 		fp = os.Stdout
 	} else {
 		var err error

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -31,7 +31,7 @@ func load(ctx *cli.Context) error {
 	}
 	var buf []byte
 	var err error
-	if ctx.Args().Len() == 1 || ctx.Args().Get(1) == "--" {
+	if ctx.Args().Len() == 1 {
 		buf, err = ioutil.ReadAll(os.Stdin)
 	} else {
 		buf, err = ioutil.ReadFile(ctx.Args().Get(1))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -238,7 +238,7 @@ func reorderOptions(app *cli.App, args []string) []string {
 				newArgs = append(newArgs, args[i])
 			}
 		} else {
-			if strings.HasPrefix(option, "-") && !stringContains(args, "--generate-bash-completion") && option != "--" {
+			if strings.HasPrefix(option, "-") && !stringContains(args, "--generate-bash-completion") {
 				logger.Fatalf("unknown option: %s", option)
 			}
 			others = append(others, option)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -238,7 +238,7 @@ func reorderOptions(app *cli.App, args []string) []string {
 				newArgs = append(newArgs, args[i])
 			}
 		} else {
-			if strings.HasPrefix(option, "-") && !stringContains(args, "--generate-bash-completion") {
+			if strings.HasPrefix(option, "-") && !stringContains(args, "--generate-bash-completion") && option != "--" {
 				logger.Fatalf("unknown option: %s", option)
 			}
 			others = append(others, option)

--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -525,8 +525,10 @@ dump metadata into a JSON file
 #### Synopsis
 
 ```
-juicefs dump [command options] META-ADDR FILE
+juicefs dump [command options] META-ADDR [FILE]
 ```
+
+When the FILE is not provided, STDOUT will be used instead.
 
 #### Options
 
@@ -542,5 +544,7 @@ load metadata from a previously dumped JSON file
 #### Synopsis
 
 ```
-juicefs load [command options] META-ADDR FILE
+juicefs load [command options] META-ADDR [FILE]
 ```
+
+When the FILE is not provided, STDIN will be used instead.

--- a/docs/zh_cn/command_reference.md
+++ b/docs/zh_cn/command_reference.md
@@ -525,8 +525,10 @@ juicefs warmup [command options] [PATH ...]
 #### 使用
 
 ```
-juicefs dump [command options] META-ADDR FILE
+juicefs dump [command options] META-ADDR [FILE]
 ```
+
+如果没有指定导出文件路径，会导出到标准输出。
 
 #### 选项
 
@@ -542,5 +544,7 @@ juicefs dump [command options] META-ADDR FILE
 #### 使用
 
 ```
-juicefs load [command options] META-ADDR FILE
+juicefs load [command options] META-ADDR [FILE]
 ```
+
+如果没有指定导入文件路径，会从标准输入导入。


### PR DESCRIPTION
This PR change to FILE argument of dump/load to be optional, then STDOUT/STDIN will be used, then we can use it like this:

```bash
$ ./juicefs dump 127.0.0.1/ | ./juicefs load 127.0.0.1/2
```