### PR TITLE
docs: use META-URL to replace REDIS-URL

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -27,7 +27,7 @@ import (
 func dump(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
 	if ctx.Args().Len() < 1 {
-		return fmt.Errorf("META-ADDR is needed")
+		return fmt.Errorf("META-URL is needed")
 	}
 	var fp io.WriteCloser
 	if ctx.Args().Len() == 1 {
@@ -48,7 +48,7 @@ func dumpFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "dump",
 		Usage:     "dump metadata into a JSON file",
-		ArgsUsage: "META-ADDR [FILE]",
+		ArgsUsage: "META-URL [FILE]",
 		Action:    dump,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -239,7 +239,7 @@ func formatFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "format",
 		Usage:     "format a volume",
-		ArgsUsage: "REDIS-URL NAME",
+		ArgsUsage: "META-URL NAME",
 		Flags: []cli.Flag{
 			&cli.IntFlag{
 				Name:  "block-size",

--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -31,7 +31,7 @@ func checkFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "fsck",
 		Usage:     "Check consistency of file system",
-		ArgsUsage: "REDIS-URL",
+		ArgsUsage: "META-URL",
 		Action:    fsck,
 	}
 }
@@ -39,7 +39,7 @@ func checkFlags() *cli.Command {
 func fsck(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
 	if ctx.Args().Len() < 1 {
-		return fmt.Errorf("REDIS-URL is needed")
+		return fmt.Errorf("META-URL is needed")
 	}
 	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
 	format, err := m.Load()

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -73,7 +73,7 @@ func gatewayFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "gateway",
 		Usage:     "S3-compatible gateway",
-		ArgsUsage: "REDIS-URL ADDRESS",
+		ArgsUsage: "META-URL ADDRESS",
 		Flags:     flags,
 		Action:    gateway,
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -36,7 +36,7 @@ func gcFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "gc",
 		Usage:     "collect any leaked objects",
-		ArgsUsage: "REDIS-URL",
+		ArgsUsage: "META-URL",
 		Action:    gc,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
@@ -104,7 +104,7 @@ func showProgress(p *gcProgress) {
 func gc(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
 	if ctx.Args().Len() < 1 {
-		return fmt.Errorf("REDIS-URL is needed")
+		return fmt.Errorf("META-URL is needed")
 	}
 	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
 	format, err := m.Load()

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -27,7 +27,7 @@ import (
 func load(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
 	if ctx.Args().Len() < 1 {
-		return fmt.Errorf("META-ADDR is needed")
+		return fmt.Errorf("META-URL is needed")
 	}
 	var buf []byte
 	var err error
@@ -47,7 +47,7 @@ func loadFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "load",
 		Usage:     "load metadata from a previously dumped JSON file",
-		ArgsUsage: "META-ADDR [FILE]",
+		ArgsUsage: "META-URL [FILE]",
 		Action:    load,
 	}
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -324,7 +324,7 @@ func mountFlags() *cli.Command {
 	cmd := &cli.Command{
 		Name:      "mount",
 		Usage:     "mount a volume",
-		ArgsUsage: "REDIS-URL MOUNTPOINT",
+		ArgsUsage: "META-URL MOUNTPOINT",
 		Action:    mount,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -39,7 +39,7 @@ func printJson(v interface{}) {
 func status(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
 	if ctx.Args().Len() < 1 {
-		return fmt.Errorf("REDIS-URL is needed")
+		return fmt.Errorf("META-URL is needed")
 	}
 	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
 
@@ -72,7 +72,7 @@ func statusFlags() *cli.Command {
 	return &cli.Command{
 		Name:      "status",
 		Usage:     "show status of JuiceFS",
-		ArgsUsage: "REDIS-URL",
+		ArgsUsage: "META-URL",
 		Action:    status,
 		Flags: []cli.Flag{
 			&cli.Uint64Flag{

--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -97,7 +97,7 @@ Format a volume. It's the first step for initializing a new file system volume.
 #### Synopsis
 
 ```
-juicefs format [command options] REDIS-URL NAME
+juicefs format [command options] META-URL NAME
 ```
 
 #### Options
@@ -147,7 +147,7 @@ Mount a volume. The volume shoud be formatted first.
 #### Synopsis
 
 ```
-juicefs mount [command options] REDIS-URL MOUNTPOINT
+juicefs mount [command options] META-URL MOUNTPOINT
 ```
 
 #### Options
@@ -247,7 +247,7 @@ S3-compatible gateway.
 #### Synopsis
 
 ```
-juicefs gateway [command options] REDIS-URL ADDRESS
+juicefs gateway [command options] META-URL ADDRESS
 ```
 
 #### Options
@@ -424,7 +424,7 @@ Collect any leaked objects.
 #### Synopsis
 
 ```
-juicefs gc [command options] REDIS-URL
+juicefs gc [command options] META-URL
 ```
 
 #### Options
@@ -447,7 +447,7 @@ Check consistency of file system.
 #### Synopsis
 
 ```
-juicefs fsck [command options] REDIS-URL
+juicefs fsck [command options] META-URL
 ```
 
 ### juicefs profile
@@ -485,7 +485,7 @@ show status of JuiceFS
 #### Synopsis
 
 ```
-juicefs status [command options] REDIS-URL
+juicefs status [command options] META-URL
 ```
 
 #### Options

--- a/docs/en/command_reference.md
+++ b/docs/en/command_reference.md
@@ -525,7 +525,7 @@ dump metadata into a JSON file
 #### Synopsis
 
 ```
-juicefs dump [command options] META-ADDR [FILE]
+juicefs dump [command options] META-URL [FILE]
 ```
 
 When the FILE is not provided, STDOUT will be used instead.
@@ -544,7 +544,7 @@ load metadata from a previously dumped JSON file
 #### Synopsis
 
 ```
-juicefs load [command options] META-ADDR [FILE]
+juicefs load [command options] META-URL [FILE]
 ```
 
 When the FILE is not provided, STDIN will be used instead.

--- a/docs/en/encrypt.md
+++ b/docs/en/encrypt.md
@@ -77,7 +77,7 @@ $ openssl genrsa -out my-priv-key.pem -aes256 2048
 2. Provide the key during format:
 
 ```shell
-$ juicefs format --encrypt-rsa-key my-priv-key.pem REDIS-URI NAME
+$ juicefs format --encrypt-rsa-key my-priv-key.pem META-URL NAME
 ```
 
 > **Note**: If the private key is protected by a passphrase, it should be specified using `JFS_RSA_PASSPHRASE` for `juicefs mount`.

--- a/docs/en/juicefs_on_macos.md
+++ b/docs/en/juicefs_on_macos.md
@@ -41,7 +41,7 @@ $ juicefs mount redis://192.168.1.8:6379/1 ~/music
 
 ## 4. Automatically mount JuiceFS on boot
 
-Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Replace `<NAME>` with JuiceFS volume name. Add following contents to the file (again, replace `NAME`, `PATH-TO-JUICEFS`, `REDIS-URL` and `MOUNTPOINT` with appropriate value):
+Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Replace `<NAME>` with JuiceFS volume name. Add following contents to the file (again, replace `NAME`, `PATH-TO-JUICEFS`, `META-URL` and `MOUNTPOINT` with appropriate value):
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -54,7 +54,7 @@ Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Re
         <array>
                 <string>PATH-TO-JUICEFS</string>
                 <string>mount</string>
-                <string>REDIS-URL</string>
+                <string>META-URL</string>
                 <string>MOUNTPOINT</string>
         </array>
         <key>RunAtLoad</key>

--- a/docs/en/mount_at_boot.md
+++ b/docs/en/mount_at_boot.md
@@ -7,10 +7,10 @@ This is a guide about how to mount JuiceFS automatically at boot.
 Copy `juicefs` as `/sbin/mount.juicefs`, then edit `/etc/fstab` with following line:
 
 ```
-<REDIS-URL>    <MOUNTPOINT>       juicefs     _netdev[,<MOUNT-OPTIONS>]     0  0
+<META-URL>    <MOUNTPOINT>       juicefs     _netdev[,<MOUNT-OPTIONS>]     0  0
 ```
 
-The format of `<REDIS-URL>` is `redis://<user>:<password>@<host>:<port>/<db>`, e.g. `redis://localhost:6379/1`. And replace `<MOUNTPOINT>` with specific path you wanna mount JuiceFS to, e.g. `/jfs`. If you need set [mount options](command_reference.md#juicefs-mount), replace `[,<MOUNT-OPTIONS>]` with comma separated options list. The following line is an example:
+The format of `<META-URL>` is `redis://<user>:<password>@<host>:<port>/<db>`, e.g. `redis://localhost:6379/1`. And replace `<MOUNTPOINT>` with specific path you wanna mount JuiceFS to, e.g. `/jfs`. If you need set [mount options](command_reference.md#juicefs-mount), replace `[,<MOUNT-OPTIONS>]` with comma separated options list. The following line is an example:
 
 ```
 redis://localhost:6379/1    /jfs       juicefs     _netdev,max-uploads=50,writeback,cache-size=2048     0  0
@@ -24,7 +24,7 @@ $ sudo chkconfig --add netfs
 
 ## macOS
 
-Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Replace `<NAME>` with JuiceFS volume name. Add following contents to the file (again, replace `NAME`, `PATH-TO-JUICEFS`, `REDIS-URL` and `MOUNTPOINT` with appropriate value):
+Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Replace `<NAME>` with JuiceFS volume name. Add following contents to the file (again, replace `NAME`, `PATH-TO-JUICEFS`, `META-URL` and `MOUNTPOINT` with appropriate value):
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -37,7 +37,7 @@ Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Re
         <array>
                 <string>PATH-TO-JUICEFS</string>
                 <string>mount</string>
-                <string>REDIS-URL</string>
+                <string>META-URL</string>
                 <string>MOUNTPOINT</string>
         </array>
         <key>RunAtLoad</key>

--- a/docs/en/quick_start_guide.md
+++ b/docs/en/quick_start_guide.md
@@ -135,10 +135,10 @@ $ sudo cp /usr/local/bin/juicefs /sbin/mount.juicefs
 Edit the `/etc/fstab` configuration file, start a new line, and add a record according to the following format:
 
 ```
-<REDIS-URL> <MOUNTPOINT> juicefs _netdev[,<MOUNT-OPTIONS>] 0 0
+<META-URL> <MOUNTPOINT> juicefs _netdev[,<MOUNT-OPTIONS>] 0 0
 ```
 
-- Please replace `<REDIS-URL>` with the actual Redis database address in the format of `redis://<user>:<password>@<host>:<port>/<db>`, for example: `redis ://localhost:6379/1`.
+- Please replace `<META-URL>` with the actual Redis database address in the format of `redis://<user>:<password>@<host>:<port>/<db>`, for example: `redis ://localhost:6379/1`.
 - Please replace `<MOUNTPOINT>` with the actual mount point of the file system, for example: `/jfs`.
 - If necessary, please replace `[,<MOUNT-OPTIONS>]` with the actual [mount option](command_reference.md#juicefs-mount) to be set, and multiple options are separated by commas.
 

--- a/docs/en/redis_best_practices.md
+++ b/docs/en/redis_best_practices.md
@@ -29,7 +29,7 @@ There're some [fundamental things](https://redis.io/topics/sentinel#fundamental-
 
 Please read the [official documentation](https://redis.io/topics/sentinel) for more information.
 
-Once Redis servers and Sentinels are deployed, the `REDIS-URL` can be specified as `[redis[s]://][USER:PASSWORD@]MASTERNAME,SENTINEL_ADDRS:SENTINEL_PORT[/DB]`, for example:
+Once Redis servers and Sentinels are deployed, the `META-URL` can be specified as `[redis[s]://][USER:PASSWORD@]MASTERNAME,SENTINEL_ADDRS:SENTINEL_PORT[/DB]`, for example:
 
 ```bash
 $ ./juicefs mount rediss://:sentinelPass@masterName,1.2.3.4,1.2.5.6:5000/2 ~/jfs

--- a/docs/zh_cn/command_reference.md
+++ b/docs/zh_cn/command_reference.md
@@ -525,7 +525,7 @@ juicefs warmup [command options] [PATH ...]
 #### 使用
 
 ```
-juicefs dump [command options] META-ADDR [FILE]
+juicefs dump [command options] META-URL [FILE]
 ```
 
 如果没有指定导出文件路径，会导出到标准输出。
@@ -544,7 +544,7 @@ juicefs dump [command options] META-ADDR [FILE]
 #### 使用
 
 ```
-juicefs load [command options] META-ADDR [FILE]
+juicefs load [command options] META-URL [FILE]
 ```
 
 如果没有指定导入文件路径，会从标准输入导入。

--- a/docs/zh_cn/command_reference.md
+++ b/docs/zh_cn/command_reference.md
@@ -97,7 +97,7 @@ $ source /etc/bash_completion.d/juicefs
 #### 使用
 
 ```
-juicefs format [command options] REDIS-URL NAME
+juicefs format [command options] META-URL NAME
 ```
 
 #### 选项
@@ -147,7 +147,7 @@ RSA 私钥的路径 (PEM)
 #### 使用
 
 ```
-juicefs mount [command options] REDIS-URL MOUNTPOINT
+juicefs mount [command options] META-URL MOUNTPOINT
 ```
 
 #### 选项
@@ -247,7 +247,7 @@ juicefs umount [command options] MOUNTPOINT
 #### 使用
 
 ```
-juicefs gateway [command options] REDIS-URL ADDRESS
+juicefs gateway [command options] META-URL ADDRESS
 ```
 
 #### 选项
@@ -424,7 +424,7 @@ juicefs bench [command options] PATH
 #### 使用
 
 ```
-juicefs gc [command options] REDIS-URL
+juicefs gc [command options] META-URL
 ```
 
 #### 选项
@@ -447,7 +447,7 @@ juicefs gc [command options] REDIS-URL
 #### 使用
 
 ```
-juicefs fsck [command options] REDIS-URL
+juicefs fsck [command options] META-URL
 ```
 
 ### juicefs profile
@@ -485,7 +485,7 @@ juicefs profile [command options] MOUNTPOINT/LOGFILE
 #### 使用
 
 ```
-juicefs status [command options] REDIS-URL
+juicefs status [command options] META-URL
 ```
 
 #### 选项

--- a/docs/zh_cn/encrypt.md
+++ b/docs/zh_cn/encrypt.md
@@ -59,7 +59,7 @@ $ openssl genrsa -out my-priv-key.pem -aes256 2048
 2. 在格式化时提供该密钥
 
 ```shell
-$ juicefs format --encrypt-rsa-key my-priv-key.pem REDIS-URI NAME
+$ juicefs format --encrypt-rsa-key my-priv-key.pem META-URL NAME
 ```
 
 > **注意**：如果私钥受密码保护，在执行 `juicefs mount` 时应使用 `JFS_RSA_PASSPHRASE` 来指定该密码。

--- a/docs/zh_cn/juicefs_on_macos.md
+++ b/docs/zh_cn/juicefs_on_macos.md
@@ -41,7 +41,7 @@ $ juicefs mount redis://192.168.1.8:6379/1 ~/music
 
 ## 4. 开机自动挂载 JuiceFS
 
-Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Replace `<NAME>` with JuiceFS volume name. Add following contents to the file (again, replace `NAME`, `PATH-TO-JUICEFS`, `REDIS-URL` and `MOUNTPOINT` with appropriate value):
+Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Replace `<NAME>` with JuiceFS volume name. Add following contents to the file (again, replace `NAME`, `PATH-TO-JUICEFS`, `META-URL` and `MOUNTPOINT` with appropriate value):
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -54,7 +54,7 @@ Create a file named `io.juicefs.<NAME>.plist` under `~/Library/LaunchAgents`. Re
         <array>
                 <string>PATH-TO-JUICEFS</string>
                 <string>mount</string>
-                <string>REDIS-URL</string>
+                <string>META-URL</string>
                 <string>MOUNTPOINT</string>
         </array>
         <key>RunAtLoad</key>

--- a/docs/zh_cn/quick_start_guide.md
+++ b/docs/zh_cn/quick_start_guide.md
@@ -139,10 +139,10 @@ $ sudo cp /usr/local/bin/juicefs /sbin/mount.juicefs
 编辑 `/etc/fstab` 配置文件，另起新行，参照以下格式添加一条记录：
 
 ```
-<REDIS-URL>    <MOUNTPOINT>       juicefs     _netdev[,<MOUNT-OPTIONS>]     0  0
+<META-URL>    <MOUNTPOINT>       juicefs     _netdev[,<MOUNT-OPTIONS>]     0  0
 ```
 
-- 请将 `<REDIS-URL>` 替换成实际的 Redis 数据库地址，格式为 `redis://<user>:<password>@<host>:<port>/<db>`，例如：`redis://localhost:6379/1`。
+- 请将 `<META-URL>` 替换成实际的 Redis 数据库地址，格式为 `redis://<user>:<password>@<host>:<port>/<db>`，例如：`redis://localhost:6379/1`。
 - 请将 `<MOUNTPOINT>` 替换成文件系统实际的挂载点，例如：`/jfs`。
 - 如果需要，请将 `[,<MOUNT-OPTIONS>]` 替换为实际要设置的 [挂载选项](command_reference.md#juicefs-mount)，多个选项之间用逗号分隔。
 

--- a/docs/zh_cn/redis_best_practices.md
+++ b/docs/zh_cn/redis_best_practices.md
@@ -29,7 +29,7 @@ There're some [fundamental things](https://redis.io/topics/sentinel#fundamental-
 
 Please read the [official documentation](https://redis.io/topics/sentinel) for more information.
 
-Once Redis servers and Sentinels are deployed, the `REDIS-URL` can be specified as `[redis[s]://][USER:PASSWORD@]MASTERNAME,SENTINEL_ADDRS:SENTINEL_PORT[/DB]`, for example:
+Once Redis servers and Sentinels are deployed, the `META-URL` can be specified as `[redis[s]://][USER:PASSWORD@]MASTERNAME,SENTINEL_ADDRS:SENTINEL_PORT[/DB]`, for example:
 
 ```bash
 $ ./juicefs mount rediss://:sentinelPass@masterName,1.2.3.4,1.2.5.6:5000/2 ~/jfs


### PR DESCRIPTION
JuiceFS support multiple database as meta engine, so we should use META-URL instead of REDIS-URL

closes #539 