### PR TITLE
Fix lock owner in SQLite

### DIFF
--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -396,19 +396,20 @@ func testLocks(t *testing.T, m Meta) {
 		t.Fatalf("create f: %s", st)
 	}
 	// flock
-	if st := m.Flock(ctx, inode, 1, syscall.F_RDLCK, false); st != 0 {
+	o1 := uint64(0xF000000000000001)
+	if st := m.Flock(ctx, inode, o1, syscall.F_RDLCK, false); st != 0 {
 		t.Fatalf("flock rlock: %s", st)
 	}
 	if st := m.Flock(ctx, inode, 2, syscall.F_RDLCK, false); st != 0 {
 		t.Fatalf("flock rlock: %s", st)
 	}
-	if st := m.Flock(ctx, inode, 1, syscall.F_WRLCK, false); st != syscall.EAGAIN {
+	if st := m.Flock(ctx, inode, o1, syscall.F_WRLCK, false); st != syscall.EAGAIN {
 		t.Fatalf("flock wlock: %s", st)
 	}
 	if st := m.Flock(ctx, inode, 2, syscall.F_UNLCK, false); st != 0 {
 		t.Fatalf("flock unlock: %s", st)
 	}
-	if st := m.Flock(ctx, inode, 1, syscall.F_WRLCK, false); st != 0 {
+	if st := m.Flock(ctx, inode, o1, syscall.F_WRLCK, false); st != 0 {
 		t.Fatalf("flock wlock again: %s", st)
 	}
 	if st := m.Flock(ctx, inode, 2, syscall.F_WRLCK, false); st != syscall.EAGAIN {
@@ -417,12 +418,12 @@ func testLocks(t *testing.T, m Meta) {
 	if st := m.Flock(ctx, inode, 2, syscall.F_RDLCK, false); st != syscall.EAGAIN {
 		t.Fatalf("flock rlock: %s", st)
 	}
-	if st := m.Flock(ctx, inode, 1, syscall.F_UNLCK, false); st != 0 {
+	if st := m.Flock(ctx, inode, o1, syscall.F_UNLCK, false); st != 0 {
 		t.Fatalf("flock unlock: %s", st)
 	}
 
 	// POSIX locks
-	if st := m.Setlk(ctx, inode, 1, false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
+	if st := m.Setlk(ctx, inode, o1, false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
 		t.Fatalf("plock rlock: %s", st)
 	}
 	if st := m.Setlk(ctx, inode, 2, false, syscall.F_RDLCK, 0, 0x2FFFF, 1); st != 0 {
@@ -434,18 +435,18 @@ func testLocks(t *testing.T, m Meta) {
 	if st := m.Setlk(ctx, inode, 2, false, syscall.F_WRLCK, 0x10000, 0x20000, 1); st != 0 {
 		t.Fatalf("plock wlock: %s", st)
 	}
-	if st := m.Setlk(ctx, inode, 1, false, syscall.F_UNLCK, 0, 0x20000, 1); st != 0 {
+	if st := m.Setlk(ctx, inode, o1, false, syscall.F_UNLCK, 0, 0x20000, 1); st != 0 {
 		t.Fatalf("plock unlock: %s", st)
 	}
 	if st := m.Setlk(ctx, inode, 2, false, syscall.F_WRLCK, 0, 0xFFFF, 10); st != 0 {
 		t.Fatalf("plock wlock: %s", st)
 	}
-	if st := m.Setlk(ctx, inode, 1, false, syscall.F_WRLCK, 0, 0xFFFF, 1); st != syscall.EAGAIN {
+	if st := m.Setlk(ctx, inode, o1, false, syscall.F_WRLCK, 0, 0xFFFF, 1); st != syscall.EAGAIN {
 		t.Fatalf("plock rlock: %s", st)
 	}
 	var ltype, pid uint32 = syscall.F_WRLCK, 1
 	var start, end uint64 = 0, 0xFFFF
-	if st := m.Getlk(ctx, inode, 1, &ltype, &start, &end, &pid); st != 0 || ltype != syscall.F_WRLCK || pid != 10 || start != 0 || end != 0xFFFF {
+	if st := m.Getlk(ctx, inode, o1, &ltype, &start, &end, &pid); st != 0 || ltype != syscall.F_WRLCK || pid != 10 || start != 0 || end != 0xFFFF {
 		t.Fatalf("plock get rlock: %s, %d %d %x %x", st, ltype, pid, start, end)
 	}
 	if st := m.Setlk(ctx, inode, 2, false, syscall.F_UNLCK, 0, 0x2FFFF, 1); st != 0 {
@@ -453,7 +454,7 @@ func testLocks(t *testing.T, m Meta) {
 	}
 	ltype = syscall.F_WRLCK
 	start, end = 0, 0xFFFFFF
-	if st := m.Getlk(ctx, inode, 1, &ltype, &start, &end, &pid); st != 0 || ltype != syscall.F_UNLCK || pid != 0 || start != 0 || end != 0 {
+	if st := m.Getlk(ctx, inode, o1, &ltype, &start, &end, &pid); st != 0 || ltype != syscall.F_UNLCK || pid != 0 || start != 0 || end != 0 {
 		t.Fatalf("plock get rlock: %s, %d %d %x %x", st, ltype, pid, start, end)
 	}
 

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -99,14 +99,14 @@ type xattr struct {
 type flock struct {
 	Inode Ino    `xorm:"notnull unique(flock)"`
 	Sid   uint64 `xorm:"notnull unique(flock)"`
-	Owner uint64 `xorm:"notnull unique(flock)"`
+	Owner int64  `xorm:"notnull unique(flock)"`
 	Ltype byte   `xorm:"notnull"`
 }
 
 type plock struct {
 	Inode   Ino    `xorm:"notnull unique(plock)"`
 	Sid     uint64 `xorm:"notnull unique(plock)"`
-	Owner   uint64 `xorm:"notnull unique(plock)"`
+	Owner   int64  `xorm:"notnull unique(plock)"`
 	Records []byte `xorm:"blob notnull"`
 }
 
@@ -381,7 +381,7 @@ func (m *dbMeta) getSession(row *session, detail bool) (*Session, error) {
 		}
 		s.Flocks = make([]Flock, 0, len(frows))
 		for _, frow := range frows {
-			s.Flocks = append(s.Flocks, Flock{frow.Inode, frow.Owner, string(frow.Ltype)})
+			s.Flocks = append(s.Flocks, Flock{frow.Inode, uint64(frow.Owner), string(frow.Ltype)})
 		}
 
 		if err := m.engine.Find(&prows, &plock{Sid: s.Sid}); err != nil {
@@ -389,7 +389,7 @@ func (m *dbMeta) getSession(row *session, detail bool) (*Session, error) {
 		}
 		s.Plocks = make([]Plock, 0, len(prows))
 		for _, prow := range prows {
-			s.Plocks = append(s.Plocks, Plock{prow.Inode, prow.Owner, prow.Records})
+			s.Plocks = append(s.Plocks, Plock{prow.Inode, uint64(prow.Owner), prow.Records})
 		}
 	}
 	return &s, nil

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -296,6 +296,10 @@ func (m *dbMeta) NewSession() error {
 	if err := m.engine.Sync2(new(session)); err != nil { // old client has no info field
 		return err
 	}
+	// update the owner from uint64 to int64
+	if err := m.engine.Sync2(new(flock), new(plock)); err != nil {
+		logger.Fatalf("update table flock, plock: %s", err)
+	}
 	if m.conf.ReadOnly {
 		return nil
 	}


### PR DESCRIPTION
SQLite and PG does not support uint64 (always be int64), will fail the query if a value is greater than 1<<63. For lock owner, which could be greater than 1<<63. 

This PR change the column type to int64 for Owner, and cast it to int64 always. 