### PR TITLE
speedup listing on file

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15.x'
+        go-version: '1.16.x'
       id: go
 
     - name: Check out code

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - mysql
   - postgresql
 go:
-  - "1.15"
+  - "1.16"
 branches:
   only:
     - main

--- a/docs/en/client_compile_and_upgrade.md
+++ b/docs/en/client_compile_and_upgrade.md
@@ -16,7 +16,7 @@ $ git clone https://github.com/juicedata/juicefs.git
 
 The JuiceFS client is developed in Go language, so before compiling, you must install the dependent tools locally in advance:
 
-- [Go](https://golang.org) 1.15+
+- [Go](https://golang.org) 1.16+
 - GCC 5.4+
 
 > **Tip**: For users in China, in order to download the Go modules faster, it is recommended to set the mirror server through the `GOPROXY` environment variable. For example: [Goproxy China](https://github.com/goproxy/goproxy.cn).

--- a/docs/en/hadoop_java_sdk.md
+++ b/docs/en/hadoop_java_sdk.md
@@ -69,7 +69,7 @@ JuiceFS Hadoop Java SDK need extra 4 * [`juicefs.memory-size`](#io-configuration
 
 Compilation depends on the following tools:
 
-- [Go](https://golang.org/) 1.15+
+- [Go](https://golang.org/) 1.16+
 - JDK 8+
 - [Maven](https://maven.apache.org/) 3.3+
 - git

--- a/docs/en/how_to_setup_object_storage.md
+++ b/docs/en/how_to_setup_object_storage.md
@@ -511,7 +511,7 @@ $ sudo apt-get install librados-dev
 $ sudo yum install librados-devel
 ```
 
-Then compile JuiceFS for Ceph (ensure you have Go 1.15+ and GCC 5.4+):
+Then compile JuiceFS for Ceph (ensure you have Go 1.16+ and GCC 5.4+):
 
 ```bash
 $ make juicefs.ceph

--- a/docs/zh_cn/client_compile_and_upgrade.md
+++ b/docs/zh_cn/client_compile_and_upgrade.md
@@ -14,7 +14,7 @@ $ git clone https://github.com/juicedata/juicefs.git
 
 JuiceFS 客户端使用 Go 语言开发，因此在编译之前，你提前在本地安装好依赖的工具：
 
-- [Go](https://golang.org) 1.15+
+- [Go](https://golang.org) 1.16+
 - GCC 5.4+
 
 > **提示**：对于中国地区用户，为了加快获取 Go 模块的速度，建议通过 `GOPROXY` 环境变量设置国内的镜像服务器。例如：[Goproxy China](https://github.com/goproxy/goproxy.cn)。

--- a/docs/zh_cn/how_to_setup_object_storage.md
+++ b/docs/zh_cn/how_to_setup_object_storage.md
@@ -516,7 +516,7 @@ $ sudo apt-get install librados-dev
 $ sudo yum install librados-devel
 ```
 
-然后为 Ceph 编译 JuiceFS（要求 Go 1.15+ 和 GCC 5.4+）：
+然后为 Ceph 编译 JuiceFS（要求 Go 1.16+ 和 GCC 5.4+）：
 
 ```bash
 $ make juicefs.ceph

--- a/fstests/Makefile
+++ b/fstests/Makefile
@@ -35,4 +35,4 @@ secfs.test:
 flock:
 	git clone https://github.com/gofrs/flock.git
 	mkdir /jfs/tmp
-	cd flock && TMPDIR=/jfs/tmp go test .
+	cd flock && go mod init github.com/gofrs/flock.git && go mod tidy && TMPDIR=/jfs/tmp go test .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juicedata/juicefs
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.39.0

--- a/pkg/object/file.go
+++ b/pkg/object/file.go
@@ -178,15 +178,18 @@ func walk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		return nil
 	}
 
-	infos, err := readDirSorted(path)
+	entries, err := readDirSorted(path)
 	if err != nil {
 		return walkFn(path, info, err)
 	}
 
-	for _, fi := range infos {
-		p := filepath.Join(path, fi.Name())
-		err = walk(p, fi, walkFn)
-		if err != nil && err != filepath.SkipDir {
+	for _, e := range entries {
+		p := filepath.Join(path, e.Name())
+		in, err := e.Info()
+		if err == nil {
+			err = walk(p, in, walkFn)
+		}
+		if err != nil && err != filepath.SkipDir && !os.IsNotExist(err) {
 			return err
 		}
 	}
@@ -212,37 +215,47 @@ func Walk(root string, walkFn filepath.WalkFunc) error {
 	return err
 }
 
-type mInfo struct {
+type mEntry struct {
+	os.DirEntry
 	name string
-	os.FileInfo
+	fi   os.FileInfo
 }
 
-func (m *mInfo) Name() string {
+func (m *mEntry) Name() string {
 	return m.name
+}
+
+func (m *mEntry) Info() (os.FileInfo, error) {
+	if m.fi != nil {
+		return m.fi, nil
+	}
+	return m.DirEntry.Info()
 }
 
 // readDirSorted reads the directory named by dirname and returns
 // a sorted list of directory entries.
-func readDirSorted(dirname string) ([]os.FileInfo, error) {
+func readDirSorted(dirname string) ([]os.DirEntry, error) {
 	f, err := os.Open(dirname)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	fis, err := f.Readdir(-1)
-	for i, fi := range fis {
-		if !fi.IsDir() && !fi.Mode().IsRegular() {
+	entries, err := f.ReadDir(-1)
+	for i, e := range entries {
+		if e.IsDir() {
+			entries[i] = &mEntry{e, e.Name() + dirSuffix, nil}
+		} else if !e.Type().IsRegular() {
 			// follow symlink
-			f, _ := os.Stat(filepath.Join(dirname, fi.Name()))
-			fi = &mInfo{fi.Name(), f}
-			fis[i] = fi
-		}
-		if fi.IsDir() {
-			fis[i] = &mInfo{fi.Name() + dirSuffix, fi}
+			fi, _ := os.Stat(filepath.Join(dirname, e.Name()))
+			name := e.Name()
+			if fi.IsDir() {
+				name = e.Name() + dirSuffix
+			}
+			entries[i] = &mEntry{e, name, fi}
 		}
 	}
-	sort.Slice(fis, func(i, j int) bool { return fis[i].Name() < fis[j].Name() })
-	return fis, err
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, err
 }
 
 func (d *filestore) List(prefix, marker string, limit int64) ([]Object, error) {


### PR DESCRIPTION
file.Readdir() calls lstat() on every file, so it's slow on huge directory.

This PR changed to use file.ReadDir(), which does not call lstat(), then we can return some of the files earlier.