### PR TITLE
meta/tikv: enable 1pc when commit

### DIFF
--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -187,6 +187,7 @@ func (c *tikvClient) txn(f func(kvTxn) error) error {
 		return err
 	}
 	if !tx.IsReadOnly() {
+		tx.SetEnable1PC(true)
 		err = tx.Commit(context.Background())
 	}
 	return err


### PR DESCRIPTION
https://github.com/tikv/client-go/blob/master/tikv/txn.go#L287-L291
> // SetEnable1PC indicates that the transaction will try to use 1 phase commit(which should be faster).
> // 1PC does not work if the keys to update in the current txn are in multiple regions.