### PR TITLE
fix bandwidth limit

### DIFF
--- a/pkg/object/bwlimit.go
+++ b/pkg/object/bwlimit.go
@@ -16,6 +16,7 @@
 package object
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -33,6 +34,14 @@ func (l *limitedReader) Read(buf []byte) (int, error) {
 		l.r.Wait(int64(n))
 	}
 	return n, err
+}
+
+// Seek call the Seek in underlying reader.
+func (l *limitedReader) Seek(offset int64, whence int) (int64, error) {
+	if s, ok := l.ReadCloser.(io.Seeker); ok {
+		return s.Seek(offset, whence)
+	}
+	return 0, fmt.Errorf("%v does not support Seek()", l.ReadCloser)
 }
 
 type bwlimit struct {

--- a/pkg/object/metrics.go
+++ b/pkg/object/metrics.go
@@ -16,6 +16,7 @@
 package object
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -77,7 +78,10 @@ func (counter *readCounter) Close() error {
 
 // Seek call the Seek in underlying reader.
 func (counter *readCounter) Seek(offset int64, whence int) (int64, error) {
-	return counter.Reader.(io.Seeker).Seek(offset, whence)
+	if s, ok := counter.Reader.(io.Seeker); ok {
+		return s.Seek(offset, whence)
+	}
+	return 0, fmt.Errorf("%v does not support Seek()", counter.Reader)
 }
 
 type withMetrics struct {


### PR DESCRIPTION
```
panic: interface conversion: *object.limitedReader is not io.Seeker: missing method Seek

goroutine 242 [running]:
github.com/juicedata/juicefs/pkg/object.(*readCounter).Seek(0xc00083e0a0, 0x0, 0x0, 0x0, 0xc000856020, 0x9)
 /workspace/juicefs/pkg/object/metrics.go:80 +0x47
github.com/juicedata/juicefs/pkg/object.generateChecksum.func1(0x7f871d0a1a40, 0xc00083e0a0)
 /workspace/juicefs/pkg/object/checksum.go:40 +0x39
github.com/juicedata/juicefs/pkg/object.generateChecksum(0x7f871d0a1a40, 0xc00083e0a0, 0xc000856020, 0x9)
 /workspace/juicefs/pkg/object/checksum.go:51 +0x410
github.com/juicedata/juicefs/pkg/object.(*s3client).Put(0xc0007fdc40, 0xc000810100, 0x17, 0x2ed8a00, 0xc00083e0a0, 0x0, 0x0)
 /workspace/juicefs/pkg/object/s3.go:116 +0xe8
github.com/juicedata/juicefs/pkg/object.(*withPrefix).Put(0xc0007fdc60, 0xc0008100c0, 0x11, 0x2ed8a00, 0xc00083e0a0, 0x10d6dc741a0fc754, 0x60ebd833)
 /workspace/juicefs/pkg/object/prefix.go:61 +0xa6
github.com/juicedata/juicefs/pkg/object.(*withMetrics).Put.func1(0xc03313ecd0d6dc74, 0x456734db7)
 /workspace/juicefs/pkg/object/metrics.go:127 +0xcb
github.com/juicedata/juicefs/pkg/object.(*withMetrics).track(0xc0006637e0, 0x27a04c2, 0x3, 0xc00087ddb8, 0xc00087dde8, 0x40bca8)
 /workspace/juicefs/pkg/object/metrics.go:97 +0x53
github.com/juicedata/juicefs/pkg/object.(*withMetrics).Put(0xc0006637e0, 0xc0008100c0, 0x11, 0x2ed89e0, 0xc00083e080, 0xc00087de50, 0x40e6f8)
 /workspace/juicefs/pkg/object/metrics.go:126 +0xa2
github.com/juicedata/juicefs/pkg/object.(*bwlimit).Put(0xc0007de200, 0xc0008100c0, 0x11, 0x2ed6e00, 0xc000858060, 0x0, 0x0)
 /workspace/juicefs/pkg/object/bwlimit.go:63 +0xf0
github.com/juicedata/juicefs/pkg/chunk.(*wChunk).put.func1(0x0, 0x0)
 /workspace/juicefs/pkg/chunk/cached_store.go:376 +0x175
github.com/juicedata/juicefs/pkg/chunk.withTimeout.func1(0xc000858030, 0xc000840060, 0xc00079a310)
 /workspace/juicefs/pkg/chunk/cached_store.go:359 +0x27
created by github.com/juicedata/juicefs/pkg/chunk.withTimeout
 /workspace/juicefs/pkg/chunk/cached_store.go:358 +0xbb
```