### PR TITLE
fix mount with empty database

### DIFF
--- a/pkg/meta/load_dump_test.go
+++ b/pkg/meta/load_dump_test.go
@@ -82,6 +82,10 @@ func TestLoadDump(t *testing.T) {
 			t.Fatalf("open file: %s", "redis.dump")
 		}
 		defer fp.Close()
+		r := m.(*redisMeta)
+		r.rdb.Incr(Background, "nextinode") // Redis counter is 1 smaller
+		r.rdb.Incr(Background, "nextchunk")
+		r.rdb.Incr(Background, "nextsession")
 		if err = m.DumpMeta(fp); err != nil {
 			t.Fatalf("dump meta: %s", err)
 		}

--- a/pkg/meta/load_dump_test.go
+++ b/pkg/meta/load_dump_test.go
@@ -82,10 +82,6 @@ func TestLoadDump(t *testing.T) {
 			t.Fatalf("open file: %s", "redis.dump")
 		}
 		defer fp.Close()
-		r := m.(*redisMeta)
-		r.rdb.Incr(Background, "nextinode") // Redis counter is 1 smaller
-		r.rdb.Incr(Background, "nextchunk")
-		r.rdb.Incr(Background, "nextsession")
 		if err = m.DumpMeta(fp); err != nil {
 			t.Fatalf("dump meta: %s", err)
 		}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -265,7 +265,7 @@ func (r *redisMeta) Init(format Format, force bool) error {
 func (r *redisMeta) Load() (*Format, error) {
 	body, err := r.rdb.Get(Background, "setting").Bytes()
 	if err == redis.Nil {
-		return nil, fmt.Errorf("no volume found")
+		return nil, fmt.Errorf("database is not formatted")
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -269,7 +269,7 @@ func (m *dbMeta) Init(format Format, force bool) error {
 	m.fmt = format
 	return m.txn(func(s *xorm.Session) error {
 		if ok {
-			_, err = m.engine.Update(&setting{"format", string(data)}, &setting{Name: "format"})
+			_, err = s.Update(&setting{"format", string(data)}, &setting{Name: "format"})
 			return err
 		}
 
@@ -491,17 +491,18 @@ func (m *dbMeta) incrCounter(name string, batch int64) (uint64, error) {
 func (m *dbMeta) nextInode() (Ino, error) {
 	m.freeMu.Lock()
 	defer m.freeMu.Unlock()
-	if m.freeInodes.next < m.freeInodes.maxid {
-		v := m.freeInodes.next
-		m.freeInodes.next++
-		return Ino(v), nil
+	if m.freeInodes.next == m.freeInodes.maxid {
+		v, err := m.incrCounter("nextInode", 100)
+		if err == nil {
+			m.freeInodes.next = v + 1
+			m.freeInodes.maxid = v + 100
+		} else {
+			return 0, err
+		}
 	}
-	v, err := m.incrCounter("nextInode", 100)
-	if err == nil {
-		m.freeInodes.next = v + 1
-		m.freeInodes.maxid = v + 100
-	}
-	return Ino(v), err
+	v := m.freeInodes.next
+	m.freeInodes.next++
+	return Ino(v), nil
 }
 
 func mustInsert(s *xorm.Session, beans ...interface{}) error {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -231,11 +231,18 @@ func (m *dbMeta) Init(format Format, force bool) error {
 		}
 	}
 
-	old, err := m.Load()
+	var s = setting{Name: "format"}
+	ok, err := m.engine.Get(&s)
 	if err != nil {
 		return err
 	}
-	if old != nil {
+
+	if ok {
+		var old Format
+		err = json.Unmarshal([]byte(s.Value), &old)
+		if err != nil {
+			return fmt.Errorf("json: %s", err)
+		}
 		if force {
 			old.SecretKey = "removed"
 			logger.Warnf("Existing volume will be overwrited: %+v", old)
@@ -246,27 +253,26 @@ func (m *dbMeta) Init(format Format, force bool) error {
 			old.SecretKey = format.SecretKey
 			old.Capacity = format.Capacity
 			old.Inodes = format.Inodes
-			if format != *old {
+			if format != old {
 				old.SecretKey = ""
 				format.SecretKey = ""
 				return fmt.Errorf("cannot update format from %+v to %+v", old, format)
 			}
 		}
-		data, err := json.MarshalIndent(format, "", "")
-		if err != nil {
-			logger.Fatalf("json: %s", err)
-		}
-		_, err = m.engine.Update(&setting{"format", string(data)}, &setting{Name: "format"})
-		return err
 	}
 
 	data, err := json.MarshalIndent(format, "", "")
 	if err != nil {
-		logger.Fatalf("json: %s", err)
+		return fmt.Errorf("json: %s", err)
 	}
 
 	m.fmt = format
 	return m.txn(func(s *xorm.Session) error {
+		if ok {
+			_, err = m.engine.Update(&setting{"format", string(data)}, &setting{Name: "format"})
+			return err
+		}
+
 		var set = &setting{"format", string(data)}
 		now := time.Now()
 		var root = &node{
@@ -2497,7 +2503,7 @@ func (m *dbMeta) DumpMeta(w io.Writer) error {
 
 	format, err := m.Load()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var crows []counter

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -295,7 +295,10 @@ func (m *dbMeta) Init(format Format, force bool) error {
 func (m *dbMeta) Load() (*Format, error) {
 	var s = setting{Name: "format"}
 	ok, err := m.engine.Get(&s)
-	if err != nil || !ok {
+	if err == nil && !ok {
+		err = fmt.Errorf("database is not formatted")
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -269,7 +269,7 @@ func (m *dbMeta) Init(format Format, force bool) error {
 	m.fmt = format
 	return m.txn(func(s *xorm.Session) error {
 		if ok {
-			_, err = m.engine.Update(&setting{"format", string(data)}, &setting{Name: "format"})
+			_, err = s.Update(&setting{"format", string(data)}, &setting{Name: "format"})
 			return err
 		}
 

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -421,10 +421,10 @@ func (m *kvMeta) Init(format Format, force bool) error {
 		logger.Fatalf("json: %s", err)
 	}
 
-	m.fmt = format
 	return m.txn(func(tx kvTxn) error {
 		tx.set(m.fmtKey("setting"), data)
 		if body == nil {
+			m.fmt = format
 			// root inode
 			var attr Attr
 			attr.Typ = TypeDirectory

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -421,10 +421,10 @@ func (m *kvMeta) Init(format Format, force bool) error {
 		logger.Fatalf("json: %s", err)
 	}
 
+	m.fmt = format
 	return m.txn(func(tx kvTxn) error {
 		tx.set(m.fmtKey("setting"), data)
 		if body == nil {
-			m.fmt = format
 			// root inode
 			var attr Attr
 			attr.Typ = TypeDirectory

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -444,7 +444,10 @@ func (m *kvMeta) Init(format Format, force bool) error {
 
 func (m *kvMeta) Load() (*Format, error) {
 	body, err := m.get(m.fmtKey("setting"))
-	if err != nil || body == nil {
+	if err == nil && body == nil {
+		err = fmt.Errorf("database is not formatted")
+	}
+	if err != nil {
 		return nil, err
 	}
 	err = json.Unmarshal(body, &m.fmt)
@@ -2048,7 +2051,7 @@ func (m *kvMeta) dumpDir(inode Ino) (map[string]*DumpedEntry, error) {
 func (m *kvMeta) DumpMeta(w io.Writer) error {
 	vals, err := m.scanValues(m.fmtKey("D"))
 	if err != nil {
-		return nil
+		return err
 	}
 	dels := make([]*DumpedDelFile, 0, len(vals))
 	for k, v := range vals {
@@ -2070,7 +2073,7 @@ func (m *kvMeta) DumpMeta(w io.Writer) error {
 
 	format, err := m.Load()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var rs [][]byte
@@ -2095,7 +2098,7 @@ func (m *kvMeta) DumpMeta(w io.Writer) error {
 
 	vals, err = m.scanValues(m.fmtKey("SS"))
 	if err != nil {
-		return nil
+		return err
 	}
 	ss := make(map[uint64][]Ino)
 	for k := range vals {


### PR DESCRIPTION
it crashed with an empty database

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x20447ec]

goroutine 1 [running]:
main.mount(0xc000786d80, 0x1b, 0x38)
	/root/work/juicefs/cmd/mount.go:108 +0x58c
github.com/urfave/cli/v2.(*Command).Run(0xc000492120, 0xc000786500, 0x0, 0x0)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x4dd
github.com/urfave/cli/v2.(*App).RunContext(0xc0003d2d00, 0x2c670a8, 0xc0001ac010, 0xc0007860c0, 0x4, 0x4, 0x0, 0x0)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
	/root/work/juicefs/cmd/main.go:99 +0x191c
```