### PR TITLE
Grafana dashboard template auto find volume names from p8s metrics label

### DIFF
--- a/docs/en/grafana_template.json
+++ b/docs/en/grafana_template.json
@@ -2146,9 +2146,12 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "dogfood",
           "value": "dogfood"
         },
+        "datasource": "${Source}",
+        "definition": "label_values(juicefs_uptime, vol_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2156,17 +2159,16 @@
         "label": null,
         "multi": false,
         "name": "name",
-        "options": [
-          {
-            "selected": false,
-            "text": "test",
-            "value": "test"
-          }
-        ],
-        "query": "test",
-        "queryValue": "",
+        "options": [],
+        "query": {
+          "query": "label_values(juicefs_uptime, vol_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 0,
+        "type": "query"
       }
     ]
   },

--- a/docs/en/hadoop_java_sdk.md
+++ b/docs/en/hadoop_java_sdk.md
@@ -233,7 +233,7 @@ CREATE TABLE IF NOT EXISTS person
 
 ## Metrics
 
-JuiceFS Hadoop Java SDK supports reporting metrics to [Prometheus Pushgateway](https://github.com/prometheus/pushgateway), then you can use [Grafana](https://grafana.com) and [dashboard template](k8s_grafana_template.json) to visualize these metrics.
+JuiceFS Hadoop Java SDK supports reporting metrics to [Prometheus Pushgateway](https://github.com/prometheus/pushgateway), then you can use [Grafana](https://grafana.com) and [dashboard template](grafana_template.json) to visualize these metrics.
 
 Enable metrics reporting through following configurations:
 

--- a/docs/en/how_to_use_on_kubernetes.md
+++ b/docs/en/how_to_use_on_kubernetes.md
@@ -231,4 +231,4 @@ scrape_configs:
 
 ### Configure Grafana dashboard
 
-JuiceFS provides a [dashboard template](./k8s_grafana_template.json) for [Grafana](https://grafana.com), which can be imported to show the collected metrics in Prometheus.
+JuiceFS provides a [dashboard template](./grafana_template.json) for [Grafana](https://grafana.com), which can be imported to show the collected metrics in Prometheus.

--- a/docs/en/p8s_metrics.md
+++ b/docs/en/p8s_metrics.md
@@ -2,7 +2,7 @@
 
 JuiceFS provides a [Prometheus](https://prometheus.io) API for each file system. The default API address is `http://localhost:9567/metrics`, you could custom the address through `--metrics` option when execute [`juicefs mount`](command_reference.md#juicefs-mount) command.
 
-JuiceFS also provides a [dashboard template](./k8s_grafana_template.json) for [Grafana](https://grafana.com), which can be imported to show the collected metrics in Prometheus.
+JuiceFS also provides a [dashboard template](./grafana_template.json) for [Grafana](https://grafana.com), which can be imported to show the collected metrics in Prometheus.
 
 Below are descriptions of each metrics.
 

--- a/docs/zh_cn/hadoop_java_sdk.md
+++ b/docs/zh_cn/hadoop_java_sdk.md
@@ -233,7 +233,7 @@ CREATE TABLE IF NOT EXISTS person
 
 ## 指标收集
 
-JuiceFS Hadoop Java SDK 支持把运行指标以 [Prometheus](https://prometheus.io) 格式上报到 [Pushgateway](https://github.com/prometheus/pushgateway)，然后可以通过 [Grafana](https://grafana.com) 以及我们[预定义的模板](../en/k8s_grafana_template.json)来展示收集的运行指标。
+JuiceFS Hadoop Java SDK 支持把运行指标以 [Prometheus](https://prometheus.io) 格式上报到 [Pushgateway](https://github.com/prometheus/pushgateway)，然后可以通过 [Grafana](https://grafana.com) 以及我们[预定义的模板](../en/grafana_template.json)来展示收集的运行指标。
 
 请用如下参数启用指标收集：
 

--- a/docs/zh_cn/how_to_use_on_kubernetes.md
+++ b/docs/zh_cn/how_to_use_on_kubernetes.md
@@ -231,4 +231,4 @@ scrape_configs:
 
 ### 配置 Grafana 仪表盘
 
-JuiceFS 为 [Grafana](https://grafana.com) 提供了一个[仪表盘模板](../en/k8s_grafana_template.json)，可以导入到 Grafana 中用于展示 Prometheus 收集的监控指标。
+JuiceFS 为 [Grafana](https://grafana.com) 提供了一个[仪表盘模板](../en/grafana_template.json)，可以导入到 Grafana 中用于展示 Prometheus 收集的监控指标。

--- a/docs/zh_cn/p8s_metrics.md
+++ b/docs/zh_cn/p8s_metrics.md
@@ -2,7 +2,7 @@
 
 JuiceFS 为每个文件系统提供一个 [Prometheus](https://prometheus.io) API。默认的 API 地址是 `http://localhost:9567/metrics`，你可以在执行 [`juicefs mount`](command_reference.md#juicefs-mount) 命令时通过 `--metrics` 选项自定义这个地址。
 
-JuiceFS 同时提供一个 [Grafana](https://grafana.com) 的 [dashboard 模板](../en/k8s_grafana_template.json)，将模板导入以后就可以展示这些收集上来的监控指标。
+JuiceFS 同时提供一个 [Grafana](https://grafana.com) 的 [dashboard 模板](../en/grafana_template.json)，将模板导入以后就可以展示这些收集上来的监控指标。
 
 以下是对各项指标含义的说明。
 


### PR DESCRIPTION
1. Use query to find volume names from prometheus data automatically instead of modifying variable manually in grafana dashboard template.
2. Rename `k8s_grafana_template.json` to `grafana_template.json` as this template has nothing k8s specific.