### PR TITLE
Improve stability for heavy random write workload

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2106,7 +2106,7 @@ func (r *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice
 			return nil
 		})
 		if err == nil {
-			needCompact = rpush.Val()%20 == 19
+			needCompact = rpush.Val()%100 == 99
 		}
 		return err
 	}, r.inodeKey(inode))
@@ -2515,7 +2515,7 @@ func (r *redisMeta) compactChunk(inode Ino, indx uint32, force bool) {
 	}
 
 	var ctx = Background
-	vals, err := r.rdb.LRange(ctx, r.chunkKey(inode, indx), 0, 200).Result()
+	vals, err := r.rdb.LRange(ctx, r.chunkKey(inode, indx), 0, 1000).Result()
 	if err != nil {
 		return
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1879,7 +1879,7 @@ func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 			return err
 		}
 		_, err = s.Cols("length", "mtime", "ctime").Update(&n, &node{Inode: inode})
-		if (len(ck.Slices)/sliceBytes)%20 == 19 {
+		if (len(ck.Slices)/sliceBytes)%100 == 99 {
 			needCompact = true
 		}
 		return err

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1820,7 +1820,7 @@ func (m *kvMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		attr.Ctimensec = uint32(now.Nanosecond())
 		val := tx.append(m.chunkKey(inode, indx), marshalSlice(off, slice.Chunkid, slice.Size, slice.Off, slice.Len))
 		tx.set(m.inodeKey(inode), m.marshal(&attr))
-		if (len(val)/sliceBytes)%20 == 0 {
+		if (len(val)/sliceBytes)%100 == 99 {
 			needCompact = true
 		}
 		return nil

--- a/pkg/vfs/compact.go
+++ b/pkg/vfs/compact.go
@@ -17,6 +17,7 @@ package vfs
 
 import (
 	"context"
+	"time"
 
 	"github.com/juicedata/juicefs/pkg/chunk"
 	"github.com/juicedata/juicefs/pkg/meta"
@@ -50,6 +51,9 @@ func readSlice(store chunk.ChunkStore, s *meta.Slice, page *chunk.Page, off int)
 }
 
 func Compact(conf chunk.Config, store chunk.ChunkStore, slices []meta.Slice, chunkid uint64) error {
+	for utils.UsedMemory() > int64(conf.BufferSize)*3/2 {
+		time.Sleep(time.Millisecond * 100)
+	}
 	var size uint32
 	for _, s := range slices {
 		size += s.Len


### PR DESCRIPTION
```
fio --group_reporting --time_based --iodepth=32 --norandommap --name=4k-file-single-randwrite --directory=/jfs-ce3/tmp --rw=randwrite --bs=4k --size=10G --runtime=300 --numjobs=1 --output 4k-random-write.txt
```