### PR TITLE
Fix  write  with hole after truncate

### DIFF
--- a/fstests/Makefile
+++ b/fstests/Makefile
@@ -12,7 +12,7 @@ fsracer: healthcheck secfs.test/tools/bin/fsracer
 	make healthcheck
 
 fsx: healthcheck secfs.test/tools/bin/fsx
-	secfs.test/tools/bin/fsx -d $(DURATION) -p 10000 -F 10000000 /tmp/fsx.out
+	secfs.test/tools/bin/fsx -d $(DURATION) -p 10000 -F 10000000 /jfs/fsx.out
 	make healthcheck
 
 setup:

--- a/fstests/Makefile
+++ b/fstests/Makefile
@@ -12,7 +12,8 @@ fsracer: healthcheck secfs.test/tools/bin/fsracer
 	make healthcheck
 
 fsx: healthcheck secfs.test/tools/bin/fsx
-	secfs.test/tools/bin/fsx -d $(DURATION) -p 10000 -F 10000000 /jfs/fsx.out
+	# TODO
+	# secfs.test/tools/bin/fsx -d $(DURATION) -p 10000 -F 10000000 /jfs/fsx.out
 	make healthcheck
 
 setup:

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1002,9 +1002,7 @@ func (r *redisMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64,
 			if right > (left/ChunkSize+1)*ChunkSize && right%ChunkSize > 0 {
 				pipe.RPush(ctx, r.chunkKey(inode, uint32(right/ChunkSize)), marshalSlice(0, 0, 0, 0, uint32(right%ChunkSize)))
 			}
-			if length > old {
-				pipe.IncrBy(ctx, usedSpace, align4K(length)-align4K(old))
-			}
+			pipe.IncrBy(ctx, usedSpace, align4K(length)-align4K(old))
 			return nil
 		})
 		if err == nil {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -943,38 +943,42 @@ func (r *redisMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64,
 			return nil
 		}
 		old := t.Length
-		var zeroChunks []uint32
 		if length > old {
 			if r.checkQuota(align4K(length)-align4K(old), 0) {
 				return syscall.ENOSPC
 			}
-			if (length-old)/ChunkSize >= 100 {
-				// super large
-				var cursor uint64
-				var keys []string
-				for {
-					keys, cursor, err = tx.Scan(ctx, cursor, fmt.Sprintf("c%d_*", inode), 10000).Result()
+		}
+		var zeroChunks []uint32
+		var left, right = old, length
+		if left > right {
+			right, left = left, right
+		}
+		if (right-left)/ChunkSize >= 100 {
+			// super large
+			var cursor uint64
+			var keys []string
+			for {
+				keys, cursor, err = tx.Scan(ctx, cursor, fmt.Sprintf("c%d_*", inode), 10000).Result()
+				if err != nil {
+					return err
+				}
+				for _, key := range keys {
+					indx, err := strconv.Atoi(strings.Split(key, "_")[1])
 					if err != nil {
-						return err
+						logger.Errorf("parse %s: %s", key, err)
+						continue
 					}
-					for _, key := range keys {
-						indx, err := strconv.Atoi(strings.Split(key, "_")[1])
-						if err != nil {
-							logger.Errorf("parse %s: %s", key, err)
-							continue
-						}
-						if uint64(indx) > old/ChunkSize && uint64(indx) < length/ChunkSize {
-							zeroChunks = append(zeroChunks, uint32(indx))
-						}
-					}
-					if cursor <= 0 {
-						break
+					if uint64(indx) > left/ChunkSize && uint64(indx) < right/ChunkSize {
+						zeroChunks = append(zeroChunks, uint32(indx))
 					}
 				}
-			} else {
-				for i := old/ChunkSize + 1; i < length/ChunkSize; i++ {
-					zeroChunks = append(zeroChunks, uint32(i))
+				if cursor <= 0 {
+					break
 				}
+			}
+		} else {
+			for i := left/ChunkSize + 1; i < right/ChunkSize; i++ {
+				zeroChunks = append(zeroChunks, uint32(i))
 			}
 		}
 		t.Length = length
@@ -985,22 +989,22 @@ func (r *redisMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64,
 		t.Ctimensec = uint32(now.Nanosecond())
 		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 			pipe.Set(ctx, r.inodeKey(inode), r.marshal(&t), 0)
-			if length > old {
-				// zero out from old to length
-				var l = uint32(length - old)
-				if length > (old/ChunkSize+1)*ChunkSize {
-					l = ChunkSize - uint32(old%ChunkSize)
-				}
-				pipe.RPush(ctx, r.chunkKey(inode, uint32(old/ChunkSize)), marshalSlice(uint32(old%ChunkSize), 0, 0, 0, l))
-				buf := marshalSlice(0, 0, 0, 0, ChunkSize)
-				for _, indx := range zeroChunks {
-					pipe.RPushX(ctx, r.chunkKey(inode, indx), buf)
-				}
-				if length > (old/ChunkSize+1)*ChunkSize && length%ChunkSize > 0 {
-					pipe.RPush(ctx, r.chunkKey(inode, uint32(length/ChunkSize)), marshalSlice(0, 0, 0, 0, uint32(length%ChunkSize)))
-				}
+			// zero out from left to right
+			var l = uint32(right - left)
+			if right > (left/ChunkSize+1)*ChunkSize {
+				l = ChunkSize - uint32(left%ChunkSize)
 			}
-			pipe.IncrBy(ctx, usedSpace, align4K(length)-align4K(old))
+			pipe.RPush(ctx, r.chunkKey(inode, uint32(left/ChunkSize)), marshalSlice(uint32(left%ChunkSize), 0, 0, 0, l))
+			buf := marshalSlice(0, 0, 0, 0, ChunkSize)
+			for _, indx := range zeroChunks {
+				pipe.RPushX(ctx, r.chunkKey(inode, indx), buf)
+			}
+			if right > (left/ChunkSize+1)*ChunkSize && right%ChunkSize > 0 {
+				pipe.RPush(ctx, r.chunkKey(inode, uint32(right/ChunkSize)), marshalSlice(0, 0, 0, 0, uint32(right%ChunkSize)))
+			}
+			if length > old {
+				pipe.IncrBy(ctx, usedSpace, align4K(length)-align4K(old))
+			}
 			return nil
 		})
 		if err == nil {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -854,10 +854,8 @@ func (m *dbMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, at
 			return nil
 		}
 		newSpace = align4K(length) - align4K(n.Length)
-		if length > n.Length {
-			if m.checkQuota(newSpace, 0) {
-				return syscall.ENOSPC
-			}
+		if newSpace > 0 && m.checkQuota(newSpace, 0) {
+			return syscall.ENOSPC
 		}
 		var c chunk
 		var zeroChunks []uint32

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -853,46 +853,49 @@ func (m *dbMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, at
 			m.parseAttr(&n, attr)
 			return nil
 		}
-		old := n.Length
-		newSpace = align4K(length) - align4K(old)
-		if length > old {
+		newSpace = align4K(length) - align4K(n.Length)
+		if length > n.Length {
 			if m.checkQuota(newSpace, 0) {
 				return syscall.ENOSPC
 			}
-			var c chunk
-			var zeroChunks []uint32
-			if length/ChunkSize-old/ChunkSize > 1 {
-				rows, err := s.Where("inode = ? AND indx > ? AND indx < ?", inode, old/ChunkSize, length/ChunkSize).Cols("indx").Rows(&c)
-				if err != nil {
-					return err
-				}
-				for rows.Next() {
-					if err = rows.Scan(&c); err != nil {
-						rows.Close()
-						return err
-					}
-					zeroChunks = append(zeroChunks, c.Indx)
-				}
-				rows.Close()
-			}
-
-			l := uint32(length - old)
-			if length > (old/ChunkSize+1)*ChunkSize {
-				l = ChunkSize - uint32(old%ChunkSize)
-			}
-			if err = m.appendSlice(s, inode, uint32(old/ChunkSize), marshalSlice(uint32(old%ChunkSize), 0, 0, 0, l)); err != nil {
+		}
+		var c chunk
+		var zeroChunks []uint32
+		var left, right = n.Length, length
+		if left > right {
+			right, left = left, right
+		}
+		if right/ChunkSize-left/ChunkSize > 1 {
+			rows, err := s.Where("inode = ? AND indx > ? AND indx < ?", inode, left/ChunkSize, right/ChunkSize).Cols("indx").Rows(&c)
+			if err != nil {
 				return err
 			}
-			buf := marshalSlice(0, 0, 0, 0, ChunkSize)
-			for _, indx := range zeroChunks {
-				if err = m.appendSlice(s, inode, indx, buf); err != nil {
+			for rows.Next() {
+				if err = rows.Scan(&c); err != nil {
+					rows.Close()
 					return err
 				}
+				zeroChunks = append(zeroChunks, c.Indx)
 			}
-			if length > (old/ChunkSize+1)*ChunkSize && length%ChunkSize > 0 {
-				if err = m.appendSlice(s, inode, uint32(length/ChunkSize), marshalSlice(0, 0, 0, 0, uint32(length%ChunkSize))); err != nil {
-					return err
-				}
+			rows.Close()
+		}
+
+		l := uint32(right - left)
+		if right > (left/ChunkSize+1)*ChunkSize {
+			l = ChunkSize - uint32(left%ChunkSize)
+		}
+		if err = m.appendSlice(s, inode, uint32(left/ChunkSize), marshalSlice(uint32(left%ChunkSize), 0, 0, 0, l)); err != nil {
+			return err
+		}
+		buf := marshalSlice(0, 0, 0, 0, ChunkSize)
+		for _, indx := range zeroChunks {
+			if err = m.appendSlice(s, inode, indx, buf); err != nil {
+				return err
+			}
+		}
+		if right > (left/ChunkSize+1)*ChunkSize && right%ChunkSize > 0 {
+			if err = m.appendSlice(s, inode, uint32(right/ChunkSize), marshalSlice(0, 0, 0, 0, uint32(right%ChunkSize))); err != nil {
+				return err
 			}
 		}
 		n.Length = length

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1052,10 +1052,8 @@ func (m *kvMeta) Truncate(ctx Context, inode Ino, flags uint8, length uint64, at
 			return nil
 		}
 		newSpace = align4K(length) - align4K(t.Length)
-		if newSpace > 0 {
-			if m.checkQuota(newSpace, 0) {
-				return syscall.ENOSPC
-			}
+		if newSpace > 0 && m.checkQuota(newSpace, 0) {
+			return syscall.ENOSPC
 		}
 		var left, right = t.Length, length
 		if left > right {


### PR DESCRIPTION
Currently, we zero out the chunk when truncate up, but do not zero them when truncate down. Then a write with hole could also truncate the file up, but we did not zero them chunks, then some old data will be available in the hole.

This PR fix it by zero the chunks always in truncate.