### PR TITLE
disable fsync in writeback mode

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -298,7 +298,7 @@ func (cache *cacheStore) add(key string, size int32, atime uint32) {
 
 func (cache *cacheStore) stage(key string, data []byte, keepCache bool) (string, error) {
 	stagingPath := cache.stagePath(key)
-	err := cache.flushPage(stagingPath, data, true)
+	err := cache.flushPage(stagingPath, data, false)
 	if err == nil && cache.capacity > 0 && keepCache {
 		path := cache.cachePath(key)
 		cache.createDir(filepath.Dir(path))


### PR DESCRIPTION
When writeback is enabled, we want to speedup the write of small files by sacrifice the durability, but the fsync will slow things down and still not great for durability (disk could be damaged).

This will disable fsync in writeback mode.