### PR TITLE
vfs: try open reader when necessary

### DIFF
--- a/pkg/vfs/handle.go
+++ b/pkg/vfs/handle.go
@@ -213,8 +213,8 @@ func newFileHandle(inode Ino, length uint64, flags uint32) uint64 {
 	switch flags & O_ACCMODE {
 	case syscall.O_RDONLY:
 		h.reader = reader.Open(inode, length)
-	case syscall.O_WRONLY:
-		h.writer = writer.Open(inode, length)
+	case syscall.O_WRONLY: // FUSE writeback_cache mode need reader even for WRONLY
+		fallthrough
 	case syscall.O_RDWR:
 		h.reader = reader.Open(inode, length)
 		h.writer = writer.Open(inode, length)


### PR DESCRIPTION
When writeback-cache mode is enabled for FUSE, it is possible to READ a file opened with O_WRONLY.
Refs: https://www.kernel.org/doc/Documentation/filesystems/fuse-io.txt