### PR TITLE
fix minio storage bucket display string

### DIFF
--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -34,7 +34,7 @@ type minio struct {
 }
 
 func (m *minio) String() string {
-	return *m.s3client.ses.Config.Endpoint
+	return fmt.Sprintf("minio://%s/%s/", *m.s3client.ses.Config.Endpoint, m.s3client.bucket)
 }
 
 func newMinio(endpoint, accessKey, secretKey string) (ObjectStorage, error) {


### PR DESCRIPTION
`./juicefs format --storage minio --bucket http://minio.juicefs.local:9000/minio/juicefs-dev ... dev`
Currently `minio` storage will display: `<INFO>: Data uses minio.juicefs.local:9000dev/` which is `{{endpoint}}{{prefix}}/` (the `{{prefix}}` is the volume name)
This PR fix it to `minio://minio.juicefs.local:9000/juicefs-dev/dev/` which is `minio://{{endpoint}}/{{bucket}}/{{prefix}}/`