### PR TITLE
Add tiered mode(stage 1). When local disk is full, spill to objec store.

### DIFF
--- a/pkg/chunk/disk_tiered.go
+++ b/pkg/chunk/disk_tiered.go
@@ -1,0 +1,283 @@
+package chunk
+
+import (
+	"errors"
+	"fmt"
+	"github.com/juicedata/juicefs/pkg/utils"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type tieredDiskItem struct {
+	size  int32
+	atime uint32
+}
+
+type tieredDiskStore struct {
+	tieredManager *tieredManager
+	totalPages    int64
+	sync.Mutex
+	dir       string
+	mode      os.FileMode
+	capacity  int64
+	freeRatio float32
+	pending   chan pendingFile
+	pages     map[string]*Page
+
+	used    int64
+	keys    map[string]tieredDiskItem
+	scanned bool
+}
+
+func (c *tieredDiskStore) createDir(dir string) {
+	// who can read the cache, should be able to access the directories and add new file.
+	readmode := c.mode & 0444
+	mode := c.mode | (readmode >> 2) | (readmode >> 1)
+	if st, err := os.Stat(dir); os.IsNotExist(err) {
+		if filepath.Dir(dir) != dir {
+			c.createDir(filepath.Dir(dir))
+		}
+		_ = os.Mkdir(dir, mode)
+		// umask may remove some permisssions
+		_ = os.Chmod(dir, mode)
+	} else if strings.HasPrefix(dir, c.dir) && err == nil && st.Mode() != mode {
+		changeMode(dir, st, mode)
+	}
+}
+
+func (c *tieredDiskStore) curFreeRatio() (float32, float32) {
+	total, free, files, ffree := getDiskUsage(c.dir)
+	return float32(free) / float32(total), float32(ffree) / float32(files)
+}
+
+func (c *tieredDiskStore) usedMemory() int64 {
+	return atomic.LoadInt64(&c.totalPages)
+}
+
+func (c *tieredDiskStore) stats() (int64, int64) {
+	c.Lock()
+	defer c.Unlock()
+	return int64(len(c.pages) + len(c.keys)), c.used + c.usedMemory()
+}
+
+func (c *tieredDiskStore) savePath(key string) string {
+	return filepath.Join(c.dir, key)
+}
+
+func (c *tieredDiskStore) add(key string, size int32, atime uint32) {
+	c.Lock()
+	defer c.Unlock()
+	it, ok := c.keys[key]
+	if ok {
+		c.used -= int64(it.size + 4096)
+	}
+	if atime == 0 {
+		// update size of staging block
+		c.keys[key] = tieredDiskItem{size, it.atime}
+	} else {
+		c.keys[key] = tieredDiskItem{size, atime}
+	}
+	c.used += int64(size + 4096)
+
+	if c.used > c.capacity {
+		logger.Debugf("Out of local disk when add new data (%s): %d blocks (%d MB)", c.dir, len(c.keys), c.used>>20)
+	}
+}
+
+func (c *tieredDiskStore) uploaded(key string, size int) {
+	c.add(key, int32(size), 0)
+}
+
+func (c *tieredDiskStore) flushPage(path string, data []byte, sync bool) error {
+	c.createDir(filepath.Dir(path))
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE, c.mode)
+	if err != nil {
+		logger.Infof("Can't create tiered disk file %s: %s", tmp, err)
+		return err
+	}
+	_, err = f.Write(data)
+	if err != nil {
+		logger.Warnf("Write to tiered disk file %s failed: %s", tmp, err)
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if sync {
+		err = f.Sync()
+		if err != nil {
+			logger.Warnf("sync tiered disk file %s failed: %s", tmp, err)
+			_ = f.Close()
+			_ = os.Remove(tmp)
+			return err
+		}
+	}
+	err = f.Close()
+	if err != nil {
+		logger.Warnf("Close tiered disk %s failed: %s", tmp, err)
+		_ = os.Remove(tmp)
+		return err
+	}
+	err = os.Rename(tmp, path)
+	if err != nil {
+		logger.Infof("Rename tiered disk %s -> %s failed: %s", tmp, path, err)
+		_ = os.Remove(tmp)
+	}
+	return err
+}
+
+func (c *tieredDiskStore) save(key string, data []byte) (string, error) {
+	if c.used > c.capacity {
+		return "", errors.New(fmt.Sprintf("out of tiered disk. capacity:%d used:%d", c.capacity, c.used))
+	}
+	tieredDiskPath := c.savePath(key)
+	err := c.flushPage(tieredDiskPath, data, false)
+	if err == nil && c.capacity > 0 {
+		path := c.tieredManager.tieredStore.cachedStore.bcache.(*cacheManager).getStore(key).cachePath(key)
+		c.createDir(filepath.Dir(path))
+		if err := os.Link(tieredDiskPath, path); err == nil {
+			c.add(key, int32(len(data)), uint32(time.Now().Unix()))
+		} else {
+			logger.Warnf("link %s to %s failed: %s", tieredDiskPath, path, err)
+		}
+	}
+	return tieredDiskPath, err
+}
+
+func (c *tieredDiskStore) load(key string) (ReadCloser, error) {
+	return c.tieredManager.tieredStore.cachedStore.bcache.(*cacheManager).getStore(key).load(key)
+}
+
+func (c *tieredDiskStore) remove(key string) {
+	c.Lock()
+	path := c.savePath(key)
+	if c.keys[key].atime > 0 {
+		c.used -= int64(c.keys[key].size + 4096)
+		delete(c.keys, key)
+	} else if c.scanned {
+		path = "" // not existed
+	}
+	c.Unlock()
+	if path != "" {
+		_ = os.Remove(path)
+		_ = os.Remove(c.savePath(key))
+	}
+}
+
+func newTieredDiskStore(tieredManager *tieredManager, dir string, tieredDiskSize int64, pendingPages int, config *TieredConfig) *tieredDiskStore {
+	if config.TieredDiskMode == 0 {
+		config.TieredDiskMode = 0600 // only owner can read/write cache
+	}
+	if config.TieredDiskFreeSpace == 0.0 {
+		config.TieredDiskFreeSpace = 0.1 // 10%
+	}
+	c := &tieredDiskStore{
+		tieredManager: tieredManager,
+		dir:           dir,
+		mode:          config.TieredDiskMode,
+		capacity:      tieredDiskSize,
+		freeRatio:     config.TieredDiskFreeSpace,
+		keys:          make(map[string]tieredDiskItem),
+		pending:       make(chan pendingFile, pendingPages),
+		pages:         make(map[string]*Page),
+	}
+	c.createDir(c.dir)
+	br, fr := c.curFreeRatio()
+	if br < c.freeRatio || fr < c.freeRatio {
+		logger.Warnf("No enough space (%d%%) or inodes (%d%%) for tired disk in %s: free ratio should be >= %d%%", int(br*100), int(fr*100), c.dir, int(c.freeRatio*100))
+	}
+	logger.Infof("Disk (%s): capacity (%d MB), free ratio (%d%%), max pending pages (%d)", c.dir, c.capacity>>20, int(c.freeRatio*100), pendingPages)
+	return c
+}
+
+type tieredManager struct {
+	stores      []*tieredDiskStore
+	tieredStore *tieredStore
+}
+
+type TieredManager interface {
+	save(key string, data []byte) (string, error)
+	remove(key string)
+	load(key string) (ReadCloser, error)
+	uploaded(key string, size int)
+	stats() (int64, int64)
+	usedMemory() int64
+}
+
+func newTieredManager(tieredStore *tieredStore, config *TieredConfig) TieredManager {
+
+	var dirs []string
+	for _, d := range utils.SplitDir(config.TieredDiskDir) {
+		dd := expandDir(d)
+		dirs = append(dirs, dd...)
+	}
+	if len(dirs) == 0 {
+		logger.Warnf("No tired disk existed")
+	}
+	sort.Strings(dirs)
+	dirSize := config.TieredDiskSize << 20
+	dirSize /= int64(len(dirs))
+	m := &tieredManager{
+		stores:      make([]*tieredDiskStore, len(dirs)),
+		tieredStore: tieredStore,
+	}
+	// 20% of buffer could be used for pending pages
+	pendingPages := config.TieredDiskBufferSize * 2 / 10 / config.BlockSize / len(dirs)
+	for i, d := range dirs {
+		m.stores[i] = newTieredDiskStore(m, strings.TrimSpace(d)+string(filepath.Separator), dirSize, pendingPages, config)
+	}
+	return m
+}
+
+func (m *tieredManager) getStore(key string) *tieredDiskStore {
+	return m.stores[keyHash(key)%uint32(len(m.stores))]
+}
+
+func (m *tieredManager) usedMemory() int64 {
+	var used int64
+	for _, s := range m.stores {
+		used += s.usedMemory()
+	}
+	return used
+}
+
+func (m *tieredManager) stats() (int64, int64) {
+	var cnt, used int64
+	for _, s := range m.stores {
+		c, u := s.stats()
+		cnt += c
+		used += u
+	}
+	return cnt, used
+}
+
+func (m *tieredManager) save(key string, data []byte, ) (string, error) {
+	if len(m.stores) == 0 {
+		return "", errors.New("no tiered local disk dir")
+	}
+	return m.getStore(key).save(key, data)
+}
+
+func (m *tieredManager) load(key string) (ReadCloser, error) {
+	if len(m.stores) == 0 {
+		return nil, errors.New("no tiered local disk dir")
+	}
+	return m.getStore(key).load(key)
+}
+
+func (m *tieredManager) remove(key string) {
+	if len(m.stores) > 0 {
+		m.getStore(key).remove(key)
+	}
+}
+
+func (m *tieredManager) uploaded(key string, size int) {
+	if len(m.stores) > 0 {
+		m.getStore(key).uploaded(key, size)
+	}
+}

--- a/pkg/chunk/tired_store.go
+++ b/pkg/chunk/tired_store.go
@@ -1,0 +1,291 @@
+package chunk
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/juicedata/juicefs/pkg/object"
+	"os"
+	"time"
+)
+
+type TieredConfig struct {
+	Config
+	TieredDiskDir        string
+	TieredDiskMode       os.FileMode
+	TieredDiskSize       int64
+	TieredDiskFreeSpace  float32
+	TieredDiskBufferSize int
+}
+
+type tieredWChunk struct {
+	rChunk
+	tiredStore  *tieredStore
+	pages       [][]*Page
+	uploaded    int
+	errors      chan error
+	uploadError error
+	pendings    int
+}
+
+func (c *tieredWChunk) SetID(id uint64) {
+	c.id = id
+}
+
+func (c *tieredWChunk) WriteAt(p []byte, off int64) (n int, err error) {
+	if int(off)+len(p) > chunkSize {
+		return 0, fmt.Errorf("write out of chunk boudary: %d > %d", int(off)+len(p), chunkSize)
+	}
+	if off < int64(c.uploaded) {
+		return 0, fmt.Errorf("Cannot overwrite uploaded block: %d < %d", off, c.uploaded)
+	}
+
+	// Fill previous blocks with zeros
+	if c.length < int(off) {
+		zeros := make([]byte, int(off)-c.length)
+		_, _ = c.WriteAt(zeros, int64(c.length))
+	}
+
+	for n < len(p) {
+		indx := c.index(int(off) + n)
+		boff := (int(off) + n) % c.store.conf.BlockSize
+		var bs = pageSize
+		if indx > 0 || bs > c.store.conf.BlockSize {
+			bs = c.store.conf.BlockSize
+		}
+		bi := boff / bs
+		bo := boff % bs
+		var page *Page
+		if bi < len(c.pages[indx]) {
+			page = c.pages[indx][bi]
+		} else {
+			page = allocPage(bs)
+			page.Data = page.Data[:0]
+			c.pages[indx] = append(c.pages[indx], page)
+		}
+		left := len(p) - n
+		if bo+left > bs {
+			page.Data = page.Data[:bs]
+		} else if len(page.Data) < bo+left {
+			page.Data = page.Data[:bo+left]
+		}
+		n += copy(page.Data[bo:], p[n:])
+	}
+	if int(off)+n > c.length {
+		c.length = int(off) + n
+	}
+	return n, nil
+}
+
+func (c *tieredWChunk) put(key string, p *Page) error {
+	p.Acquire()
+	return withTimeout(func() error {
+		defer p.Release()
+		st := time.Now()
+		err := c.store.storage.Put(key, bytes.NewReader(p.Data))
+		used := time.Since(st)
+		logger.Debugf("PUT %s (%s, %.3fs)", key, err, used.Seconds())
+		if used > SlowRequest {
+			logger.Infof("slow request: PUT %v (%s, %.3fs)", key, err, used.Seconds())
+		}
+		return err
+	}, c.store.conf.PutTimeout)
+}
+
+func (c *tieredWChunk) syncUpload(key string, block *Page) {
+	blen := len(block.Data)
+	bufSize := c.store.compressor.CompressBound(blen)
+	var buf *Page
+	if bufSize > blen {
+		buf = NewOffPage(bufSize)
+	} else {
+		buf = block
+		buf.Acquire()
+	}
+	n, err := c.store.compressor.Compress(buf.Data, block.Data)
+	if err != nil {
+		logger.Fatalf("compress chunk %v: %s", c.id, err)
+		return
+	}
+	buf.Data = buf.Data[:n]
+	block.Release()
+
+	c.store.currentUpload <- true
+	defer func() {
+		buf.Release()
+		<-c.store.currentUpload
+	}()
+
+	try := 0
+	for try <= 10 && c.uploadError == nil {
+		err = c.put(key, buf)
+		if err == nil {
+			c.errors <- nil
+			return
+		}
+		try++
+		logger.Warnf("upload %s: %s (try %d)", key, err, try)
+		time.Sleep(time.Second * time.Duration(try*try))
+	}
+	c.errors <- fmt.Errorf("upload block %s: %s (after %d tries)", key, err, try)
+}
+
+func (c *tieredWChunk) upload(indx int) {
+	blen := c.blockSize(indx)
+	key := c.key(indx)
+	pages := c.pages[indx]
+	c.pages[indx] = nil
+	c.pendings++
+
+	go func() {
+		var block *Page
+		if len(pages) == 1 {
+			block = pages[0]
+		} else {
+			block = NewOffPage(blen)
+			var off int
+			for _, b := range pages {
+				off += copy(block.Data[off:], b.Data)
+				freePage(b)
+			}
+			if off != blen {
+				logger.Fatalf("block length does not match: %v != %v", off, blen)
+			}
+		}
+
+		tieredDiskPath, err := c.tiredStore.tieredManager.save(key, block.Data)
+		if err != nil {
+			logger.Infof("write %s to disk: %s, spill to object store", tieredDiskPath, err)
+			c.syncUpload(key, block)
+		}
+		c.errors <- nil
+	}()
+}
+
+func (c *tieredWChunk) ID() uint64 {
+	return c.id
+}
+
+func (c *tieredWChunk) Len() int {
+	return c.length
+}
+
+func (c *tieredWChunk) FlushTo(offset int) error {
+	if offset < c.uploaded {
+		logger.Fatalf("Invalid offset: %d < %d", offset, c.uploaded)
+	}
+	for i, block := range c.pages {
+		start := i * c.store.conf.BlockSize
+		end := start + c.store.conf.BlockSize
+		if start >= c.uploaded && end <= offset {
+			if block != nil {
+				c.upload(i)
+			}
+			c.uploaded = end
+		}
+	}
+
+	return nil
+}
+
+func (c *tieredWChunk) Finish(length int) error {
+	if c.length != length {
+		return fmt.Errorf("Length mismatch: %v != %v", c.length, length)
+	}
+
+	n := (length-1)/c.store.conf.BlockSize + 1
+	if err := c.FlushTo(n * c.store.conf.BlockSize); err != nil {
+		return err
+	}
+	for i := 0; i < c.pendings; i++ {
+		if err := <-c.errors; err != nil {
+			c.uploadError = err
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *tieredWChunk) Abort() {
+	for i := range c.pages {
+		for _, b := range c.pages[i] {
+			freePage(b)
+		}
+		c.pages[i] = nil
+	}
+	// delete uploaded blocks
+	c.length = c.uploaded
+	_ = c.Remove()
+}
+
+type tieredStore struct {
+	storage       *object.ObjectStorage
+	cachedStore   *cachedStore
+	tieredManager TieredManager
+	TiredConfig   TieredConfig
+}
+
+func tieredChunkForWrite(id uint64, store *tieredStore) *tieredWChunk {
+	return &tieredWChunk{
+		rChunk:     rChunk{id, 0, store.cachedStore},
+		pages:      make([][]*Page, chunkSize/store.cachedStore.conf.BlockSize),
+		errors:     make(chan error, chunkSize/store.cachedStore.conf.BlockSize),
+		tiredStore: store,
+	}
+}
+
+func NewTieredStore(c ChunkStore, storage *object.ObjectStorage, config TieredConfig) ChunkStore {
+
+	s := &tieredStore{
+		storage:     storage,
+		cachedStore: c.(*cachedStore),
+		TiredConfig: config,
+	}
+	s.tieredManager = newTieredManager(s, &config)
+	return s
+}
+
+func (store *tieredStore) NewReader(chunkid uint64, length int) Reader {
+	return store.cachedStore.NewReader(chunkid, length)
+}
+
+func (store *tieredStore) NewWriter(chunkid uint64) Writer {
+	return tieredChunkForWrite(chunkid, store)
+}
+
+func (store *tieredStore) Remove(chunkid uint64, length int) error {
+	c := chunkForRead(chunkid, length, store.cachedStore)
+	if c.length == 0 {
+		// no block
+		return nil
+	}
+
+	lastIndx := (c.length - 1) / c.store.conf.BlockSize
+	var err error
+	for i := 0; i <= lastIndx; i++ {
+		// there could be multiple clients try to remove the same chunk in the same time,
+		// any of them should succeed if any blocks is removed
+		key := c.key(i)
+		c.store.pendingMutex.Lock()
+		delete(c.store.pendingKeys, key)
+		c.store.pendingMutex.Unlock()
+		// delete cache first
+		c.store.bcache.remove(key)
+		// delete local disk
+		store.tieredManager.remove(key)
+
+		// todo: optimize when the data is not in remote
+		// delete remote
+		if e := c.delete(i); e != nil {
+			err = e
+		}
+	}
+	return err
+}
+
+func (store *tieredStore) FillCache(chunkid uint64, length uint32) error {
+	return store.cachedStore.FillCache(chunkid, length)
+}
+
+func (store *tieredStore) UsedMemory() int64 {
+	return store.tieredManager.usedMemory()
+}


### PR DESCRIPTION
The issue is [JuiceFS Tiered Mode Design](https://github.com/juicedata/juicefs/issues/719) .

To implement JuiceFS tiered mode, we need several PRs, this is the first PR.

If this PR accepted, then JuiceFS have two modes:

1. cache mode
2. tiered mode

cache mode is good for long-lifetime data, the purpose is to speed up the data access.
tiered mode leverage the cache mode  when people access data in object store, however , if people write the data , then 
the new logical will take affect. We will firstly try to write our local disk (tiered-disk-dir), if it's full, then we will spill to object store.

## Usage

Formatting file system

```shell
./juicefs format \
        --storage file \
        --bucket /tmp/remote \
        redis://192.168.31.95:6379/2 \
        tiered-storage

```

Mount file system

```shell
sudo ./juicefs mount \
        --mode tiered \
        --cache-dir /tmp/m1:/tmp/m2 \
        --tiered-disk-dir /tmp/d1:tmp/d2 \
        --tiered-disk-size 4 \
        redis://192.168.31.95:6379/2 \
        /tmp/jack
```


// sudo  ./juicefs umount --force /tmp/jack

Tired-disk-size is set to 4m, because we  have configured two directories, so the quota for each directory is 2m, 10% free ratio. If it is full, it should be spilled into the /tmp/remote.

## How to verify

1. Copy a file larger than or less than 4M, at this time/tmp/remote should have no file;
2. Copy a file much larger than 4M,/tmp/remote should have the file.
