### PR TITLE
Integrate Github codebase visualizer into JuiceFS workflow

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -1,0 +1,17 @@
+name: Create diagram
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+jobs:
+  get_data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Update diagram
+        uses: githubocto/repo-visualizer@main
+        with:
+          excluded_paths: ".github"
+          output_file: "docs/images/repo-diagram.svg"


### PR DESCRIPTION
Use [repo-visualizer](https://github.com/githubocto/repo-visualizer) to generate a diagram of the project.

Some examples of the generated SVG diagram:

1. https://github.com/githubocto/repo-visualizer-demo
2. https://github.com/suzaku/shonenjump

With this configuration, a new diagram will be committed in `docs/images` whenever something is pushed to `main`.