### PR TITLE
fix compaction when skip some slices for sql and tikv engine

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2284,7 +2284,7 @@ func (m *dbMeta) compactChunk(inode Ino, indx uint32, force bool) {
 	if st != 0 {
 		return
 	}
-	logger.Debugf("compact %d:%d: skipped %d slices (%d bytes) %d slices (%d bytes)", inode, indx, skipped/sliceBytes, pos, len(ss), size)
+	logger.Debugf("compact %d:%d: skipped %d slices (%d bytes) %d slices (%d bytes)", inode, indx, skipped, pos, len(ss), size)
 	err = m.newMsg(CompactChunk, chunks, chunkid)
 	if err != nil {
 		logger.Warnf("compact %d %d with %d slices: %s", inode, indx, len(ss), err)

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2301,7 +2301,7 @@ func (m *dbMeta) compactChunk(inode Ino, indx uint32, force bool) {
 			return syscall.EINVAL
 		}
 
-		c2.Slices = append(append(c2.Slices[:skipped], marshalSlice(pos, chunkid, size, 0, size)...), c2.Slices[len(c.Slices):]...)
+		c2.Slices = append(append(c2.Slices[:skipped*sliceBytes], marshalSlice(pos, chunkid, size, 0, size)...), c2.Slices[len(c.Slices):]...)
 		if _, err := ses.Where("Inode = ? AND indx = ?", inode, indx).Update(c2); err != nil {
 			return err
 		}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1891,7 +1891,7 @@ func (m *kvMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		attr.Ctimensec = uint32(now.Nanosecond())
 		val := tx.append(m.chunkKey(inode, indx), marshalSlice(off, slice.Chunkid, slice.Size, slice.Off, slice.Len))
 		tx.set(m.inodeKey(inode), m.marshal(&attr))
-		needCompact = (len(val)/sliceBytes)%50 == 49
+		needCompact = (len(val)/sliceBytes)%100 == 99
 		return nil
 	})
 	if err == nil {


### PR DESCRIPTION
When some slices was skipped in compaction, the new slices will be corrupted.

Closes #749 