### PR TITLE
require go1.15 and build release with go1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.x'
+          go-version: '1.16.x'
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juicedata/juicefs
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.39.0


### PR DESCRIPTION
Go 1.17 is out, so we can build the release with Go1.16 and require Go1.15+

Close #767 