### PR TITLE
keep SGID when file is non-group-executable

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1127,11 +1127,16 @@ func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode u
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			if cur.Mode&01777 != cur.Mode {
+			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
+				// clear SUID and SGID
 				cur.Mode &= 01777
-				changed = true
+				attr.Mode &= 01777
+			} else {
+				// keep SGID if the file is non-group-executable
+				cur.Mode &= 03777
+				attr.Mode &= 03777
 			}
-			attr.Mode &= 01777
+			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {
 			cur.Uid = attr.Uid

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -122,13 +122,11 @@ func testMetaClient(t *testing.T, m Meta) {
 	}
 	// check owner permission
 	var p1, c1 Ino
-	if st := m.Mkdir(ctx2, 1, "d1", 02777, 022, 0, &p1, attr); st != 0 {
+	if st := m.Mkdir(ctx2, 1, "d1", 02766, 022, 0, &p1, attr); st != 0 {
 		t.Fatalf("mkdir d1: %s", st)
 	}
 	attr.Gid = 1
 	m.SetAttr(ctx, p1, SetAttrGID, 0, attr)
-	attr.Mode |= 02000
-	m.SetAttr(ctx, p1, SetAttrMode, 0, attr)
 	if attr.Mode&02000 == 0 {
 		t.Fatalf("SGID is lost")
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -784,11 +784,16 @@ func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			if cur.Mode&01777 != cur.Mode {
+			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
+				// clear SUID and SGID
 				cur.Mode &= 01777
-				changed = true
+				attr.Mode &= 01777
+			} else {
+				// keep SGID if the file is non-group-executable
+				cur.Mode &= 03777
+				attr.Mode &= 03777
 			}
-			attr.Mode &= 01777
+			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {
 			cur.Uid = attr.Uid

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -979,11 +979,16 @@ func (m *kvMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			if cur.Mode&01777 != cur.Mode {
+			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
+				// clear SUID and SGID
 				cur.Mode &= 01777
-				changed = true
+				attr.Mode &= 01777
+			} else {
+				// keep SGID if the file is non-group-executable
+				cur.Mode &= 03777
+				attr.Mode &= 03777
 			}
-			attr.Mode &= 01777
+			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {
 			cur.Uid = attr.Uid


### PR DESCRIPTION
From man 2 chown:


>   When the owner or group of an executable file are changed by an unprivileged user the S_ISUID and
>  S_ISGID mode bits are cleared.  POSIX does not specify   whether  this  also  should happen when root
>  does the chown(); the Linux behavior depends on the kernel version.  In case of a non-group-executable file
>       (i.e., one for which the S_IXGRP bit is not set) the S_ISGID bit indicates mandatory locking, and is not cleared by a chown().
