### PR TITLE
disable check of object storage using env

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -204,8 +204,10 @@ func format(c *cli.Context) error {
 		logger.Fatalf("object storage: %s", err)
 	}
 	logger.Infof("Data uses %s", blob)
-	if err := test(blob); err != nil {
-		logger.Fatalf("Storage %s is not configured correctly: %s", blob, err)
+	if os.Getenv("NO_CHECK_OBJECT_STORAGE") != "" {
+		if err := test(blob); err != nil {
+			logger.Fatalf("Storage %s is not configured correctly: %s", blob, err)
+		}
 	}
 
 	err = m.Init(format, c.Bool("force"))

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -204,7 +204,7 @@ func format(c *cli.Context) error {
 		logger.Fatalf("object storage: %s", err)
 	}
 	logger.Infof("Data uses %s", blob)
-	if os.Getenv("NO_CHECK_OBJECT_STORAGE") != "" {
+	if os.Getenv("NO_CHECK_OBJECT_STORAGE") == "" {
 		if err := test(blob); err != nil {
 			logger.Fatalf("Storage %s is not configured correctly: %s", blob, err)
 		}

--- a/pkg/object/ceph.go
+++ b/pkg/object/ceph.go
@@ -208,7 +208,7 @@ func newCeph(endpoint, cluster, user string) (ObjectStorage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Can't create connection to cluster %s for user %s: %s", cluster, user, err)
 	}
-	if os.Getenv("NO_CHECK_OBJECT_STORAGE") != "" {
+	if os.Getenv("NO_CHECK_OBJECT_STORAGE") == "" {
 		if err := conn.ReadDefaultConfigFile(); err != nil {
 			return nil, fmt.Errorf("Can't read default config file: %s", err)
 		}

--- a/pkg/object/ceph.go
+++ b/pkg/object/ceph.go
@@ -208,7 +208,7 @@ func newCeph(endpoint, cluster, user string) (ObjectStorage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Can't create connection to cluster %s for user %s: %s", cluster, user, err)
 	}
-	if !os.Getenv("NO_CHECK_OBJECT_STORAGE") == "" {
+	if os.Getenv("NO_CHECK_OBJECT_STORAGE") != "" {
 		if err := conn.ReadDefaultConfigFile(); err != nil {
 			return nil, fmt.Errorf("Can't read default config file: %s", err)
 		}

--- a/pkg/object/ceph.go
+++ b/pkg/object/ceph.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -207,11 +208,13 @@ func newCeph(endpoint, cluster, user string) (ObjectStorage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Can't create connection to cluster %s for user %s: %s", cluster, user, err)
 	}
-	if err := conn.ReadDefaultConfigFile(); err != nil {
-		logger.Fatalf("Can't read default config file: %s", err)
-	}
-	if err := conn.Connect(); err != nil {
-		return nil, fmt.Errorf("Can't connect to cluster %s: %s", cluster, err)
+	if !os.Getenv("NO_CHECK_OBJECT_STORAGE") == "" {
+		if err := conn.ReadDefaultConfigFile(); err != nil {
+			return nil, fmt.Errorf("Can't read default config file: %s", err)
+		}
+		if err := conn.Connect(); err != nil {
+			return nil, fmt.Errorf("Can't connect to cluster %s: %s", cluster, err)
+		}
 	}
 	return &ceph{
 		name: name,


### PR DESCRIPTION
Inside CSI controller and node pod, we can't setup the configuration for Ceph from secrets, so we can disable the check for it in node and controller pod.