### PR TITLE
hadoop: fix concat bug

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -1232,6 +1232,11 @@ public class JuiceFileSystemImpl extends FileSystem {
     if (getFileStatus(dst).getLen() == 0) {
       throw new IOException(dst + "is empty");
     }
+    for (Path src : srcs) {
+      if (!exists(src)) {
+        throw new FileNotFoundException(src.toString());
+      }
+    }
     byte[][] srcbytes = new byte[srcs.length][];
     int bufsize = 0;
     for (int i = 0; i < srcs.length; i++) {
@@ -1243,11 +1248,14 @@ public class JuiceFileSystemImpl extends FileSystem {
     for (int i = 0; i < srcs.length; i++) {
       buf.put(offset, srcbytes[i], 0, srcbytes[i].length);
       buf.putByte(offset + srcbytes[i].length, (byte) 0);
-      offset += srcbytes.length + 1;
+      offset += srcbytes[i].length + 1;
     }
     int r = lib.jfs_concat(Thread.currentThread().getId(), handle, normalizePath(dst), buf, bufsize);
     if (r < 0) {
       throw error(r, dst);
+    }
+    for (Path src : srcs) {
+      delete(src, false);
     }
   }
 

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -16,6 +16,7 @@
 package io.juicefs;
 
 import junit.framework.TestCase;
+import org.apache.commons.io.IOUtils;
 import org.apache.flink.runtime.fs.hdfs.HadoopRecoverableWriter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
@@ -420,5 +421,27 @@ public class JuiceFileSystemTest extends TestCase {
 
   public void testFlinkHadoopRecoverableWriter() throws Exception {
     new HadoopRecoverableWriter(fs);
+  }
+
+  public void testConcat() throws Exception {
+    Path trg = new Path("/concat");
+    Path src1 = new Path("/tmp/concat1");
+    Path src2 = new Path("/tmp/concat2");
+    FSDataOutputStream ou = fs.create(trg);
+    ou.write("hello".getBytes());
+    ou.close();
+    FSDataOutputStream sou1 = fs.create(src1);
+    sou1.write("hello".getBytes());
+    sou1.close();
+    FSDataOutputStream sou2 = fs.create(src2);
+    sou2.write("hello".getBytes());
+    sou2.close();
+    fs.concat(trg, new Path[]{src1, src2} );
+    FSDataInputStream in = fs.open(trg);
+    assertEquals("hellohellohello", IOUtils.toString(in));
+    in.close();
+    // src should be deleted after concat
+    assertFalse(fs.exists(src1));
+    assertFalse(fs.exists(src2));
   }
 }


### PR DESCRIPTION
srcs should be deleted after concat according to HDFS implementation

