### PR TITLE
keep existing LZ4 algr when formatted with default algr.

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -210,6 +210,11 @@ func format(c *cli.Context) error {
 		}
 	}
 
+	if !c.Bool("force") && format.Compression == "none" { // default
+		if old, err := m.Load(); err == nil && old.Compression == "lz4" { // lz4 is the previous default algr
+			format.Compression = old.Compression // keep the existing default compress algr
+		}
+	}
 	err = m.Init(format, c.Bool("force"))
 	if err != nil {
 		logger.Fatalf("format: %s", err)


### PR DESCRIPTION
`lz4` is the previous default compress algrithm, and we changed that
to `none` in v0.12, then you can't update the AK/SK without specifying
`--compresss` for existing volumes.

This PR allows user to update AK/SK without specify `--compress` for
existing volumes.