### PR TITLE
sql.go: fix delete file range error

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2215,7 +2215,7 @@ func (m *dbMeta) cleanupDeletedFiles() {
 		rows.Close()
 		for _, f := range fs {
 			logger.Debugf("cleanup chunks of inode %d with %d bytes", f.Inode, f.Length)
-			m.deleteFile(d.Inode, d.Length)
+			m.deleteFile(f.Inode, f.Length)
 		}
 	}
 }


### PR DESCRIPTION
Should use `f` to delete but not `d`. `d` will always be the last
element.

Signed-off-by: 炽天 <hanxin.hx@alibaba-inc.com>