### PR TITLE
sql.go: update parent when rename

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1731,6 +1731,7 @@ func (r *redisMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst
 			r.parseAttr(a, &tattr)
 			if exchange {
 				tattr.Ctime = now.Unix()
+				tattr.Parent = parentSrc
 				tattr.Ctimensec = uint32(now.Nanosecond())
 				if dtyp == TypeDirectory && parentSrc != parentDst {
 					dattr.Nlink--

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1548,6 +1548,7 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 				return syscall.ENOENT // corrupt entry
 			}
 			if exchange {
+				dn.Parent = parentSrc
 				dn.Ctime = now
 				if de.Type == TypeDirectory && parentSrc != parentDst {
 					dpn.Nlink--
@@ -1606,7 +1607,7 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 			if _, err := s.Cols("inode", "type").Update(&se, &edge{Parent: parentDst, Name: de.Name}); err != nil {
 				return err
 			}
-			if _, err := s.Cols("ctime").Update(dn, &node{Inode: dino}); err != nil {
+			if _, err := s.Cols("ctime", "parent").Update(dn, &node{Inode: dino}); err != nil {
 				return err
 			}
 		} else {
@@ -1668,7 +1669,7 @@ func (m *dbMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 				return err
 			}
 		}
-		if _, err := s.Cols("ctime").Update(&sn, &node{Inode: sn.Inode}); err != nil {
+		if _, err := s.Cols("ctime", "parent").Update(&sn, &node{Inode: sn.Inode}); err != nil {
 			return err
 		}
 		if _, err := s.Cols("nlink", "mtime", "ctime").Update(&dpn, &node{Inode: parentDst}); err != nil {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1606,6 +1606,7 @@ func (m *kvMeta) Rename(ctx Context, parentSrc Ino, nameSrc string, parentDst In
 			m.parseAttr(a, &tattr)
 			if exchange {
 				tattr.Ctime = now.Unix()
+				tattr.Parent = parentSrc
 				tattr.Ctimensec = uint32(now.Nanosecond())
 				if dtyp == TypeDirectory && parentSrc != parentDst {
 					dattr.Nlink--


### PR DESCRIPTION
Rename may bring a parent change and make parent mismatch between
`node.parent` and `edge.parent`.

Signed-off-by: 炽天 <hanxin.hx@alibaba-inc.com>