### PR TITLE
sql: fix delete chunk sql error

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2298,7 +2298,7 @@ func (m *dbMeta) deleteChunk(inode Ino, indx uint32) error {
 				return err
 			}
 		}
-		n, err := ses.Delete(chunk{Inode: c.Inode, Indx: c.Indx})
+		n, err := ses.Where("inode = ? AND indx = ?", inode, indx).Delete(&c)
 		if err == nil && n == 0 {
 			err = fmt.Errorf("chunk %d:%d changed, try restarting transaction", inode, indx)
 		}


### PR DESCRIPTION
Deleting SQL should have condition in xorm, otherwise we will get `where
inode = ?` here if `indx = 0`. This will lead to large files to be deleted
partially.

Signed-off-by: 炽天 <hanxin.hx@alibaba-inc.com>