### PR TITLE
fix redis-sentinel addresses parsing

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -117,7 +117,7 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 	var rdb *redis.Client
 	if strings.Contains(opt.Addr, ",") {
 		var fopt redis.FailoverOptions
-		ps := strings.Split(opt.Addr, ",")
+		ps := strings.Split(addr, ",")
 		fopt.MasterName = ps[0]
 		fopt.SentinelAddrs = ps[1:]
 		_, port, _ := net.SplitHostPort(fopt.SentinelAddrs[len(fopt.SentinelAddrs)-1])
@@ -125,8 +125,10 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 			port = "26379"
 		}
 		for i, addr := range fopt.SentinelAddrs {
-			h, p, _ := net.SplitHostPort(addr)
-			if p == "" {
+			h, p, e := net.SplitHostPort(addr)
+			if e != nil {
+				fopt.SentinelAddrs[i] = net.JoinHostPort(addr, port)
+			} else if p == "" {
 				fopt.SentinelAddrs[i] = net.JoinHostPort(h, port)
 			}
 		}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -117,7 +117,7 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 	var rdb *redis.Client
 	if strings.Contains(opt.Addr, ",") {
 		var fopt redis.FailoverOptions
-		ps := strings.Split(addr, ",")
+		ps := strings.Split(opt.Addr, ",")
 		fopt.MasterName = ps[0]
 		fopt.SentinelAddrs = ps[1:]
 		_, port, _ := net.SplitHostPort(fopt.SentinelAddrs[len(fopt.SentinelAddrs)-1])


### PR DESCRIPTION
with meta url being: `redis://mymaster,10.XX.XX.197,10.XX.XX.193,10.XX.XX.67:26379`

from: 

```
 SentinelAddrs: ([]string) (len=3 cap=3) {
  (string) (len=6) ":26379",
  (string) (len=6) ":26379",
  (string) (len=18) "10.XX.XX.67:26379"
 },
```

to

```
 SentinelAddrs: ([]string) (len=3 cap=3) {
  (string) (len=20) "10.XX.XX.197:26379",
  (string) (len=20) "10.XX.XX.193:26379",
  (string) (len=18) "10.XX.XX.67:26379"
 },
```

Close https://github.com/juicedata/juicefs/pull/953