### PR TITLE
reduce the size of juicefs.lite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ juicefs: Makefile cmd/*.go pkg/*/*.go
 	go build -ldflags="$(LDFLAGS)"  -o juicefs ./cmd
 
 juicefs.lite: Makefile cmd/*.go pkg/*/*.go
-	go build -tags nogateway,nocos,nobos,nohdfs,noibmcos,nobs,nooss,noqingstor,noscs,nosftp,noswift,noupyun,noazure,nogs \
+	go build -tags nogateway,nocos,nobos,nohdfs,noibmcos,noobs,nooss,noqingstor,noscs,nosftp,noswift,noupyun,noazure,nogs,noufile,nob2,nosqlite,nomysql,nopg,notikv \
 		-ldflags="$(LDFLAGS)" -o juicefs.lite ./cmd
 
 juicefs.ceph: Makefile cmd/*.go pkg/*/*.go

--- a/pkg/meta/dump.go
+++ b/pkg/meta/dump.go
@@ -29,11 +29,6 @@ const (
 	jsonWriteSize = 64 << 10
 )
 
-type freeID struct {
-	next  uint64
-	maxid uint64
-}
-
 type DumpedCounters struct {
 	UsedSpace         int64 `json:"usedSpace"`
 	UsedInodes        int64 `json:"usedInodes"`

--- a/pkg/meta/sql_lock.go
+++ b/pkg/meta/sql_lock.go
@@ -1,3 +1,5 @@
+// +build !nosqlite !nomysql !nopg
+
 /*
  * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
  *

--- a/pkg/meta/sql_mysql.go
+++ b/pkg/meta/sql_mysql.go
@@ -1,0 +1,26 @@
+// +build !nomysql
+
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+import (
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func init() {
+	Register("mysql", newSQLMeta)
+}

--- a/pkg/meta/sql_pg.go
+++ b/pkg/meta/sql_pg.go
@@ -1,0 +1,26 @@
+// +build !nopg
+
+/*
+ * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+import (
+	_ "github.com/lib/pq"
+)
+
+func init() {
+	Register("postgres", newSQLMeta)
+}

--- a/pkg/meta/sql_sqlite.go
+++ b/pkg/meta/sql_sqlite.go
@@ -1,0 +1,27 @@
+// +build !nosqlite
+
+/*
+ * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+import (
+	"github.com/mattn/go-sqlite3"
+)
+
+func init() {
+	errBusy = sqlite3.ErrBusy
+	Register("sqlite3", newSQLMeta)
+}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -80,8 +80,7 @@ var drivers = make(map[string]func(string) (tkvClient, error))
 func newTkvClient(driver, addr string) (tkvClient, error) {
 	fn, ok := drivers[driver]
 	if !ok {
-		return nil, fmt.Errorf("invalid driver %s != expected %s", driver, "tikv")
-
+		return nil, fmt.Errorf("unsupported driver %s", driver)
 	}
 	return fn(addr)
 }
@@ -89,7 +88,7 @@ func newTkvClient(driver, addr string) (tkvClient, error) {
 func newKVMeta(driver, addr string, conf *Config) (Meta, error) {
 	client, err := newTkvClient(driver, addr)
 	if err != nil {
-		return nil, fmt.Errorf("unable to connect driver %s addr %s: %s", driver, addr, err)
+		return nil, fmt.Errorf("connect to addr %s: %s", addr, err)
 	}
 	// TODO: ping server and check latency > Millisecond
 	// logger.Warnf("The latency to database is too high: %s", time.Since(start))

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -28,11 +28,12 @@ import (
 
 func init() {
 	Register("memkv", newKVMeta)
+	drivers["memkv"] = newMockClient
 }
 
 const settingPath = "/tmp/juicefs.memkv.setting.json"
 
-func newMockClient() (tkvClient, error) {
+func newMockClient(addr string) (tkvClient, error) {
 	client := &memKV{items: btree.New(2), temp: &kvItem{}}
 	if d, err := ioutil.ReadFile(settingPath); err == nil {
 		var buffer map[string][]byte

--- a/pkg/meta/types.go
+++ b/pkg/meta/types.go
@@ -29,6 +29,11 @@ const (
 	jsonWriteSize = 64 << 10
 )
 
+type freeID struct {
+	next  uint64
+	maxid uint64
+}
+
 type DumpedCounters struct {
 	UsedSpace         int64 `json:"usedSpace"`
 	UsedInodes        int64 `json:"usedInodes"`
@@ -283,4 +288,53 @@ func loadAttr(d *DumpedAttr) *Attr {
 		Rdev:      d.Rdev,
 		Full:      true,
 	} // Length and Parent not set
+}
+
+func collectEntry(e *DumpedEntry, entries map[Ino]*DumpedEntry, showProgress func(totalIncr, currentIncr int64)) error {
+	typ := typeFromString(e.Attr.Type)
+	inode := e.Attr.Inode
+	if showProgress != nil {
+		if typ == TypeDirectory {
+			showProgress(int64(len(e.Entries)), 1)
+		} else {
+			showProgress(0, 1)
+		}
+	}
+
+	if exist, ok := entries[inode]; ok {
+		attr := e.Attr
+		eattr := exist.Attr
+		if typ != TypeFile || typeFromString(eattr.Type) != TypeFile {
+			return fmt.Errorf("inode conflict: %d", inode)
+		}
+		eattr.Nlink++
+		if eattr.Ctime*1e9+int64(eattr.Ctimensec) < attr.Ctime*1e9+int64(attr.Ctimensec) {
+			attr.Nlink = eattr.Nlink
+			entries[inode] = e
+		}
+		return nil
+	}
+	entries[inode] = e
+
+	if typ == TypeFile {
+		e.Attr.Nlink = 1 // reset
+	} else if typ == TypeDirectory {
+		if inode == 1 { // root inode
+			e.Parent = 1
+		}
+		e.Attr.Nlink = 2
+		for name, child := range e.Entries {
+			child.Name = name
+			child.Parent = inode
+			if typeFromString(child.Attr.Type) == TypeDirectory {
+				e.Attr.Nlink++
+			}
+			if err := collectEntry(child, entries, showProgress); err != nil {
+				return err
+			}
+		}
+	} else if e.Attr.Nlink != 1 { // nlink should be 1 for other types
+		return fmt.Errorf("invalid nlink %d for inode %d type %s", e.Attr.Nlink, inode, e.Attr.Type)
+	}
+	return nil
 }

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -1,0 +1,300 @@
+/*
+ * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package meta
+
+import (
+	"bytes"
+	"fmt"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/juicedata/juicefs/pkg/utils"
+)
+
+const (
+	usedSpace    = "usedSpace"
+	totalInodes  = "totalInodes"
+	delfiles     = "delfiles"
+	allSessions  = "sessions"
+	sessionInfos = "sessionInfos"
+	sliceRefs    = "sliceRef"
+)
+
+const (
+	// fallocate
+	fallocKeepSize  = 0x01
+	fallocPunchHole = 0x02
+	// RESERVED: fallocNoHideStale   = 0x04
+	fallocCollapesRange = 0x08
+	fallocZeroRange     = 0x10
+	fallocInsertRange   = 0x20
+)
+
+type msgCallbacks struct {
+	sync.Mutex
+	callbacks map[uint32]MsgCallback
+}
+
+var logger = utils.GetLogger("juicefs")
+
+func errno(err error) syscall.Errno {
+	if err == nil {
+		return 0
+	}
+	if eno, ok := err.(syscall.Errno); ok {
+		return eno
+	}
+	if err == redis.Nil {
+		return syscall.ENOENT
+	}
+	if strings.HasPrefix(err.Error(), "OOM") {
+		return syscall.ENOSPC
+	}
+	logger.Errorf("error: %s\n%s", err, debug.Stack())
+	return syscall.EIO
+}
+
+func accessMode(attr *Attr, uid uint32, gid uint32) uint8 {
+	if uid == 0 {
+		return 0x7
+	}
+	mode := attr.Mode
+	if uid == attr.Uid {
+		return uint8(mode>>6) & 7
+	}
+	if gid == attr.Gid {
+		return uint8(mode>>3) & 7
+	}
+	return uint8(mode & 7)
+}
+
+func align4K(length uint64) int64 {
+	if length == 0 {
+		return 1 << 12
+	}
+	return int64((((length - 1) >> 12) + 1) << 12)
+}
+
+func lookupSubdir(m Meta, subdir string) (Ino, error) {
+	var root Ino = 1
+	for subdir != "" {
+		ps := strings.SplitN(subdir, "/", 2)
+		if ps[0] != "" {
+			var attr Attr
+			r := m.Lookup(Background, root, ps[0], &root, &attr)
+			if r != 0 {
+				return 0, fmt.Errorf("lookup subdir %s: %s", ps[0], r)
+			}
+			if attr.Typ != TypeDirectory {
+				return 0, fmt.Errorf("%s is not a redirectory", ps[0])
+			}
+		}
+		if len(ps) == 1 {
+			break
+		}
+		subdir = ps[1]
+	}
+	return root, nil
+}
+
+type plockRecord struct {
+	ltype uint32
+	pid   uint32
+	start uint64
+	end   uint64
+}
+
+func loadLocks(d []byte) []plockRecord {
+	var ls []plockRecord
+	rb := utils.FromBuffer(d)
+	for rb.HasMore() {
+		ls = append(ls, plockRecord{rb.Get32(), rb.Get32(), rb.Get64(), rb.Get64()})
+	}
+	return ls
+}
+
+func dumpLocks(ls []plockRecord) []byte {
+	wb := utils.NewBuffer(uint32(len(ls)) * 24)
+	for _, l := range ls {
+		wb.Put32(l.ltype)
+		wb.Put32(l.pid)
+		wb.Put64(l.start)
+		wb.Put64(l.end)
+	}
+	return wb.Bytes()
+}
+
+func updateLocks(ls []plockRecord, nl plockRecord) []plockRecord {
+	// ls is ordered by l.start without overlap
+	size := len(ls)
+	for i := 0; i < size && nl.start <= nl.end; i++ {
+		l := ls[i]
+		if nl.start < l.start && nl.end >= l.start {
+			// split nl
+			ls = append(ls, nl)
+			ls[len(ls)-1].end = l.start - 1
+			nl.start = l.start
+		}
+		if nl.start > l.start && nl.start <= l.end {
+			// split l
+			l.end = nl.start - 1
+			ls = append(ls, l)
+			ls[i].start = nl.start
+			l = ls[i]
+		}
+		if nl.start == l.start {
+			ls[i].ltype = nl.ltype // update l
+			ls[i].pid = nl.pid
+			if l.end > nl.end {
+				// split l
+				ls[i].end = nl.end
+				l.start = nl.end + 1
+				ls = append(ls, l)
+			}
+			nl.start = ls[i].end + 1
+		}
+	}
+	if nl.start <= nl.end {
+		ls = append(ls, nl)
+	}
+	sort.Slice(ls, func(i, j int) bool { return ls[i].start < ls[j].start })
+	for i := 0; i < len(ls); {
+		if ls[i].ltype == F_UNLCK || ls[i].start > ls[i].end {
+			// remove empty one
+			copy(ls[i:], ls[i+1:])
+			ls = ls[:len(ls)-1]
+		} else {
+			if i+1 < len(ls) && ls[i].ltype == ls[i+1].ltype && ls[i].pid == ls[i+1].pid && ls[i].end+1 == ls[i+1].start {
+				// combine continuous range
+				ls[i].end = ls[i+1].end
+				ls[i+1].start = ls[i+1].end + 1
+			}
+			i++
+		}
+	}
+	return ls
+}
+
+func emptyDir(r Meta, ctx Context, inode Ino, concurrent chan int) syscall.Errno {
+	if st := r.Access(ctx, inode, 3, nil); st != 0 {
+		return st
+	}
+	var entries []*Entry
+	if st := r.Readdir(ctx, inode, 0, &entries); st != 0 {
+		return st
+	}
+	var wg sync.WaitGroup
+	var status syscall.Errno
+	for _, e := range entries {
+		if e.Inode == inode || len(e.Name) == 2 && string(e.Name) == ".." {
+			continue
+		}
+		if e.Attr.Typ == TypeDirectory {
+			select {
+			case concurrent <- 1:
+				wg.Add(1)
+				go func(child Ino, name string) {
+					defer wg.Done()
+					e := emptyEntry(r, ctx, inode, name, child, concurrent)
+					if e != 0 {
+						status = e
+					}
+					<-concurrent
+				}(e.Inode, string(e.Name))
+			default:
+				if st := emptyEntry(r, ctx, inode, string(e.Name), e.Inode, concurrent); st != 0 {
+					return st
+				}
+			}
+		} else {
+			if st := r.Unlink(ctx, inode, string(e.Name)); st != 0 {
+				return st
+			}
+		}
+	}
+	wg.Wait()
+	return status
+}
+
+func emptyEntry(r Meta, ctx Context, parent Ino, name string, inode Ino, concurrent chan int) syscall.Errno {
+	st := emptyDir(r, ctx, inode, concurrent)
+	if st == 0 {
+		st = r.Rmdir(ctx, parent, name)
+		if st == syscall.ENOTEMPTY {
+			st = emptyEntry(r, ctx, parent, name, inode, concurrent)
+		}
+	}
+	return st
+}
+
+func Remove(r Meta, ctx Context, parent Ino, name string) syscall.Errno {
+	if st := r.Access(ctx, parent, 3, nil); st != 0 {
+		return st
+	}
+	var inode Ino
+	var attr Attr
+	if st := r.Lookup(ctx, parent, name, &inode, &attr); st != 0 {
+		return st
+	}
+	if attr.Typ != TypeDirectory {
+		return r.Unlink(ctx, parent, name)
+	}
+	concurrent := make(chan int, 50)
+	return emptyEntry(r, ctx, parent, name, inode, concurrent)
+}
+
+func GetSummary(r Meta, ctx Context, inode Ino, summary *Summary, recursive bool) syscall.Errno {
+	var attr Attr
+	if st := r.GetAttr(ctx, inode, &attr); st != 0 {
+		return st
+	}
+	if attr.Typ == TypeDirectory {
+		var entries []*Entry
+		if st := r.Readdir(ctx, inode, 1, &entries); st != 0 {
+			return st
+		}
+		for _, e := range entries {
+			if e.Inode == inode || len(e.Name) == 2 && bytes.Equal(e.Name, []byte("..")) {
+				continue
+			}
+			if e.Attr.Typ == TypeDirectory {
+				if recursive {
+					if st := GetSummary(r, ctx, e.Inode, summary, recursive); st != 0 {
+						return st
+					}
+				} else {
+					summary.Dirs++
+					summary.Size += 4096
+				}
+			} else {
+				summary.Files++
+				summary.Length += e.Attr.Length
+				summary.Size += uint64(align4K(e.Attr.Length))
+			}
+		}
+		summary.Dirs++
+		summary.Size += 4096
+	} else {
+		summary.Files++
+		summary.Length += attr.Length
+		summary.Size += uint64(align4K(attr.Length))
+	}
+	return 0
+}

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -52,6 +52,11 @@ type msgCallbacks struct {
 	callbacks map[uint32]MsgCallback
 }
 
+type freeID struct {
+	next  uint64
+	maxid uint64
+}
+
 var logger = utils.GetLogger("juicefs")
 
 func errno(err error) syscall.Errno {

--- a/pkg/object/b2.go
+++ b/pkg/object/b2.go
@@ -1,3 +1,5 @@
+// +build !nob2
+
 /*
  * JuiceFS, Copyright (C) 2018 Juicedata, Inc.
  *

--- a/pkg/object/redis.go
+++ b/pkg/object/redis.go
@@ -1,3 +1,5 @@
+// +build !noredis
+
 /*
  * JuiceFS, Copyright (C) 2020 Juicedata, Inc.
  *

--- a/pkg/object/tikv.go
+++ b/pkg/object/tikv.go
@@ -1,3 +1,5 @@
+// +build !notikv
+
 /*
  * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
  *

--- a/pkg/object/ufile.go
+++ b/pkg/object/ufile.go
@@ -1,4 +1,19 @@
-// Copyright (C) 2018-present Juicedata Inc.
+// +build !noufile
+
+/*
+ * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package object
 


### PR DESCRIPTION
The full build is 80MB, current lite version is 43MB, this PR reduce the size to 25MB by removing TiKV, PG, MySQL, SQLite engines.