### PR TITLE
change frsize to 4096

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -412,7 +412,7 @@ func (fs *fileSystem) StatFs(cancel <-chan struct{}, in *fuse.InHeader, out *fus
 	out.Bfree = st.Bavail
 	out.Files = st.Files
 	out.Ffree = st.Favail
-	out.Frsize = st.Bsize
+	out.Frsize = 4096
 	return 0
 }
 

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -92,7 +92,7 @@ func (j *juice) Statfs(path string, stat *fuse.Statfs_t) int {
 	blocks := totalspace / bsize
 	bavail := availspace / bsize
 	stat.Namemax = 255
-	stat.Frsize = bsize
+	stat.Frsize = 4096
 	stat.Bsize = bsize
 	stat.Blocks = blocks
 	stat.Bfree = bavail


### PR DESCRIPTION
`du` aligns the size of file to `frsize` of the file system,  the `frsize` of local file system is 4K, but JuiceFS has it as 64K. we see different result when comparing the size of files in local file system and JuiceFS, see #1014 for details.

It's meaningless in JuiceFS , so we can change it to 4K, so it's compatible with local file system.

close #1014 