### PR TITLE
metadata: should not skip error if open a file not exist

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1934,6 +1934,10 @@ func (r *redisMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) sysca
 	if r.conf.ReadOnly && flags&(syscall.O_WRONLY|syscall.O_RDWR|syscall.O_TRUNC|syscall.O_APPEND) != 0 {
 		return syscall.EROFS
 	}
+	if attr != nil {
+		// reset attr.Full to avoid mismatch between inode and attr
+		attr.Full = false
+	}
 	if r.conf.OpenCache > 0 && r.of.OpenCheck(inode, attr) {
 		return 0
 	}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1945,7 +1945,7 @@ func (r *redisMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) sysca
 		// TODO: tracking update in Redis
 		r.of.Open(inode, attr)
 	}
-	return 0
+	return err
 }
 
 func (r *redisMeta) Close(ctx Context, inode Ino) syscall.Errno {

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -313,6 +313,10 @@ func testMetaClient(t *testing.T, m Meta) {
 
 	// data
 	var chunkid uint64
+	// try to open a file that does not exist
+	if st := m.Open(ctx, 99999, 2, &Attr{}); st != syscall.ENOENT {
+		t.Fatalf("open not exist inode got %d, expected %d", st, syscall.ENOENT)
+	}
 	if st := m.Open(ctx, inode, 2, attr); st != 0 {
 		t.Fatalf("open f: %s", st)
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1934,6 +1934,10 @@ func (m *dbMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) syscall.
 	if m.conf.ReadOnly && flags&(syscall.O_WRONLY|syscall.O_RDWR|syscall.O_TRUNC|syscall.O_APPEND) != 0 {
 		return syscall.EROFS
 	}
+	if attr != nil {
+		// reset attr.Full to avoid mismatch between inode and attr
+		attr.Full = false
+	}
 	if m.conf.OpenCache > 0 && m.of.OpenCheck(inode, attr) {
 		return 0
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1944,7 +1944,7 @@ func (m *dbMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) syscall.
 	if err == 0 {
 		m.of.Open(inode, attr)
 	}
-	return 0
+	return err
 }
 
 func (m *dbMeta) Close(ctx Context, inode Ino) syscall.Errno {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1900,7 +1900,7 @@ func (m *kvMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) syscall.
 	if err == 0 {
 		m.of.Open(inode, attr)
 	}
-	return 0
+	return err
 }
 
 func (m *kvMeta) Close(ctx Context, inode Ino) syscall.Errno {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1890,6 +1890,10 @@ func (m *kvMeta) Open(ctx Context, inode Ino, flags uint32, attr *Attr) syscall.
 	if m.conf.ReadOnly && flags&(syscall.O_WRONLY|syscall.O_RDWR|syscall.O_TRUNC|syscall.O_APPEND) != 0 {
 		return syscall.EROFS
 	}
+	if attr != nil {
+		// reset attr.Full to avoid mismatch between inode and attr
+		attr.Full = false
+	}
 	if m.conf.OpenCache > 0 && m.of.OpenCheck(inode, attr) {
 		return 0
 	}


### PR DESCRIPTION
The original implements will always return ok if open a file that does
not exist.

Another unresolved problem is that if an "attr" is given with "Full=true", even
if they do not match, the "GetAttr()" call will still be skipped. But
this does not seem to be a serious problem.

Signed-off-by: 炽天 <hanxin.hx@alibaba-inc.com>