### PR TITLE
fix minio with sync

### DIFF
--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -73,12 +73,10 @@ func newMinio(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 		return nil, fmt.Errorf("no bucket name provided in %s: %s", endpoint, err)
 	}
 	bucket := uri.Path[1:]
-	for strings.HasSuffix(bucket, "/") {
-		bucket = bucket[:len(bucket)-1]
-	}
 	if strings.Contains(bucket, "/") && strings.HasPrefix(bucket, "minio/") {
 		bucket = bucket[len("minio/"):]
 	}
+	bucket = strings.Split(bucket, "/")[0]
 	return &minio{s3client{bucket, s3.New(ses), ses}}, nil
 }
 

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -405,7 +405,7 @@ func TestMinIO(t *testing.T) {
 	if os.Getenv("MINIO_TEST_BUCKET") == "" {
 		t.SkipNow()
 	}
-	b, _ := newMinio(fmt.Sprintf("http://%s", os.Getenv("MINIO_TEST_BUCKET")), "", "")
+	b, _ := newMinio(fmt.Sprintf("http://%s/some/path", os.Getenv("MINIO_TEST_BUCKET")), "", "")
 	testStorage(t, b)
 }
 


### PR DESCRIPTION
When a subpath is specified with Minio, juice sync fails with 403.

TODO: we should enable the unit test with Minio