### PR TITLE
fix used space in df

### DIFF
--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -92,7 +92,7 @@ func TestFileSystem(t *testing.T) {
 	store := chunk.NewCachedStore(objStore, *conf.Chunk)
 	fs, _ := NewFileSystem(&conf, m, store)
 	ctx := meta.NewContext(1, 1, []uint32{2})
-	if total, avail := fs.StatFS(ctx); total != 1<<30 || avail != (1<<30)-(64<<10) {
+	if total, avail := fs.StatFS(ctx); total != 1<<30 || avail != (1<<30) {
 		t.Fatalf("statfs: %d %d", total, avail)
 	}
 	if e := fs.Access(ctx, "/", 7); e != 0 {

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -406,13 +406,16 @@ func (fs *fileSystem) StatFs(cancel <-chan struct{}, in *fuse.InHeader, out *fus
 		return fuse.Status(err)
 	}
 	out.NameLen = 255
-	out.Bsize = st.Bsize
-	out.Blocks = st.Blocks
-	out.Bavail = st.Bavail
-	out.Bfree = st.Bavail
+	out.Frsize = 4096
+	out.Bsize = 4096
+	out.Blocks = st.Total / uint64(out.Bsize)
+	if out.Blocks < 1 {
+		out.Blocks = 1
+	}
+	out.Bavail = st.Avail / uint64(out.Bsize)
+	out.Bfree = out.Bavail
 	out.Files = st.Files
 	out.Ffree = st.Favail
-	out.Frsize = 4096
 	return 0
 }
 

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -191,7 +191,6 @@ func (m *baseMeta) StatFS(ctx Context, totalspace, availspace, iused, iavail *ui
 	if used < 0 {
 		used = 0
 	}
-	used = ((used >> 16) + 1) << 16 // aligned to 64K
 	if m.fmt.Capacity > 0 {
 		*totalspace = m.fmt.Capacity
 		if *totalspace < uint64(used) {

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -79,8 +79,8 @@ func TestVFSBasic(t *testing.T) {
 
 	if st, e := v.StatFS(ctx, 1); e != 0 {
 		t.Fatalf("statfs 1: %s", e)
-	} else if st.Blocks-st.Bavail != 1 {
-		t.Fatalf("used: %d", st.Blocks-st.Bavail)
+	} else if st.Total-st.Avail != 0 {
+		t.Fatalf("used: %d", st.Total-st.Avail)
 	}
 
 	// dirs

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -32,9 +32,8 @@ const O_ACCMODE = syscall.O_ACCMODE
 const F_UNLCK = syscall.F_UNLCK
 
 type Statfs struct {
-	Bsize  uint32
-	Blocks uint64
-	Bavail uint64
+	Total  uint64
+	Avail  uint64
 	Files  uint64
 	Favail uint64
 }
@@ -42,14 +41,9 @@ type Statfs struct {
 func (v *VFS) StatFS(ctx Context, ino Ino) (st *Statfs, err syscall.Errno) {
 	var totalspace, availspace, iused, iavail uint64
 	_ = v.Meta.StatFS(ctx, &totalspace, &availspace, &iused, &iavail)
-	var bsize uint64 = 0x10000
-	blocks := totalspace / bsize
-	bavail := blocks - (totalspace-availspace+bsize-1)/bsize
-
 	st = new(Statfs)
-	st.Bsize = uint32(bsize)
-	st.Blocks = blocks
-	st.Bavail = bavail
+	st.Total = totalspace
+	st.Avail = availspace
 	st.Files = iused + iavail
 	st.Favail = iavail
 	logit(ctx, "statfs (%d): OK (%d,%d,%d,%d)", ino, totalspace-availspace, availspace, iused, iavail)

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -88,7 +88,7 @@ func (j *juice) Statfs(path string, stat *fuse.Statfs_t) int {
 	// defer trace(path)(stat)
 	var totalspace, availspace, iused, iavail uint64
 	j.fs.Meta().StatFS(ctx, &totalspace, &availspace, &iused, &iavail)
-	var bsize uint64 = 0x10000
+	var bsize uint64 = 4096
 	blocks := totalspace / bsize
 	bavail := availspace / bsize
 	stat.Namemax = 255


### PR DESCRIPTION
After we change the frsize to 4K, the bsize is still 64K, and we use bsize to calculate the blocks, but df use `frsize` to calculate the used space in Linux.

This PR change both to 4K.

Closes #1069