### PR TITLE
tkv: use snap for dumping meta

### DIFF
--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2186,7 +2186,14 @@ func (m *kvMeta) DumpMeta(w io.Writer) (err error) {
 		}
 	}
 
-	vals, err = m.scanValues(m.fmtKey("SS"), nil)
+	if m.root == 1 {
+		err = m.snap.txn(func(tx kvTxn) error {
+			vals = tx.scanValues(m.fmtKey("SS"), nil)
+			return nil
+		})
+	} else {
+		vals, err = m.scanValues(m.fmtKey("SS"), nil)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -60,6 +60,7 @@ type tkvClient interface {
 type kvMeta struct {
 	baseMeta
 	client tkvClient
+	snap   *memKV
 }
 
 var drivers = make(map[string]func(string) (tkvClient, error))
@@ -1985,9 +1986,9 @@ func (m *kvMeta) RemoveXattr(ctx Context, inode Ino, name string) syscall.Errno 
 	return errno(m.deleteKeys(m.xattrKey(inode, name)))
 }
 
-func (m *kvMeta) dumpEntry(inode Ino) (*DumpedEntry, error) {
+func (m *kvMeta) dumpEntry(inode Ino, useSnap bool) (*DumpedEntry, error) {
 	e := &DumpedEntry{}
-	return e, m.txn(func(tx kvTxn) error {
+	f := func(tx kvTxn) error {
 		a := tx.get(m.inodeKey(inode))
 		if a == nil {
 			return fmt.Errorf("inode %d not found", inode)
@@ -2030,7 +2031,12 @@ func (m *kvMeta) dumpEntry(inode Ino) (*DumpedEntry, error) {
 		}
 
 		return nil
-	})
+	}
+	if useSnap {
+		return e, m.snap.txn(f)
+	} else {
+		return e, m.txn(f)
+	}
 }
 
 func (m *kvMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, depth int, showProgress func(totalIncr, currentIncr int64)) error {
@@ -2039,7 +2045,16 @@ func (m *kvMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, depth i
 			panic(err)
 		}
 	}
-	vals, err := m.scanValues(m.entryKey(inode, ""), nil)
+	var vals map[string][]byte
+	var err error
+	if m.root == 1 {
+		err = m.snap.txn(func(tx kvTxn) error {
+			vals = tx.scanValues(m.entryKey(inode, ""), nil)
+			return nil
+		})
+	} else {
+		vals, err = m.scanValues(m.entryKey(inode, ""), nil)
+	}
 	if err != nil {
 		return err
 	}
@@ -2058,7 +2073,7 @@ func (m *kvMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, depth i
 	for idx, name := range sortedName {
 		typ, inode := m.parseEntry(vals[name])
 		var entry *DumpedEntry
-		entry, err = m.dumpEntry(inode)
+		entry, err = m.dumpEntry(inode, m.root == 1)
 		if err != nil {
 			return err
 		}
@@ -2092,37 +2107,6 @@ func (m *kvMeta) DumpMeta(w io.Writer) (err error) {
 			}
 		}
 	}()
-
-	if m.root == 1 {
-		switch m.client.(type) {
-		case *memKV:
-		default:
-			client := &memKV{items: btree.New(2), temp: &kvItem{}}
-			if err = m.txn(func(tx kvTxn) error {
-				used := parseCounter(tx.get(m.counterKey(usedSpace)))
-				inodeTotal := parseCounter(tx.get(m.counterKey(totalInodes)))
-				guessKeyTotal := int64(math.Ceil((float64(used/inodeTotal/(64*1024*1024)) + float64(3)) * float64(inodeTotal)))
-				progress, bar := utils.NewDynProgressBar("Make snap progress: ", false)
-				bar.SetTotal(guessKeyTotal, false)
-				threshold := 0.1
-				tx.scan(nil, func(key, value []byte) {
-					client.set(string(key), value)
-					if bar.Current() > int64(math.Ceil(float64(guessKeyTotal)*(1-threshold))) {
-						guessKeyTotal += int64(math.Ceil(float64(guessKeyTotal) * threshold))
-						bar.SetTotal(guessKeyTotal, false)
-					}
-					bar.Increment()
-				})
-				bar.SetTotal(0, true)
-				progress.Wait()
-				return nil
-			}); err != nil {
-				return err
-			}
-			m.client = client
-		}
-	}
-
 	vals, err := m.scanValues(m.fmtKey("D"), nil)
 	if err != nil {
 		return err
@@ -2137,7 +2121,40 @@ func (m *kvMeta) DumpMeta(w io.Writer) (err error) {
 		dels = append(dels, &DumpedDelFile{inode, b.Get64(), m.parseInt64(v)})
 	}
 
-	tree, err := m.dumpEntry(m.root)
+	var tree *DumpedEntry
+	if m.root == 1 {
+		// make snap
+		switch c := m.client.(type) {
+		case *memKV:
+			m.snap = c
+		default:
+			m.snap = &memKV{items: btree.New(2), temp: &kvItem{}}
+			if err = m.txn(func(tx kvTxn) error {
+				used := parseCounter(tx.get(m.counterKey(usedSpace)))
+				inodeTotal := parseCounter(tx.get(m.counterKey(totalInodes)))
+				guessKeyTotal := int64(math.Ceil((float64(used/inodeTotal/(64*1024*1024)) + float64(3)) * float64(inodeTotal)))
+				progress, bar := utils.NewDynProgressBar("Make snap progress: ", false)
+				bar.SetTotal(guessKeyTotal, false)
+				threshold := 0.1
+				tx.scan(nil, func(key, value []byte) {
+					m.snap.set(string(key), value)
+					if bar.Current() > int64(math.Ceil(float64(guessKeyTotal)*(1-threshold))) {
+						guessKeyTotal += int64(math.Ceil(float64(guessKeyTotal) * threshold))
+						bar.SetTotal(guessKeyTotal, false)
+					}
+					bar.Increment()
+				})
+				bar.SetTotal(0, true)
+				progress.Wait()
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		tree, err = m.dumpEntry(m.root, true)
+	} else {
+		tree, err = m.dumpEntry(m.root, false)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backup will call DumpMeta in the background, so it raises critical problem if m.client is replaced