### PR TITLE
Fix potential metadata corrupt in Redis caused by gc

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2313,7 +2313,7 @@ func (r *redisMeta) cleanupLeakedInodes(delete bool) {
 				var attr Attr
 				r.parseAttr([]byte(v.(string)), &attr)
 				ino, _ := strconv.Atoi(keys[i][1:])
-				if _, ok := foundInodes[Ino(ino)]; !ok && time.Unix(attr.Atime, 0).Before(cutoff) {
+				if _, ok := foundInodes[Ino(ino)]; !ok && time.Unix(attr.Ctime, 0).Before(cutoff) {
 					logger.Infof("found dangling inode: %s %+v", keys[i], attr)
 					if delete {
 						err = r.doDeleteSustainedInode(0, Ino(ino))


### PR DESCRIPTION
The `gc` command will scan all the entries and inodes to find out dangling (not used by any entry) inodes.  The scanning of entries is not atomic, so we ignore all the inodes (checking the atime) created in last hour. There is still a chance that a inode was renamed and both the old name and new name are missed from the scanning, then the inode will be identify as dangling and deleted.

This PR change it to check the Ctime of inode, ignore the inodes that was created or renamed within a hour.