### PR TITLE
meta: unify counters for all metadata engines

### DIFF
--- a/pkg/meta/metadata-sub.sample
+++ b/pkg/meta/metadata-sub.sample
@@ -18,7 +18,7 @@
     "usedInodes": 11,
     "nextInodes": 30,
     "nextChunk": 9,
-    "nextSession": 1,
+    "nextSession": 0,
     "nextTrash": 1,
     "nextCleanupSlices": 0
   },

--- a/pkg/meta/metadata.sample
+++ b/pkg/meta/metadata.sample
@@ -18,7 +18,7 @@
     "usedInodes": 11,
     "nextInodes": 30,
     "nextChunk": 9,
-    "nextSession": 1,
+    "nextSession": 0,
     "nextTrash": 1,
     "nextCleanupSlices": 0
   },

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -284,7 +284,7 @@ func (m *dbMeta) Init(format Format, force bool) error {
 		var cs = []counter{
 			{"nextInode", 2}, // 1 is root
 			{"nextChunk", 1},
-			{"nextSession", 1},
+			{"nextSession", 0},
 			{"usedSpace", 0},
 			{"totalInodes", 0},
 			{"nextCleanupSlices", 0},
@@ -2761,9 +2761,8 @@ func (m *dbMeta) LoadMeta(r io.Reader) error {
 	progress.Wait()
 
 	counters := &DumpedCounters{
-		NextInode:   2,
-		NextChunk:   1,
-		NextSession: 1,
+		NextInode: 2,
+		NextChunk: 1,
 	}
 	refs := make(map[uint64]*chunkRef)
 

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -373,7 +373,6 @@ func (m *kvMeta) Init(format Format, force bool) error {
 			tx.set(m.inodeKey(1), m.marshal(attr))
 			tx.incrBy(m.counterKey("nextInode"), 2)
 			tx.incrBy(m.counterKey("nextChunk"), 1)
-			tx.incrBy(m.counterKey("nextSession"), 1)
 		}
 		return nil
 	})
@@ -2415,9 +2414,8 @@ func (m *kvMeta) LoadMeta(r io.Reader) error {
 	progress.Wait()
 
 	counters := &DumpedCounters{
-		NextInode:   2,
-		NextChunk:   1,
-		NextSession: 1,
+		NextInode: 2,
+		NextChunk: 1,
 	}
 	refs := make(map[string]int64)
 


### PR DESCRIPTION
|             | Redis - Key | SQL/TKV - Key | Redis - Value | SQL/TKV - Value |
| ----------- | ----------- | ------------- | ------------- | --------------- |
| NextInode   | nextinode   | nextInode     | max used      | next available  |
| NextChunk   | nextchunk   | nextChunk     | max used      | next available  |
| NextSession | nextsession | nextSession   | max used      | max used        |

- Redis nextInode & nextChunk have different meanings, which is handled here: https://github.com/juicedata/juicefs/blob/main/pkg/meta/redis.go#L271-L276
- All other counters are identical in the three engines.