### PR TITLE
utils: use stdout as the default log output

### DIFF
--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -35,11 +35,11 @@ func TestInfo(t *testing.T) {
 			if err := MountTmp(metaUrl, mountpoint); err != nil {
 				t.Fatalf("mount failed: %v", err)
 			}
-			defer func(mountpoint string) {
+			defer func() {
 				if err := UmountTmp(mountpoint); err != nil {
 					t.Fatalf("umount failed: %v", err)
 				}
-			}(mountpoint)
+			}()
 
 			if err := os.MkdirAll(fmt.Sprintf("%s/dir1", mountpoint), 0777); err != nil {
 				t.Fatalf("mkdirAll failed: %v", err)
@@ -55,15 +55,15 @@ func TestInfo(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creat temporary file failed: %v", err)
 			}
+			defer tmpFile.Close()
 			defer os.Remove(tmpFile.Name())
 			// mock os.Stdout
 			patches := gomonkey.ApplyGlobalVar(os.Stdout, *tmpFile)
 			defer patches.Reset()
 
 			infoArgs := []string{"", "info", fmt.Sprintf("%s/dir1", mountpoint)}
-			err = Main(infoArgs)
-			if err != nil {
-				t.Fatalf("info failed: %v", err)
+			if err = Main(infoArgs); err != nil {
+				t.Fatalf("test info failed: %v", err)
 			}
 			content, err := ioutil.ReadFile(tmpFile.Name())
 			if err != nil {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -29,42 +29,36 @@ import (
 func TestStatus(t *testing.T) {
 	Convey("TestInfo", t, func() {
 		Convey("TestInfo", func() {
-			tmpFile, err := os.CreateTemp("/tmp", "")
-			if err != nil {
-				t.Fatalf("creat tmp file failed: %v", err)
-			}
-			defer tmpFile.Close()
-			defer os.Remove(tmpFile.Name())
-			if err != nil {
-				t.Fatalf("create temporary file: %v", err)
-			}
-			// mock os.Stdout
-			patches := gomonkey.ApplyGlobalVar(os.Stdout, *tmpFile)
-			defer patches.Reset()
 			metaUrl := "redis://localhost:6379/10"
 			mountpoint := "/tmp/testDir"
-			statusArgs := []string{"", "status", metaUrl}
-
 			defer ResetRedis(metaUrl)
 			if err := MountTmp(metaUrl, mountpoint); err != nil {
 				t.Fatalf("mount failed: %v", err)
 			}
 			defer func() {
-				err := UmountTmp(mountpoint)
-				if err != nil {
+				if err := UmountTmp(mountpoint); err != nil {
 					t.Fatalf("umount failed: %v", err)
 				}
 			}()
 
-			if err := Main(statusArgs); err != nil {
+			tmpFile, err := os.CreateTemp("/tmp", "")
+			if err != nil {
+				t.Fatalf("creat temporary file failed: %v", err)
+			}
+			defer tmpFile.Close()
+			defer os.Remove(tmpFile.Name())
+			// mock os.Stdout
+			patches := gomonkey.ApplyGlobalVar(os.Stdout, *tmpFile)
+			defer patches.Reset()
+
+			statusArgs := []string{"", "status", metaUrl}
+			if err = Main(statusArgs); err != nil {
 				t.Fatalf("test status failed: %v", err)
 			}
-
 			content, err := ioutil.ReadFile(tmpFile.Name())
 			if err != nil {
 				t.Fatalf("readFile failed: %v", err)
 			}
-
 			s := sections{}
 			if err = json.Unmarshal(content, &s); err != nil {
 				t.Fatalf("test status failed: %v", err)

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -69,7 +69,7 @@ func (l *logHandle) Log(args ...interface{}) {
 
 func newLogger(name string) *logHandle {
 	l := &logHandle{name: name}
-	l.Out = os.Stderr
+	l.Out = os.Stdout
 	l.Formatter = l
 	l.Level = logrus.InfoLevel
 	l.Hooks = make(logrus.LevelHooks)


### PR DESCRIPTION
close #1025 

This change should be highlighted in the next release note in case some users are parsing the output of `juicefs` commands with script.