### PR TITLE
meta/mysql: don't error out if there are 'duplicate' keys in Sync2

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -202,8 +202,11 @@ func (m *dbMeta) Init(format Format, force bool) error {
 	if err := m.db.Sync2(new(setting), new(counter)); err != nil {
 		logger.Fatalf("create table setting, counter: %s", err)
 	}
-	if err := m.db.Sync2(new(node), new(edge), new(symlink), new(xattr)); err != nil {
-		logger.Fatalf("create table node, edge, symlink, xattr: %s", err)
+	if err := m.db.Sync2(new(edge)); err != nil && !strings.Contains(err.Error(), "Duplicate entry") {
+		logger.Fatalf("create table edge: %s", err)
+	}
+	if err := m.db.Sync2(new(node), new(symlink), new(xattr)); err != nil {
+		logger.Fatalf("create table node, symlink, xattr: %s", err)
 	}
 	if err := m.db.Sync2(new(chunk), new(chunkRef)); err != nil {
 		logger.Fatalf("create table chunk, chunk_ref: %s", err)


### PR DESCRIPTION
close #1125 