### PR TITLE
Directory keep SGID

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1,3 +1,4 @@
+//go:build !noredis
 // +build !noredis
 
 /*
@@ -820,7 +821,7 @@ func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode u
 			attr.Mode |= (cur.Mode & 06000)
 		}
 		var changed bool
-		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
+		if cur.Typ == TypeFile && (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
 			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
 				// clear SUID and SGID
 				cur.Mode &= 01777

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1,3 +1,4 @@
+//go:build !nosqlite || !nomysql || !nopg
 // +build !nosqlite !nomysql !nopg
 
 /*
@@ -623,7 +624,7 @@ func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 			attr.Mode |= (cur.Mode & 06000)
 		}
 		var changed bool
-		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
+		if cur.Type == TypeFile && (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
 			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
 				// clear SUID and SGID
 				cur.Mode &= 01777

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -721,7 +721,7 @@ func (m *kvMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 			attr.Mode |= (cur.Mode & 06000)
 		}
 		var changed bool
-		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
+		if cur.Typ == TypeFile && (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
 			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
 				// clear SUID and SGID
 				cur.Mode &= 01777


### PR DESCRIPTION
When operating a directory, although the group has x permissions, it needs to retain the SGID.
closes https://github.com/juicedata/juicefs/issues/1132