### PR TITLE
Keep SGID for directory

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -341,7 +341,7 @@ func (m *baseMeta) marshal(attr *Attr) []byte {
 	return w.Bytes()
 }
 
-func clearSGID(ctx Context, cur *Attr, set *Attr) {
+func clearSUGID(ctx Context, cur *Attr, set *Attr) {
 	switch runtime.GOOS {
 	case "darwin":
 		if ctx.Uid() != 0 {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -17,6 +17,7 @@ package meta
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -338,6 +339,30 @@ func (m *baseMeta) marshal(attr *Attr) []byte {
 	w.Put64(uint64(attr.Parent))
 	logger.Tracef("attr: %+v -> %+v", attr, w.Bytes())
 	return w.Bytes()
+}
+
+func clearSGID(ctx Context, cur *Attr, set *Attr) {
+	switch runtime.GOOS {
+	case "darwin":
+		if ctx.Uid() != 0 {
+			// clear SUID and SGID
+			cur.Mode &= 01777
+			set.Mode &= 01777
+		}
+	case "linux":
+		// same as ext
+		if cur.Typ != TypeDirectory {
+			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
+				// clear SUID and SGID
+				cur.Mode &= 01777
+				set.Mode &= 01777
+			} else {
+				// keep SGID if the file is non-group-executable
+				cur.Mode &= 03777
+				set.Mode &= 03777
+			}
+		}
+	}
 }
 
 func (r *baseMeta) Resolve(ctx Context, parent Ino, path string, inode *Ino, attr *Attr) syscall.Errno {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -821,15 +821,7 @@ func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode u
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
-				// clear SUID and SGID
-				cur.Mode &= 01777
-				attr.Mode &= 01777
-			} else {
-				// keep SGID if the file is non-group-executable
-				cur.Mode &= 03777
-				attr.Mode &= 03777
-			}
+			clearSGID(ctx, &cur, attr)
 			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -821,7 +821,7 @@ func (r *redisMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode u
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			clearSGID(ctx, &cur, attr)
+			clearSUGID(ctx, &cur, attr)
 			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {

--- a/pkg/meta/redis_test.go
+++ b/pkg/meta/redis_test.go
@@ -188,7 +188,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	}
 	// check owner permission
 	var p1, c1 Ino
-	if st := m.Mkdir(ctx2, 1, "d1", 02766, 022, 0, &p1, attr); st != 0 {
+	if st := m.Mkdir(ctx2, 1, "d1", 02755, 022, 0, &p1, attr); st != 0 {
 		t.Fatalf("mkdir d1: %s", st)
 	}
 	attr.Gid = 1

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -598,7 +598,7 @@ func (m *dbMeta) doGetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno {
 	return errno(err)
 }
 
-func clearSGIDSQL(ctx Context, cur *node, set *Attr) {
+func clearSUGIDSQL(ctx Context, cur *node, set *Attr) {
 	switch runtime.GOOS {
 	case "darwin":
 		if ctx.Uid() != 0 {
@@ -640,7 +640,7 @@ func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			clearSGIDSQL(ctx, &cur, attr)
+			clearSUGIDSQL(ctx, &cur, attr)
 			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -598,6 +598,30 @@ func (m *dbMeta) doGetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno {
 	return errno(err)
 }
 
+func clearSGIDSQL(ctx Context, cur *node, set *Attr) {
+	switch runtime.GOOS {
+	case "darwin":
+		if ctx.Uid() != 0 {
+			// clear SUID and SGID
+			cur.Mode &= 01777
+			set.Mode &= 01777
+		}
+	case "linux":
+		// same as ext
+		if cur.Type != TypeDirectory {
+			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
+				// clear SUID and SGID
+				cur.Mode &= 01777
+				set.Mode &= 01777
+			} else {
+				// keep SGID if the file is non-group-executable
+				cur.Mode &= 03777
+				set.Mode &= 03777
+			}
+		}
+	}
+}
+
 func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint8, attr *Attr) syscall.Errno {
 	defer timeit(time.Now())
 	inode = m.checkRoot(inode)
@@ -616,15 +640,7 @@ func (m *dbMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
-				// clear SUID and SGID
-				cur.Mode &= 01777
-				attr.Mode &= 01777
-			} else {
-				// keep SGID if the file is non-group-executable
-				cur.Mode &= 03777
-				attr.Mode &= 03777
-			}
+			clearSGIDSQL(ctx, &cur, attr)
 			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -723,7 +723,7 @@ func (m *kvMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			clearSGID(ctx, &cur, attr)
+			clearSUGID(ctx, &cur, attr)
 			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -723,15 +723,7 @@ func (m *kvMeta) SetAttr(ctx Context, inode Ino, set uint16, sugidclearmode uint
 		}
 		var changed bool
 		if (cur.Mode&06000) != 0 && (set&(SetAttrUID|SetAttrGID)) != 0 {
-			if ctx.Uid() != 0 || (cur.Mode>>3)&1 != 0 {
-				// clear SUID and SGID
-				cur.Mode &= 01777
-				attr.Mode &= 01777
-			} else {
-				// keep SGID if the file is non-group-executable
-				cur.Mode &= 03777
-				attr.Mode &= 03777
-			}
+			clearSGID(ctx, &cur, attr)
 			changed = true
 		}
 		if set&SetAttrUID != 0 && cur.Uid != attr.Uid {


### PR DESCRIPTION
The man page of chown does not mention the behavior for directory, so we keep the behavior close to ext3/ext4 in Linux.

In macOS (darwin), we pick the behavior in APFS.

close #1132 