### PR TITLE
cmd: add `config` command to change config of a volume

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,103 @@
+/*
+ * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/urfave/cli/v2"
+)
+
+var changableConfigs = []cli.Flag{
+	&cli.Uint64Flag{
+		Name:  "capacity",
+		Value: 0,
+		Usage: "the limit for space in GiB",
+	},
+	&cli.Uint64Flag{
+		Name:  "inodes",
+		Value: 0,
+		Usage: "the limit for number of inodes",
+	},
+	&cli.StringFlag{
+		Name:  "access-key",
+		Usage: "Access key for object storage (env ACCESS_KEY)",
+	},
+	&cli.StringFlag{
+		Name:  "secret-key",
+		Usage: "Secret key for object storage (env SECRET_KEY)",
+	},
+	&cli.IntFlag{
+		Name:  "trash-days",
+		Value: 1,
+		Usage: "number of days after which removed files will be permanently deleted",
+	},
+}
+
+func config(ctx *cli.Context) error {
+	setLoggerLevel(ctx)
+	if ctx.Args().Len() < 1 {
+		return fmt.Errorf("META-URL is needed")
+	}
+	m := meta.NewClient(ctx.Args().Get(0), &meta.Config{Retries: 10, Strict: true})
+
+	format, err := m.Load()
+	if err != nil {
+		return err
+	}
+	var msg strings.Builder
+	for _, flag := range ctx.LocalFlagNames() {
+		switch flag {
+		case "capacity":
+			msg.WriteString(fmt.Sprintf("%10s: %d -> %d\n", flag, format.Capacity, ctx.Uint64(flag)))
+			format.Capacity = ctx.Uint64(flag)
+		case "inodes":
+			msg.WriteString(fmt.Sprintf("%10s: %d -> %d\n", flag, format.Inodes, ctx.Uint64(flag)))
+			format.Inodes = ctx.Uint64(flag)
+		case "access-key":
+			msg.WriteString(fmt.Sprintf("%10s: %s -> %s\n", flag, format.AccessKey, ctx.String(flag)))
+			format.AccessKey = ctx.String(flag)
+		case "secret-key":
+			msg.WriteString(fmt.Sprintf("%10s: updated\n", flag))
+			format.SecretKey = ctx.String(flag)
+		case "trash-days":
+			msg.WriteString(fmt.Sprintf("%10s: %d -> %d\n", flag, format.TrashDays, ctx.Uint64(flag)))
+			format.TrashDays = ctx.Int(flag)
+		}
+	}
+	if msg.Len() == 0 {
+		format.RemoveSecret()
+		printJson(format)
+		return nil
+	}
+
+	if err = m.Init(*format, false); err == nil {
+		fmt.Println(msg.String()[:msg.Len()-1])
+	}
+	return err
+}
+
+func configFlags() *cli.Command {
+	return &cli.Command{
+		Name:      "config",
+		Usage:     "change config of a volume",
+		ArgsUsage: "META-URL",
+		Action:    config,
+		Flags:     changableConfigs,
+	}
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,32 +23,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var changableConfigs = []cli.Flag{
-	&cli.Uint64Flag{
-		Name:  "capacity",
-		Value: 0,
-		Usage: "the limit for space in GiB",
-	},
-	&cli.Uint64Flag{
-		Name:  "inodes",
-		Value: 0,
-		Usage: "the limit for number of inodes",
-	},
-	&cli.StringFlag{
-		Name:  "access-key",
-		Usage: "Access key for object storage (env ACCESS_KEY)",
-	},
-	&cli.StringFlag{
-		Name:  "secret-key",
-		Usage: "Secret key for object storage (env SECRET_KEY)",
-	},
-	&cli.IntFlag{
-		Name:  "trash-days",
-		Value: 1,
-		Usage: "number of days after which removed files will be permanently deleted",
-	},
-}
-
 func config(ctx *cli.Context) error {
 	setLoggerLevel(ctx)
 	if ctx.Args().Len() < 1 {
@@ -69,6 +43,9 @@ func config(ctx *cli.Context) error {
 		case "inodes":
 			msg.WriteString(fmt.Sprintf("%10s: %d -> %d\n", flag, format.Inodes, ctx.Uint64(flag)))
 			format.Inodes = ctx.Uint64(flag)
+		case "bucket":
+			msg.WriteString(fmt.Sprintf("%10s: %s -> %s\n", flag, format.Bucket, ctx.String(flag)))
+			format.Bucket = ctx.String(flag)
 		case "access-key":
 			msg.WriteString(fmt.Sprintf("%10s: %s -> %s\n", flag, format.AccessKey, ctx.String(flag)))
 			format.AccessKey = ctx.String(flag)
@@ -98,6 +75,31 @@ func configFlags() *cli.Command {
 		Usage:     "change config of a volume",
 		ArgsUsage: "META-URL",
 		Action:    config,
-		Flags:     changableConfigs,
+		Flags: []cli.Flag{
+			&cli.Uint64Flag{
+				Name:  "capacity",
+				Usage: "the limit for space in GiB",
+			},
+			&cli.Uint64Flag{
+				Name:  "inodes",
+				Usage: "the limit for number of inodes",
+			},
+			&cli.StringFlag{
+				Name:  "bucket",
+				Usage: "A bucket URL to store data",
+			},
+			&cli.StringFlag{
+				Name:  "access-key",
+				Usage: "Access key for object storage",
+			},
+			&cli.StringFlag{
+				Name:  "secret-key",
+				Usage: "Secret key for object storage",
+			},
+			&cli.IntFlag{
+				Name:  "trash-days",
+				Usage: "number of days after which removed files will be permanently deleted",
+			},
+		},
 	}
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -62,7 +62,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("trash-days %d != expect 2", format.TrashDays)
 	}
 
-	if err = Main([]string{"", "config", metaUrl, "--capacity", "100", "--inodes", "1000000"}); err != nil {
+	if err = Main([]string{"", "config", metaUrl, "--capacity", "10", "--inodes", "1000000"}); err != nil {
 		t.Fatalf("config: %s", err)
 	}
 	if err = Main([]string{"", "config", metaUrl, "--bucket", "/tmp/newBucket", "--access-key", "testAK", "--secret-key", "testSK"}); err != nil {
@@ -74,7 +74,7 @@ func TestConfig(t *testing.T) {
 	if err = json.Unmarshal(data, &format); err != nil {
 		t.Fatalf("json unmarshal: %s", err)
 	}
-	if format.Capacity != 100 || format.Inodes != 1000000 ||
+	if format.Capacity != 10<<30 || format.Inodes != 1000000 ||
 		format.Bucket != "/tmp/newBucket" || format.AccessKey != "testAK" || format.SecretKey != "removed" {
 		t.Fatalf("unexpect format: %+v", format)
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,81 @@
+/*
+ * JuiceFS, Copyright (C) 2021 Juicedata, Inc.
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/juicedata/juicefs/pkg/meta"
+)
+
+func getStdout(args []string) ([]byte, error) {
+	tmp, err := os.CreateTemp("/tmp", "jfstest-*")
+	if err != nil {
+		return nil, err
+	}
+	defer tmp.Close()
+	defer os.Remove(tmp.Name())
+	patch := gomonkey.ApplyGlobalVar(os.Stdout, *tmp)
+	defer patch.Reset()
+
+	if err = Main(args); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(tmp.Name())
+}
+
+func TestConfig(t *testing.T) {
+	metaUrl := "redis://localhost:6379/10"
+	ResetRedis(metaUrl)
+	if err := Main([]string{"", "format", metaUrl, "--bucket", "/tmp/testBucket", "test"}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	if err := Main([]string{"", "config", metaUrl, "--trash-days", "2"}); err != nil {
+		t.Fatalf("config: %s", err)
+	}
+	data, err := getStdout([]string{"", "config", metaUrl})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.TrashDays != 2 {
+		t.Fatalf("trash-days %d != expect 2", format.TrashDays)
+	}
+
+	if err = Main([]string{"", "config", metaUrl, "--capacity", "100", "--inodes", "1000000"}); err != nil {
+		t.Fatalf("config: %s", err)
+	}
+	if err = Main([]string{"", "config", metaUrl, "--bucket", "/tmp/newBucket", "--access-key", "testAK", "--secret-key", "testSK"}); err != nil {
+		t.Fatalf("config: %s", err)
+	}
+	if data, err = getStdout([]string{"", "config", metaUrl}); err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.Capacity != 100 || format.Inodes != 1000000 ||
+		format.Bucket != "/tmp/newBucket" || format.AccessKey != "testAK" || format.SecretKey != "removed" {
+		t.Fatalf("unexpect format: %+v", format)
+	}
+}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -239,7 +239,7 @@ func formatFlags() *cli.Command {
 	default:
 		defaultBucket = "/var/jfs"
 	}
-	cmd := &cli.Command{
+	return &cli.Command{
 		Name:      "format",
 		Usage:     "format a volume",
 		ArgsUsage: "META-URL NAME",
@@ -248,6 +248,16 @@ func formatFlags() *cli.Command {
 				Name:  "block-size",
 				Value: 4096,
 				Usage: "size of block in KiB",
+			},
+			&cli.Uint64Flag{
+				Name:  "capacity",
+				Value: 0,
+				Usage: "the limit for space in GiB",
+			},
+			&cli.Uint64Flag{
+				Name:  "inodes",
+				Value: 0,
+				Usage: "the limit for number of inodes",
 			},
 			&cli.StringFlag{
 				Name:  "compress",
@@ -270,9 +280,23 @@ func formatFlags() *cli.Command {
 				Usage: "A bucket URL to store data",
 			},
 			&cli.StringFlag{
+				Name:  "access-key",
+				Usage: "Access key for object storage (env ACCESS_KEY)",
+			},
+			&cli.StringFlag{
+				Name:  "secret-key",
+				Usage: "Secret key for object storage (env SECRET_KEY)",
+			},
+			&cli.StringFlag{
 				Name:  "encrypt-rsa-key",
 				Usage: "A path to RSA private key (PEM)",
 			},
+			&cli.IntFlag{
+				Name:  "trash-days",
+				Value: 1,
+				Usage: "number of days after which removed files will be permanently deleted",
+			},
+
 			&cli.BoolFlag{
 				Name:  "force",
 				Usage: "overwrite existing format",
@@ -284,6 +308,4 @@ func formatFlags() *cli.Command {
 		},
 		Action: format,
 	}
-	cmd.Flags = append(cmd.Flags, changableConfigs...)
-	return cmd
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -239,7 +239,7 @@ func formatFlags() *cli.Command {
 	default:
 		defaultBucket = "/var/jfs"
 	}
-	return &cli.Command{
+	cmd := &cli.Command{
 		Name:      "format",
 		Usage:     "format a volume",
 		ArgsUsage: "META-URL NAME",
@@ -248,16 +248,6 @@ func formatFlags() *cli.Command {
 				Name:  "block-size",
 				Value: 4096,
 				Usage: "size of block in KiB",
-			},
-			&cli.Uint64Flag{
-				Name:  "capacity",
-				Value: 0,
-				Usage: "the limit for space in GiB",
-			},
-			&cli.Uint64Flag{
-				Name:  "inodes",
-				Value: 0,
-				Usage: "the limit for number of inodes",
 			},
 			&cli.StringFlag{
 				Name:  "compress",
@@ -280,23 +270,9 @@ func formatFlags() *cli.Command {
 				Usage: "A bucket URL to store data",
 			},
 			&cli.StringFlag{
-				Name:  "access-key",
-				Usage: "Access key for object storage (env ACCESS_KEY)",
-			},
-			&cli.StringFlag{
-				Name:  "secret-key",
-				Usage: "Secret key for object storage (env SECRET_KEY)",
-			},
-			&cli.StringFlag{
 				Name:  "encrypt-rsa-key",
 				Usage: "A path to RSA private key (PEM)",
 			},
-			&cli.IntFlag{
-				Name:  "trash-days",
-				Value: 1,
-				Usage: "number of days after which removed files will be permanently deleted",
-			},
-
 			&cli.BoolFlag{
 				Name:  "force",
 				Usage: "overwrite existing format",
@@ -308,4 +284,6 @@ func formatFlags() *cli.Command {
 		},
 		Action: format,
 	}
+	cmd.Flags = append(cmd.Flags, changableConfigs...)
+	return cmd
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,6 +85,7 @@ func Main(args []string) error {
 			warmupFlags(),
 			dumpFlags(),
 			loadFlags(),
+			configFlags(),
 		},
 	}
 

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -168,6 +168,7 @@ func (r *redisMeta) Init(format Format, force bool) error {
 		} else {
 			format.UUID = old.UUID
 			// these can be safely updated.
+			old.Bucket = format.Bucket
 			old.AccessKey = format.AccessKey
 			old.SecretKey = format.SecretKey
 			old.Capacity = format.Capacity

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -239,6 +239,7 @@ func (m *dbMeta) Init(format Format, force bool) error {
 		} else {
 			format.UUID = old.UUID
 			// these can be safely updated.
+			old.Bucket = format.Bucket
 			old.AccessKey = format.AccessKey
 			old.SecretKey = format.SecretKey
 			old.Capacity = format.Capacity

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -330,6 +330,7 @@ func (m *kvMeta) Init(format Format, force bool) error {
 		} else {
 			format.UUID = old.UUID
 			// these can be safely updated.
+			old.Bucket = format.Bucket
 			old.AccessKey = format.AccessKey
 			old.SecretKey = format.SecretKey
 			old.Capacity = format.Capacity


### PR DESCRIPTION
close #1063 

For now the `format` command is not touched, so it can still be used to change the config as well.  However, the new `config` is a recommended way, and `format` will be deprecated (only keep the real **FORMAT** function) after one or two minor versions.