### PR TITLE
fix mkdir/rename/delete/rmr with trailing slash

### DIFF
--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -276,10 +276,13 @@ func TestFileSystem(t *testing.T) {
 	if err := fs.Delete(ctx, "/ddd/"); err != syscall.ENOTEMPTY {
 		t.Fatalf("delete /ddd/: %s", err)
 	}
-	if err := fs.Rmr(ctx, "/ddd/"); err != 0 {
-		t.Fatalf("rmr /ddd/: %s", err)
+	if err := fs.Rename(ctx, "/ddd/", "/ttt/", 0); err != 0 {
+		t.Fatalf("delete /ddd/: %s", err)
 	}
-	if _, err := fs.Stat(ctx, "/ddd/"); err != syscall.ENOENT {
-		t.Fatalf("stat /ddd/: %s", err)
+	if err := fs.Rmr(ctx, "/ttt/"); err != 0 {
+		t.Fatalf("rmr /ttt/: %s", err)
+	}
+	if _, err := fs.Stat(ctx, "/ttt/"); err != syscall.ENOENT {
+		t.Fatalf("stat /ttt/: %s", err)
 	}
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -262,4 +262,24 @@ func TestFileSystem(t *testing.T) {
 	if e := fs.Close(); e != nil {
 		t.Fatalf("close: %s", e)
 	}
+
+	// path with trailing /
+	if err := fs.Mkdir(ctx, "/ddd/", 0777); err != 0 {
+		t.Fatalf("mkdir /ddd/: %s", err)
+	}
+	if _, err := fs.Create(ctx, "/ddd/ddd", 0777); err != 0 {
+		t.Fatalf("create /ddd/ddd: %s", err)
+	}
+	if _, err := fs.Create(ctx, "/ddd/fff/", 0777); err != syscall.EINVAL {
+		t.Fatalf("create /ddd/fff/: %s", err)
+	}
+	if err := fs.Delete(ctx, "/ddd/"); err != syscall.ENOTEMPTY {
+		t.Fatalf("delete /ddd/: %s", err)
+	}
+	if err := fs.Rmr(ctx, "/ddd/"); err != 0 {
+		t.Fatalf("rmr /ddd/: %s", err)
+	}
+	if _, err := fs.Stat(ctx, "/ddd/"); err != syscall.ENOENT {
+		t.Fatalf("stat /ddd/: %s", err)
+	}
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -618,9 +618,17 @@ func (n *jfsObjects) PutObject(ctx context.Context, bucket string, object string
 	}
 
 	p := n.path(bucket, object)
-	if strings.HasSuffix(object, sep) && r.Size() == 0 {
+	if strings.HasSuffix(object, sep) {
 		if err = n.mkdirAll(ctx, p, os.FileMode(0755)); err != nil {
 			err = jfsToObjectErr(ctx, err, bucket, object)
+			return
+		}
+		if r.Size() > 0 {
+			err = minio.ObjectExistsAsDirectory{
+				Bucket: bucket,
+				Object: object,
+				Err:    syscall.EEXIST,
+			}
 			return
 		}
 	} else if err = n.putObject(ctx, bucket, p, r, opts); err != nil {


### PR DESCRIPTION
Slash is a separator in JuiceFS, the trailing slash means the last component is a directory, so we can't allow upload an object with trailing slash.

close #1129