### PR TITLE
fix gateway GetObjectInfo http code 500 to 404

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -527,7 +527,7 @@ func (n *jfsObjects) GetObjectInfo(ctx context.Context, bucket, object string, o
 		return
 	}
 	if strings.HasSuffix(object, sep) && !fi.IsDir() {
-		err = jfsToObjectErr(ctx, os.ErrNotExist, bucket, object)
+		err = jfsToObjectErr(ctx, syscall.ENOENT, bucket, object)
 		return
 	}
 	return minio.ObjectInfo{


### PR DESCRIPTION
os.ErrNotExist triggers 500 http code (InternalError), syscall.ENOENT triggers 404 code which is expected