### PR TITLE
change default cache-size to 100GB

### DIFF
--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -59,10 +59,8 @@ func fsck(ctx *cli.Context) error {
 		GetTimeout: time.Second * 60,
 		PutTimeout: time.Second * 60,
 		MaxUpload:  20,
-		Prefetch:   0,
 		BufferSize: 300,
 		CacheDir:   "memory",
-		CacheSize:  0,
 	}
 
 	blob, err := createStorage(format)

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -97,10 +97,8 @@ func gc(ctx *cli.Context) error {
 		GetTimeout: time.Second * 60,
 		PutTimeout: time.Second * 60,
 		MaxUpload:  20,
-		Prefetch:   0,
 		BufferSize: 300,
 		CacheDir:   "memory",
-		CacheSize:  300,
 	}
 
 	blob, err := createStorage(format)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -378,7 +378,7 @@ func clientFlags() []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:  "cache-size",
-			Value: 1 << 10,
+			Value: 100 << 10,
 			Usage: "size of cached objects in MiB",
 		},
 		&cli.Float64Flag{

--- a/docs/en/reference/command_reference.md
+++ b/docs/en/reference/command_reference.md
@@ -231,7 +231,7 @@ upload objects in background (default: false)
 directory paths of local cache, use colon to separate multiple paths (default: `"$HOME/.juicefs/cache"` or `"/var/jfsCache"`)
 
 `--cache-size value`<br />
-size of cached objects in MiB (default: 1024)
+size of cached objects in MiB (default: 102400)
 
 `--free-space-ratio value`<br />
 min free space (ratio) (default: 0.1)
@@ -316,7 +316,7 @@ upload objects in background (default: false)
 directory paths of local cache, use colon to separate multiple paths (default: `"$HOME/.juicefs/cache"` or `/var/jfsCache`)
 
 `--cache-size value`<br />
-size of cached objects in MiB (default: 1024)
+size of cached objects in MiB (default: 102400)
 
 `--free-space-ratio value`<br />
 min free space (ratio) (default: 0.1)

--- a/docs/zh_cn/administration/cache_management.md
+++ b/docs/zh_cn/administration/cache_management.md
@@ -68,7 +68,7 @@ JuiceFS 客户端会根据读取模式自动预读数据放入缓存，从而提
 ```
 --prefetch value          并发预读 N 个块 (默认: 1)
 --cache-dir value         本地缓存目录路径；使用冒号隔离多个路径 (默认: "$HOME/.juicefs/cache" 或 "/var/jfsCache")
---cache-size value        缓存对象的总大小；单位为 MiB (默认: 1024)
+--cache-size value        缓存对象的总大小；单位为 MiB (默认: 102400)
 --free-space-ratio value  最小剩余空间比例 (默认: 0.1)
 --cache-partial-only      仅缓存随机小块读 (默认: false)
 ```

--- a/docs/zh_cn/reference/command_reference.md
+++ b/docs/zh_cn/reference/command_reference.md
@@ -231,7 +231,7 @@ consul注册中心地址(默认: "127.0.0.1:8500")
 本地缓存目录路径；使用冒号隔离多个路径 (默认: `"$HOME/.juicefs/cache"` 或 `"/var/jfsCache"`)
 
 `--cache-size value`<br />
-缓存对象的总大小；单位为 MiB (默认: 1024)
+缓存对象的总大小；单位为 MiB (默认: 102400)
 
 `--free-space-ratio value`<br />
 最小剩余空间比例 (默认: 0.1)
@@ -316,7 +316,7 @@ juicefs gateway [command options] META-URL ADDRESS
 本地缓存目录路径；使用冒号隔离多个路径 (默认: `"$HOME/.juicefs/cache"` 或 `/var/jfsCache`)
 
 `--cache-size value`<br />
-缓存对象的总大小；单位为 MiB (默认: 1024)
+缓存对象的总大小；单位为 MiB (默认: 102400)
 
 `--free-space-ratio value`<br />
 最小剩余空间比例 (默认: 0.1)

--- a/sdk/java/src/main/java/io/juicefs/Main.java
+++ b/sdk/java/src/main/java/io/juicefs/Main.java
@@ -190,7 +190,7 @@ public class Main {
           System.out.println("- " + jfsName);
         }
         System.out.println("\tcacheSize=" + cacheSize.getOrDefault("juicefs." + jfsName + ".cache-size",
-                cacheSize.getOrDefault("juicefs.cache-size", "1024")) + "MiB");
+                cacheSize.getOrDefault("juicefs.cache-size", "100")) + "MiB");
       }
 
       for (Map.Entry<String, String> entry : cacheDir.entrySet()) {


### PR DESCRIPTION
The Java SDK still use 100MB memory as block cache.

close #1076