### PR TITLE
improve s3 url parsing

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -116,9 +116,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 	name := strings.ToLower(u.Scheme)
 	endpoint := u.Host
 
-	//localhost[:8080] 127.0.0.1[:8080]  s3.ap-southeast-1.amazonaws.com[:8080] s3-ap-southeast-1.amazonaws.com[:8080]
-	pattern := `^((localhost)|(s3[.-].*.amazonaws.com)|((1\d{2}|2[0-4]\d|25[0-5]|[1-9]\d|[1-9])\.((1\d{2}|2[0-4]\d|25[0-5]|[1-9]\d|\d)\.){2}(1\d{2}|2[0-4]\d|25[0-5]|[1-9]\d|\d)))?(:\d*)?$`
-	isS3PathType := regexp.MustCompile(pattern).MatchString(endpoint)
+	isS3PathTypeUrl := isS3PathType(endpoint)
 
 	if name == "file" {
 		endpoint = u.Path
@@ -128,7 +126,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 	} else {
 		endpoint = "http://" + endpoint
 	}
-	if name == "minio" || name == "s3" && isS3PathType {
+	if name == "minio" || name == "s3" && isS3PathTypeUrl {
 		// bucket name is part of path
 		endpoint += u.Path
 	}
@@ -151,7 +149,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			store = object.WithPrefix(store, strings.SplitN(u.Path[1:], "/", 2)[1])
 		}
 	case "s3":
-		if isS3PathType && strings.Count(u.Path, "/") > 1 {
+		if isS3PathTypeUrl && strings.Count(u.Path, "/") > 1 {
 			store = object.WithPrefix(store, strings.SplitN(u.Path[1:], "/", 2)[1])
 		} else if len(u.Path) > 1 {
 			store = object.WithPrefix(store, u.Path[1:])
@@ -162,6 +160,12 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 		}
 	}
 	return store, nil
+}
+
+func isS3PathType(endpoint string) bool {
+	//localhost[:8080] 127.0.0.1[:8080]  s3.ap-southeast-1.amazonaws.com[:8080] s3-ap-southeast-1.amazonaws.com[:8080]
+	pattern := `^((localhost)|(s3[.-].*.amazonaws.com)|((1\d{2}|2[0-4]\d|25[0-5]|[1-9]\d|[1-9])\.((1\d{2}|2[0-4]\d|25[0-5]|[1-9]\d|\d)\.){2}(1\d{2}|2[0-4]\d|25[0-5]|[1-9]\d|\d)))?(:\d*)?$`
+	return regexp.MustCompile(pattern).MatchString(endpoint)
 }
 
 const USAGE = `juicefs [options] sync [options] SRC DST

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -61,3 +61,30 @@ func TestSync(t *testing.T) {
 	}
 
 }
+
+func Test_isS3PathType(t *testing.T) {
+
+	tests := []struct {
+		endpoint string
+		want     bool
+	}{
+		{"localhost", true},
+		{"localhost:8080", true},
+		{"127.0.0.1", true},
+		{"127.0.0.1:8080", true},
+		{"s3.ap-southeast-1.amazonaws.com", true},
+		{"s3.ap-southeast-1.amazonaws.com:8080", true},
+		{"s3-ap-southeast-1.amazonaws.com", true},
+		{"s3-ap-southeast-1.amazonaws.com:8080", true},
+		{"ap-southeast-1.amazonaws.com", false},
+		{"s3-ap-southeast-1", false},
+		{"s3-ap-southeast-1:8080", false},
+	}
+	for _, tt := range tests {
+		t.Run("Test host", func(t *testing.T) {
+			if got := isS3PathType(tt.endpoint); got != tt.want {
+				t.Errorf("isS3PathType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
support 

- `s3-ENDOINT.amazonaws.com/BUCKET/PREFIX`  

- `s3.ENDOINT.amazonaws.com/BUCKET/PREFIX` 

- `localhost:8088/BUCKET/PREFIX`

- `localhost/BUCKET/PREFIX`

- `127.0.0.1:8088/BUCKET/PREFIX`

- `127.0.0.1/BUCKET/PREFIX`