### PR TITLE
Docs: update "Sync Accounts between Multiple Hosts" doc

### DIFF
--- a/docs/en/administration/sync_accounts_between_multiple_hosts.md
+++ b/docs/en/administration/sync_accounts_between_multiple_hosts.md
@@ -8,7 +8,7 @@ slug: /sync_accounts_between_multiple_hosts
 
 JuiceFS supports POSIX compatible ACL to manage permissions in the granularity of directory or file. The behavior is the same as a local file system.
 
-In order to make the permission experience intuitive to user (e.g. the files accessible by user A in host X should be accessible in host Y with the same user), the same user who want to access JuiceFS should have the same UID and GID on all hosts.
+To provide users with an intuitive and consistent permission management experience (e.g. the files accessible by user A in host X should be accessible in host Y with the same user), the same user who want to access JuiceFS should have the same UID and GID on all hosts.
 
 Here we provide a simple [Ansible](https://www.ansible.com/community) playbook to demonstrate how to ensure an account with same UID and GID on multiple hosts.
 
@@ -18,7 +18,7 @@ If you are using JuiceFS in Hadoop environment, besides sync accounts between mu
 
 ## Install Ansible
 
-Select a host as a [control node](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#managed-node-requirements) which can access all hosts using `ssh` with the same privileged account like `root` or other sudo account. Install ansible on this host. Read [Installing Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible) for more installation details.
+Select a host as a [control node](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#managed-node-requirements) which can access all hosts using `ssh` with the same privileged account like `root` or other sudo account. Install Ansible on this host. Read [Installing Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible) for more installation details.
 
 
 

--- a/docs/en/administration/sync_accounts_between_multiple_hosts.md
+++ b/docs/en/administration/sync_accounts_between_multiple_hosts.md
@@ -3,6 +3,7 @@ sidebar_label: Sync Accounts between Multiple Hosts
 sidebar_position: 10
 slug: /sync_accounts_between_multiple_hosts
 ---
+
 # Sync Accounts between Multiple Hosts
 
 JuiceFS supports POSIX compatible ACL to manage permissions in the granularity of directory or file. The behavior is the same as a local file system.
@@ -11,9 +12,11 @@ In order to make the permission experience intuitive to user (e.g. the files acc
 
 Here we provide a simple [Ansible](https://www.ansible.com/community) playbook to demonstrate how to ensure an account with same UID and GID on multiple hosts.
 
-> **Note**: Besides sync accounts between multiple hosts, you can also specify a global user list and user group file, please refer to [here](../deployment/hadoop_java_sdk.md#other-configurations) for more information.
+:::note
+If you are using JuiceFS in Hadoop environment, besides sync accounts between multiple hosts, you can also specify a global user list and user group file, please refer to [here](../deployment/hadoop_java_sdk.md#other-configurations) for more information.
+:::
 
-## Install ansible
+## Install Ansible
 
 Select a host as a [control node](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#managed-node-requirements) which can access all hosts using `ssh` with the same privileged account like `root` or other sudo account. Install ansible on this host. Read [Installing Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible) for more installation details.
 
@@ -47,7 +50,7 @@ Create a file named `hosts` in this directory, place IP addresses of all hosts n
 
 Here we ensure an account `alice` with UID 1200 and  group `staff` with GID 500 on 2 hosts:
 
-```
+```shell
 ~/account-sync$ cat hosts
 172.16.255.163
 172.16.255.180
@@ -77,7 +80,7 @@ Now the new account `alice:staff` has been created on these 2 hosts.
 
 If the UID or GID specified has been allocated to another user or group on some hosts, the creation would failed.
 
-```
+```shell
 ~/account-sync$ ansible-playbook -i hosts -u root --ssh-extra-args "-o StrictHostKeyChecking=no" \
 --extra-vars "group=ubuntu gid=1000 user=ubuntu uid=1000" play.yaml
 
@@ -102,32 +105,30 @@ PLAY RECAP *********************************************************************
 
 In above example,  the group ID 1000 has been allocated to another group on host `172.16.255.180` , we should **change the GID**  or **delete the group with GID 1000** on host `172.16.255.180` , then run the playbook again.
 
+:::caution
+If the user account has already existed on the host and we change it to another UID or GID value, the user may loss permissions to the files and directories which they previously have. For example:
 
+```shell
+$ ls -l /tmp/hello.txt
+-rw-r--r-- 1 alice staff 6 Apr 26 21:43 /tmp/hello.txt
+$ id alice
+uid=1200(alice) gid=500(staff) groups=500(staff)
+```
 
-> **CAUTION**
->
-> If the user account has already existed on the host and we change it to another UID or GID value, the user may loss permissions to the files and directories which they previously have. For example:
->
-> ```
-> $ ls -l /tmp/hello.txt
-> -rw-r--r-- 1 alice staff 6 Apr 26 21:43 /tmp/hello.txt
-> $ id alice
-> uid=1200(alice) gid=500(staff) groups=500(staff)
-> ```
->
-> We change the UID of alice from 1200 to 1201
->
-> ```
-> ~/account-sync$ ansible-playbook -i hosts -u root --ssh-extra-args "-o StrictHostKeyChecking=no" \
-> --extra-vars "group=staff gid=500 user=alice uid=1201" play.yaml
-> ```
->
-> Now we have no permission to remove this file as its owner is not alice:
->
-> ```
-> $ ls -l /tmp/hello.txt
-> -rw-r--r-- 1 1200 staff 6 Apr 26 21:43 /tmp/hello.txt
-> $ rm /tmp/hello.txt
-> rm: remove write-protected regular file '/tmp/hello.txt'? y
-> rm: cannot remove '/tmp/hello.txt': Operation not permitted
-> ```
+We change the UID of alice from 1200 to 1201
+
+```shell
+~/account-sync$ ansible-playbook -i hosts -u root --ssh-extra-args "-o StrictHostKeyChecking=no" \
+--extra-vars "group=staff gid=500 user=alice uid=1201" play.yaml
+```
+
+Now we have no permission to remove this file as its owner is not alice:
+
+```shell
+$ ls -l /tmp/hello.txt
+-rw-r--r-- 1 1200 staff 6 Apr 26 21:43 /tmp/hello.txt
+$ rm /tmp/hello.txt
+rm: remove write-protected regular file '/tmp/hello.txt'? y
+rm: cannot remove '/tmp/hello.txt': Operation not permitted
+```
+:::

--- a/docs/zh_cn/administration/sync_accounts_between_multiple_hosts.md
+++ b/docs/zh_cn/administration/sync_accounts_between_multiple_hosts.md
@@ -3,15 +3,18 @@ sidebar_label: 多主机间同步账户
 sidebar_position: 10
 slug: /sync_accounts_between_multiple_hosts
 ---
+
 # JuiceFS 多主机间同步账户
 
 JuiceFS 支持 POSIX 兼容的 ACL，以目录或文件的粒度管理权限。该行为与本地文件系统相同。
 
-为了让用户获得直观的权限管理体验（例如，用户 A 在主机 X 中访问的文件，在主机 Y 中也应该可以用相同的用户身份访问），想要访问 JuiceFS 存储的同一个用户，应该在所有主机上具有相同的 UID 和 GID。
+为了让用户获得直观一致的权限管理体验（例如，用户 A 在主机 X 中访问的文件，在主机 Y 中也应该可以用相同的用户身份访问），想要访问 JuiceFS 存储的同一个用户，应该在所有主机上具有相同的 UID 和 GID。
 
 在这里，我们提供了一个简单的 [Ansible](https://www.ansible.com/community) playbook 来演示如何确保一个帐户在多个主机上具有相同的 UID 和 GID。
 
-> **注意**：除了在多主机间同步账户以外，也可以指定一个全局的用户列表和所属用户组文件，具体请参见[这里](../deployment/hadoop_java_sdk.md#其他配置)。
+:::note 注意
+如果你是在 Hadoop 环境使用 JuiceFS，除了在多主机间同步账户以外，也可以指定一个全局的用户列表和所属用户组文件，具体请参见[这里](../deployment/hadoop_java_sdk.md#其他配置)。
+:::
 
 ## 安装 Ansible
 
@@ -43,7 +46,7 @@ JuiceFS 支持 POSIX 兼容的 ACL，以目录或文件的粒度管理权限。�
 
 在这里，我们确保在 2 台主机上使用 UID 1200 的帐户 `alice` 和 GID 500 的 `staff` 组：
 
-```
+```shell
 ~/account-sync$ cat hosts
 172.16.255.163
 172.16.255.180
@@ -73,7 +76,7 @@ PLAY RECAP *********************************************************************
 
 如果指定的 UID 或 GID 已分配给某些主机上的另一个用户或组，则创建将失败。
 
-```
+```shell
 ~/account-sync$ ansible-playbook -i hosts -u root --ssh-extra-args "-o StrictHostKeyChecking=no" \
 --extra-vars "group=ubuntu gid=1000 user=ubuntu uid=1000" play.yaml
 
@@ -98,32 +101,30 @@ PLAY RECAP *********************************************************************
 
 在上面的示例中，组 ID 1000 已分配给主机 `172.16.255.180` 上的另一个组，我们应该 **更改 GID** 或 **删除主机 `172.16.255.180` 上 GID 为 1000** 的组，然后再次运行 playbook。
 
+:::caution 注意
+如果用户帐户已经存在于主机上，并且我们将其更改为另一个 UID 或 GID 值，则用户可能会失去对他们以前拥有的文件和目录的权限。例如：
 
+```shell
+$ ls -l /tmp/hello.txt
+-rw-r--r-- 1 alice staff 6 Apr 26 21:43 /tmp/hello.txt
+$ id alice
+uid=1200(alice) gid=500(staff) groups=500(staff)
+```
 
-> **小心**
->
-> 如果用户帐户已经存在于主机上，并且我们将其更改为另一个 UID 或 GID 值，则用户可能会失去对他们以前拥有的文件和目录的权限。例如：
->
-> ```
-> $ ls -l /tmp/hello.txt
-> -rw-r--r-- 1 alice staff 6 Apr 26 21:43 /tmp/hello.txt
-> $ id alice
-> uid=1200(alice) gid=500(staff) groups=500(staff)
-> ```
->
-> 我们将 alice 的 UID 从 1200 改为 1201
->
-> ```
-> ~/account-sync$ ansible-playbook -i hosts -u root --ssh-extra-args "-o StrictHostKeyChecking=no" \
-> --extra-vars "group=staff gid=500 user=alice uid=1201" play.yaml
-> ```
->
-> 现在我们没有权限删除这个文件，因为它的所有者不是 alice：
->
-> ```
-> $ ls -l /tmp/hello.txt
-> -rw-r--r-- 1 1200 staff 6 Apr 26 21:43 /tmp/hello.txt
-> $ rm /tmp/hello.txt
-> rm: remove write-protected regular file '/tmp/hello.txt'? y
-> rm: cannot remove '/tmp/hello.txt': Operation not permitted
-> ```
+我们将 alice 的 UID 从 1200 改为 1201
+
+```shell
+~/account-sync$ ansible-playbook -i hosts -u root --ssh-extra-args "-o StrictHostKeyChecking=no" \
+--extra-vars "group=staff gid=500 user=alice uid=1201" play.yaml
+```
+
+现在我们没有权限删除这个文件，因为它的所有者不是 alice：
+
+```shell
+$ ls -l /tmp/hello.txt
+-rw-r--r-- 1 1200 staff 6 Apr 26 21:43 /tmp/hello.txt
+$ rm /tmp/hello.txt
+rm: remove write-protected regular file '/tmp/hello.txt'? y
+rm: cannot remove '/tmp/hello.txt': Operation not permitted
+```
+:::


### PR DESCRIPTION
Prompt the user for a global UID, GID config file that can only be used in a Hadoop environment.
