### PR TITLE
format: Only try to create bucket when it really doesn't exist

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -91,16 +91,16 @@ func randSeq(n int) string {
 
 func doTesting(store object.ObjectStorage, key string, data []byte) error {
 	if err := store.Put(key, bytes.NewReader(data)); err != nil {
-		if strings.Contains(err.Error(), "Access Denied") {
-			return fmt.Errorf("Failed to put: %s", err)
+		if strings.Contains(err.Error(), "NoSuchBucket") {
+			if err2 := store.Create(); err2 != nil {
+				return fmt.Errorf("Failed to create %s: %s, previous error: %s\nPlease create bucket %s manually, then format again.",
+					store, err2, err, store)
+			}
+			if err := store.Put(key, bytes.NewReader(data)); err != nil {
+				return fmt.Errorf("Failed to put: %s", err)
+			}
 		}
-		if err2 := store.Create(); err2 != nil {
-			return fmt.Errorf("Failed to create %s: %s,  previous error: %s\nplease create bucket %s manually, then format again",
-				store, err2, err, store)
-		}
-		if err := store.Put(key, bytes.NewReader(data)); err != nil {
-			return fmt.Errorf("Failed to put: %s", err)
-		}
+		return fmt.Errorf("Failed to put: %s", err)
 	}
 	p, err := store.Get(key, 0, -1)
 	if err != nil {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -91,16 +91,16 @@ func randSeq(n int) string {
 
 func doTesting(store object.ObjectStorage, key string, data []byte) error {
 	if err := store.Put(key, bytes.NewReader(data)); err != nil {
-		if strings.Contains(err.Error(), "NoSuchBucket") {
-			if err2 := store.Create(); err2 != nil {
-				return fmt.Errorf("Failed to create %s: %s, previous error: %s\nPlease create bucket %s manually, then format again.",
-					store, err2, err, store)
-			}
-			if err := store.Put(key, bytes.NewReader(data)); err != nil {
-				return fmt.Errorf("Failed to put: %s", err)
-			}
+		if strings.Contains(err.Error(), "Access Denied") {
+			return fmt.Errorf("Failed to put: %s", err)
 		}
-		return fmt.Errorf("Failed to put: %s", err)
+		if err2 := store.Create(); err2 != nil {
+			return fmt.Errorf("Failed to create %s: %s,  previous error: %s\nplease create bucket %s manually, then format again",
+				store, err2, err, store)
+		}
+		if err := store.Put(key, bytes.NewReader(data)); err != nil {
+			return fmt.Errorf("Failed to put: %s", err)
+		}
 	}
 	p, err := store.Get(key, 0, -1)
 	if err != nil {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -95,8 +95,13 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 			return fmt.Errorf("Failed to put: %s", err)
 		}
 		if err2 := store.Create(); err2 != nil {
-			return fmt.Errorf("Failed to create %s: %s,  previous error: %s\nplease create bucket %s manually, then format again",
-				store, err2, err, store)
+			if strings.Contains(err.Error(), "NoSuchBucket") {
+				return fmt.Errorf("Failed to create bucket %s: %s, previous error: %s\nPlease create bucket %s manually, then format again.",
+					store, err2, err, store)
+			} else {
+				return fmt.Errorf("Failed to create bucket %s: %s, previous error: %s",
+					store, err2, err)
+			}
 		}
 		if err := store.Put(key, bytes.NewReader(data)); err != nil {
 			return fmt.Errorf("Failed to put: %s", err)

--- a/pkg/chunk/singleflight_test.go
+++ b/pkg/chunk/singleflight_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-func TestSigleFlight(t *testing.T) {
+func TestSingleFlight(t *testing.T) {
 	g := &Controller{}
 	gp := &sync.WaitGroup{}
 	for i := 0; i < 100000; i++ {


### PR DESCRIPTION
When the bucket does not exist, the object store will return the corresponding error code `NoSuchBucket` (e.g. [S3](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList), [OSS](https://help.aliyun.com/document_detail/185804.htm?#title-p5t-cwc-kcv), [COS](https://cloud.tencent.com/document/product/436/7730#.E9.94.99.E8.AF.AF.E7.A0.81.E5.88.97.E8.A1.A8)). This PR fix creates a bucket only when it really does not exist.

Incorrect conditional judgments can cause the log to output something that is confusing to the user, e.g. `please create bucket XXX manually, then format again`.
