### PR TITLE
fix mkdir on windows platform

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -381,7 +381,7 @@ func (fs *FileSystem) Stat(ctx meta.Context, path string) (fi *FileStat, err sys
 
 // parentDir returns parent of /foo/bar/ as /foo
 func parentDir(p string) string {
-	return filepath.Dir(strings.TrimRight(p, "/"))
+	return path.Dir(strings.TrimRight(p, "/"))
 }
 
 func (fs *FileSystem) Mkdir(ctx meta.Context, p string, mode uint16) (err syscall.Errno) {


### PR DESCRIPTION
On Windows platform, the `mkdir` would result in `FileNotFoundException` as below if we want create a sub directory `126` under directory `xyz`(The JuiceFS volume has been mounted at `Z:`)
```
PS C:\Users\liyong> mkdir Z:/xyz/126
mkdir : Could not find file '126'.
At line:1 char:1
+ mkdir Z:/xyz/126
+ ~~~~~~~~~~~~~~~~
    + CategoryInfo          : WriteError: (Z:\xyz\126:String) [New-Item], FileNotFoundException
    + FullyQualifiedErrorId : CreateDirectoryIOError,Microsoft.PowerShell.Commands.NewItemCommand
```
The directory path for `Mkdir` is canonicalized to `/xyz/126`, but the `parentDir()` uses system dependent `filepath.Dir()` function, which result in `\xyz` instead of the expected `/xyz`. 

This PR fix this problem.