### PR TITLE
cmd: always call setproctitle

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -306,6 +306,6 @@ func removePassword(uri string) {
 				break
 			}
 		}
-		gspt.SetProcTitle(strings.Join(os.Args, " "))
 	}
+	gspt.SetProcTitle(strings.Join(os.Args, " "))
 }


### PR DESCRIPTION
We have to always call the `gspt.SetProcTitle` to adjust the title, or it will be reset to args[0] after the `gspt` package initialized.
See: https://github.com/erikdubbelboer/gspt/blob/ce36a5128377/gspt.go#L55