### PR TITLE
add SAIC Motor in adopter list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -12,6 +12,7 @@ For users of JuiceFS:
 | [Megvii](https://megvii.com)                                                            | Production  | AI                     |
 | [Piesat Information Technology Co., Ltd.](https://www.piesat.cn)                        | Production  | File Sharing           |
 | [Gene Way](http://www.geneway.cn)                                                       | Production  | File Sharing           |
+| [SAIC Motor](https://www.saicmotor.com/english/index.shtml)                             | Production  | AI           |
 | [Dingdong Fresh](https://www.100.me)                                                    | Testing     | Big Data               |
 | [UniSound](https://www.unisound.com)                                                    | Testing     | AI                     |
 | [SF-Express](https://www.sf-express.com)                                                | Testing     | Big Data, File Sharing |

--- a/ADOPTERS_CN.md
+++ b/ADOPTERS_CN.md
@@ -12,6 +12,7 @@
 | [旷视](https://megvii.com)                       | Production | AI                   |
 | [航天宏图](https://www.piesat.cn)                | Production | 共享文件存储         |
 | [溯源精微](http://www.geneway.cn)                | Production | 共享文件存储         |
+| [上汽集团](https://www.saicmotor.com/chinese/)     | Production | AI         |
 | [叮咚买菜](https://www.100.me)                   | Testing    | 大数据               |
 | [云知声](https://www.unisound.com)               | Testing    | AI                   |
 | [顺丰速运](https://www.sf-express.com)           | Testing    | 大数据，共享文件存储 |


### PR DESCRIPTION
SAIC Motor uses JuiceFS in the private cloud, and share their use case in https://mp.weixin.qq.com/s/Lh5UEVw4-gCe6wAVcmznxg

Add SAIC Motor in adopter list.