### PR TITLE
Fixed deadlock when truncate a released file handle.

### DIFF
--- a/pkg/vfs/handle.go
+++ b/pkg/vfs/handle.go
@@ -209,14 +209,12 @@ func (v *VFS) newFileHandle(inode Ino, length uint64, flags uint32) uint64 {
 func (v *VFS) releaseFileHandle(ino Ino, fh uint64) {
 	h := v.findHandle(ino, fh)
 	if h != nil {
+		v.releaseHandle(ino, fh)
 		h.Lock()
-		// rwlock_wait_for_unlock:
 		for (h.writing | h.writers | h.readers) != 0 {
 			h.cond.WaitWithTimeout(time.Millisecond * 100)
 		}
-		h.writing = 1 // for remove
 		h.Unlock()
 		h.Close()
-		v.releaseHandle(ino, fh)
 	}
 }


### PR DESCRIPTION
When a file handle is released, a write lock was hold forever,
then concurrent truncate (open with new handle) will be deadlock.

This PR remove the write lock when release a file handle, also
remove it before closing the handle. There should be no other
read/write operations.