### PR TITLE
docs: Update for_local.md storage option to s3

### DIFF
--- a/docs/en/getting-started/for_local.md
+++ b/docs/en/getting-started/for_local.md
@@ -142,7 +142,7 @@ If the `myjfs.db` file already exists, delete it first and then execute the foll
 :::
 
 ```shell
-juicefs format --storage oss \
+juicefs format --storage s3 \
     --bucket https://myjfs.s3.us-west-1.amazonaws.com \
     --access-key ABCDEFGHIJKLMNopqXYZ \
     --secret-key ZYXwvutsrqpoNMLkJiHgfeDCBA \


### PR DESCRIPTION
As the practice example uses AWS, it would be better to set --storage option to s3 directly.