### PR TITLE
meta/tikv: fix scan of tikv, limiting the upperbound

### DIFF
--- a/pkg/meta/tkv_prefix.go
+++ b/pkg/meta/tkv_prefix.go
@@ -52,8 +52,7 @@ func (tx *prefixTxn) scanRange(begin_, end_ []byte) map[string][]byte {
 }
 func (tx *prefixTxn) scan(prefix []byte, handler func(key, value []byte)) {
 	tx.kvTxn.scan(tx.realKey(prefix), func(key, value []byte) {
-		key = tx.origKey(key)
-		handler(key, value)
+		handler(tx.origKey(key), value)
 	})
 }
 func (tx *prefixTxn) scanKeys(prefix []byte) [][]byte {

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -128,7 +128,7 @@ func (tx *tikvTxn) scanRange(begin, end []byte) map[string][]byte {
 }
 
 func (tx *tikvTxn) scan(prefix []byte, handler func(key, value []byte)) {
-	it, err := tx.Iter(prefix, nil) //nolint:typecheck
+	it, err := tx.Iter(prefix, nextKey(prefix))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
close #1454 

`nil` means unbounded upperBound, which makes `iter` returns unrelated keys