### PR TITLE
docs: ascii punctuations should be used in english documentations

### DIFF
--- a/docs/en/administration/metadata/redis_best_practices.md
+++ b/docs/en/administration/metadata/redis_best_practices.md
@@ -119,7 +119,7 @@ After recovering Redis data, you can continue to use the JuiceFS file system wit
 
 ### Azure Cache for Redis
 
-[Azure Cache for Redis](https://azure.microsoft.com/en-us/services/cache) is a fully managed, in-memory cache that enables high-performance and scalable architectures. Use it to create cloud or hybrid deployments that handle millions of requests per second at sub-millisecond latency—all with the configuration, security, and availability benefits of a managed service.
+[Azure Cache for Redis](https://azure.microsoft.com/en-us/services/cache) is a fully managed, in-memory cache that enables high-performance and scalable architectures. Use it to create cloud or hybrid deployments that handle millions of requests per second at sub-millisecond latency-all with the configuration, security, and availability benefits of a managed service.
 
 ### Alibaba Cloud ApsaraDB for Redis
 

--- a/docs/en/benchmark/stats_watcher.md
+++ b/docs/en/benchmark/stats_watcher.md
@@ -13,25 +13,25 @@ By default, this command will monitor the JuiceFS process corresponding to the s
 
 #### usage
 
-- cpu：CPU usage of the process
-- mem：physical memory used by the process
-- buf：current buffer size of JuiceFS, limited by mount option `--buffer-size`
+- cpu: CPU usage of the process
+- mem: physical memory used by the process
+- buf: current buffer size of JuiceFS, limited by mount option `--buffer-size`
 
 #### fuse
 
-- ops/lat：number of operations handled by FUSE per second, and the average latency (in milliseconds) of them
-- read/write：read/write bandwidth handled by FUSE
+- ops/lat: number of operations handled by FUSE per second, and the average latency (in milliseconds) of them
+- read/write: read/write bandwidth handled by FUSE
 
 #### meta
 
-- ops/lat：number of metadata operations and the average latency (in milliseconds) of them. Please note operations returned directly in cache are not counted, so that the result is closer to real performance of metadata engines
+- ops/lat: number of metadata operations and the average latency (in milliseconds) of them. Please note operations returned directly in cache are not counted, so that the result is closer to real performance of metadata engines
 
 #### blockcache
 
-- read/write：read/write bandwidth of client local data cache
+- read/write: read/write bandwidth of client local data cache
 
 #### object
 
-- get/put：Get/Put bandwidth between client and object storage
+- get/put: Get/Put bandwidth between client and object storage
 
 Moreover, users can acquire verbose statistics (like read/write ops and the average latency) by setting `--verbosity 1`, or customize displayed items by changing `--schema`. For more information, please check `juicefs stats -h`.

--- a/docs/en/getting-started/_quick_start_guide.md
+++ b/docs/en/getting-started/_quick_start_guide.md
@@ -13,7 +13,7 @@ To create a JuiceFS file system, you need the following 3 preparations:
 3. JuiceFS Client
 
 :::tip
-Don’t know JuiceFS? You can check first [What is JuiceFS?](../introduction/introduction.md)
+Don't know JuiceFS? You can check first [What is JuiceFS?](../introduction/introduction.md)
 :::
 
 ## 1. Redis Database
@@ -57,8 +57,8 @@ $ sudo docker run -d --name minio \
 
 Then, access the service:
 
-- **MinIO Web Console**：http://127.0.0.1:9900
-- **MinIO API**：http://127.0.0.1:9000
+- **MinIO Web Console**: http://127.0.0.1:9900
+- **MinIO API**: http://127.0.0.1:9000
 
 The initial Access Key and Secret Key of the root user are both `minioadmin`.
 

--- a/docs/en/getting-started/for_local.md
+++ b/docs/en/getting-started/for_local.md
@@ -10,7 +10,7 @@ The JuiceFS file system consists of ["Object Storage"](../reference/how_to_setup
 
 ## Install Client
 
-For details, please refer to [Installation & Upgrade](installation.md)。
+For details, please refer to [Installation & Upgrade](installation.md).
 
 Regardless of the operating system you are using, when you execute `juicefs` in the terminal and it returns the help message of the program, it means that you have successfully installed the JuiceFS client.
 
@@ -31,7 +31,7 @@ As you can see, there are 3 types of information required to format a file syste
 3. **NAME**: the name of the file system.
 
 :::tip
-JuiceFS supports a wide range of storage media and metadata storage engines, see [JuiceFS supported storage medias](../reference/how_to_setup_object_storage.md) and [JuiceFS supported metadata storage engines](../reference/how_to_setup_metadata_engine.md)。
+JuiceFS supports a wide range of storage media and metadata storage engines, see [JuiceFS supported storage medias](../reference/how_to_setup_object_storage.md) and [JuiceFS supported metadata storage engines](../reference/how_to_setup_metadata_engine.md).
 :::
 
 ### Hands-on Practice

--- a/docs/en/reference/how_to_setup_metadata_engine.md
+++ b/docs/en/reference/how_to_setup_metadata_engine.md
@@ -248,7 +248,7 @@ $ juicefs format --storage s3 \
     pics
 ```
 
-Executing the above command will automatically create a database file named `my-jfs.db` in the current directory, **please take good care of this file**！
+Executing the above command will automatically create a database file named `my-jfs.db` in the current directory, **please take good care of this file**!
 
 Mount the file system:
 

--- a/docs/en/reference/how_to_setup_object_storage.md
+++ b/docs/en/reference/how_to_setup_object_storage.md
@@ -689,8 +689,8 @@ $ sudo docker run -d --name minio \
 
 It is accessed using the following address:
 
-- **MinIO UI**：[http://127.0.0.1:9900](http://127.0.0.1:9900/)
-- **MinIO API**：[http://127.0.0.1:9000](http://127.0.0.1:9000/)
+- **MinIO UI**: [http://127.0.0.1:9900](http://127.0.0.1:9900/)
+- **MinIO API**: [http://127.0.0.1:9000](http://127.0.0.1:9000/)
 
 The initial Access Key and Secret Key of the object store are both `minioadmin`.
 

--- a/docs/en/reference/posix_compatibility.md
+++ b/docs/en/reference/posix_compatibility.md
@@ -53,7 +53,7 @@ JuiceFS passed most of its file system related tests.
 ### Test Steps
 
 1. Download LTP [release](https://github.com/linux-test-project/ltp/releases/download/20210524/ltp-full-20210524.tar.bz2) from GitHub
-2. Unarchive, compile and install：
+2. Unarchive, compile and install:
 
 ```bash
 $ tar -jvxf ltp-full-20210524.tar.bz2
@@ -100,11 +100,11 @@ Machine Architecture: x86_64
 
 Reasons for the skipped and failed tests:
 
-- fcntl17，fcntl17_64: automatically detect deadlock when trying to add POSIX locks. JuiceFS doesn't support it yet
+- fcntl17, fcntl17_64: automatically detect deadlock when trying to add POSIX locks. JuiceFS doesn't support it yet
 - getxattr05: need ACL, which is not supported yet
-- ioctl_loop05，ioctl_ns07，setxattr03: need `ioctl`, which is not supported yet
+- ioctl_loop05, ioctl_ns07, setxattr03: need `ioctl`, which is not supported yet
 - lseek11: handle SEEK_DATA and SEEK_HOLE flags properly in `lseek`. JuiceFS uses kernel general function, which doesn't support these two flags
-- open14，openat03: handle O_TMPFILE flag in `open`. JuiceFS can do nothing with it since it's not supported by FUSE
+- open14, openat03: handle O_TMPFILE flag in `open`. JuiceFS can do nothing with it since it's not supported by FUSE
 
 ### Appendix
 

--- a/docs/en/tutorials/aliyun.md
+++ b/docs/en/tutorials/aliyun.md
@@ -52,7 +52,7 @@ If you must access the database through the public network, you can enhance the 
 
 On the other hand, if you cannot successfully connect to the cloud database through the public network, then you can check the whitelist of the database.
 
-|    Database     |                          Redis                          |                      MySQL、PostgreSQL                       |                            SQLite                            |
+|    Database     |                          Redis                          |                      MySQL/PostgreSQL                       |                            SQLite                            |
 | :-------------: | :-----------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
 | **Performance** |                          High                           |                            Medium                            |                             Low                              |
 | **Management**  |                          High                           |                            Medium                            |                             Low                              |

--- a/docs/en/tutorials/juicefs_on_k3s.md
+++ b/docs/en/tutorials/juicefs_on_k3s.md
@@ -13,8 +13,8 @@ In this article, we will build a K3s cluster with two nodes, install and configu
 
 K3s has very low **minimum requirements** for hardware:
 
-- **Memory**：512MB+（recommend 1GB+）
-- **CPU**：1 core
+- **Memory**: 512MB+ (recommend 1GB+)
+- **CPU**: 1 core
 
 When deploying a production cluster, you can usually use the Raspberry Pi 4B (4 CPU cores, 8G memory) as the starting point for the hardware of a node. For details, see [Hardware Requirements](https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#hardware).
 
@@ -38,7 +38,7 @@ NAME     STATUS   ROLES                  AGE   VERSION
 k3s-s1   Ready    control-plane,master   28h   v1.21.4+k3s1
 ```
 
-Get the `node-token`：
+Get the `node-token`:
 
 ```shell
 $ sudo -u root cat /var/lib/rancher/k3s/server/node-token

--- a/docs/en/tutorials/juicefs_on_kubesphere.md
+++ b/docs/en/tutorials/juicefs_on_kubesphere.md
@@ -34,7 +34,7 @@ To install JuiceFS CSI Driver, you first need to create an application template.
 Click in the workspace to enter the application management, select "App Repositories", click the create button to add JuiceFS CSI Repository, fill in:
 
 - Repository name: juicefs-csi-driver
-- Index URL：https://juicedata.github.io/juicefs-csi-driver/
+- Index URL: https://juicedata.github.io/juicefs-csi-driver/
 
 ![](../images/kubesphere_app_shop_en.png)
 

--- a/docs/en/tutorials/qcloud.md
+++ b/docs/en/tutorials/qcloud.md
@@ -28,7 +28,7 @@ JuiceFS can be installed on all operating systems provided by Tencent Cloud CVM.
 | **CPU**               | 1 Core                   |
 | **RAM**               | 2 GB                     |
 | **Storage**           | 50 GB                    |
-| **OS**                | Ubuntu Server 20.04 64位 |
+| **OS**                | Ubuntu Server 20.04 64-bit |
 | **Location**          | Shanghai 5               |
 
 ### 2. Database
@@ -43,7 +43,7 @@ Of course, you can also use cloud database services provided on other cloud plat
 
 If you must access the database through the public network, you can enhance the security of your data by strictly limiting the IP addresses that are allowed to access the database through the whitelist feature provided by the cloud database console. On the other hand, if you cannot connect to the cloud database through the public network, then you can check the whitelist of the database.
 
-|    Database     |                          Redis                          |                      MySQL、PostgreSQL                       |                            SQLite                            |
+|    Database     |                          Redis                          |                      MySQL/PostgreSQL                       |                            SQLite                            |
 | :-------------: | :-----------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
 | **Performance** |                          High                           |                            Medium                            |                             Low                              |
 | **Management**  |                          High                           |                            Medium                            |                             Low                              |


### PR DESCRIPTION
Some punctuations scattered in `docs/en` should be ASCII chars but unicode currently.