### PR TITLE
CI: change windows version

### DIFF
--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/**'
 
 
+
 jobs:
   wintest:
     runs-on: windows-2019

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   wintest:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       Actions_Allow_Unsecure_Commands: true
     steps:


### PR DESCRIPTION
The failed action is https://github.com/juicedata/juicefs/runs/5316344226?check_suite_focus=true and
the reason is the update of window's version . More details may refer to https://github.com/actions/virtual-environments/issues/4856 .