### PR TITLE
fix s3 gateway DeleteObjects panic

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -390,12 +390,14 @@ func (n *jfsObjects) DeleteObject(ctx context.Context, bucket, object string, op
 }
 
 func (n *jfsObjects) DeleteObjects(ctx context.Context, bucket string, objects []minio.ObjectToDelete, options minio.ObjectOptions) (objs []minio.DeletedObject, errs []error) {
-	for _, object := range objects {
-		_, err := n.DeleteObject(ctx, bucket, object.ObjectName, options)
-		if err == nil {
-			objs = append(objs, minio.DeletedObject{ObjectName: object.ObjectName})
-		} else {
-			errs = append(errs, err)
+	objs = make([]minio.DeletedObject, len(objects))
+	errs = make([]error, len(objects))
+	for idx, object := range objects {
+		_, errs[idx] = n.DeleteObject(ctx, bucket, object.ObjectName, options)
+		if errs[idx] == nil {
+			objs[idx] = minio.DeletedObject{
+				ObjectName: object.ObjectName,
+			}
 		}
 	}
 	return


### PR DESCRIPTION
delete objects will cause panic when has errs, use the same logic as gateway-s3.go (L:538)

**panic here：**
![screenshot-20220307-162608](https://user-images.githubusercontent.com/6017354/156999308-f37ed511-85fd-4dbc-ab71-895063088203.png)
![screenshot-20220307-164542](https://user-images.githubusercontent.com/6017354/156999422-7c6352b3-447a-4d4f-9631-3040f9eb9de8.png)
 
**fix this bug, reference gateway-s3.go  (L:538) logic:**
![screenshot-20220307-165651](https://user-images.githubusercontent.com/6017354/156999534-5da2c608-7782-4a9a-b82a-17f186e45230.png)

