### PR TITLE
make: disable JFS_PAGE_STACK for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,5 @@ release:
 		juicedata/golang-cross:latest release --rm-dist
 
 test:
-	JFS_PAGE_STACK=1 go test -v -cover ./pkg/... -coverprofile=cov1.out
-	sudo JFS_PAGE_STACK=1 JFS_GC_SKIPPEDTIME=1 `which go` test -v -cover ./cmd/... -coverprofile=cov2.out -coverpkg=./pkg/...,./cmd/...
+	go test -v -cover ./pkg/... -coverprofile=cov1.out
+	sudo JFS_GC_SKIPPEDTIME=1 `which go` test -v -cover ./cmd/... -coverprofile=cov2.out -coverpkg=./pkg/...,./cmd/...


### PR DESCRIPTION
close #1540 
Test may fail because of deep stack:
```
=== RUN   TestSingleFlight
panic: runtime error: growslice: cap out of range
goroutine 83304 [running]:
github.com/juicedata/juicefs/pkg/chunk.(*Page).Acquire(0xc014cf9580)
	/home/travis/gopath/src/github.com/juicedata/juicefs/pkg/chunk/page.go:77 +0x125
github.com/juicedata/juicefs/pkg/chunk.(*Controller).Execute(0xc000557a60, 0x1bc5736, 0x2, 0x1bce9b8, 0xc014cf82c0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/juicedata/juicefs/pkg/chunk/singleflight.go:42 +0xe5
github.com/juicedata/juicefs/pkg/chunk.TestSingleFlight.func1(0xc000557a60, 0xc000046cb0, 0x14484)
	/home/travis/gopath/src/github.com/juicedata/juicefs/pkg/chunk/singleflight_test.go:32 +0x7e
created by github.com/juicedata/juicefs/pkg/chunk.TestSingleFlight
	/home/travis/gopath/src/github.com/juicedata/juicefs/pkg/chunk/singleflight_test.go:31 +0xa6
```