### PR TITLE
Fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
   - id: juicefs-linux-amd64
     env:
       - CC=/usr/bin/musl-gcc
-    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.CommitDate}} -linkmode external -extldflags '-static'
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}} -linkmode external -extldflags '-static'
     main: ./cmd
     goos:
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,16 @@ builds:
       - darwin
     goarch:
       - amd64
+  - id: juicefs-darwin-arm64
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}}
+    main: ./cmd
+    goos:
+      - darwin
+    goarch:
+      - arm64
   - id: juicefs-linux-amd64
     env:
       - CC=/usr/bin/musl-gcc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     env:
       - CC=x86_64-w64-mingw32-gcc
       - CXX=x86_64-w64-mingw32-g++
-    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.CommitDate}}
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}}
     flags:
       - -buildmode
       - exe
@@ -27,7 +27,7 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.CommitDate}}
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}}
     main: ./cmd
     goos:
       - darwin
@@ -45,7 +45,7 @@ builds:
   - id: juicefs-linux-arm64
     env:
       - CC=aarch64-linux-gnu-gcc
-    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.CommitDate}}
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}}
     main: ./cmd
     goos:
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ project_name: juicefs
 env:
   - GO111MODULE=on
   - CGO_ENABLED=1
+  - REVISIONDATE={{ .Env.REVISIONDATE }}
 before:
   hooks:
     - go mod download

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ juicefs.exe: /usr/local/include/winfsp cmd/*.go pkg/*/*.go
 .PHONY: snapshot release test
 snapshot:
 	docker run --rm --privileged \
+		-e REVISIONDATE=$(REVISIONDATE) \
 		-e PRIVATE_KEY=${PRIVATE_KEY} \
 		-v ~/go/pkg/mod:/go/pkg/mod \
 		-v `pwd`:/go/src/github.com/juicedata/juicefs \

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ snapshot:
 
 release:
 	docker run --rm --privileged \
+		-e REVISIONDATE=$(REVISIONDATE) \
 		-e PRIVATE_KEY=${PRIVATE_KEY} \
 		--env-file .release-env \
 		-v ~/go/pkg/mod:/go/pkg/mod \


### PR DESCRIPTION
1. `.CommitDate` of new version of [goreleaser](https://github.com/goreleaser/goreleaser) has timestamp part, use environment instead of `.CommitDate`
2. Add macOS arm64 arch build `juicefs` binary