### PR TITLE
delte local cache even max-deletes=0

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -295,6 +295,7 @@ func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 		CacheMode:      os.FileMode(0600),
 		CacheFullBlock: !c.Bool("cache-partial-only"),
 		AutoCreate:     true,
+		MaxDeletes:     c.Int("max-deletes"),
 	}
 
 	if chunkConf.CacheDir != "memory" {

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -294,7 +294,6 @@ func (c *rChunk) Remove() error {
 				err = e
 			}
 		}
-		c.store.bcache.remove(key)
 	}
 	return err
 }

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -289,9 +289,12 @@ func (c *rChunk) Remove() error {
 		delete(c.store.pendingKeys, key)
 		c.store.pendingMutex.Unlock()
 		c.store.bcache.remove(key)
-		if e := c.delete(i); e != nil {
-			err = e
+		if c.store.conf.MaxDeletes >= 1 {
+			if e := c.delete(i); e != nil {
+				err = e
+			}
 		}
+		c.store.bcache.remove(key)
 	}
 	return err
 }
@@ -654,6 +657,7 @@ type Config struct {
 	BufferSize     int
 	Readahead      int
 	Prefetch       int
+	MaxDeletes     int
 }
 
 type cachedStore struct {


### PR DESCRIPTION
When we set `max-delete=0`,  Juicefs will not start any thread to delete the block, even if the block in local. However, `max-delete` should control the number of delete requests to the object storage. Deleting the data in the local cache will not affect it.