### PR TITLE
meta/redis: use smaller retry backoff in sentinel mode

### DIFF
--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -19,11 +19,13 @@ package meta
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -59,6 +61,23 @@ type freeID struct {
 }
 
 var logger = utils.GetLogger("juicefs")
+
+type queryMap struct {
+	url.Values
+}
+
+func (qm *queryMap) duration(key string, d time.Duration) time.Duration {
+	val := qm.Get(key)
+	if val == "" {
+		return d
+	}
+	if dur, err := time.ParseDuration(val); err == nil {
+		return dur
+	} else {
+		logger.Warnf("Parse duration %s for key %s: %s", val, key, err)
+		return d
+	}
+}
 
 func errno(err error) syscall.Errno {
 	if err == nil {


### PR DESCRIPTION
#1593 

```
try = 0: sleep = 0
	if kill -9 (connection refused): write wait = 0
	if down host (i/o timeout): write wait = opt.WriteTimeout = 5s
min, max = opt.MinRetryBackoff, opt.MaxRetryBackoff = 20ms, 10s
try = 1; sleep ~= min << 1 / 2 + min = 40ms
try = 2; sleep ~= min << 2 / 2 + min = 60ms
...
try = 9; sleep ~= min << 9 / 2 + min = 5s
try = 10; sleep ~= min << 10 / 2 + min = 10s

Once = (10 + 5 + 2.5 + 1.25 + ...) + 11 * (write wait)
	= 20s or 75s
Total = Once * 2
	= 40s or 150s
```