### PR TITLE
Workflow: canonicalize Hadoop Java SDK name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Build SDK
         run: make -C sdk/java package-all && sudo chown -R $USER sdk/java/target
 
+      - name: Canonicalize SDK name
+        run: |
+          sdk1=$(ls sdk/java/target/juicefs-hadoop-*.jar)
+          sdk2=$(echo $sdk1 | sed 's@^\(.*\)\.jar$@\1-amd64.jar@')
+          mv $sdk1 $sdk2
+        shell: bash
+
       - name: Upload SDK
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Add the `-amd64` suffix to the JAR package name of the Hadoop Java SDK to indicate the CPU architecture
