### PR TITLE
sync: fix empty value of StringSliceFlag

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -623,7 +623,7 @@ func producer(tasks chan<- object.Object, src, dst object.ObjectStorage, config 
 	if err != nil {
 		logger.Fatal(err)
 	}
-	if config.Exclude != nil {
+	if len(config.Exclude) > 0 {
 		rules := initRules(src, dst)
 		srckeys = filter(srckeys, rules)
 		dstkeys = filter(dstkeys, rules)
@@ -834,7 +834,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 
 	if config.Manager == "" {
 		go producer(tasks, src, dst, config)
-		if config.Workers != nil {
+		if len(config.Workers) > 0 {
 			addr, err := startManager(tasks)
 			if err != nil {
 				return err


### PR DESCRIPTION
After upgrading `urfave` from v2.3.0 to v2.4.0, the default value of StringSliceFlag is an empty slice, not nil any more (maybe a bug of `urfave` cuz the comment is not changed)