### PR TITLE
sqlite test load dump err

### DIFF
--- a/pkg/meta/load_dump_test.go
+++ b/pkg/meta/load_dump_test.go
@@ -111,6 +111,7 @@ func TestLoadDump(t *testing.T) {
 		m := testLoad(t, sqluri, sampleFile)
 		testDump(t, m, 1, sampleFile, "sqlite3.dump")
 	})
+	
 	t.Run("Metadata Engine: SQLite --SubDir d1", func(t *testing.T) {
 		_ = testLoad(t, sqluri, sampleFile)
 		m := NewClient(sqluri, &Config{Retries: 10, Strict: true, Subdir: "d1"})


### PR DESCRIPTION
https://app.travis-ci.com/github/juicedata/juicefs/builds/248772028
The specific err is as follows
--- FAIL: TestLoadDump (0.91s)
    --- PASS: TestLoadDump/Metadata_Engine:_Redis (0.02s)
    --- PASS: TestLoadDump/Metadata_Engine:_Redis;_--SubDir_d1_ (0.02s)
    --- PASS: TestLoadDump/Metadata_Engine:_SQLite (0.43s)
    --- FAIL: TestLoadDump/Metadata_Engine:_SQLite_--SubDir_d1 (0.43s)
    --- PASS: TestLoadDump/Metadata_Engine:_TKV (0.00s)
    --- PASS: TestLoadDump/Metadata_Engine:_TKV_--SubDir_d1_ (0.00s)