### PR TITLE
meta: create subdir automatically

### DIFF
--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -125,13 +125,18 @@ func lookupSubdir(m Meta, subdir string) (Ino, error) {
 		ps := strings.SplitN(subdir, "/", 2)
 		if ps[0] != "" {
 			var attr Attr
-			r := m.Lookup(Background, root, ps[0], &root, &attr)
+			var inode Ino
+			r := m.Lookup(Background, root, ps[0], &inode, &attr)
+			if r == syscall.ENOENT {
+				r = m.Mkdir(Background, root, ps[0], 0777, 0, 0, &inode, &attr)
+			}
 			if r != 0 {
 				return 0, fmt.Errorf("lookup subdir %s: %s", ps[0], r)
 			}
 			if attr.Typ != TypeDirectory {
 				return 0, fmt.Errorf("%s is not a redirectory", ps[0])
 			}
+			root = inode
 		}
 		if len(ps) == 1 {
 			break


### PR DESCRIPTION
fix #1709 

The auto-created subdir has mode 777, and uid/gid = 0.