### PR TITLE
Verify Etag from OBS

### DIFF
--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -199,12 +199,11 @@ func (s *obsClient) UploadPart(key string, uploadID string, num int, body []byte
 	sum := md5.Sum(body)
 	params.ContentMD5 = base64.StdEncoding.EncodeToString(sum[:])
 	resp, err := s.c.UploadPart(params)
+	if err == nil && strings.Trim(resp.ETag, "\"") != obs.Hex(sum[:]) {
+		err = fmt.Errorf("unexpected ETag: %s != %s", strings.Trim(resp.ETag, "\""), obs.Hex(sum[:]))
+	}
 	if err != nil {
 		return nil, err
-	}
-	hexMd5 := obs.Hex(sum[:])
-	if resp.ETag != hexMd5 {
-		return nil, fmt.Errorf("unexpected ETag: %s != %s", resp.ETag, hexMd5)
 	}
 	return &Part{Num: num, ETag: resp.ETag}, err
 }

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -51,6 +51,7 @@ func (s *obsClient) Create() error {
 	params := &obs.CreateBucketInput{}
 	params.Bucket = s.bucket
 	params.Location = s.region
+	params.AvailableZone = "3az"
 	_, err := s.c.CreateBucket(params)
 	if err != nil && isExists(err) {
 		err = nil
@@ -128,9 +129,8 @@ func (s *obsClient) Put(key string, in io.Reader) error {
 	params.ContentMD5 = base64.StdEncoding.EncodeToString(sum[:])
 	params.ContentType = mimeType
 	resp, err := s.c.PutObject(params)
-	hexMd5 := obs.Hex(sum)
-	if err == nil && resp.ETag != hexMd5 {
-		err = fmt.Errorf("unexpected ETag: %s != %s", resp.ETag, hexMd5)
+	if err == nil && strings.Trim(resp.ETag, "\"") != obs.Hex(sum) {
+		err = fmt.Errorf("unexpected ETag: %s != %s", strings.Trim(resp.ETag, "\""), obs.Hex(sum))
 	}
 	return err
 }


### PR DESCRIPTION
We have experienced data loss from OBS silently, so we should double check the returned ETag from OBS. 