### PR TITLE
sql: changing name column type to binary type

### DIFF
--- a/pkg/meta/dump.go
+++ b/pkg/meta/dump.go
@@ -132,9 +132,9 @@ func parseHex(c byte) (byte, error) {
 	}
 }
 
-func unescape(s string) string {
+func unescape(s string) []byte {
 	if !strings.ContainsRune(s, '%') {
-		return s
+		return []byte(s)
 	}
 
 	p := []byte(s)
@@ -152,7 +152,7 @@ func unescape(s string) string {
 		p[n] = c
 		n++
 	}
-	return string(p[:n])
+	return p[:n]
 }
 
 func (de *DumpedEntry) writeJSON(bw *bufio.Writer, depth int) error {

--- a/pkg/meta/load_dump_test.go
+++ b/pkg/meta/load_dump_test.go
@@ -33,13 +33,13 @@ const sampleFile = "metadata.sample"
 const subSampleFile = "metadata-sub.sample"
 
 func TestEscape(t *testing.T) {
-	var cs []byte = []byte("hello 世界")
+	var cs = []byte("hello 世界")
 	for i := 0; i < 256; i++ {
 		cs = append(cs, byte(i))
 	}
 	s := string(cs)
 	r := unescape(escape(s))
-	if r != s {
+	if bytes.Compare(r, cs) != 0 {
 		t.Fatalf("expected %v, but got %v", s, r)
 	}
 }

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3055,7 +3055,7 @@ func (m *redisMeta) loadEntry(e *DumpedEntry, cs *DumpedCounters, refs map[strin
 		if len(e.Entries) > 0 {
 			dentries := make(map[string]interface{})
 			for _, c := range e.Entries {
-				dentries[unescape(c.Name)] = m.packEntry(typeFromString(c.Attr.Type), c.Attr.Inode)
+				dentries[string(unescape(c.Name))] = m.packEntry(typeFromString(c.Attr.Type), c.Attr.Inode)
 			}
 			p.HSet(ctx, m.entryKey(inode), dentries)
 		}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -54,7 +54,7 @@ type counter struct {
 
 type edge struct {
 	Parent Ino    `xorm:"unique(edge) notnull"`
-	Name   []byte `xorm:"unique(edge) varbinary(1024) notnull"`
+	Name   []byte `xorm:"unique(edge) varbinary(2048) notnull"`
 	Inode  Ino    `xorm:"notnull"`
 	Type   uint8  `xorm:"notnull"`
 }
@@ -77,7 +77,7 @@ type node struct {
 
 type namedNode struct {
 	node `xorm:"extends"`
-	Name []byte `xorm:"varbinary(1024)"`
+	Name []byte `xorm:"varbinary(2048)"`
 }
 
 type chunk struct {
@@ -92,7 +92,7 @@ type chunkRef struct {
 }
 type symlink struct {
 	Inode  Ino    `xorm:"pk"`
-	Target []byte `xorm:"varbinary(1024) notnull"`
+	Target []byte `xorm:"blob notnull"`
 }
 
 type xattr struct {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2314,7 +2314,7 @@ func (m *kvMeta) loadEntry(e *DumpedEntry, cs *DumpedCounters, refs map[string]i
 		} else if attr.Typ == TypeDirectory {
 			attr.Length = 4 << 10
 			for _, c := range e.Entries {
-				tx.set(m.entryKey(inode, unescape(c.Name)), m.packEntry(typeFromString(c.Attr.Type), c.Attr.Inode))
+				tx.set(m.entryKey(inode, string(unescape(c.Name))), m.packEntry(typeFromString(c.Attr.Type), c.Attr.Inode))
 			}
 		} else if attr.Typ == TypeSymlink {
 			symL := unescape(e.Symlink)


### PR DESCRIPTION
This pr is mainly to solve the problem that juicefs cannot create files whose filenames are not UTF8 encoded when using the sql type of metadata engine
To solve this problem, the metadata database field type needs to be updated, so there is a certain compatibility problem with the old version. The following is a smooth upgrade scheme for upgrading the old version to this version:

1. If there are old clients in mount state, they can be upgraded without stopping them
2. Enter the metadata database and manually execute sql
```sql
alter table jfs_edge
    modify name varbinary(2048) not null;
alter table jfs_symlink
    modify target blob not null;
```


3. At this time, the old client in the mount state can already write files with non-utf8 file names, but it should be noted that after executing sql, the old version of the client cannot use the metadata engine to remount, That is to say, the client in the non-mounted state is incompatible with the metadata engine after executing sql, and a new version of the client is required to mount. 

Close #1684  #1567 