### PR TITLE
Add log to print SA email when create a GCS client

### DIFF
--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -182,16 +182,17 @@ func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 		return nil, err
 	}
 
+	// The block below only logs the GCS client's credential service account's email and type, added for providing extra useful logging information to end users.
 	credential, err := google.FindDefaultCredentials(ctx)
 	if err == nil {
 		credentialContent := map[string]interface{}{}
 		if err := json.Unmarshal(credential.JSON, &credentialContent); err == nil {
-			logger.Infof("GCS client credentail client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
+			logger.Infof("GCS client credentail's client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
 		} else {
 			logger.Errorf("GCS client credential's json unmarshal error: %v", err)
 		}
 	} else {
-		logger.Errorf("GCS client fetches default credential error: %v", err)
+		logger.Errorf("GCS client fetching default credential failed with error: %v", err)
 	}
 
 	return &gs{client: client, bucket: bucket, region: region}, nil

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -184,8 +184,11 @@ func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 
 	credential, err := google.FindDefaultCredentials(ctx)
 	credentialContent := map[string]interface{}{}
-	json.Unmarshal(credential.JSON, &credentialContent)
-	logger.Infof("GCS client credentail client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
+	if err := json.Unmarshal(credential.JSON, &credentialContent); err == nil {
+		logger.Infof("GCS client credentail client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
+	} else {
+		logger.Errorf("google.FindDefaultCredentials json unmarshal error: %v", err)
+	}
 
 	return &gs{client: client, bucket: bucket, region: region}, nil
 }

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -55,7 +55,16 @@ func (g *gs) Create() error {
 		return nil
 	}
 
-	projectID := getProjectID()
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if projectID == "" {
+		projectID, _ = metadata.ProjectID()
+	}
+	if projectID == "" {
+		cred, err := google.FindDefaultCredentials(context.Background())
+		if err == nil {
+			projectID = cred.ProjectID
+		}
+	}
 	if projectID == "" {
 		return errors.New("GOOGLE_CLOUD_PROJECT environment variable must be set")
 	}
@@ -146,20 +155,6 @@ func (g *gs) List(prefix, marker string, limit int64) ([]Object, error) {
 		objs[i] = &obj{item.Name, item.Size, item.Updated, strings.HasSuffix(item.Name, "/")}
 	}
 	return objs, nil
-}
-
-func getProjectID() string {
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	if projectID == "" {
-		projectID, _ = metadata.ProjectID()
-	}
-	if projectID == "" {
-		cred, err := google.FindDefaultCredentials(context.Background())
-		if err == nil {
-			projectID = cred.ProjectID
-		}
-	}
-	return projectID
 }
 
 func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -21,6 +21,7 @@ package object
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -180,11 +181,23 @@ func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	if err != nil {
 		return nil, err
 	}
+	logger.Infof("Pid: %v", getProjectID())
 	if serviceAccount, err := client.ServiceAccount(ctx, getProjectID()); err == nil {
 		logger.Infof("GCS client created with ServiceAccount: %v", serviceAccount)
 	} else {
 		logger.Infof("GCS client created without ServiceAccount")
 	}
+
+	credential, err := google.FindDefaultCredentials(ctx)
+	content := map[string]interface{}{}
+
+	json.Unmarshal(credential.JSON, &content)
+	if content["client_email"] != nil {
+		logger.Infof("GCS client email: %v", content["client_email"])
+	} else {
+		logger.Infof("WARNING: no service account credential. User account credential?")
+	}
+
 	return &gs{client: client, bucket: bucket, region: region}, nil
 }
 

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -185,12 +185,7 @@ func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	credential, err := google.FindDefaultCredentials(ctx)
 	credentialContent := map[string]interface{}{}
 	json.Unmarshal(credential.JSON, &credentialContent)
-	logger.Infof("credentialContent: %v", credentialContent)
-	if credentialContent["client_email"] != nil {
-		logger.Infof("GCS client credentail client_email: %v, type: %v", credentialContent["client_email"], credentialContent["type"])
-	} else {
-		logger.Warnf("GCS client credentail has no service account email, type: %v", credentialContent["type"])
-	}
+	logger.Infof("GCS client credentail client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
 
 	return &gs{client: client, bucket: bucket, region: region}, nil
 }

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -183,11 +183,15 @@ func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	}
 
 	credential, err := google.FindDefaultCredentials(ctx)
-	credentialContent := map[string]interface{}{}
-	if err := json.Unmarshal(credential.JSON, &credentialContent); err == nil {
-		logger.Infof("GCS client credentail client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
+	if err == nil {
+		credentialContent := map[string]interface{}{}
+		if err := json.Unmarshal(credential.JSON, &credentialContent); err == nil {
+			logger.Infof("GCS client credentail client_email: \"%v\", type: \"%v\"", credentialContent["client_email"], credentialContent["type"])
+		} else {
+			logger.Errorf("GCS client credential's json unmarshal error: %v", err)
+		}
 	} else {
-		logger.Errorf("google.FindDefaultCredentials json unmarshal error: %v", err)
+		logger.Errorf("GCS client fetches default credential error: %v", err)
 	}
 
 	return &gs{client: client, bucket: bucket, region: region}, nil

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -181,21 +181,15 @@ func newGS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("Pid: %v", getProjectID())
-	if serviceAccount, err := client.ServiceAccount(ctx, getProjectID()); err == nil {
-		logger.Infof("GCS client created with ServiceAccount: %v", serviceAccount)
-	} else {
-		logger.Infof("GCS client created without ServiceAccount")
-	}
 
 	credential, err := google.FindDefaultCredentials(ctx)
-	content := map[string]interface{}{}
-
-	json.Unmarshal(credential.JSON, &content)
-	if content["client_email"] != nil {
-		logger.Infof("GCS client email: %v", content["client_email"])
+	credentialContent := map[string]interface{}{}
+	json.Unmarshal(credential.JSON, &credentialContent)
+	logger.Infof("credentialContent: %v", credentialContent)
+	if credentialContent["client_email"] != nil {
+		logger.Infof("GCS client credentail client_email: %v, type: %v", credentialContent["client_email"], credentialContent["type"])
 	} else {
-		logger.Infof("WARNING: no service account credential. User account credential?")
+		logger.Warnf("GCS client credentail has no service account email, type: %v", credentialContent["type"])
 	}
 
 	return &gs{client: client, bucket: bucket, region: region}, nil


### PR DESCRIPTION
So to help debug with issues when connecting with GCS
https://juicefs.slack.com/archives/C03400WJ2C8/p1649932508711669

And this allows me to test with different ways of google auth login:

So if I do `gcloud auth application-default login` but start juices directly, I got:
```
2022/04/14 14:22:31.439873 juicefs[10746] <INFO>: GCS client credentail client_email: "<nil>", type: "<nil>" [gs.go:188]
```
And this will only make allow me to read the buckets but not able to write (permission error)

And if I do `gcloud auth application-default login` but start juices with `export GOOGLE_APPLICATION_CREDENTIALS=/content/.config/application_default_credentials.json`
then it is like:
```
2022/04/14 14:25:16.601912 juicefs[10778] <INFO>: GCS client credentail client_email: "<nil>", type: "authorized_user" [gs.go:188]
```
This will allow me to write.

So adding this log I feel is quite helpful and also if some service account is used it also can print out the SA's email.