### PR TITLE
add Trip.com in adopter list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,6 +17,7 @@ For users of JuiceFS:
 | [UniSound](https://www.unisound.com)                                                    | Production  | AI                     |
 | [NetEase Games](http://www.neteasegames.com)                                            | Production  | Big Data, File Sharing |
 | [Yimian](https://www.yimian.io)                                                         | Production  | Big Data               |
+| [Trip.com](https://us.trip.com/)                                                        | Prodcution  | Big Data, File Sharing |
 | [Volcano Engine](https://www.volcengine.com)                                            | Testing     | File Sharing           |
 | [Dingdong Fresh](https://www.100.me)                                                    | Testing     | Big Data               |
 | [SF-Express](https://www.sf-express.com)                                                | Testing     | Big Data, File Sharing |

--- a/ADOPTERS_CN.md
+++ b/ADOPTERS_CN.md
@@ -17,6 +17,7 @@
 | [云知声](https://www.unisound.com)               | Production | AI                                                                                  |
 | [网易游戏](https://game.163.com)                 | Production | 大数据，共享文件存储                                                                |
 | [一面数据](https://www.yimian.com.cn)            | Production | 大数据                                                                              |
+| [携程旅行](https://www.ctrip.com)                 | Production | 大数据，共享文件存储                                                                 |
 | [火山引擎](https://www.volcengine.com)           | Testing    | 共享文件存储                                                                        |
 | [叮咚买菜](https://www.100.me)                   | Testing    | 大数据                                                                              |
 | [顺丰速运](https://www.sf-express.com)           | Testing    | 大数据，共享文件存储                                                                |


### PR DESCRIPTION
Trip.com uses the JuiceFS in file sharing, data backup and clickhouse data tiering, add it in the adopter list.