### PR TITLE
add vivo in adopter list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,7 +17,8 @@ For users of JuiceFS:
 | [UniSound](https://www.unisound.com)                                                    | Production  | AI                     |
 | [NetEase Games](http://www.neteasegames.com)                                            | Production  | Big Data, File Sharing |
 | [Yimian](https://www.yimian.io)                                                         | Production  | Big Data               |
-| [Trip.com](https://us.trip.com/)                                                        | Prodcution  | Big Data, File Sharing |
+| [Trip.com](https://us.trip.com/)                                                        | Production  | Big Data, File Sharing |
+| [vivo](https://www.vivo.com)                                                            | Production  | AI, File Sharing       |
 | [Volcano Engine](https://www.volcengine.com)                                            | Testing     | File Sharing           |
 | [Dingdong Fresh](https://www.100.me)                                                    | Testing     | Big Data               |
 | [SF-Express](https://www.sf-express.com)                                                | Testing     | Big Data, File Sharing |

--- a/ADOPTERS_CN.md
+++ b/ADOPTERS_CN.md
@@ -18,6 +18,7 @@
 | [网易游戏](https://game.163.com)                 | Production | 大数据，共享文件存储                                                                |
 | [一面数据](https://www.yimian.com.cn)            | Production | 大数据                                                                              |
 | [携程旅行](https://www.ctrip.com)                 | Production | 大数据，共享文件存储                                                                 |
+| [vivo](https://www.vivo.com)                    | Production | AI, 共享文件存储                                                                   |
 | [火山引擎](https://www.volcengine.com)           | Testing    | 共享文件存储                                                                        |
 | [叮咚买菜](https://www.100.me)                   | Testing    | 大数据                                                                              |
 | [顺丰速运](https://www.sf-express.com)           | Testing    | 大数据，共享文件存储                                                                |


### PR DESCRIPTION
Vivo uses the JuiceFS in AI and other workloads for storage, management intensive data. Add vivo in the adopter list.