### PR TITLE
fix partial match

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -786,14 +786,20 @@ func slidingWindowForPath(pattern, key string) []string {
 
 // Consistent with rsync behavior, the matching order is adjusted according to the order of the "include" and "exclude" options
 func includeObject(rules []*rule, key string) bool {
-	for _, rule := range rules {
-		for _, k := range slidingWindowForPath(rule.pattern, key) {
-			match, err := path.Match(rule.pattern, k)
-			if err != nil {
-				logger.Fatalf("pattern error : %v", err)
-			}
-			if match {
-				return rule.include
+	parts := strings.Split(key, "/")
+	for idx := range parts {
+		key = strings.Join(parts[:idx+1], "/")
+		if key != "" {
+			for _, rule := range rules {
+				for _, k := range slidingWindowForPath(rule.pattern, key) {
+					match, err := path.Match(rule.pattern, k)
+					if err != nil {
+						logger.Fatalf("pattern error : %v", err)
+					}
+					if match {
+						return rule.include
+					}
+				}
 			}
 		}
 	}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -565,6 +565,9 @@ func Test_includeObject(t *testing.T) {
 		{rules: []*rule{{pattern: "/a*/b*", include: false}}, key: "/a1/b1/c1/d.txt/", want: false},
 		{rules: []*rule{{pattern: "a*/b*/c", include: false}}, key: "a1/b1/c1/d.txt/", want: true},
 		{rules: []*rule{{pattern: "a", include: false}}, key: "a/b/c/d/", want: false},
+		{rules: []*rule{{pattern: "a.go", include: true}, {pattern: "pkg", include: false}}, key: "a/pkg/c/a.go", want: false},
+		{rules: []*rule{{pattern: "a", include: false}, {pattern: "pkg", include: true}}, key: "a/pkg/c/a.go", want: false},
+		{rules: []*rule{{pattern: "a.go", include: true}, {pattern: "pkg", include: false}}, key: "", want: true},
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
When both include and exclude can be matched, the matching part in the original path has a higher priority closer to the beginning of the path
```bash
# juicefs
 $ tree jfs_source
jfs_source
└── pkg
    ├── chunk
    │   ├── mem_cache.go
    │   └── singleflight_test.go
    └── winfsp
        ├── trace.go
        └── winfs.go

3 directories, 4 files
 $ juicefs sync jfs_source/ jfs_sync_dir/ --dirs --include 'chu*/' --exclude 'pkg'
2022/04/24 17:53:04.606866 juicefs[18994] <INFO>: Syncing from file:///tmp/jfs_source/ to file:///tmp/jfs_sync_dir/ [sync.go:610]
Scanned objects count: 1 / 1 [==============================================================]  done
 Copied objects count: 0
 Copied objects bytes: 0.00 b (0 Bytes)   0.00 b/s
Checked objects bytes: 0.00 b (0 Bytes)   0.00 b/s
Deleted objects count: 0
Skipped objects count: 1
 Failed objects count: 0
2022/04/24 17:53:04.608266 juicefs[18994] <INFO>: Found: 1, copied: 0 (0 B), checked: 0 B, deleted: 0, skipped: 1, failed: 0 [sync.go:874]
 $  tree jfs_sync_dir/
jfs_sync_dir/

0 directories, 0 files



# rsync
$ rsync jfs_source/ rsync_dir/ -r    --include 'chu*'  --exclude 'pkg'  -v
building file list ... done

sent 36 bytes  received 20 bytes  112.00 bytes/sec
total size is 0  speedup is 0.00
$ tree rsync_dir/
rsync_dir/

0 directories, 0 files

```
Close #1884 