### PR TITLE
proofread: fuse_mount_options.md minor change

### DIFF
--- a/docs/en/reference/fuse_mount_options.md
+++ b/docs/en/reference/fuse_mount_options.md
@@ -5,7 +5,7 @@ slug: /fuse_mount_options
 ---
 # FUSE Mount Options
 
-This is a guide that lists important FUSE mount options. These mount options are specified by `-o` option when execute [`juicefs mount`](../reference/command_reference.md#juicefs-mount) command (use comma to separate multiple options). For example:
+This guide lists important FUSE mount options. These mount options are specified by the option `-o`  when execute the command [`juicefs mount`](../reference/command_reference.md#juicefs-mount) (use comma to separate multiple options). For example:
 
 ```bash
 juicefs mount -d -o allow_other,writeback_cache localhost ~/jfs
@@ -17,7 +17,7 @@ Enable debug log
 
 ## allow_other
 
-This option overrides the security measure restricting file access to the user mounting the file system. So all users (including root) can access the files. This option is by default only allowed to root, but this restriction can be removed with `user_allow_other` configuration option in `/etc/fuse.conf`.
+This option overrides the default security restriction that only users amounting the file system can access to files. That is all users (including root) can access the files. Only root is allowed to use this option by default, but this restriction can be removed by the configuration option `user_allow_other` in `/etc/fuse.conf`.
 
 ## writeback_cache
 
@@ -25,4 +25,4 @@ This option overrides the security measure restricting file access to the user m
 This mount option requires at least version 3.15 Linux kernel
 :::
 
-FUSE supports ["writeback-cache mode"](https://www.kernel.org/doc/Documentation/filesystems/fuse-io.txt), which means the `write()` syscall can often complete very fast. It's recommended enable this mount option when write very small data (e.g. 100 bytes) frequently.
+FUSE supports ["writeback-cache mode"](https://www.kernel.org/doc/Documentation/filesystems/fuse-io.txt), which means the `write()` syscall can often complete rapidly. It's recommended to enable this mount option when write small data (e.g. 100 bytes) frequently.

--- a/docs/en/reference/p8s_metrics.md
+++ b/docs/en/reference/p8s_metrics.md
@@ -18,7 +18,7 @@ Please see the ["Monitoring"](../administration/monitoring.md) documentation to 
 | `mp`       | Mount point path |
 
 :::info
-When Prometheus scrapes a target, it attaches `instance` label automatically to the scraped time series which serve to identify the scraped target, its format is `<host>:<port>`. Refer to [official document](https://prometheus.io/docs/concepts/jobs_instances) for more information.
+When Prometheus scrapes a target, it attaches `instance` label automatically to the scraped time series which serve to identify the scraped target, and its format is `<host>:<port>`. Refer to [official document](https://prometheus.io/docs/concepts/jobs_instances) for more information.
 :::
 
 :::info
@@ -51,7 +51,7 @@ If the monitoring metrics are reported through [Prometheus Pushgateway](https://
 | Name                                              | Description                                | Unit   |
 | ----                                              | -----------                                | ----   |
 | `juicefs_transaction_durations_histogram_seconds` | Transactions latency distributions         | second |
-| `juicefs_transaction_restart`                     | Number of times a transaction is restarted |        |
+| `juicefs_transaction_restart`                     | Number of times a transaction restarted |        |
 
 ## FUSE
 
@@ -99,7 +99,7 @@ If the monitoring metrics are reported through [Prometheus Pushgateway](https://
 
 | Name     | Description                                                    |
 | ----     | -----------                                                    |
-| `method` | Request method to object storage (e.g. GET, PUT, HEAD, DELETE) |
+| `method` | Method to request object storage (e.g. GET, PUT, HEAD, DELETE) |
 
 ### Metrics
 

--- a/docs/en/reference/posix_compatibility.md
+++ b/docs/en/reference/posix_compatibility.md
@@ -9,7 +9,7 @@ JuiceFS ensures POSIX compatibility with the help of pjdfstest and LTP.
 
 ## Pjdfstest
 
- [Pjdfstest](https://github.com/pjd/pjdfstest) is a test suite that helps exercise POSIX system calls. JuiceFS passed all of its latest 8813 tests:
+ [Pjdfstest](https://github.com/pjd/pjdfstest) is a test suite that helps to test POSIX system calls. JuiceFS passed all of its latest 8813 tests:
 
 ```
 All tests successful.
@@ -22,12 +22,12 @@ Files=235, Tests=8813, 233 wallclock secs ( 2.77 usr  0.38 sys +  2.57 cusr  3.9
 Result: PASS
 ```
 
-Besides the things covered by pjdfstest, JuiceFS provides:
+Besides the features covered by pjdfstest, JuiceFS provides:
 
-- Close-to-open consistency. Once a file is closed, the following open and read are guaranteed see the data written before close. Within same mount point, read can see all data written before it immediately.
-- Rename and all other metadata operations are atomic guaranteed by transaction of metadata engines.
+- Close-to-open consistency. Once a file is closed, it is guaranteed to view the written data in the following open and read. Within the same mount point, all the written data can be read immediately.
+- Rename and all other metadata operations are atomic, which are guaranteed by transaction of metadata engines.
 - Open files remain accessible after unlink from same mount point.
-- Mmap is supported (tested with FSx).
+- Mmap (tested with FSx).
 - Fallocate with punch hole support.
 - Extended attributes (xattr).
 - BSD locks (flock).
@@ -41,7 +41,7 @@ Besides the things covered by pjdfstest, JuiceFS provides:
 >
 > The LTP testsuite contains a collection of tools for testing the Linux kernel and related features. Our goal is to improve the Linux kernel and system libraries by bringing test automation to the testing effort.
 
-JuiceFS passed most of its file system related tests.
+JuiceFS passed most of the file system related tests.
 
 ### Test Environment
 
@@ -98,17 +98,17 @@ Kernel Version: 5.4.0-1029-aws
 Machine Architecture: x86_64
 ```
 
-Reasons for the skipped and failed tests:
+Here are causes of the skipped and failed tests:
 
-- fcntl17, fcntl17_64: automatically detect deadlock when trying to add POSIX locks. JuiceFS doesn't support it yet
-- getxattr05: need ACL, which is not supported yet
-- ioctl_loop05, ioctl_ns07, setxattr03: need `ioctl`, which is not supported yet
-- lseek11: handle SEEK_DATA and SEEK_HOLE flags properly in `lseek`. JuiceFS uses kernel general function, which doesn't support these two flags
-- open14, openat03: handle O_TMPFILE flag in `open`. JuiceFS can do nothing with it since it's not supported by FUSE
+- fcntl17, fcntl17_64: it requires file system to automatically detect deadlock when trying to add POSIX locks. JuiceFS doesn't support it yet.
+- getxattr05: need ACL, which is not supported yet.
+- ioctl_loop05, ioctl_ns07, setxattr03: need `ioctl`, which is not supported yet.
+- lseek11: require `lseek` to handle SEEK_DATA and SEEK_HOLE flags. JuiceFS however uses kernel general function, which doesn't support these two flags.
+- open14, openat03: need `open` to handle O_TMPFILE flag. JuiceFS can do nothing with it since it's not supported by FUSE.
 
 ### Appendix
 
-Deleted cases in `fs` and `syscalls`:
+Here are deleted cases in `fs` and `syscalls`:
 
 ```bash
 # fs --> fs-jfs


### PR DESCRIPTION
@davies  Could you give a quick review on this proofread? Only minor changes have been made. Thanks! :)

A question here: https://github.com/juicedata/juicefs/blob/main/docs/en/reference/fuse_mount_options.md#debug 
Does the option `-d` refers to enabling debug log? Maybe it is better to make it clearer in the document? 