### PR TITLE
add Horizon Robotics to the adopter list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,6 +19,7 @@ For users of JuiceFS:
 | [Yimian](https://www.yimian.io)                                                         | Production  | Big Data               |
 | [Trip.com](https://us.trip.com/)                                                        | Production  | Big Data, File Sharing |
 | [vivo](https://www.vivo.com)                                                            | Production  | AI, File Sharing       |
+| [Horizon Robotics](https://horizon.ai)                                                  | Production  | AI                     |
 | [Volcano Engine](https://www.volcengine.com)                                            | Testing     | File Sharing           |
 | [Dingdong Fresh](https://www.100.me)                                                    | Testing     | Big Data               |
 | [SF-Express](https://www.sf-express.com)                                                | Testing     | Big Data, File Sharing |

--- a/ADOPTERS_CN.md
+++ b/ADOPTERS_CN.md
@@ -19,6 +19,7 @@
 | [一面数据](https://www.yimian.com.cn)            | Production | 大数据                                                                              |
 | [携程旅行](https://www.ctrip.com)                 | Production | 大数据，共享文件存储                                                                 |
 | [vivo](https://www.vivo.com)                    | Production | AI, 共享文件存储                                                                   |
+| [地平线](https://horizon.ai)                    | Production | AI             |
 | [火山引擎](https://www.volcengine.com)           | Testing    | 共享文件存储                                                                        |
 | [叮咚买菜](https://www.100.me)                   | Testing    | 大数据                                                                              |
 | [顺丰速运](https://www.sf-express.com)           | Testing    | 大数据，共享文件存储                                                                |


### PR DESCRIPTION
Horizon Robotics uses the JuiceFS to store and manage datasets in its AI platform and train models for self-driving cars.

Add it to the adopter list.