### PR TITLE
meta/tkv: dump metadata using snapshot

### DIFF
--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -43,7 +43,6 @@ type kvTxn interface {
 	get(key []byte) []byte
 	gets(keys ...[]byte) [][]byte
 	scanRange(begin, end []byte) map[string][]byte
-	scan(prefix []byte, handler func(key, value []byte))
 	scanKeys(prefix []byte) [][]byte
 	scanValues(prefix []byte, limit int, filter func(k, v []byte) bool) map[string][]byte
 	exist(prefix []byte) bool
@@ -56,6 +55,7 @@ type kvTxn interface {
 type tkvClient interface {
 	name() string
 	txn(f func(kvTxn) error) error
+	scan(prefix []byte, handler func(key, value []byte)) error
 	reset(prefix []byte) error
 	close() error
 	shouldRetry(err error) bool
@@ -2280,26 +2280,26 @@ func (m *kvMeta) DumpMeta(w io.Writer, root Ino) (err error) {
 			defer func() { m.snap = nil }()
 			m.snap = &memKV{items: btree.New(2), temp: &kvItem{}}
 			bar := progress.AddCountBar("Snapshot keys", 0)
-			if err = m.txn(func(tx kvTxn) error {
-				used := parseCounter(tx.get(m.counterKey(usedSpace)))
-				inodeTotal := parseCounter(tx.get(m.counterKey(totalInodes)))
-				var guessKeyTotal int64 = 3 // setting, nextInode, nextChunk
-				if inodeTotal > 0 {
-					guessKeyTotal += int64(math.Ceil((float64(used/inodeTotal/(64*1024*1024)) + float64(3)) * float64(inodeTotal)))
+			bUsed, _ := m.get(m.counterKey(usedSpace))
+			bInodes, _ := m.get(m.counterKey(totalInodes))
+			used := parseCounter(bUsed)
+			inodeTotal := parseCounter(bInodes)
+			var guessKeyTotal int64 = 3 // setting, nextInode, nextChunk
+			if inodeTotal > 0 {
+				guessKeyTotal += int64(math.Ceil((float64(used/inodeTotal/(64*1024*1024)) + float64(3)) * float64(inodeTotal)))
+			}
+			bar.SetCurrent(0) // Reset
+			bar.SetTotal(guessKeyTotal)
+			threshold := 0.1
+			err := m.client.scan(nil, func(key, value []byte) {
+				m.snap.set(string(key), value)
+				if bar.Current() > int64(math.Ceil(float64(guessKeyTotal)*(1-threshold))) {
+					guessKeyTotal += int64(math.Ceil(float64(guessKeyTotal) * threshold))
+					bar.SetTotal(guessKeyTotal)
 				}
-				bar.SetCurrent(0) // Reset
-				bar.SetTotal(guessKeyTotal)
-				threshold := 0.1
-				tx.scan(nil, func(key, value []byte) {
-					m.snap.set(string(key), value)
-					if bar.Current() > int64(math.Ceil(float64(guessKeyTotal)*(1-threshold))) {
-						guessKeyTotal += int64(math.Ceil(float64(guessKeyTotal) * threshold))
-						bar.SetTotal(guessKeyTotal)
-					}
-					bar.Increment()
-				})
-				return nil
-			}); err != nil {
+				bar.Increment()
+			})
+			if err != nil {
 				return err
 			}
 			bar.Done()

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -127,20 +127,6 @@ func (tx *etcdTxn) scanRange(begin_, end_ []byte) map[string][]byte {
 	return ret
 }
 
-func (tx *etcdTxn) scan(prefix []byte, handler func(key []byte, value []byte)) {
-	resp, err := tx.kv.Get(tx.ctx,
-		string(prefix),
-		etcd.WithPrefix(),
-		etcd.WithSerializable())
-	if err != nil {
-		panic(fmt.Errorf("get prefix %v: %s", string(prefix), err))
-	}
-	for _, kv := range resp.Kvs {
-		tx.observed[string(kv.Key)] = kv.ModRevision
-		handler(kv.Key, kv.Value)
-	}
-}
-
 func (tx *etcdTxn) scanKeys(prefix []byte) [][]byte {
 	resp, err := tx.kv.Get(tx.ctx, string(prefix), etcd.WithPrefix(), etcd.WithKeysOnly())
 	if err != nil {
@@ -289,6 +275,40 @@ func (c *etcdClient) txn(f func(kvTxn) error) (err error) {
 }
 
 var conflicted = errors.New("conflicted transaction")
+
+func (c *etcdClient) scan(prefix []byte, handler func(key []byte, value []byte)) error {
+	var start = prefix
+	var end = string(nextKey(prefix))
+	resp, err := c.client.Get(context.Background(), "anything")
+	if err != nil {
+		return err
+	}
+	currentRev := resp.Header.Revision
+	var following bool
+	for {
+		resp, err := c.client.Get(context.Background(),
+			string(start),
+			etcd.WithRange(end),
+			etcd.WithLimit(1024),
+			etcd.WithMaxModRev(currentRev),
+			etcd.WithSerializable())
+		if err != nil {
+			return fmt.Errorf("get start %v: %s", string(start), err)
+		}
+		if following && len(resp.Kvs) > 0 {
+			resp.Kvs = resp.Kvs[1:]
+		}
+		if len(resp.Kvs) == 0 {
+			break
+		}
+		for _, kv := range resp.Kvs {
+			handler(kv.Key, kv.Value)
+		}
+		start = resp.Kvs[len(resp.Kvs)-1].Key
+		following = true
+	}
+	return nil
+}
 
 func (c *etcdClient) reset(prefix []byte) error {
 	_, err := c.kv.Delete(context.Background(), string(prefix), etcd.WithPrefix())

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -98,10 +98,8 @@ func testTKV(t *testing.T, c tkvClient) {
 	}
 
 	var keys [][]byte
-	txn(func(kt kvTxn) {
-		kt.scan([]byte("k"), func(key, value []byte) {
-			keys = append(keys, key)
-		})
+	c.scan([]byte("k"), func(key, value []byte) {
+		keys = append(keys, key)
 	})
 	if len(keys) != 2 || string(keys[0]) != "k" || string(keys[1]) != "k2" {
 		t.Fatalf("keys: %+v", keys)


### PR DESCRIPTION
Currently, we use transaction to scan all the metadata, which is heavy (bookkeeping) and easy to fail (timeout or others), this  PR change it to iterator on read-only snapshot (based on timestamp or revision).