### PR TITLE
Revert "meta/tkv: dump metadata using snapshot"

### DIFF
--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -32,6 +32,23 @@ type badgerTxn struct {
 	c *badger.DB
 }
 
+func (tx *badgerTxn) scan(prefix []byte, handler func(key []byte, value []byte)) {
+	it := tx.t.NewIterator(badger.IteratorOptions{
+		Prefix:         prefix,
+		PrefetchValues: true,
+		PrefetchSize:   1024,
+	})
+	defer it.Close()
+	for it.Rewind(); it.Valid(); it.Next() {
+		item := it.Item()
+		value, err := item.ValueCopy(nil)
+		if err != nil {
+			panic(err)
+		}
+		handler(it.Item().Key(), value)
+	}
+}
+
 func (tx *badgerTxn) get(key []byte) []byte {
 	item, err := tx.t.Get(key)
 	if err == badger.ErrKeyNotFound {
@@ -204,26 +221,6 @@ func (c *badgerClient) txn(f func(kvTxn) error) (err error) {
 	}
 	// tx could be committed
 	return txn.t.Commit()
-}
-
-func (c *badgerClient) scan(prefix []byte, handler func(key []byte, value []byte)) error {
-	tx := c.client.NewTransaction(false)
-	defer tx.Discard()
-	it := tx.NewIterator(badger.IteratorOptions{
-		Prefix:         prefix,
-		PrefetchValues: true,
-		PrefetchSize:   10240,
-	})
-	defer it.Close()
-	for it.Rewind(); it.Valid(); it.Next() {
-		item := it.Item()
-		value, err := item.ValueCopy(nil)
-		if err != nil {
-			return err
-		}
-		handler(it.Item().Key(), value)
-	}
-	return nil
 }
 
 func (c *badgerClient) reset(prefix []byte) error {

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -98,6 +98,22 @@ func (tx *memTxn) scanRange(begin_, end_ []byte) map[string][]byte {
 	return ret
 }
 
+func (tx *memTxn) scan(prefix []byte, handler func(key []byte, value []byte)) {
+	tx.store.Lock()
+	defer tx.store.Unlock()
+	begin := string(prefix)
+	end := string(nextKey(prefix))
+	tx.store.items.AscendGreaterOrEqual(&kvItem{key: begin}, func(i btree.Item) bool {
+		it := i.(*kvItem)
+		if it.key >= end {
+			return false
+		}
+		tx.observed[it.key] = it.ver
+		handler([]byte(it.key), it.value)
+		return true
+	})
+}
+
 func nextKey(key []byte) []byte {
 	if len(key) == 0 {
 		return nil
@@ -270,22 +286,6 @@ func (c *memKV) txn(f func(kvTxn) error) error {
 	return nil
 }
 
-func (c *memKV) scan(prefix []byte, handler func(key []byte, value []byte)) error {
-	c.Lock()
-	defer c.Unlock()
-	begin := string(prefix)
-	end := string(nextKey(prefix))
-	c.items.AscendGreaterOrEqual(&kvItem{key: begin}, func(i btree.Item) bool {
-		it := i.(*kvItem)
-		if it.key >= end {
-			return false
-		}
-		handler([]byte(it.key), it.value)
-		return true
-	})
-	return nil
-}
-
 func (c *memKV) reset(prefix []byte) error {
 	if len(prefix) == 0 {
 		c.Lock()
@@ -295,9 +295,10 @@ func (c *memKV) reset(prefix []byte) error {
 		return nil
 	}
 	return c.txn(func(kt kvTxn) error {
-		return c.scan(prefix, func(key, value []byte) {
+		kt.scan(prefix, func(key, value []byte) {
 			kt.dels(key)
 		})
+		return nil
 	})
 }
 

--- a/pkg/meta/tkv_prefix.go
+++ b/pkg/meta/tkv_prefix.go
@@ -53,7 +53,11 @@ func (tx *prefixTxn) scanRange(begin_, end_ []byte) map[string][]byte {
 	}
 	return m
 }
-
+func (tx *prefixTxn) scan(prefix []byte, handler func(key, value []byte)) {
+	tx.kvTxn.scan(tx.realKey(prefix), func(key, value []byte) {
+		handler(tx.origKey(key), value)
+	})
+}
 func (tx *prefixTxn) scanKeys(prefix []byte) [][]byte {
 	keys := tx.kvTxn.scanKeys(tx.realKey(prefix))
 	for i, k := range keys {
@@ -107,15 +111,6 @@ type prefixClient struct {
 func (c *prefixClient) txn(f func(kvTxn) error) error {
 	return c.tkvClient.txn(func(tx kvTxn) error {
 		return f(&prefixTxn{tx, c.prefix})
-	})
-}
-
-func (c *prefixClient) scan(prefix []byte, handler func(key, value []byte)) error {
-	k := make([]byte, len(c.prefix)+len(prefix))
-	copy(k, c.prefix)
-	copy(k[len(c.prefix):], prefix)
-	return c.tkvClient.scan(k, func(key, value []byte) {
-		handler(key[len(c.prefix):], value)
 	})
 }
 

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -98,8 +98,10 @@ func testTKV(t *testing.T, c tkvClient) {
 	}
 
 	var keys [][]byte
-	c.scan([]byte("k"), func(key, value []byte) {
-		keys = append(keys, key)
+	txn(func(kt kvTxn) {
+		kt.scan([]byte("k"), func(key, value []byte) {
+			keys = append(keys, key)
+		})
 	})
 	if len(keys) != 2 || string(keys[0]) != "k" || string(keys[1]) != "k2" {
 		t.Fatalf("keys: %+v", keys)

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -31,7 +31,6 @@ import (
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv"
-	"github.com/tikv/client-go/v2/txnkv/txnutil"
 )
 
 func init() {
@@ -137,6 +136,20 @@ func (tx *tikvTxn) scanRange(begin, end []byte) map[string][]byte {
 	return tx.scanRange0(begin, end, -1, nil)
 }
 
+func (tx *tikvTxn) scan(prefix []byte, handler func(key, value []byte)) {
+	it, err := tx.Iter(prefix, nextKey(prefix))
+	if err != nil {
+		panic(err)
+	}
+	defer it.Close()
+	for it.Valid() {
+		handler(it.Key(), it.Value())
+		if err = it.Next(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func (tx *tikvTxn) scanKeys(prefix []byte) [][]byte {
 	it, err := tx.Iter(prefix, nextKey(prefix))
 	if err != nil {
@@ -232,29 +245,6 @@ func (c *tikvClient) txn(f func(kvTxn) error) (err error) {
 		err = tx.Commit(context.Background())
 	}
 	return err
-}
-
-func (c *tikvClient) scan(prefix []byte, handler func(key, value []byte)) error {
-	ts, err := c.client.CurrentTimestamp("global")
-	if err != nil {
-		return err
-	}
-	snap := c.client.GetSnapshot(ts)
-	snap.SetScanBatchSize(10240)
-	snap.SetNotFillCache(true)
-	snap.SetPriority(txnutil.PriorityLow)
-	it, err := snap.Iter(prefix, nextKey(prefix))
-	if err != nil {
-		return err
-	}
-	defer it.Close()
-	for it.Valid() {
-		handler(it.Key(), it.Value())
-		if err = it.Next(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (c *tikvClient) reset(prefix []byte) error {


### PR DESCRIPTION
Reverts juicedata/juicefs#1961

Without creating a safepoint, the GC may remove the data before scan finished, which may end up with partial file system.