### PR TITLE
add user agent for oss #1992

### DIFF
--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -380,6 +380,7 @@ func newOSS(endpoint, accessKey, secretKey string) (ObjectStorage, error) {
 	client.Config.HTTPTimeout.HeaderTimeout = time.Second * 5    // 60s
 	client.Config.HTTPTimeout.LongTimeout = time.Second * 30     // 300s
 	client.Config.IsEnableCRC = false                            // CRC64ECMA is much slower than CRC32C
+	client.Config.UserAgent = UserAgent
 
 	bucket, err := client.Bucket(bucketName)
 	if err != nil {


### PR DESCRIPTION
After adding UserAgent header，ali can analyzes the request's delay for customers using juicefs， and can make some optimizations

close #1992 