### PR TITLE
vfs: hide .control from readdir

### DIFF
--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -47,8 +47,8 @@ type internalNode struct {
 }
 
 var internalNodes = []*internalNode{
-	{logInode, ".accesslog", &Attr{Mode: 0400}},
 	{controlInode, ".control", &Attr{Mode: 0666}},
+	{logInode, ".accesslog", &Attr{Mode: 0400}},
 	{statsInode, ".stats", &Attr{Mode: 0444}},
 	{configInode, ".config", &Attr{Mode: 0400}},
 	{trashInode, meta.TrashName, &Attr{Mode: 0555}},

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -314,7 +314,7 @@ func (v *VFS) Readdir(ctx Context, ino Ino, size uint32, off int, fh uint64, plu
 		h.children = inodes
 		if ino == rootID && !v.Conf.HideInternal {
 			// add internal nodes
-			for _, node := range internalNodes {
+			for _, node := range internalNodes[1:] {
 				h.children = append(h.children, &meta.Entry{
 					Inode: node.inode,
 					Name:  []byte(node.name),

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -600,8 +600,8 @@ func TestInternalFile(t *testing.T) {
 			internalFiles[string(e.Name)] = true
 		}
 	}
-	if len(internalFiles) != 4 {
-		t.Fatalf("there should be 4 internal files but got %d", len(internalFiles))
+	if len(internalFiles) != 3 {
+		t.Fatalf("there should be 3 internal files but got %d", len(internalFiles))
 	}
 	v.Releasedir(ctx, 1, fh)
 


### PR DESCRIPTION
File `.control` is used for internal communication, should be hide from end users.