### PR TITLE
CI:TestFuse fdleak err

### DIFF
--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -290,6 +290,7 @@ func FdLeak(t *testing.T, mnt string) {
 
 	if runtime.GOOS == "linux" {
 		infos := listFds(0, "")
+		t.Logf("infos is %v",infos)
 		if len(infos) > 15 {
 			t.Errorf("found %d open file descriptors for 100x ReadFile: %v", len(infos), infos)
 		}
@@ -318,7 +319,8 @@ func listFds(pid int, prefix string) []string {
 	// Note: Readdirnames filters "." and ".."
 	names, err := f.Readdirnames(0)
 	if err != nil {
-		log.Panic(err)
+		fmt.Printf("Readdirnames err: %v\n", err)
+		return nil
 	}
 	var out []string
 	var filtered []string

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -274,9 +274,10 @@ func PosixLock(t *testing.T, mp string) {
 	}
 }
 
-func FdLeak(t *testing.T, mnt string) {
+func FdLeak(t *testing.T, mp string) {
 	t.Log("fdleak begin")
-	fn := mnt + "/file"
+	fn := mp + "/file"
+	t.Logf("fn is %s",fn)
 
 	if err := ioutil.WriteFile(fn, []byte("hello world"), 0755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -290,7 +291,7 @@ func FdLeak(t *testing.T, mnt string) {
 
 	if runtime.GOOS == "linux" {
 		infos := listFds(0, "")
-		t.Logf("infos is %v",infos)
+		t.Log(strings.Join(infos, ";;"))
 		if len(infos) > 15 {
 			t.Errorf("found %d open file descriptors for 100x ReadFile: %v", len(infos), infos)
 		}

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -382,6 +382,7 @@ func TestFUSE(t *testing.T) {
 	posixtest.All["Xattrs"] = Xattrs
 	posixtest.All["Flock"] = Flock
 	posixtest.All["POSIXLock"] = PosixLock
+	posixtest.All["FdLeak"] = FdLeak
 	for c, f := range posixtest.All {
 		cleanup(mp)
 		t.Run(c, func(t *testing.T) {

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -283,6 +283,8 @@ func FdLeak(t *testing.T, mp string) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
+	fds := listFds(0, "")
+	t.Logf("before read,fds is ",strings.Join(fds, ";;"))
 	for i := 0; i < 100; i++ {
 		if _, err := ioutil.ReadFile(fn); err != nil {
 			t.Fatalf("ReadFile: %v", err)
@@ -291,7 +293,7 @@ func FdLeak(t *testing.T, mp string) {
 
 	if runtime.GOOS == "linux" {
 		infos := listFds(0, "")
-		t.Log(strings.Join(infos, ";;"))
+		t.Log("after read,infos is "strings.Join(infos, ";;"))
 		if len(infos) > 15 {
 			t.Errorf("found %d open file descriptors for 100x ReadFile: %v", len(infos), infos)
 		}

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -275,7 +275,6 @@ func PosixLock(t *testing.T, mp string) {
 }
 
 func FdLeak(t *testing.T, mp string) {
-	t.Log("fdleak begin")
 	fn := mp + "/file"
 	t.Logf("fn is %s",fn)
 
@@ -284,7 +283,7 @@ func FdLeak(t *testing.T, mp string) {
 	}
 
 	fds := listFds(0, "")
-	t.Logf("before read,fds is ",strings.Join(fds, ";;"))
+	t.Logf("before reading files,fds is %s",strings.Join(fds, ";;"))
 	for i := 0; i < 100; i++ {
 		if _, err := ioutil.ReadFile(fn); err != nil {
 			t.Fatalf("ReadFile: %v", err)
@@ -293,12 +292,11 @@ func FdLeak(t *testing.T, mp string) {
 
 	if runtime.GOOS == "linux" {
 		infos := listFds(0, "")
-		t.Log("after read,infos is "strings.Join(infos, ";;"))
+		t.Logf("after reading files,infos is %s",strings.Join(infos, ";;"))
 		if len(infos) > 15 {
 			t.Errorf("found %d open file descriptors for 100x ReadFile: %v", len(infos), infos)
 		}
 	}
-	t.Log("fdleak end")
 }
 
 


### PR DESCRIPTION
--- FAIL: TestFUSE/FdLeak (0.03s)
test.go:202: found 20 open file descriptors for 100x ReadFile: [0r=/dev/null 3rw=socket:[57270] 6rw=/dev/pts/0 8rw=socket:[57271] 9w=/dev/null 10r=/proc/22265/fd 12rw=/tmp/meta459760190 13rw=/tmp/meta459760190 14rw=/tmp/meta459760190 15rw=/tmp/meta459760190 16rw=/dev/fuse 17rw=/tmp/meta459760190 19rw=/tmp/meta459760190 20rw=/tmp/meta459760190 22rw=/tmp/meta459760190 23rw=/tmp/meta459760190 24rw=/tmp/meta459760190 25rw=/tmp/meta459760190 26rw=/tmp/meta459760190 (filtered: pipe:[57263], pipe:[57263], anon_inode:[eventpoll], pipe:[57267], pipe:[57267])]

More details may refer to https://github.com/juicedata/juicefs/issues/1797 .