### PR TITLE
Docs: use absolute path to represent the mount point in quick start guide

### DIFF
--- a/docs/en/getting-started/for_distributed.md
+++ b/docs/en/getting-started/for_distributed.md
@@ -103,7 +103,7 @@ Once a file system is created, the relevant information including name, object s
 Since the "data" and "metadata" of this file system are stored in cloud services, the file system can be mounted on any computer with a JuiceFS client installed for shared reads and writes at the same time. For example:
 
 ```shell
-juicefs mount redis://tom:mypassword@myjfs-sh-abc.apse1.cache.amazonaws.com:6379/1 mnt
+juicefs mount redis://tom:mypassword@myjfs-sh-abc.apse1.cache.amazonaws.com:6379/1 ~/jfs
 ```
 
 #### Strong data consistency guarantee
@@ -123,7 +123,8 @@ juicefs mount
     --background \
     --cache-dir /mycache \
     --cache-size 512000 \
-    redis://tom:mypassword@myjfs-sh-abc.apse1.cache.amazonaws.com:6379/1 mnt
+    redis://tom:mypassword@myjfs-sh-abc.apse1.cache.amazonaws.com:6379/1 \
+    ~/jfs
 ```
 
 :::note
@@ -152,10 +153,10 @@ By default, CentOS 6 does not mount the network file system during boot, you nee
 
 ### 6. Unmounting the file system
 
-You can unmount the JuiceFS file system (assuming the mount point path is `mnt`) by the command `juicefs umount`.
+You can unmount the JuiceFS file system (assuming the mount point path is `~/jfs`) by the command `juicefs umount`.
 
 ```shell
-juicefs umount mnt
+juicefs umount ~/jfs
 ```
 
 #### Unmounting failure
@@ -163,7 +164,7 @@ juicefs umount mnt
 If the command fails to unmount the file system after execution, it will prompt `Device or resource busy`.
 
 ```shell
-2021-05-09 22:42:55.757097 I | fusermount: failed to unmount mnt: Device or resource busy
+2021-05-09 22:42:55.757097 I | fusermount: failed to unmount ~/jfs: Device or resource busy
 exit status 1
 ```
 
@@ -176,5 +177,5 @@ The following command may result in file corruption and loss, so be careful to u
 You can add the option `--force` or `-f` to force the file system unmounted if you are clear about the consequence of the operation.
 
 ```shell
-juicefs umount --force mnt
+juicefs umount --force ~/jfs
 ```

--- a/docs/en/getting-started/for_local.md
+++ b/docs/en/getting-started/for_local.md
@@ -84,28 +84,28 @@ The mount point (MOUNTPOINT) on Windows systems should use a disk letter that is
 As SQLite is a single-file database, please pay attention to the path of the database file when mounting it. JuiceFS supports both relative and absolute paths.
 :::
 
-The following command mounts the `myjfs` file system to the `mnt` folder in the current directory.
+The following command mounts the `myjfs` file system to the `~/jfs` folder:
 
 ```shell
-juicefs mount sqlite3://myjfs.db mnt
+juicefs mount sqlite3://myjfs.db ~/jfs
 ```
 
 ![](../images/sqlite-mount-local.png)
 
 The client mounts the file system in the foreground by default. As you can see in the above image, the program keeps running in the current terminal. To unmount the file system, press <kbd>Ctrl</kbd> + <kbd>C</kbd> or close the terminal window.
 
-In order to keep the file system mounted in the background, you can specify the `-d` or `--background` option when mounting, i.e. to mount the file system in the daemon.
+In order to keep the file system mounted in the background, you can specify the `-d` or `--background` option when mounting, i.e. to mount the file system in the daemon:
 
 ```shell
-juicefs mount sqlite3://myjfs.db mnt -d
+juicefs mount sqlite3://myjfs.db ~/jfs -d
 ```
 
-Next, any files stored in the mount point `mnt` will be split into specific blocks according to [How JuiceFS Stores Files](../introduction/architecture.md#how-juicefs-stores-files), and stored in `$HOME/.juicefs/local/myjfs` directory; the corresponding metadata will be stored in the `myjfs.db` database.
+Next, any files stored in the mount point `~/jfs` will be split into specific blocks according to [How JuiceFS Stores Files](../introduction/architecture.md#how-juicefs-stores-files), and stored in `$HOME/.juicefs/local/myjfs` directory; the corresponding metadata will be stored in the `myjfs.db` database.
 
-In the end, the mount point `mnt` can be unmounted by executing the following command.
+In the end, the mount point `~/jfs` can be unmounted by executing the following command.
 
 ```shell
-juicefs umount mnt
+juicefs umount ~/jfs
 ```
 
 ## Go Further
@@ -120,8 +120,8 @@ JuiceFS supports almost all object storage services, see [JuiceFS supported stor
 
 In general, only 2 steps are required to create an object storage:
 
-1. Create a `Bucket` and get the Endpoint address.
-2. Create the `Access Key ID` and `Access Key Secret`, i.e., the access keys for the Object Storage API.
+1. Create a **Bucket** and get the Endpoint address.
+2. Create the **Access Key ID** and **Access Key Secret**, i.e., the access keys for the Object Storage API.
 
 Taking AWS S3 as an example, a resource that has been created would be like below.
 
@@ -151,7 +151,7 @@ juicefs format --storage s3 \
 
 The command above creates a file system using the same database name and file system name with the object storage options provided.
 
-- `--storage`: Used to set the storage type, e.g. oss, s3, etc.
+- `--storage`: Used to set the storage type, e.g. `oss`, `s3`, etc.
 - `--bucket`: Used to set the Endpoint address of the object storage.
 - `--access-key`: Used to set the Object Storage Access Key ID.
 - `--secret-key`: Used to set the Object Storage Access Key Secret.
@@ -163,7 +163,7 @@ Please replace the information in the above command with your own object storage
 You can mount the file system once it is created.
 
 ```shell
-juicefs mount sqlite3://myjfs.db mnt
+juicefs mount sqlite3://myjfs.db ~/jfs
 ```
 
 As you can see, the mount command is exactly the same as using the local storage because JuiceFS has already written the metadata of the object storage to the `myjfs.db` database, so there is no need to provide it again when mounting.

--- a/docs/zh_cn/getting-started/for_distributed.md
+++ b/docs/zh_cn/getting-started/for_distributed.md
@@ -42,7 +42,7 @@ JuiceFS 目前支持的基于网络的数据库有：
 
 ### 1. 安装客户端
 
-在所有需要挂载文件系统的计算机上安装 JuiceFS 客户端，详情参照[安装 & 升级](installation.md)。
+在所有需要挂载文件系统的计算机上安装 JuiceFS 客户端，详情参照[「安装 & 升级」](installation.md)。
 
 ### 2. 准备对象存储
 
@@ -103,7 +103,7 @@ juicefs format \
 由于这个文件系统的「数据」和「元数据」都存储在基于网络的云服务中，因此在任何安装了 JuiceFS 客户端的计算机上都可以同时挂载该文件系统进行共享读写。例如：
 
 ```shell
-juicefs mount redis://tom:mypassword@myjfs-sh-abc.redis.rds.aliyuncs.com:6379/1 mnt
+juicefs mount redis://tom:mypassword@myjfs-sh-abc.redis.rds.aliyuncs.com:6379/1 ~/jfs
 ```
 
 #### 数据强一致性保证
@@ -123,7 +123,8 @@ juicefs mount
     --background \
     --cache-dir /mycache \
     --cache-size 512000 \
-    redis://tom:mypassword@myjfs-sh-abc.redis.rds.aliyuncs.com:6379/1 mnt
+    redis://tom:mypassword@myjfs-sh-abc.redis.rds.aliyuncs.com:6379/1 \
+    ~/jfs
 ```
 
 :::note 注意
@@ -152,10 +153,10 @@ redis://tom:mypassword@myjfs-sh-abc.redis.rds.aliyuncs.com:6379/1    /mnt/myjfs 
 
 ### 6. 卸载文件系统
 
-你可以通过 `juicefs umount` 命令卸载 JuiceFS 文件系统（假设挂载点路径是 `mnt`）：
+你可以通过 `juicefs umount` 命令卸载 JuiceFS 文件系统（假设挂载点路径是 `~/jfs`）：
 
 ```shell
-juicefs umount mnt
+juicefs umount ~/jfs
 ```
 
 #### 卸载失败
@@ -163,7 +164,7 @@ juicefs umount mnt
 如果执行命令后，文件系统卸载失败，提示 `Device or resource busy`：
 
 ```shell
-2021-05-09 22:42:55.757097 I | fusermount: failed to unmount mnt: Device or resource busy
+2021-05-09 22:42:55.757097 I | fusermount: failed to unmount ~/jfs: Device or resource busy
 exit status 1
 ```
 
@@ -176,5 +177,5 @@ exit status 1
 当然，在你能够确保数据安全的前提下，也可以在卸载命令中添加 `--force` 或 `-f` 参数，强制卸载文件系统：
 
 ```shell
-juicefs umount --force mnt
+juicefs umount --force ~/jfs
 ```

--- a/docs/zh_cn/getting-started/for_local.md
+++ b/docs/zh_cn/getting-started/for_local.md
@@ -84,28 +84,28 @@ Windows 系统的挂载点（MOUNTPOINT）应该使用尚未占用的盘符，�
 由于 SQLite 是单文件数据库，挂载时要注意数据库文件的的路径，JuiceFS 同时支持相对路径和绝对路径。
 :::
 
-以下命令将 `myjfs` 文件系统挂载到当前目录下的 `mnt` 文件夹：
+以下命令将 `myjfs` 文件系统挂载到 `~/jfs` 文件夹：
 
 ```shell
-juicefs mount sqlite3://myjfs.db mnt
+juicefs mount sqlite3://myjfs.db ~/jfs
 ```
 
 ![](../images/sqlite-mount-local.png)
 
 默认情况下，客户端会在前台挂载文件系统。就像你在上图中看到的那样，程序会一直运行在当前终端进程中，使用 <kbd>Ctrl</kbd> + <kbd>C</kbd> 组合键或关闭终端窗口，文件系统会被卸载。
 
-为了让文件系统可以在后台保持挂载，你可以在挂载时指定 `-d` 或 `--background` 选项，即让客户端在守护进程中挂载文件系统。
+为了让文件系统可以在后台保持挂载，你可以在挂载时指定 `-d` 或 `--background` 选项，即让客户端在守护进程中挂载文件系统：
 
 ```shell
-juicefs mount sqlite3://myjfs.db mnt -d
+juicefs mount sqlite3://myjfs.db ~/jfs -d
 ```
 
-接下来，任何存入挂载点 `mnt` 的文件，都会按照 [JuiceFS 的文件存储格式](../introduction/architecture.md#如何存储文件)被拆分成特定的「数据块」并存入 `$HOME/.juicefs/local/myjfs` 目录中，相对应的「元数据」会全部存储在 `myjfs.db` 数据库中。
+接下来，任何存入挂载点 `~/jfs` 的文件，都会按照 [JuiceFS 的文件存储格式](../introduction/architecture.md#如何存储文件)被拆分成特定的「数据块」并存入 `$HOME/.juicefs/local/myjfs` 目录中，相对应的「元数据」会全部存储在 `myjfs.db` 数据库中。
 
-最后执行以下命令可以将挂载点 `mnt` 卸载：
+最后执行以下命令可以将挂载点 `~/jfs` 卸载：
 
 ```shell
-juicefs umount mnt
+juicefs umount ~/jfs
 ```
 
 ## 更进一步
@@ -120,8 +120,8 @@ JuiceFS 支持几乎所有的对象存储服务，查看「[JuiceFS 支持的存
 
 一般来说，创建对象存储通常只需要 2 个环节：
 
-1. 创建 `Bucket` 存储桶，拿到 Endpoint 地址；
-2. 创建 `Access Key ID` 和 `Access Key Secret`，即对象存储 API 的访问密钥。
+1. 创建 **Bucket** 存储桶，拿到 Endpoint 地址；
+2. 创建 **Access Key ID** 和 **Access Key Secret**，即对象存储 API 的访问密钥。
 
 以阿里云 OSS 为例，创建好的资源大概像下面这样：
 
@@ -130,7 +130,7 @@ JuiceFS 支持几乎所有的对象存储服务，查看「[JuiceFS 支持的存
 - **Access Key Secret**：`ZYXwvutsrqpoNMLkJiHgfeDCBA`
 
 :::note 注意
-创建对象存储时的过程各个平台会略有差别，建议查看云平台的帮助手册操作。另外，有些平台可能会针对内外网提供不同的 Endpoint 地址，由于本文要从本地访问对象存储，因此请选择使用面向外网访问的地址。
+创建对象存储的过程各个平台会略有差别，建议查看云平台的帮助手册操作。另外，有些平台可能会针对内外网提供不同的 Endpoint 地址，由于本文要从本地访问对象存储，因此请选择使用面向外网访问的地址。
 :::
 
 ### 上手实践
@@ -151,7 +151,7 @@ juicefs format --storage oss \
 
 在上述命令中，数据库和文件系统名称保持不变，增加了对象存储相关的信息：
 
-- `--storage`：设置存储类型，比如 oss、s3 等；
+- `--storage`：设置存储类型，比如 `oss`、`s3` 等；
 - `--bucket`：设置对象存储的 Endpoint 地址；
 - `--access-key`：设置对象存储 API 访问密钥 Access Key ID；
 - `--secret-key`：设置对象存储 API 访问密钥 Access Key Secret。
@@ -163,7 +163,7 @@ juicefs format --storage oss \
 创建完成即可进行挂载：
 
 ```shell
-juicefs mount sqlite3://myjfs.db mnt
+juicefs mount sqlite3://myjfs.db ~/jfs
 ```
 
 可以看到，挂载命令与使用本地存储时完全一样，因为 JuiceFS 已经把对象存储相关的信息写入了 `myjfs.db` 数据库，挂载时无需重复提供。


### PR DESCRIPTION
Using the relative path `mnt` to represent the mount point may make it unclear to the user what the specific mount directory is. Using an absolute path will make it clearer.
