### PR TITLE
Using juicefs directly via SPI in Hadoop

### DIFF
--- a/sdk/java/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/sdk/java/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -1,0 +1,15 @@
+# JuiceFS, Copyright 2022 Juicedata, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+io.juicefs.JuiceFileSystem


### PR DESCRIPTION
Maybe we could set the SPI file to make hadoop fs to discover the juicefs directly.