### PR TITLE
fix head marker format

### DIFF
--- a/docs/en/tutorials/juicefs_on_colab.md
+++ b/docs/en/tutorials/juicefs_on_colab.md
@@ -1,5 +1,7 @@
 ---
-sidebar_label: Use JuiceFS on Colab with Google CloudSQL and GCS sidebar_position: 4 slug: /juicefs_on_colab
+sidebar_label: Use JuiceFS on Colab with Google CloudSQL and GCS
+sidebar_position: 4
+slug: /juicefs_on_colab
 ---
 
 # Use JuiceFS on Colab with Google CloudSQL and GCS


### PR DESCRIPTION
Fix the header marker format which would result in `docusaurus build` failed when deploy to [web](https://juicefs.com/docs/)