### PR TITLE
meta/sql: ignore error about duplicated index

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -345,11 +345,11 @@ func (m *dbMeta) doNewSession(sinfo []byte) error {
 		return fmt.Errorf("update table session2, delslices: %s", err)
 	}
 	// add primary key
-	if err = m.db.Sync2(new(edge), new(chunk), new(xattr), new(sustained)); err != nil {
+	if err = m.db.Sync2(new(edge), new(chunk), new(xattr), new(sustained)); err != nil && !strings.Contains(err.Error(), "Duplicate entry") {
 		return fmt.Errorf("update table edge, chunk, xattr, sustained: %s", err)
 	}
 	// update the owner from uint64 to int64
-	if err = m.db.Sync2(new(flock), new(plock)); err != nil {
+	if err = m.db.Sync2(new(flock), new(plock)); err != nil && !strings.Contains(err.Error(), "Duplicate entry") {
 		return fmt.Errorf("update table flock, plock: %s", err)
 	}
 


### PR DESCRIPTION
xorm may try to create duplicated index during `Sync2`, we should ignore that. 

closes #2080 