### PR TITLE
meta: add pessimistic lock to reduce conflicted transaction in database

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -82,7 +82,7 @@ type baseMeta struct {
 	fmt  Format
 
 	root         Ino
-	txlocks      [nlocks]sync.Mutex // Pessimistic locks to reduce conflict on Redis
+	txlocks      [nlocks]sync.Mutex // Pessimistic locks to reduce conflict
 	subTrash     internalNode
 	sid          uint64
 	of           *openfiles

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -621,12 +621,16 @@ func (m *dbMeta) shouldRetry(err error) bool {
 	}
 }
 
-func (m *dbMeta) txn(f func(s *xorm.Session) error) error {
+func (m *dbMeta) txn(f func(s *xorm.Session) error, inodes ...Ino) error {
 	if m.conf.ReadOnly {
 		return syscall.EROFS
 	}
 	start := time.Now()
 	defer func() { txDist.Observe(time.Since(start).Seconds()) }()
+	if len(inodes) > 0 {
+		m.txLock(int(inodes[0]))
+		defer m.txUnlock(int(inodes[0]))
+	}
 	var err error
 	for i := 0; i < 50; i++ {
 		_, err = m.db.Transaction(func(s *xorm.Session) (interface{}, error) {
@@ -1159,7 +1163,7 @@ func (m *dbMeta) doMknod(ctx Context, parent Ino, name string, _type uint8, mode
 		}
 		m.parseAttr(&n, attr)
 		return nil
-	})
+	}, parent)
 	if err == nil {
 		m.updateStats(align4K(0), 1)
 	}
@@ -1306,7 +1310,7 @@ func (m *dbMeta) doUnlink(ctx Context, parent Ino, name string) syscall.Errno {
 			}
 		}
 		return err
-	})
+	}, parent)
 	if err == nil && trash == 0 {
 		if n.Type == TypeFile && n.Nlink == 0 {
 			m.fileDeleted(opened, n.Inode, n.Length)
@@ -1403,7 +1407,7 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string) syscall.Errno {
 			_, err = s.Cols("nlink", "mtime", "ctime").Update(&pn, &node{Inode: pn.Inode})
 		}
 		return err
-	})
+	}, parent)
 	if err == nil && trash == 0 {
 		m.updateStats(-align4K(0), -1)
 	}
@@ -1699,7 +1703,7 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			}
 		}
 		return err
-	})
+	}, parentSrc)
 	if err == nil && !exchange && trash == 0 {
 		if dino > 0 && dn.Type == TypeFile && dn.Nlink == 0 {
 			m.fileDeleted(opened, dino, dn.Length)
@@ -1778,7 +1782,7 @@ func (m *dbMeta) doLink(ctx Context, inode, parent Ino, name string, attr *Attr)
 			m.parseAttr(&n, attr)
 		}
 		return err
-	}))
+	}, parent))
 }
 
 func (m *dbMeta) doReaddir(ctx Context, inode Ino, plus uint8, entries *[]*Entry, limit int) syscall.Errno {
@@ -2038,7 +2042,7 @@ func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 			needCompact = (len(ck.Slices)/sliceBytes)%100 == 99
 		}
 		return err
-	})
+	}, inode)
 	if err == nil {
 		if needCompact {
 			go m.compactChunk(inode, indx, false)

--- a/pkg/meta/sql_lock.go
+++ b/pkg/meta/sql_lock.go
@@ -82,7 +82,7 @@ func (m *dbMeta) Flock(ctx Context, inode Ino, owner_ uint64, ltype uint32, bloc
 				err = fmt.Errorf("insert/update failed")
 			}
 			return err
-		}))
+		}, inode))
 
 		if !block || err != syscall.EAGAIN {
 			break
@@ -221,7 +221,7 @@ func (m *dbMeta) Setlk(ctx Context, inode Ino, owner_ uint64, block bool, ltype 
 				err = fmt.Errorf("insert/update failed")
 			}
 			return err
-		}))
+		}, inode))
 
 		if !block || err != syscall.EAGAIN {
 			break

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -632,12 +632,16 @@ func (m *kvMeta) shouldRetry(err error) bool {
 	return m.client.shouldRetry(err)
 }
 
-func (m *kvMeta) txn(f func(tx kvTxn) error) error {
+func (m *kvMeta) txn(f func(tx kvTxn) error, inodes ...Ino) error {
 	if m.conf.ReadOnly {
 		return syscall.EROFS
 	}
 	start := time.Now()
 	defer func() { txDist.Observe(time.Since(start).Seconds()) }()
+	if len(inodes) > 0 {
+		m.txLock(int(inodes[0]))
+		defer m.txUnlock(int(inodes[0]))
+	}
 	var err error
 	for i := 0; i < 50; i++ {
 		if err = m.client.txn(f); m.shouldRetry(err) {
@@ -1066,7 +1070,7 @@ func (m *kvMeta) doMknod(ctx Context, parent Ino, name string, _type uint8, mode
 			tx.set(m.symKey(ino), []byte(path))
 		}
 		return nil
-	})
+	}, parent)
 	if err == nil {
 		m.updateStats(align4K(0), 1)
 	}
@@ -1179,7 +1183,7 @@ func (m *kvMeta) doUnlink(ctx Context, parent Ino, name string) syscall.Errno {
 			}
 		}
 		return nil
-	})
+	}, parent)
 	if err == nil && trash == 0 {
 		if _type == TypeFile && attr.Nlink == 0 {
 			m.fileDeleted(opened, inode, attr.Length)
@@ -1255,7 +1259,7 @@ func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string) syscall.Errno {
 			tx.dels(tx.scanKeys(m.xattrKey(inode, ""))...)
 		}
 		return nil
-	})
+	}, parent)
 	if err == nil && trash == 0 {
 		m.updateStats(-align4K(0), -1)
 	}
@@ -1470,7 +1474,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			tx.set(m.inodeKey(parentDst), m.marshal(&dattr))
 		}
 		return nil
-	})
+	}, parentSrc)
 	if err == nil && !exchange && trash == 0 {
 		if dino > 0 && dtyp == TypeFile && tattr.Nlink == 0 {
 			m.fileDeleted(opened, dino, tattr.Length)
@@ -1527,7 +1531,7 @@ func (m *kvMeta) doLink(ctx Context, inode, parent Ino, name string, attr *Attr)
 			*attr = iattr
 		}
 		return nil
-	}))
+	}, parent))
 }
 
 func (m *kvMeta) doReaddir(ctx Context, inode Ino, plus uint8, entries *[]*Entry, limit int) syscall.Errno {
@@ -1693,7 +1697,7 @@ func (m *kvMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		tx.set(m.inodeKey(inode), m.marshal(&attr))
 		needCompact = (len(val)/sliceBytes)%100 == 99
 		return nil
-	})
+	}, inode)
 	if err == nil {
 		if needCompact {
 			go m.compactChunk(inode, indx, false)
@@ -1876,7 +1880,7 @@ func (m *kvMeta) deleteChunk(inode Ino, indx uint32) error {
 			}
 		}
 		return nil
-	})
+	}, inode)
 	if err != nil {
 		return err
 	}

--- a/pkg/meta/tkv_lock.go
+++ b/pkg/meta/tkv_lock.go
@@ -83,7 +83,7 @@ func (m *kvMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, block
 				tx.set(ikey, marshalFlock(ls))
 			}
 			return nil
-		})
+		}, inode)
 
 		if !block || err != syscall.EAGAIN {
 			break
@@ -205,7 +205,7 @@ func (m *kvMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype u
 				tx.set(ikey, marshalPlock(owners))
 			}
 			return nil
-		})
+		}, inode)
 
 		if !block || err != syscall.EAGAIN {
 			break


### PR DESCRIPTION
This PR bring the pessimistic lock used in Redis engine to all of the meta engines.