### PR TITLE
add a tool to run tests again meta engine

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,7 @@ func Main(args []string) error {
 			cmdWebDav(),
 			cmdBench(),
 			cmdObjbench(),
+			cmdMdtest(),
 			cmdWarmup(),
 			cmdRmr(),
 			cmdSync(),

--- a/cmd/mdtest.go
+++ b/cmd/mdtest.go
@@ -154,6 +154,7 @@ func cmdMdtest() *cli.Command {
 		Name:      "mdtest",
 		Action:    mdtest,
 		Category:  "TOOL",
+		Hidden:    true,
 		Usage:     "run test on meta engines",
 		ArgsUsage: "META-URL PATH",
 		Description: `


### PR DESCRIPTION
This is a internal test tool similar to mdtest, but run in userland, expected to be faster.