### PR TITLE
meta/sql: use repeatable-read for transaction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -240,3 +240,5 @@ replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt
 replace github.com/vbauerster/mpb/v7 v7.0.3 => github.com/juicedata/mpb/v7 v7.0.4-0.20220411070607-092927ed0122
 
 replace google.golang.org/grpc v1.43.0 => google.golang.org/grpc v1.29.0
+
+replace xorm.io/xorm v1.0.7 => gitea.com/davies/xorm v1.0.8-0.20220528043536-552d84d1b34a

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ cloud.google.com/go/storage v1.21.0/go.mod h1:XmRlxkgPjlBONznT2dDUU/5XlpU2OjMnKu
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 git.apache.org/thrift.git v0.13.0 h1:/3bz5WZ+sqYArk7MBBBbDufMxKKOA56/6JO6psDpUDY=
 git.apache.org/thrift.git v0.13.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+gitea.com/davies/xorm v1.0.8-0.20220528043536-552d84d1b34a h1:awR9qREIs6qSnKr/cmSewVwDo74/kQ32x0CDEXUtiB8=
+gitea.com/davies/xorm v1.0.8-0.20220528043536-552d84d1b34a/go.mod h1:uF9EtbhODq5kNWxMbnBEj8hRRZnlcNSz2t2N7HW/+A4=
 gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a h1:lSA0F4e9A2NcQSqGqTOXqu2aRi/XEQxDCBwM8yJtE6s=
 gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a/go.mod h1:EXuID2Zs0pAQhH8yz+DNjUbjppKQzKFAn28TMYPB6IU=
 github.com/Arvintian/scs-go-sdk v1.1.0 h1:vqVOfoMD6XSr7eG1a2M9oSiQwhDZYKKdH2rrZRPx6So=
@@ -1392,5 +1394,3 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 xorm.io/builder v0.3.7 h1:2pETdKRK+2QG4mLX4oODHEhn5Z8j1m8sXa7jfu+/SZI=
 xorm.io/builder v0.3.7/go.mod h1:aUW0S9eb9VCaPohFCH3j7czOx1PMW3i1HrSzbLYGBSE=
-xorm.io/xorm v1.0.7 h1:26yBTDVI+CfQpVz2Y88fISh+aiJXIPP4eNoTJlwzsC4=
-xorm.io/xorm v1.0.7/go.mod h1:uF9EtbhODq5kNWxMbnBEj8hRRZnlcNSz2t2N7HW/+A4=

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -661,8 +661,12 @@ func (m *dbMeta) roTxn(f func(s *xorm.Session) error) error {
 	var err error
 	s := m.db.NewSession()
 	defer s.Close()
+	var opt = sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	}
 	for i := 0; i < 50; i++ {
-		if err := s.BeginTx(&sql.TxOptions{sql.LevelRepeatableRead, true}); err != nil {
+		if err := s.BeginTx(&opt); err != nil {
 			logger.Debugf("Start transaction failed, try again (tried %d): %s", i+1, err)
 			time.Sleep(time.Millisecond * time.Duration(i*i))
 			continue

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -662,8 +662,7 @@ func (m *dbMeta) roTxn(f func(s *xorm.Session) error) error {
 	s := m.db.NewSession()
 	defer s.Close()
 	for i := 0; i < 50; i++ {
-		// TODO: read-only
-		if err := s.Begin(); err != nil {
+		if err := s.BeginTx(&sql.TxOptions{sql.LevelRepeatableRead, true}); err != nil {
 			logger.Debugf("Start transaction failed, try again (tried %d): %s", i+1, err)
 			time.Sleep(time.Millisecond * time.Duration(i*i))
 			continue


### PR DESCRIPTION
This PR upgrade xorm to 1.3.0 and patch it to always use repeatable-read isolation level for transaction.


close #2110 