### PR TITLE
fix clickhouse du jfscache err

### DIFF
--- a/.github/workflows/tpch_clickhouse.yml
+++ b/.github/workflows/tpch_clickhouse.yml
@@ -152,7 +152,6 @@ jobs:
           clickhouse-client --query "INSERT INTO supplier FORMAT CSV" < supplier.tbl
           time clickhouse-client --query "INSERT INTO lineorder FORMAT CSV" < lineorder.tbl
           sudo du -sh /data/jfs/
-          sudo du -sh /var/jfsCache/
           df -lh
 
 
@@ -255,7 +254,6 @@ jobs:
                                      ORDER BY
                                          year ASC,
                                          C_NATION ASC;"
-          sudo du -sh /var/jfsCache/
           sudo du -sh /data/jfs/
           df -lh
 

--- a/.github/workflows/tpch_clickhouse_limitcache.yml
+++ b/.github/workflows/tpch_clickhouse_limitcache.yml
@@ -153,7 +153,6 @@ jobs:
           clickhouse-client --query "INSERT INTO supplier FORMAT CSV" < supplier.tbl
           time clickhouse-client --query "INSERT INTO lineorder FORMAT CSV" < lineorder.tbl
           sudo du -sh /data/jfs/
-          sudo du -sh /var/jfsCache/
           df -lh
 
       - name: ClickHouse Test
@@ -255,7 +254,6 @@ jobs:
                                      ORDER BY
                                          year ASC,
                                          C_NATION ASC;"
-          sudo du -sh /var/jfsCache/
           sudo du -sh /data/jfs/
           df -lh
 


### PR DESCRIPTION
du: cannot access '/var/jfsCache/33b603ab-cdaf-44b4-b05a-48ee7e332813/raw/chunks/0/5/5628_0_1048576': No such file or directory
du: cannot access '/var/jfsCache/33b603ab-cdaf-44b4-b05a-48ee7e332813/raw/chunks/0/5/5275_0_1048576': No such file or directory
du: cannot access '/var/jfsCache/33b603ab-cdaf-44b4-b05a-48ee7e332813/raw/chunks/0/5/5415_0_4096': No such file or directory
More details may refer to https://github.com/juicedata/juicefs/runs/6599792359?check_suite_focus=true.