### PR TITLE
meta/tkv: Speedup dump for kv storage

### DIFF
--- a/pkg/meta/dump.go
+++ b/pkg/meta/dump.go
@@ -208,6 +208,7 @@ func (de *DumpedEntry) writeJSON(bw *bufio.Writer, depth int) error {
 	write(fmt.Sprintf("\n%s}", prefix))
 	return nil
 }
+
 func (de *DumpedEntry) writeJsonWithOutEntry(bw *bufio.Writer, depth int) error {
 	prefix := strings.Repeat(jsonIndent, depth)
 	fieldPrefix := prefix + jsonIndent

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -34,8 +34,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/google/btree"
-
 	"github.com/juicedata/juicefs/pkg/utils"
 )
 
@@ -63,8 +61,8 @@ type tkvClient interface {
 
 type kvMeta struct {
 	baseMeta
-	client tkvClient
-	snap   *memKV
+	client  tkvClient
+	entries map[Ino]*DumpedEntry
 }
 
 var drivers = make(map[string]func(string) (tkvClient, error))
@@ -2233,15 +2231,18 @@ func (m *kvMeta) doRemoveXattr(ctx Context, inode Ino, name string) syscall.Errn
 	}))
 }
 
-func (m *kvMeta) dumpEntry(inode Ino, typ uint8) (*DumpedEntry, error) {
-	e := &DumpedEntry{}
-	f := func(tx kvTxn) error {
+func (m *kvMeta) dumpEntry(inode Ino, e *DumpedEntry) error {
+	if m.entries != nil {
+		sort.Slice(e.Chunks, func(i, j int) bool { return e.Chunks[i].Index < e.Chunks[j].Index })
+		return nil
+	}
+	return m.client.txn(func(tx kvTxn) error {
 		a := tx.get(m.inodeKey(inode))
 		if a == nil {
 			logger.Warnf("inode %d not found", inode)
 		}
 
-		attr := &Attr{Typ: typ, Nlink: 1}
+		attr := &Attr{Nlink: 1}
 		m.parseAttr(a, attr)
 		e.Attr = dumpAttr(attr)
 		e.Attr.Inode = inode
@@ -2257,7 +2258,7 @@ func (m *kvMeta) dumpEntry(inode Ino, typ uint8) (*DumpedEntry, error) {
 		}
 
 		if attr.Typ == TypeFile {
-			vals = tx.scanRange(m.chunkKey(inode, 0), m.chunkKey(inode, uint32(attr.Length/ChunkSize)+1))
+			vals := tx.scanRange(m.chunkKey(inode, 0), m.chunkKey(inode, uint32(attr.Length/ChunkSize)+1))
 			for indx := uint32(0); uint64(indx)*ChunkSize < attr.Length; indx++ {
 				v, ok := vals[string(m.chunkKey(inode, indx))]
 				if !ok {
@@ -2278,12 +2279,7 @@ func (m *kvMeta) dumpEntry(inode Ino, typ uint8) (*DumpedEntry, error) {
 			e.Symlink = string(l)
 		}
 		return nil
-	}
-	if m.snap != nil {
-		return e, m.snap.txn(f)
-	} else {
-		return e, m.txn(f)
-	}
+	})
 }
 
 func (m *kvMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, depth int, showProgress func(totalIncr, currentIncr int64)) error {
@@ -2292,40 +2288,46 @@ func (m *kvMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, depth i
 			panic(err)
 		}
 	}
-	var vals map[string][]byte
+	var entries map[string]*DumpedEntry
 	var err error
-	if m.snap != nil {
-		err = m.snap.txn(func(tx kvTxn) error {
-			vals = tx.scanValues(m.entryKey(inode, ""), -1, nil)
-			return nil
-		})
-	} else {
-		vals, err = m.scanValues(m.entryKey(inode, ""), -1, nil)
-	}
-	if err != nil {
-		return err
-	}
-	if showProgress != nil {
-		showProgress(int64(len(vals)), 0)
-	}
-	if err = tree.writeJsonWithOutEntry(bw, depth); err != nil {
-		return err
-	}
 	var sortedName []string
-	for k := range vals {
-		sortedName = append(sortedName, k)
-	}
-	sort.Slice(sortedName, func(i, j int) bool { return sortedName[i][10:] < sortedName[j][10:] })
-
-	for idx, name := range sortedName {
-		typ, inode := m.parseEntry(vals[name])
-		var entry *DumpedEntry
-		entry, err = m.dumpEntry(inode, typ)
+	if m.entries != nil {
+		e := m.entries[inode]
+		entries = e.Entries
+		for n := range e.Entries {
+			sortedName = append(sortedName, n)
+		}
+	} else {
+		vals, err := m.scanValues(m.entryKey(inode, ""), -1, nil)
 		if err != nil {
 			return err
 		}
-		entry.Name = name[10:]
-		if typ == TypeDirectory {
+		entries = map[string]*DumpedEntry{}
+		for k, value := range vals {
+			name := k[10:]
+			typ, inode := m.parseEntry(value)
+			sortedName = append(sortedName, name)
+			entries[name] = &DumpedEntry{Name: name, Attr: &DumpedAttr{Inode: inode, Type: typeToString(typ)}}
+		}
+	}
+	sort.Slice(sortedName, func(i, j int) bool { return sortedName[i] < sortedName[j] })
+	if showProgress != nil && m.entries == nil {
+		showProgress(int64(len(entries)), 0)
+	}
+
+	if err = tree.writeJsonWithOutEntry(bw, depth); err != nil {
+		return err
+	}
+
+	for idx, name := range sortedName {
+		entry := entries[name]
+		entry.Name = name
+		inode := entry.Attr.Inode
+		err = m.dumpEntry(inode, entry)
+		if err != nil {
+			return err
+		}
+		if entry.Attr.Type == "directory" {
 			err = m.dumpDir(inode, entry, bw, depth+2, showProgress)
 		} else {
 			err = entry.writeJSON(bw, depth+2)
@@ -2333,7 +2335,7 @@ func (m *kvMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, depth i
 		if err != nil {
 			return err
 		}
-		if idx != len(vals)-1 {
+		if idx != len(entries)-1 {
 			bwWrite(",")
 		}
 		if showProgress != nil {
@@ -2372,46 +2374,85 @@ func (m *kvMeta) DumpMeta(w io.Writer, root Ino) (err error) {
 	progress := utils.NewProgress(false, false)
 	var tree, trash *DumpedEntry
 	root = m.checkRoot(root)
+
 	if root == 1 { // make snap
-		switch c := m.client.(type) {
-		case *memKV:
-			m.snap = c
-		default:
-			defer func() { m.snap = nil }()
-			m.snap = &memKV{items: btree.New(2), temp: &kvItem{}}
-			bar := progress.AddCountBar("Snapshot keys", 0)
-			bUsed, _ := m.get(m.counterKey(usedSpace))
-			bInodes, _ := m.get(m.counterKey(totalInodes))
-			used := parseCounter(bUsed)
-			inodeTotal := parseCounter(bInodes)
-			var guessKeyTotal int64 = 3 // setting, nextInode, nextChunk
-			if inodeTotal > 0 {
-				guessKeyTotal += int64(math.Ceil((float64(used/inodeTotal/(64*1024*1024)) + float64(3)) * float64(inodeTotal)))
-			}
-			bar.SetCurrent(0) // Reset
-			bar.SetTotal(guessKeyTotal)
-			threshold := 0.1
-			err := m.client.scan(nil, func(key, value []byte) {
-				m.snap.set(string(key), value)
-				if bar.Current() > int64(math.Ceil(float64(guessKeyTotal)*(1-threshold))) {
-					guessKeyTotal += int64(math.Ceil(float64(guessKeyTotal) * threshold))
-					bar.SetTotal(guessKeyTotal)
+		m.entries = make(map[Ino]*DumpedEntry)
+		defer func() {
+			m.entries = nil
+		}()
+		bar := progress.AddCountBar("Snapshot keys", 0)
+		bUsed, _ := m.get(m.counterKey(usedSpace))
+		bInodes, _ := m.get(m.counterKey(totalInodes))
+		used := parseCounter(bUsed)
+		inodeTotal := parseCounter(bInodes)
+		var guessKeyTotal int64 = 3 // setting, nextInode, nextChunk
+		if inodeTotal > 0 {
+			guessKeyTotal += int64(math.Ceil((float64(used/inodeTotal/(64*1024*1024)) + float64(3)) * float64(inodeTotal)))
+		}
+		bar.SetCurrent(0) // Reset
+		bar.SetTotal(guessKeyTotal)
+		threshold := 0.1
+		var cnt int
+		err := m.client.scan(nil, func(key, value []byte) {
+			if len(key) > 9 && key[0] == 'A' {
+				ino := m.decodeInode(key[1:9])
+				e := m.entries[ino]
+				if e == nil {
+					e = &DumpedEntry{}
+					m.entries[ino] = e
 				}
-				bar.Increment()
-			})
-			if err != nil {
-				return err
+				if len(key) == 10 && key[9] == 'I' {
+					attr := &Attr{Nlink: 1}
+					m.parseAttr(value, attr)
+					e.Attr = dumpAttr(attr)
+					e.Attr.Inode = ino
+				} else if len(key) > 10 && key[9] == 'X' {
+					e.Xattrs = append(e.Xattrs, &DumpedXattr{string(key[10:]), string(value)})
+				} else if len(key) == 14 && key[9] == 'C' {
+					indx := binary.BigEndian.Uint32(key[10:])
+					ss := readSliceBuf(value)
+					slices := make([]*DumpedSlice, 0, len(ss))
+					for _, s := range ss {
+						slices = append(slices, &DumpedSlice{Chunkid: s.chunkid, Pos: s.pos, Size: s.size, Off: s.off, Len: s.len})
+					}
+					e.Chunks = append(e.Chunks, &DumpedChunk{indx, slices})
+				} else if len(key) > 10 && key[9] == 'D' {
+					name := string(key[10:])
+					_, inode := m.parseEntry(value)
+					child := m.entries[inode]
+					if child == nil {
+						child = &DumpedEntry{}
+						m.entries[inode] = child
+					}
+					if e.Entries == nil {
+						e.Entries = map[string]*DumpedEntry{}
+					}
+					e.Entries[name] = child
+				} else if len(key) == 10 && key[9] == 'S' {
+					e.Symlink = string(value)
+				}
 			}
-			bar.Done()
+			cnt++
+			if cnt%100 == 0 && bar.Current() > int64(math.Ceil(float64(guessKeyTotal)*(1-threshold))) {
+				guessKeyTotal += int64(math.Ceil(float64(guessKeyTotal) * threshold))
+				bar.SetTotal(guessKeyTotal)
+			}
+			bar.Increment()
+		})
+		if err != nil {
+			return err
 		}
-		if trash, err = m.dumpEntry(TrashInode, TypeDirectory); err != nil {
-			trash = nil
+		bar.Done()
+		tree = m.entries[root]
+		trash = m.entries[TrashInode]
+	} else {
+		tree = &DumpedEntry{}
+		if err = m.dumpEntry(root, tree); err != nil {
+			return err
 		}
 	}
-	if tree, err = m.dumpEntry(root, TypeDirectory); err != nil {
-		return err
-	}
-	if tree == nil {
+
+	if tree.Attr == nil {
 		return errors.New("The entry of the root inode was not found")
 	}
 	tree.Name = "FSTree"
@@ -2436,14 +2477,7 @@ func (m *kvMeta) DumpMeta(w io.Writer, root Ino) (err error) {
 		}
 	}
 
-	if root == 1 {
-		err = m.snap.txn(func(tx kvTxn) error {
-			vals = tx.scanValues(m.fmtKey("SS"), -1, nil)
-			return nil
-		})
-	} else {
-		vals, err = m.scanValues(m.fmtKey("SS"), -1, nil)
-	}
+	vals, err = m.scanValues(m.fmtKey("SS"), -1, nil)
 	if err != nil {
 		return err
 	}
@@ -2486,6 +2520,7 @@ func (m *kvMeta) DumpMeta(w io.Writer, root Ino) (err error) {
 
 	bar := progress.AddCountBar("Dumped entries", 1) // with root
 	bar.Increment()
+	bar.SetTotal(int64(len(m.entries)))
 	if trash != nil {
 		trash.Name = "Trash"
 		bar.IncrTotal(1)

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -277,7 +277,7 @@ func (c *memKV) scan(prefix []byte, handler func(key []byte, value []byte)) erro
 	end := string(nextKey(prefix))
 	c.items.AscendGreaterOrEqual(&kvItem{key: begin}, func(i btree.Item) bool {
 		it := i.(*kvItem)
-		if it.key >= end {
+		if end != "" && it.key >= end {
 			return false
 		}
 		handler([]byte(it.key), it.value)


### PR DESCRIPTION
The btree used by memkv is still to slow, this PR change to use go map instead.