### PR TITLE
CI:fix rm action err

### DIFF
--- a/.github/workflows/rmdirectory.yml
+++ b/.github/workflows/rmdirectory.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     #The branches below must be a subset of the branches above
     branches:
+      - 'main'
       - 'release-**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/rmdirectory.yml
+++ b/.github/workflows/rmdirectory.yml
@@ -55,7 +55,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 400w Files in a Directory of 400 Children Directory
         run: |
-          cd /tmp/juicefs-sync-test/
+          cd /tmp/juicefs-load-test/
           sudo chmod 777 mkdir
           echo "rm 400w files in a directory of 400 children directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -106,7 +106,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 400w Files in a Directory of 400 Children Directory
         run: |
-          cd /tmp/juicefs-sync-test/
+          cd /tmp/juicefs-load-test/
           sudo chmod 777 mkdir
           echo "rm 400w files in a directory of 400 children directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -169,7 +169,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 400w Files in a Directory of 400 Children Directory
         run: |
-          cd /tmp/juicefs-sync-test/
+          cd /tmp/juicefs-load-test/
           sudo chmod 777 mkdir
           echo "rm 400w files in a directory of 400 children directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -218,7 +218,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 400w Files in a Directory of 400 Children Directory
         run: |
-          cd /tmp/juicefs-sync-test/
+          cd /tmp/juicefs-load-test/
           sudo chmod 777 mkdir
           echo "rm 400w files in a directory of 400 children directory"
           git clone https://github.com/juicedata/juicefs.git

--- a/.github/workflows/rmfiles.yml
+++ b/.github/workflows/rmfiles.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     #The branches below must be a subset of the branches above
     branches:
+      - 'main'
       - 'release-**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/rmfiles.yml
+++ b/.github/workflows/rmfiles.yml
@@ -55,7 +55,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 100w Files in Depth of 1 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           sudo chmod 777 ../mkdir
           echo "rm 100w files in depth of 1 directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -64,13 +64,13 @@ jobs:
           sudo ./juicefs rmr ../aaa/
       - name: Rm 100w Files in Depth of 10 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 100w files in depth of 10 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa0/
       - name: Rm 200w Files in Depth of 20 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 200w files in depth of 20 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa2/
@@ -116,7 +116,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 100w Files in Depth of 1 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           sudo chmod 777 ../mkdir
           echo "rm 100w files in depth of 1 directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -125,13 +125,13 @@ jobs:
           sudo ./juicefs rmr ../aaa/
       - name: Rm 100w Files in Depth of 10 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 100w files in depth of 10 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa0/
       - name: Rm 200w Files in Depth of 20 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 200w files in depth of 20 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa2/
@@ -189,7 +189,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 100w Files in Depth of 1 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           sudo chmod 777 ../mkdir
           echo "rm 100w files in depth of 1 directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -198,13 +198,13 @@ jobs:
           sudo ./juicefs rmr ../aaa/
       - name: Rm 100w Files in Depth of 10 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 100w files in depth of 10 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa0/
       - name: Rm 200w Files in Depth of 20 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 200w files in depth of 20 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa2/
@@ -249,7 +249,7 @@ jobs:
           load_file: "META_4M_EMPTY_FILE_RM.json"
       - name: Rm 100w Files in Depth of 1 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           sudo chmod 777 ../mkdir
           echo "rm 100w files in depth of 1 directory"
           git clone https://github.com/juicedata/juicefs.git
@@ -258,13 +258,13 @@ jobs:
           sudo ./juicefs rmr ../aaa/
       - name: Rm 100w Files in Depth of 10 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 100w files in depth of 10 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa0/
       - name: Rm 200w Files in Depth of 20 Directory
         run: |
-          cd /tmp/juicefs-sync-test/mkdir/
+          cd /tmp/juicefs-load-test/mkdir/
           echo "rm 200w files in depth of 20 directory"
           cd juicefs
           sudo ./juicefs rmr ../aaa2/


### PR DESCRIPTION
/home/runner/work/_temp/d5604aef-e1c5-4e69-8bff-ac019aa78f50.sh: line 1: cd: /tmp/juicefs-sync-test/: No such file or directory
Error: Process completed with exit code 1.

https://github.com/juicedata/juicefs/runs/6747044587?check_suite_focus=true