### PR TITLE
eliminate panic which is triggered by missing argument

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -205,7 +205,7 @@ func reorderOptions(app *cli.App, args []string) []string {
 		option := args[i]
 		if ok, hasValue := isFlag(cmdFlags, option); ok {
 			newArgs = append(newArgs, option)
-			if hasValue {
+			if hasValue && len(args[i+1:]) > 0 {
 				i++
 				newArgs = append(newArgs, args[i])
 			}


### PR DESCRIPTION
Hi community, I find panic will be triggered by missing argument, like below

<img width="658" alt="image" src="https://user-images.githubusercontent.com/27723125/172545007-747abdc5-7b18-484b-b669-50d48b358f40.png">

I think that eliminating this panic will make Juicefs CLI  more friendly.

