### PR TITLE
Revert "meta: reduce concurrency of RMR (#2102)"

### DIFF
--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -285,7 +285,7 @@ func Remove(r Meta, ctx Context, parent Ino, name string) syscall.Errno {
 	if attr.Typ != TypeDirectory {
 		return r.Unlink(ctx, parent, name)
 	}
-	concurrent := make(chan int, 10)
+	concurrent := make(chan int, 50)
 	return emptyEntry(r, ctx, parent, name, inode, concurrent)
 }
 


### PR DESCRIPTION
This reverts commit 03175d2b7f7b41ff1eb679d716deafeb0b6412c0.