### PR TITLE
cmd/rmr: remove entries in batch

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -438,7 +438,7 @@ func (fs *FileSystem) Rmr(ctx meta.Context, p string) (err syscall.Errno) {
 	if err != 0 {
 		return
 	}
-	err = meta.Remove(fs.m, ctx, parent.inode, path.Base(p), nil)
+	err = fs.m.Remove(ctx, parent.inode, path.Base(p), nil)
 	fs.invalidateEntry(parent.inode, path.Base(p))
 	return
 }

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -105,14 +105,14 @@ type baseMeta struct {
 	en engine
 }
 
-func newBaseMeta(addr string, conf *Config) baseMeta {
+func newBaseMeta(addr string, conf *Config) *baseMeta {
 	if conf.Retries == 0 {
 		conf.Retries = 10
 	}
 	if conf.Heartbeat == 0 {
 		conf.Heartbeat = 12 * time.Second
 	}
-	return baseMeta{
+	return &baseMeta{
 		addr:         utils.RemovePassword(addr),
 		conf:         conf,
 		root:         1,
@@ -125,6 +125,14 @@ func newBaseMeta(addr string, conf *Config) baseMeta {
 			callbacks: make(map[uint32]MsgCallback),
 		},
 	}
+}
+
+func (m *baseMeta) getEngine() engine {
+	return m.en
+}
+
+func (m *baseMeta) getBase() *baseMeta {
+	return m
 }
 
 func (m *baseMeta) checkRoot(inode Ino) Ino {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -127,10 +127,6 @@ func newBaseMeta(addr string, conf *Config) *baseMeta {
 	}
 }
 
-func (m *baseMeta) getEngine() engine {
-	return m.en
-}
-
 func (m *baseMeta) getBase() *baseMeta {
 	return m
 }

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -55,15 +55,6 @@ func testMeta(t *testing.T, m Meta) {
 	if err := m.Reset(); err != nil {
 		t.Fatalf("reset meta: %s", err)
 	}
-	var base *baseMeta
-	switch m := m.(type) {
-	case *redisMeta:
-		base = &m.baseMeta
-	case *dbMeta:
-		base = &m.baseMeta
-	case *kvMeta:
-		base = &m.baseMeta
-	}
 	testMetaClient(t, m)
 	testTruncateAndDelete(t, m)
 	testTrash(t, m)
@@ -78,6 +69,7 @@ func testMeta(t *testing.T, m Meta) {
 	testCopyFileRange(t, m)
 	testCloseSession(t, m)
 	testConcurrentDir(t, m)
+	base := m.getBase()
 	base.conf.OpenCache = time.Second
 	base.of.expire = time.Second
 	testOpenCache(t, m)

--- a/pkg/meta/benchmarks_test.go
+++ b/pkg/meta/benchmarks_test.go
@@ -116,7 +116,7 @@ func BenchmarkReadSliceBuf(b *testing.B) {
 
 func prepareParent(m Meta, name string, inode *Ino) error {
 	ctx := Background
-	if err := Remove(m, ctx, 1, name, nil); err != 0 && err != syscall.ENOENT {
+	if err := m.Remove(ctx, 1, name, nil); err != 0 && err != syscall.ENOENT {
 		return fmt.Errorf("remove: %s", err)
 	}
 	if err := m.Mkdir(ctx, 1, name, 0755, 0, 0, inode, nil); err != 0 {

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -344,6 +344,10 @@ type Meta interface {
 	// Dump the tree under root, which may be modified by checkRoot
 	DumpMeta(w io.Writer, root Ino) error
 	LoadMeta(r io.Reader) error
+
+	// getEngine return the actual engine.
+	getEngine() engine
+	getBase() *baseMeta
 }
 
 type Creator func(driver, addr string, conf *Config) (Meta, error)

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -337,6 +337,8 @@ type Meta interface {
 	CompactAll(ctx Context, bar *utils.Bar) syscall.Errno
 	// ListSlices returns all slices used by all files.
 	ListSlices(ctx Context, slices map[Ino][]Slice, delete bool, showProgress func()) syscall.Errno
+	// Remove all files and directories recursively.
+	Remove(ctx Context, parent Ino, name string, count *uint64) syscall.Errno
 
 	// OnMsg add a callback for the given message type.
 	OnMsg(mtype uint32, cb MsgCallback)
@@ -345,8 +347,7 @@ type Meta interface {
 	DumpMeta(w io.Writer, root Ino) error
 	LoadMeta(r io.Reader) error
 
-	// getEngine return the actual engine.
-	getEngine() engine
+	// getBase return the base engine.
 	getBase() *baseMeta
 }
 

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -72,7 +72,7 @@ import (
 */
 
 type redisMeta struct {
-	baseMeta
+	*baseMeta
 	rdb        redis.UniversalClient
 	prefix     string
 	shaLookup  string // The SHA returned by Redis for the loaded `scriptLookup`

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -155,7 +155,7 @@ type delfile struct {
 }
 
 type dbMeta struct {
-	baseMeta
+	*baseMeta
 	db   *xorm.Engine
 	snap *dbSnap
 }

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -61,7 +61,7 @@ type tkvClient interface {
 }
 
 type kvMeta struct {
-	baseMeta
+	*baseMeta
 	client tkvClient
 	snap   map[Ino]*DumpedEntry
 }

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -226,55 +226,60 @@ func emptyDir(r Meta, ctx Context, inode Ino, count *uint64, concurrent chan int
 	if st := r.Access(ctx, inode, 3, nil); st != 0 {
 		return st
 	}
-	var entries []*Entry
-	if st := r.Readdir(ctx, inode, 0, &entries); st != 0 {
-		return st
-	}
-	var wg sync.WaitGroup
-	var status syscall.Errno
-	// try directories first to increase parallel
-	var dirs int
-	for i, e := range entries {
-		if e.Attr.Typ == TypeDirectory {
-			entries[dirs], entries[i] = entries[i], entries[dirs]
-			dirs++
+	for {
+		var entries []*Entry
+		if st := r.getEngine().doReaddir(ctx, inode, 0, &entries, 10000); st != 0 {
+			return st
 		}
-	}
-	for _, e := range entries {
-		if e.Inode == inode || len(e.Name) == 2 && string(e.Name) == ".." {
-			continue
+		if len(entries) == 0 {
+			return 0
 		}
-		if e.Attr.Typ == TypeDirectory {
-			select {
-			case concurrent <- 1:
-				wg.Add(1)
-				go func(child Ino, name string) {
-					defer wg.Done()
-					e := emptyEntry(r, ctx, inode, name, child, count, concurrent)
-					if e != 0 {
-						status = e
+		var wg sync.WaitGroup
+		var status syscall.Errno
+		// try directories first to increase parallel
+		var dirs int
+		for i, e := range entries {
+			if e.Attr.Typ == TypeDirectory {
+				entries[dirs], entries[i] = entries[i], entries[dirs]
+				dirs++
+			}
+		}
+		for i, e := range entries {
+			if e.Attr.Typ == TypeDirectory {
+				select {
+				case concurrent <- 1:
+					wg.Add(1)
+					go func(child Ino, name string) {
+						defer wg.Done()
+						e := emptyEntry(r, ctx, inode, name, child, count, concurrent)
+						if e != 0 {
+							status = e
+						}
+						<-concurrent
+					}(e.Inode, string(e.Name))
+				default:
+					if st := emptyEntry(r, ctx, inode, string(e.Name), e.Inode, count, concurrent); st != 0 {
+						return st
 					}
-					<-concurrent
-				}(e.Inode, string(e.Name))
-			default:
-				if st := emptyEntry(r, ctx, inode, string(e.Name), e.Inode, count, concurrent); st != 0 {
+				}
+			} else {
+				if count != nil {
+					atomic.AddUint64(count, 1)
+				}
+				if st := r.Unlink(ctx, inode, string(e.Name)); st != 0 {
 					return st
 				}
 			}
-		} else {
-			if count != nil {
-				atomic.AddUint64(count, 1)
+			if ctx.Canceled() {
+				return syscall.EINTR
 			}
-			if st := r.Unlink(ctx, inode, string(e.Name)); st != 0 {
-				return st
-			}
+			entries[i] = nil // release memory
 		}
-		if ctx.Canceled() {
-			return syscall.EINTR
+		wg.Wait()
+		if status != 0 {
+			return status
 		}
 	}
-	wg.Wait()
-	return status
 }
 
 func emptyEntry(r Meta, ctx Context, parent Ino, name string, inode Ino, count *uint64, concurrent chan int) syscall.Errno {

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -192,7 +192,7 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 		go func() {
 			inode := Ino(r.Get64())
 			name := string(r.Get(int(r.Get8())))
-			st = meta.Remove(v.Meta, ctx, inode, name, &count)
+			st = v.Meta.Remove(ctx, inode, name, &count)
 			if st != 0 {
 				logger.Errorf("remove %d/%s: %s", inode, name, st)
 			}


### PR DESCRIPTION
When removing directories with many files in parallel, they need lots of memory for these entries. 

This PR change to remove them as smaller batches (10000), so it will hold at most 500K entries in memory (100-200MB). 

For smaller directories, it will take one more readdir() to ensure that the directory is empty (better for concurrent adding files).