### PR TITLE
skip auto update brew tap in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,11 +73,3 @@ changelog:
       - '^test:'
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-
-brews:
-  - tap:
-      owner: juicedata
-      name: homebrew-tap
-    folder: Formula
-    homepage: https://github.com/juicedata/juicefs
-    description: JuiceFS is a distributed POSIX file system built on top of Redis and S3


### PR DESCRIPTION
We may create a temporary pre-release tag before an official release to test the whole release flow, this PR remove the auto homebrew tap update in goreleaser process. We'll update the homebrew tap in another process after the release.