### PR TITLE
CI: add redis failure log

### DIFF
--- a/.github/workflows/redis_compile.yml
+++ b/.github/workflows/redis_compile.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     #The branches below must be a subset of the branches above
     branches:
+      - 'main'
       - 'release-**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/redis_compile.yml
+++ b/.github/workflows/redis_compile.yml
@@ -57,7 +57,7 @@ jobs:
 
 
       - name: Log
-        if: ${{ failure() }}
+        if: ${{ always() }}
         run: |
           echo "juicefs log"
           sudo tail -n 1000 /var/log/juicefs.log

--- a/.github/workflows/redis_compile.yml
+++ b/.github/workflows/redis_compile.yml
@@ -54,6 +54,13 @@ jobs:
           make test
           stat /tmp/jfs
 
+
+      - name: Log
+        if: ${{ failure() }}
+        run: |
+          echo "juicefs log"
+          sudo tail -n 1000 /var/log/juicefs.log
+
       - name: Send Slack Notification
         if: ${{ failure() }}
         uses: juicedata/slack-notify-action@main

--- a/.github/workflows/redis_compile.yml
+++ b/.github/workflows/redis_compile.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     #The branches below must be a subset of the branches above
     branches:
-      - 'main'
       - 'release-**'
     paths-ignore:
       - 'docs/**'
@@ -57,7 +56,7 @@ jobs:
 
 
       - name: Log
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: |
           echo "juicefs log"
           sudo tail -n 1000 /var/log/juicefs.log


### PR DESCRIPTION
*** [err]: Don't rehash if redis has child proecess in tests/unit/other.tcl
Expected '[Dictionary HT]
Hash table 0 stats (main hash table):
 table size: 4096
 number of elements: 4099
 different slots: 2619
 max chain length: 7
 avg chain length (counted): 1.57
 avg chain length (computed): 1.57
 Chain length distribution:
   0: 1477 (36.06%)
   1: 1551 (37.87%)
   2: 743 (18.14%)
   3: 253 (6.18%)
   4: 59 (1.44%)
   5: 12 (0.29%)
   7: 1 (0.02%)
[Expires HT]
No stats available for empty dictionaries
' to match '*table size: 16384*' (context: type eval line 16 cmd {assert_match "*table size: 16384*" [r debug HTSTATS 9]} proc ::test)
Cleanup: may take some time... OK
make[1]: *** [Makefile:349: test] Error 1
make[1]: Leaving directory '/tmp/jfs/redis/src'
make: *** [Makefile:6: test] Error 2
Error: Process completed with exit code 2.

https://github.com/juicedata/juicefs/runs/7039510757?check_suite_focus=true