### PR TITLE
cmd/doctor: doctor command supports collecting system, syslog and other info

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -527,6 +527,7 @@ JuiceFS Version:
 			"blocks":       {name: "block.pb.gz", url: baseUrl + "block"},
 			"cmdline":      {name: "cmdline.txt", url: baseUrl + "cmdline"},
 			"goroutine":    {name: "goroutine.pb.gz", url: baseUrl + "goroutine"},
+			"stack":        {name: "goroutine.stack.txt", url: baseUrl + "goroutine?debug=1"},
 			"heap":         {name: "heap.pb.gz", url: baseUrl + "heap"},
 			"mutex":        {name: "mutex.pb.gz", url: baseUrl + "mutex"},
 			"threadcreate": {name: "threadcreate.pb.gz", url: baseUrl + "threadcreate"},

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -126,7 +126,7 @@ func copyConfigFile(srcPath, destPath string, rootPrivileges bool) error {
 	if rootPrivileges {
 		copyArgs = append(copyArgs, "sudo")
 	}
-	copyArgs = append(copyArgs, "/bin/sh", "-c", fmt.Sprintf("cp %s %s", srcPath, destPath))
+	copyArgs = append(copyArgs, "/bin/sh", "-c", fmt.Sprintf("cat %s > %s", srcPath, destPath))
 	return exec.Command(copyArgs[0], copyArgs[1:]...).Run()
 }
 
@@ -214,7 +214,7 @@ func copyLogFile(logPath, retLogPath string, limit uint64, rootPrivileges bool) 
 	if limit > 0 {
 		copyArgs = append(copyArgs, fmt.Sprintf("tail -n %d %s > %s", limit, logPath, retLogPath))
 	} else {
-		copyArgs = append(copyArgs, fmt.Sprintf("cp %s %s", logPath, retLogPath))
+		copyArgs = append(copyArgs, fmt.Sprintf("cat %s > %s", logPath, retLogPath))
 	}
 	return exec.Command(copyArgs[0], copyArgs[1:]...).Run()
 }
@@ -380,7 +380,10 @@ func geneZipFile(srcPath, destPath string) error {
 			return err
 		}
 		if !info.IsDir() {
-			file, _ := os.Open(path)
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
 			defer closeFile(file)
 			if _, err := io.Copy(writer, file); err != nil {
 				return err
@@ -426,7 +429,7 @@ func doctor(ctx *cli.Context) error {
 	mp, _ = filepath.Abs(mp)
 	timestamp := time.Now().Format("20060102150405")
 	prefix := strings.Trim(strings.Join(strings.Split(mp, "/"), "-"), "-")
-	currDir := path.Join(outDir, fmt.Sprintf("%s-%s", prefix, timestamp))
+	currDir := filepath.Join(outDir, fmt.Sprintf("%s-%s", prefix, timestamp))
 	if err := os.Mkdir(currDir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create current out dir %s: %v", currDir, err)
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -410,19 +410,11 @@ func doctor(ctx *cli.Context) error {
 
 	outDir := ctx.String("out-dir")
 	// special treatment for non-existing out dir
-	if _, err := os.Stat(outDir); os.IsNotExist(err) {
-		if err := os.Mkdir(outDir, os.ModePerm); err != nil {
+	if outDirInfo, err := os.Stat(outDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(outDir, os.ModePerm); err != nil {
 			return fmt.Errorf("failed to create out dir %s: %v", outDir, err)
 		}
-	}
-
-	// double check the file stat
-	outDirInfo, err := os.Stat(outDir)
-	if err != nil {
-		return fmt.Errorf("failed to stat out dir %s: %v", outDir, err)
-	}
-
-	if !outDirInfo.IsDir() {
+	} else if err == nil && !outDirInfo.IsDir() {
 		return fmt.Errorf("argument --out-dir is not directory: %s", outDir)
 	}
 
@@ -535,7 +527,6 @@ JuiceFS Version:
 			"blocks":       {name: "block.pb.gz", url: baseUrl + "block"},
 			"cmdline":      {name: "cmdline.txt", url: baseUrl + "cmdline"},
 			"goroutine":    {name: "goroutine.pb.gz", url: baseUrl + "goroutine"},
-			"fullstack":    {name: "full.goroutine.stack.txt", url: baseUrl + "goroutine?debug=2"},
 			"heap":         {name: "heap.pb.gz", url: baseUrl + "heap"},
 			"mutex":        {name: "mutex.pb.gz", url: baseUrl + "mutex"},
 			"threadcreate": {name: "threadcreate.pb.gz", url: baseUrl + "threadcreate"},

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,494 @@
+/*
+ * JuiceFS, Copyright 2022 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/utils"
+
+	"github.com/urfave/cli/v2"
+)
+
+var defaultOutDir = path.Join(".", "doctor")
+
+const (
+	defaultTraceTime   = 5
+	defaultProfileTime = 30
+)
+
+func cmdDoctor() *cli.Command {
+	return &cli.Command{
+		Name:      "doctor",
+		Action:    doctor,
+		Category:  "INSPECTOR",
+		ArgsUsage: "MOUNTPOINT",
+		Usage:     "Collect and show system static and runtime information",
+		Description: `
+It collects and shares information from multiple dimensions such as the running environment and system logs, etc.
+
+Examples:
+$ juicefs doctor /mnt/jfs
+
+# Result will be output to /var/log/
+$ juicefs doctor --out-dir=/var/log /mnt/jfs
+
+# Get log file up to 1000 entries
+$ juicefs doctor --out-dir=/var/log --collect-log --limit=1000 /mnt/jfs
+
+# Get pprof information
+$ juicefs doctor --out-dir=/var/log --collect-log --limit=1000 --collect-pprof /mnt/jfs
+`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "out-dir",
+				Value: defaultOutDir,
+				Usage: "the output directory of the result file",
+			},
+			&cli.BoolFlag{
+				Name:  "collect-log",
+				Usage: "enable log collection",
+			},
+			&cli.Uint64Flag{
+				Name:  "limit",
+				Usage: "the number of last entries to be collected",
+			},
+			&cli.BoolFlag{
+				Name:  "collect-pprof",
+				Usage: "enable pprof collection",
+			},
+			&cli.Uint64Flag{
+				Name:  "trace-sec",
+				Value: defaultTraceTime,
+				Usage: "trace sampling duration",
+			},
+			&cli.Uint64Flag{
+				Name:  "profile-sec",
+				Value: defaultProfileTime,
+				Usage: "profile sampling duration",
+			},
+		},
+	}
+}
+
+func getVolumeConf(mp string) (string, error) {
+	confPath := path.Join(mp, ".config")
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		return "", fmt.Errorf("error reading config %s: %v", confPath, err)
+	}
+	return string(conf), nil
+}
+
+func getCmdMount(mp string) (pid, cmd string, err error) {
+	if !isUnix() {
+		logger.Warnf("Failed to get command mount: %s is not supported", runtime.GOOS)
+		return "", "", nil
+	}
+
+	ret, err := exec.Command("bash", "-c", "ps -ef | grep 'juicefs mount' | grep "+mp).CombinedOutput()
+	// `exit status 1"` occurs when there is no matching item for `grep`
+	if err != nil && !strings.Contains(err.Error(), "exit status 1") {
+		return "", "", fmt.Errorf("failed to execute command `ps -ef | grep juicefs | grep %s`: %v", mp, err)
+	}
+
+	lines := strings.Split(string(ret), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := lines[i]
+		fields := strings.Fields(line)
+		if len(fields) <= 7 {
+			continue
+		}
+		cmdFields := fields[7:]
+		for _, arg := range cmdFields {
+			if mp == arg {
+				cmd = strings.Join(fields[7:], " ")
+				pid = fields[1]
+				break
+			}
+		}
+	}
+	if cmd == "" {
+		return "", "", fmt.Errorf("not found mount point: %s", mp)
+	}
+	return pid, cmd, nil
+}
+
+func getDefaultLogDir() (string, error) {
+	var defaultLogDir = "/var/log"
+	switch runtime.GOOS {
+	case "linux":
+		if os.Getuid() == 0 {
+			break
+		}
+		fallthrough
+	case "darwin":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("faild to get home directory")
+		}
+		defaultLogDir = path.Join(homeDir, ".juicefs")
+	}
+	return defaultLogDir, nil
+}
+
+var logArg = regexp.MustCompile(`--log([=|\s])(\S+)`)
+
+func getLogPath(cmd string) (string, error) {
+	if !isUnix() {
+		logger.Warnf("Failed to get log path: %s is not supported", runtime.GOOS)
+		return "", nil
+	}
+
+	var logPath string
+	tmp := logArg.FindStringSubmatch(cmd)
+	if len(tmp) == 3 {
+		logPath = tmp[2]
+	} else {
+		defaultLogDir, err := getDefaultLogDir()
+		if err != nil {
+			return "", err
+		}
+		logPath = path.Join(defaultLogDir, "juicefs.log")
+	}
+
+	return logPath, nil
+}
+
+func closeFile(file *os.File) {
+	if err := file.Close(); err != nil {
+		logger.Fatalf("error closing log file %s: %v", file.Name(), err)
+	}
+}
+
+func copyLogFile(logPath, retLogPath string, limit uint64) error {
+	logFile, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("error opening log file %s: %v", logPath, err)
+	}
+	defer closeFile(logFile)
+
+	tmpFile, err := ioutil.TempFile("", "juicefs-")
+	if err != nil {
+		return fmt.Errorf("error creating log file %s: %v", tmpFile.Name(), err)
+	}
+	defer closeFile(tmpFile)
+	writer := bufio.NewWriter(tmpFile)
+
+	if limit > 0 {
+		cmdStr := fmt.Sprintf("tail -n %d %s", limit, logPath)
+		ret, err := exec.Command("bash", "-c", cmdStr).Output()
+		if err != nil {
+			return fmt.Errorf("tailing log error: %v", err)
+		}
+		if _, err = writer.Write(ret); err != nil {
+			return fmt.Errorf("failed to copy log file: %v", err)
+		}
+	} else {
+		reader := bufio.NewReader(logFile)
+		if _, err := io.Copy(writer, reader); err != nil {
+			return fmt.Errorf("failed to copy log file: %v", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("failed to flush writer: %v", err)
+	}
+	if err := os.Rename(tmpFile.Name(), retLogPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+const (
+	InvalidPort  = -1
+	pprofMinPort = 6060
+	pprofMaxPort = 6099
+)
+
+func getPprofPort(pid, mp string) (int, error) {
+	if !isUnix() {
+		logger.Warnf("Failed to get pprof port: %s is not supported", runtime.GOOS)
+		return 0, nil
+	}
+
+	cmdStr := "lsof -i -nP | grep LISTEN | grep " + pid
+	if os.Getuid() == 0 {
+		cmdStr = "sudo " + cmdStr
+	}
+	ret, err := exec.Command("bash", "-c", cmdStr).CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute command `%s`: %v", cmdStr, err)
+	}
+	lines := strings.Split(string(ret), "\n")
+	if len(lines) == 0 {
+		return 0, fmt.Errorf("pprof will be collected, but no listen port")
+	}
+
+	var listenPort = -1
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 0 {
+			port, err := strconv.Atoi(strings.Split(fields[len(fields)-2], ":")[1])
+			if err != nil {
+				logger.Errorf("failed to parse port %v: %v", port, err)
+			}
+			if port >= pprofMinPort && port <= pprofMaxPort && port <= listenPort {
+				if err := checkPort(port, mp); err == nil {
+					listenPort = port
+				}
+				continue
+			}
+		}
+	}
+
+	if listenPort == -1 {
+		return 0, fmt.Errorf("no valid pprof port found")
+	}
+	return listenPort, nil
+}
+
+func getRequest(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error GET request: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("error GET request, status code %d", resp.StatusCode)
+	}
+
+	defer func(body io.ReadCloser) {
+		if err := body.Close(); err != nil {
+			logger.Errorf("error closing body: %v", err)
+		}
+	}(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response: %v", err)
+	}
+
+	return body, nil
+}
+
+// check pprof service status
+func checkPort(port int, mp string) error {
+	url := fmt.Sprintf("http://localhost:%d/debug/pprof/cmdline?debug=1", port)
+	resp, err := getRequest(url)
+	if err != nil {
+		return fmt.Errorf("error checking pprof alive: %v", err)
+	}
+	resp = bytes.ReplaceAll(resp, []byte{0}, []byte{' '})
+	fields := strings.Fields(string(resp))
+	flag := false
+	for _, field := range fields {
+		if mp == field {
+			flag = true
+		}
+	}
+	if !flag {
+		return fmt.Errorf("mount point mismatch: \n%s\n%s", resp, mp)
+	}
+
+	return nil
+}
+
+type metricItem struct {
+	name, url string
+}
+
+func reqAndSaveMetric(name string, metric metricItem, outDir string) error {
+	resp, err := getRequest(metric.url)
+	if err != nil {
+		return fmt.Errorf("error getting metric: %v", err)
+	}
+	retPath := path.Join(outDir, fmt.Sprintf("juicefs.%s", metric.name))
+	retFile, err := os.Create(retPath)
+	if err != nil {
+		logger.Fatalf("error creating metric file %s: %v", retPath, err)
+	}
+	defer closeFile(retFile)
+
+	if name == "cmdline" {
+		resp = bytes.ReplaceAll(resp, []byte{0}, []byte{' '})
+	}
+
+	writer := bufio.NewWriter(retFile)
+	if _, err := writer.Write(resp); err != nil {
+		return fmt.Errorf("error writing metric %s: %v", name, err)
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("failed to flush writer: %v", err)
+	}
+
+	return nil
+}
+
+func isUnix() bool {
+	return runtime.GOOS == "linux" || runtime.GOOS == "darwin"
+}
+
+func doctor(ctx *cli.Context) error {
+	currTime := time.Now().Format("20060102150405")
+	setup(ctx, 1)
+	mp := ctx.Args().First()
+	inode, err := utils.GetFileInode(mp)
+	if err != nil {
+		return fmt.Errorf("lookup inode for %s: %s", mp, err)
+	}
+	if inode != 1 {
+		return fmt.Errorf("path %s is not a mount point", mp)
+	}
+
+	outDir := ctx.String("out-dir")
+	// special treatment for non-existing out dir
+	if _, err := os.Stat(outDir); os.IsNotExist(err) {
+		if err := os.Mkdir(outDir, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create out dir %s: %v", outDir, err)
+		}
+	}
+
+	// double check the file stat
+	outDirInfo, err := os.Stat(outDir)
+	if err != nil {
+		return fmt.Errorf("failed to stat out dir %s: %v", outDir, err)
+	}
+
+	if !outDirInfo.IsDir() {
+		return fmt.Errorf("argument --out-dir must be directory %s", outDir)
+	}
+
+	filePath := path.Join(outDir, fmt.Sprintf("system-info-%s.log", currTime))
+	file, err := os.Create(filePath)
+	defer closeFile(file)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %v", filePath, err)
+	}
+
+	osEntry, err := utils.GetEntry()
+	if err != nil {
+		return fmt.Errorf("failed to get system info: %v", err)
+	}
+
+	result := fmt.Sprintf(`Platform: 
+%s %s
+%s
+JuiceFS Version:
+%s`, runtime.GOOS, runtime.GOARCH, osEntry, ctx.App.Version)
+
+	if _, err = file.WriteString(result); err != nil {
+		return fmt.Errorf("failed to write system info %s: %v", filePath, err)
+	}
+	fmt.Printf("\nSystem Info:\n%s\n", result)
+
+	mp, _ = filepath.Abs(mp)
+	conf, err := getVolumeConf(mp)
+	if err != nil {
+		return err
+	}
+	prefix := strings.Trim(strings.Join(strings.Split(mp, "/"), "-"), "-")
+	confPath := path.Join(outDir, fmt.Sprintf("%s-%s.config", prefix, currTime))
+	confFile, err := os.Create(confPath)
+	defer closeFile(confFile)
+	if err != nil {
+		return fmt.Errorf("failed to create config file %s: %v", confPath, err)
+	}
+	if _, err = confFile.WriteString(conf); err != nil {
+		return fmt.Errorf("failed to write config %s: %v", confPath, err)
+	}
+
+	pid, cmd, err := getCmdMount(mp)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("\nMount Command:\n%s\n\n", cmd)
+
+	if ctx.Bool("collect-log") {
+		logPath, err := getLogPath(cmd)
+		if err != nil {
+			return err
+		}
+
+		limit := ctx.Uint64("limit")
+		retLogPath := path.Join(outDir, fmt.Sprintf("%s-%s.log", prefix, currTime))
+
+		if err := copyLogFile(logPath, retLogPath, limit); err != nil {
+			return fmt.Errorf("error copying log file: %v", err)
+		}
+		logger.Infof("Log %s is collected", logPath)
+	}
+
+	if ctx.Bool("collect-pprof") {
+		port, err := getPprofPort(pid, mp)
+		if err != nil {
+			return err
+		}
+		baseUrl := fmt.Sprintf("http://localhost:%d/debug/pprof/", port)
+		trace := ctx.Uint64("trace-sec")
+		profile := ctx.Uint64("profile-sec")
+		metrics := map[string]metricItem{
+			"allocs":       {name: "allocs.pb.gz", url: baseUrl + "allocs"},
+			"blocks":       {name: "block.pb.gz", url: baseUrl + "block"},
+			"cmdline":      {name: "cmdline.txt", url: baseUrl + "cmdline"},
+			"goroutine":    {name: "goroutine.pb.gz", url: baseUrl + "goroutine"},
+			"fullstack":    {name: "full.goroutine.stack.txt", url: baseUrl + "goroutine?debug=2"},
+			"heap":         {name: "heap.pb.gz", url: baseUrl + "heap"},
+			"mutex":        {name: "mutex.pb.gz", url: baseUrl + "mutex"},
+			"threadcreate": {name: "threadcreate.pb.gz", url: baseUrl + "threadcreate"},
+			"trace":        {name: fmt.Sprintf("trace.%ds.pb.gz", trace), url: fmt.Sprintf("%strace?seconds=%d", baseUrl, trace)},
+			"profile":      {name: fmt.Sprintf("profile.%ds.pb.gz", profile), url: fmt.Sprintf("%sprofile?seconds=%d", baseUrl, profile)},
+		}
+
+		pprofOutDir := path.Join(outDir, fmt.Sprintf("pprof-%s-%s", prefix, currTime))
+		if err := os.Mkdir(pprofOutDir, os.ModePerm); err != nil {
+			return fmt.Errorf("error creating directory: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		for name, metric := range metrics {
+			wg.Add(1)
+			go func(name string, metric metricItem) {
+				defer wg.Done()
+
+				if name == "profile" {
+					logger.Infof("Trace metrics are being sampled, sampling duration: %ds", profile)
+				}
+				if name == "trace" {
+					logger.Infof("Trace metrics are being sampled, sampling duration: %ds", trace)
+				}
+				if err := reqAndSaveMetric(name, metric, pprofOutDir); err != nil {
+					logger.Errorf("Error saving metric %s: %v", name, err)
+				}
+			}(name, metric)
+		}
+		wg.Wait()
+	}
+	return nil
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -46,17 +46,20 @@ func TestDoctor(t *testing.T) {
 	})
 
 	Convey("TestDoctor_LogArg", t, func() {
-		cases := []string{
-			"--log /var/log/jfs.log",
-			"--log=/var/log/jfs.log",
-			"--log   =   /var/log/jfs.log",
-			"--log=    /var/log/jfs.log",
-			"--log    =/var/log/jfs.log",
-			"--log      /var/log/jfs.log",
+		cases := []struct {
+			arg string
+			val string
+		}{
+			{"--log /var/log/jfs.log", "/var/log/jfs.log"},
+			{"--log=/var/log/jfs.log", "/var/log/jfs.log"},
+			{"--log   =   /var/log/jfs.log", "/var/log/jfs.log"},
+			{"--log=    /var/log/jfs.log", "/var/log/jfs.log"},
+			{"--log    =/var/log/jfs.log", "/var/log/jfs.log"},
+			{"--log      /var/log/jfs.log", "/var/log/jfs.log"},
 		}
 		for i, c := range cases {
 			Convey(fmt.Sprintf("valid log arg %d", i), func() {
-				So(logArg.MatchString(c), ShouldBeTrue)
+				So(logArg.FindStringSubmatch(c.arg)[2] == c.val, ShouldBeTrue)
 			})
 		}
 	})

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,82 @@
+/*
+ * JuiceFS, Copyright 2022 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDoctor(t *testing.T) {
+	mountTemp(t, nil, nil, nil)
+	defer umountTemp(t)
+	Convey("TestDoctor", t, func() {
+		cases := []struct {
+			name string
+			args []string
+		}{
+			{"Simple cases", []string{"", "doctor"}},
+			{"Enable collecting syslog", []string{"", "doctor", "--collect-log"}},
+			{"Max 5 log entries", []string{"", "doctor", "--collect-log", "--limit", "5"}},
+		}
+
+		for _, c := range cases {
+			Convey(c.name, func() {
+				So(Main(append(c.args, testMountPoint)), ShouldBeNil)
+			})
+		}
+
+		Convey("Mount point does not exist", func() {
+			mp := "/jfs/test/mp"
+			So(Main([]string{"", "doctor", mp}), ShouldNotBeNil)
+		})
+
+		Convey("Directory is not a mount point", func() {
+			mp := "./"
+			So(Main([]string{"", "doctor", mp}), ShouldNotBeNil)
+		})
+
+	})
+
+	Convey("TestDoctor_OutDir", t, func() {
+
+		Convey("Use default out dir", func() {
+			So(Main([]string{"", "doctor", testMountPoint}), ShouldBeNil)
+		})
+
+		outDir := "./doctor/ok"
+		Convey("Specify existing out dir", func() {
+			if err := os.MkdirAll(outDir, 0755); err != nil {
+				t.Fatalf("doctor error: %v", err)
+			}
+			So(Main([]string{"", "doctor", "--out-dir", outDir, testMountPoint}), ShouldBeNil)
+			if err := os.RemoveAll(outDir); err != nil {
+				t.Fatalf("doctor error: %v", err)
+			}
+		})
+
+		Convey("Specify a non-existing out dir", func() {
+			So(Main([]string{"", "doctor", "--out-dir", "./doctor/out1", testMountPoint}), ShouldBeNil)
+		})
+
+		Convey("Specify a file as out dir", func() {
+			So(Main([]string{"", "doctor", "--out-dir", "./doctor_test.go", testMountPoint}), ShouldNotBeNil)
+		})
+	})
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,6 +73,7 @@ func Main(args []string) error {
 			cmdWarmup(),
 			cmdRmr(),
 			cmdSync(),
+			cmdDoctor(),
 		},
 	}
 

--- a/pkg/utils/utils_darwin.go
+++ b/pkg/utils/utils_darwin.go
@@ -23,7 +23,7 @@ import (
 
 func GetKernelVersion() (major, minor int) { return }
 
-func GetEntry() (string, error) {
+func GetSysInfo() (string, error) {
 	var (
 		kernel    string
 		osVersion []byte
@@ -39,7 +39,7 @@ func GetEntry() (string, error) {
 		return "", fmt.Errorf("failed to execute command `sw_vers`: %s", err)
 	}
 
-	if hardware, err = exec.Command("system_profiler", "SPMemoryDataType ", "SPStorageDataType").Output(); err != nil {
+	if hardware, err = exec.Command("system_profiler", "SPMemoryDataType", "SPStorageDataType").Output(); err != nil {
 		return "", fmt.Errorf("failed to execute command `system_profiler`: %s", err)
 	}
 

--- a/pkg/utils/utils_darwin.go
+++ b/pkg/utils/utils_darwin.go
@@ -16,4 +16,38 @@
 
 package utils
 
+import (
+	"fmt"
+	"os/exec"
+)
+
 func GetKernelVersion() (major, minor int) { return }
+
+func GetEntry() (string, error) {
+	var (
+		kernel    string
+		osVersion []byte
+		hardware  []byte
+		err       error
+	)
+
+	if kernel, err = GetKernelInfo(); err != nil {
+		return "", fmt.Errorf("failed to execute command `uname`: %s", err)
+	}
+
+	if osVersion, err = exec.Command("sw_vers").Output(); err != nil {
+		return "", fmt.Errorf("failed to execute command `sw_vers`: %s", err)
+	}
+
+	if hardware, err = exec.Command("system_profiler", "SPMemoryDataType ", "SPStorageDataType").Output(); err != nil {
+		return "", fmt.Errorf("failed to execute command `system_profiler`: %s", err)
+	}
+
+	return fmt.Sprintf(`
+Kernel: 
+%s
+OS: 
+%s
+Hardware: 
+%s`, kernel, string(osVersion), string(hardware)), nil
+}

--- a/pkg/utils/utils_linux.go
+++ b/pkg/utils/utils_linux.go
@@ -47,24 +47,15 @@ func GetKernelVersion() (major, minor int) {
 	return
 }
 
-func CheckExists(fileName string) bool {
-	if _, err := os.Stat(fileName); err != nil {
-		return false
-	} else {
-		return true
-	}
-}
-
-const procPath = "/proc/version"
-
-func GetEntry() (string, error) {
+func GetSysInfo() (string, error) {
 	var (
 		kernel    []byte
 		osVersion []byte
 		err       error
 	)
 
-	if CheckExists(procPath) {
+	procPath := "/proc/version"
+	if _, err := os.Stat(procPath); err == nil {
 		kernel, err = exec.Command("cat", procPath).Output()
 		if err != nil {
 			return "", fmt.Errorf("failed to execute command `cat %s`: %s", procPath, err)

--- a/pkg/utils/utils_linux.go
+++ b/pkg/utils/utils_linux.go
@@ -17,6 +17,9 @@
 package utils
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -42,4 +45,40 @@ func GetKernelVersion() (major, minor int) {
 		minor, _ = strconv.Atoi(ps[1])
 	}
 	return
+}
+
+func CheckExists(fileName string) bool {
+	if _, err := os.Stat(fileName); err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+const procPath = "/proc/version"
+
+func GetEntry() (string, error) {
+	var (
+		kernel    []byte
+		osVersion []byte
+		err       error
+	)
+
+	if CheckExists(procPath) {
+		kernel, err = exec.Command("cat", procPath).Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to execute command `cat %s`: %s", procPath, err)
+		}
+	}
+
+	osVersion, err = exec.Command("lsb_release", "-a").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command `lsb_release`: %s", err)
+	}
+
+	return fmt.Sprintf(`
+Kernel: 
+%s
+OS: 
+%s`, kernel, osVersion), nil
 }

--- a/pkg/utils/utils_unix.go
+++ b/pkg/utils/utils_unix.go
@@ -21,6 +21,8 @@ package utils
 
 import (
 	"os"
+	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -44,4 +46,16 @@ func GetDev(fpath string) int { // ID of device containing file
 		return int(sst.Dev)
 	}
 	return -1
+}
+
+func GetKernelInfo() (string, error) {
+	kernel, err := exec.Command("uname", "-a").Output()
+	if err != nil {
+		return "", err
+	}
+
+	// Ignore hostname information
+	tmp := strings.Split(string(kernel), " ")
+	result := strings.Join(append(tmp[:1], tmp[2:]...), " ")
+	return result, nil
 }

--- a/pkg/utils/utils_windows.go
+++ b/pkg/utils/utils_windows.go
@@ -17,7 +17,9 @@
 package utils
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 
 	"golang.org/x/sys/windows"
 )
@@ -40,3 +42,11 @@ func GetFileInode(path string) (uint64, error) {
 func GetKernelVersion() (major, minor int) { return }
 
 func GetDev(fpath string) int { return -1 }
+
+func GetEntry() (string, error) {
+	entry, err := exec.Command("systeminfo").Output()
+	if err != nil {
+		return "", fmt.Errorf("Failed to execute command `systeminfo`: %s", err)
+	}
+	return string(entry), nil
+}

--- a/pkg/utils/utils_windows.go
+++ b/pkg/utils/utils_windows.go
@@ -43,10 +43,10 @@ func GetKernelVersion() (major, minor int) { return }
 
 func GetDev(fpath string) int { return -1 }
 
-func GetEntry() (string, error) {
-	entry, err := exec.Command("systeminfo").Output()
+func GetSysInfo() (string, error) {
+	sysInfo, err := exec.Command("systeminfo").Output()
 	if err != nil {
 		return "", fmt.Errorf("Failed to execute command `systeminfo`: %s", err)
 	}
-	return string(entry), nil
+	return string(sysInfo), nil
 }


### PR DESCRIPTION
## Description
The following file will be created:
- [x] `cmd/doctor.go` 
- [x] `cmd/doctor_test.go`

## Features
It collects and displays info from multiple dimensions such as the running environment and system logs to report bugs, etc.

- **System info collection:** support collection of os, architecture, hardware, juicefs version, etc.
- **Syslog collection:** support automatic search for log location and filter logs according to the maximum number of records 
-  **Pprof metric collection:** Goroutine stack information, CPU performance statistics, memory allocation statistics, etc.
- **Mount point config collection:** support specifying mount point to obtain the config (filter sensitive info)
- **Mount command collection:** Collect juicefs mount commands and corresponding parameters

## Use cases
```
$ juicefs doctor /mnt/jfs

# Result will be output to /var/log/
$ juicefs doctor --out-dir=/var/log /mnt/jfs

# Get log file up to last 1000 entries
$ juicefs doctor --out-dir=/var/log --collect-log --limit=1000 /mnt/jfs 

# Enable pprof collection
$ juicefs doctor --out-dir=/var/log --collect-log --limit=1000 --collect-pprof /mnt/jfs

```

## How can this PR be tested?
The test files locate at `cmd/doctor_test.go`.

## Basing the PR against the correct JuiceFS version
- [x] This is a new feature and the PR is based against the latest JuiceFS development branch
- [ ] This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduce