### PR TITLE
Docs: add new "Upgrade" and "Verify the file system" document

### DIFF
--- a/docs/en/administration/upgrade.md
+++ b/docs/en/administration/upgrade.md
@@ -1,0 +1,51 @@
+# Upgrade
+
+The upgrade methods of different JuiceFS client are different, which are described below.
+
+## Mount point
+
+The JuiceFS client only has one binary file, so to upgrade the new version, you only need to replace the old one with the new one.
+
+- **Use pre-compiled client**: You can refer to the installation method of the corresponding system in [this document](../getting-started/installation.md#install-the-pre-compiled-client), download the latest client, and overwrite the old one.
+- **Manually compile client**: You can pull the latest source code and recompile it to overwrite the old version of the client. Please refer to ["Installation"](../getting-started/installation.md#manually-compiling) document for more information.
+
+:::caution
+For the file system that has been mounted using the old version of JuiceFS client, you need to [unmount file system](../getting-started/for_distributed.md#7-unmounting-the-file-system), and then re-mount it with the new version of JuiceFS client.
+
+When unmounting the file system, make sure that no application is accessing it, otherwise the unmount will fail. Do not forcibly unmount the file system, as it may cause the application to be unable to continue to access it normally.
+:::
+
+## Kubernetes CSI Driver
+
+Please refer to [official documentation](https://juicefs.com/docs/csi/upgrade-csi-driver) to learn how to upgrade JuiceFS CSI Driver.
+
+## S3 Gateway
+
+Like [mount point](#mount-point), upgrading S3 Gateway is to replace the old version with the new version.
+
+If it is [deployed through Kubernetes](../deployment/s3_gateway.md#deploy-juicefs-s3-gateway-in-kubernetes), you need to upgrade according to the specific deployment method, which is described in detail below.
+
+### Upgrade via kubectl
+
+Download and modify the `juicedata/juicefs-csi-driver` image tag in S3 Gateway [deploy YAML](https://github.com/juicedata/juicefs/blob/main/deploy/juicefs-s3-gateway.yaml) as the version you want to upgrade (see [here](https://github.com/juicedata/juicefs-csi-driver/releases) for a detailed description of all versions), then run the following command:
+
+```shell
+kubectl apply -f ./juicefs-s3-gateway.yaml
+```
+
+### Upgrade via Helm
+
+Please run the following commands in sequence to upgrade the S3 Gateway:
+
+```shell
+helm repo update
+helm upgrade juicefs-s3-gateway juicefs-s3-gateway/juicefs-s3-gateway -n kube-system -f ./values.yaml
+```
+
+## Hadoop Java SDK
+
+Please refer to the ["Install and compile the client"](../deployment/hadoop_java_sdk.md#install-and-compile-the-client) document to learn how to install the new version of the Hadoop Java SDK, and then follow the ["Deploy the client"](../deployment/hadoop_java_sdk.md#deploy-the-client) steps to redeploy the new version of the client to complete the upgrade.
+
+:::note
+Some components must be restarted before using the new version of the Hadoop Java SDK. For details, please refer to the ["Restart Services"](../deployment/hadoop_java_sdk.md#restart-services) document.
+:::

--- a/docs/en/deployment/hadoop_java_sdk.md
+++ b/docs/en/deployment/hadoop_java_sdk.md
@@ -39,7 +39,7 @@ JuiceFS Hadoop Java SDK need extra 4 * [`juicefs.memory-size`](#io-configuration
 
 ### Install the pre-compiled client
 
-Please refer to the ["Installation & Upgrade"](../getting-started/installation.md#install-the-pre-compiled-client) document to learn how to download the precompiled JuiceFS Hadoop Java SDK.
+Please refer to the ["Installation"](../getting-started/installation.md#install-the-pre-compiled-client) document to learn how to download the precompiled JuiceFS Hadoop Java SDK.
 
 ### Compile the client manually
 

--- a/docs/en/getting-started/README.md
+++ b/docs/en/getting-started/README.md
@@ -10,7 +10,7 @@ The JuiceFS file system is driven by both ["Object Storage"](../guide/how_to_set
 
 ## Install Client
 
-For details, please refer to [Installation & Upgrade](installation.md).
+For details, please refer to ["Installation"](installation.md).
 
 A help message will return after executing `juicefs` in terminal once the JuiceFS client is successfully installed regardless of operating system.
 

--- a/docs/en/getting-started/for_distributed.md
+++ b/docs/en/getting-started/for_distributed.md
@@ -42,7 +42,7 @@ For simplicity, we take Amazon ElastiCache for Redis as an example. The most bas
 
 ### 1. Install Client
 
-Install the JuiceFS client on all computers that need to mount the file system, refer to [Installation & Upgrade](installation.md) for details.
+Install the JuiceFS client on all computers that need to mount the file system, refer to ["Installation"](installation.md) for details.
 
 ### 2. Preparing Object Storage
 
@@ -151,7 +151,23 @@ redis://tom:mypassword@myjfs-sh-abc.apse1.cache.amazonaws.com:6379/1    /mnt/myj
 By default, CentOS 6 does not mount the network file system during boot, you need to run the command `sudo chkconfig --add netfs` to enable automatically mounting.
 :::
 
-### 6. Unmounting the file system
+### 6. Verify the file system
+
+After the file system is mounted, you can use the `juicefs bench` command to perform basic performance tests and functional verification of the file system to ensure that the JuiceFS file system can be accessed normally and its performance meets expectations.
+
+:::info
+The `juicefs bench` command can only complete basic performance tests. If you need a more complete evaluation of JuiceFS, please refer to ["JuiceFS Performance Evaluation Guide"](../benchmark/performance_evaluation_guide.md).
+:::
+
+```shell
+juicefs bench ~/jfs
+```
+
+After running the `juicefs bench` command, N large files (1 by default) and N small files (100 by default) will be written to and read from the JuiceFS file system according to the specified concurrency (1 by default), and statistics the throughput of read and write and the latency of a single operation, as well as the latency of accessing the metadata engine.
+
+If you encounter any problems during the verification of the file system, please refer to the ["Fault Diagnosis and Analysis"](../administration/fault_diagnosis_and_analysis.md) document for troubleshooting first.
+
+### 7. Unmounting the file system
 
 You can unmount the JuiceFS file system (assuming the mount point path is `~/jfs`) by the command `juicefs umount`.
 

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -1,10 +1,10 @@
 ---
-sidebar_label: Installation & Upgrade
+sidebar_label: Installation
 sidebar_position: 1
 slug: /installation
 ---
 
-# Installation & Upgrade
+# Installation
 
 JuiceFS has good cross-platform capability and supports running on all kinds of operating systems of almost all major architectures, including and not limited to Linux, macOS, Windows, etc.
 
@@ -273,17 +273,6 @@ The compiled client is a binary file named `juicefs.exe`, located in the current
    ```shell
    make juicefs.linux
    ```
-
-## Upgrade
-
-The JuiceFS client only has one binary file, so to upgrade the new version, you only need to replace the old one with the new one.
-
-- **Use pre-compiled client**: You can refer to the installation method of the corresponding system in this document, download the latest client, and overwrite the old one.
-- **Manually compile client**: You can pull the latest source code and recompile it to overwrite the old version of the client.
-
-:::caution
-For the file system that has been mounted using the old version of JuiceFS client, you need to [unmount file system](for_distributed.md#6-unmounting-the-file-system), and then re-mount it with the new version of JuiceFS client.
-:::
 
 ## Uninstall
 

--- a/docs/en/introduction/README.md
+++ b/docs/en/introduction/README.md
@@ -1,6 +1,6 @@
 ---
-title: What is JuiceFS?
-sidebar_label: What is JuiceFS
+title: Introduction to JuiceFS
+sidebar_label: Introduction to JuiceFS
 sidebar_position: 1
 slug: .
 ---
@@ -8,7 +8,7 @@ slug: .
 
 **JuiceFS** is a high-performance shared file system designed for cloud-native use and released under the Apache License 2.0. It provides full [POSIX](https://en.wikipedia.org/wiki/POSIX) compatibility, allowing almost all kinds of object storage to be used locally as massive local disks and to be mounted and read on different cross-platform and cross-region hosts at the same time.
 
-JuiceFS implements a distributed file system by adopting the architecture that seperates "data" and "metadata" storage. When using JuiceFS to store data, the data itself is persisted in [object storage](../guide/how_to_setup_object_storage.md#supported-object-storage) (e.g., Amazon S3), and the corresponding metadata can be persisted in various [databases](../guide/how_to_setup_metadata_engine.md) such as Redis, MySQL, TiKV, SQLite, etc., based on the scenarios and requirements. 
+JuiceFS implements a distributed file system by adopting the architecture that seperates "data" and "metadata" storage. When using JuiceFS to store data, the data itself is persisted in [object storage](../guide/how_to_setup_object_storage.md#supported-object-storage) (e.g. Amazon S3), and the corresponding metadata can be persisted in various [databases](../guide/how_to_setup_metadata_engine.md) such as Redis, MySQL, TiKV, SQLite, etc., based on the scenarios and requirements.
 
 JuiceFS provides rich APIs for various forms of data management, analysis, archiving, and backup. It can seamlessly interface with big data, machine learning, artificial intelligence and other application platforms without modifying code, and provide massive, elastic and high-performance storage at low cost. With JuiceFS, you do not need to worry about availability, disaster recovery, monitoring and expansion, and thus operation and maintaince work can be remarkably simplified, which helps companies focus more on business development and R&D efficiency improvement.
 

--- a/docs/en/reference/command_reference.md
+++ b/docs/en/reference/command_reference.md
@@ -63,7 +63,7 @@ COPYRIGHT:
 ```
 
 :::note
-If `juicefs` is not placed in your `$PATH`, you should run the script with the path to the script. For example, if `juicefs` is in current directory, you should use `./juicefs`. It is recommended to place `juicefs` in your `$PATH` for convenience. You can refer to [Installation & Upgrade](../getting-started/installation.md) for more information.
+If `juicefs` is not placed in your `$PATH`, you should run the script with the path to the script. For example, if `juicefs` is in current directory, you should use `./juicefs`. It is recommended to place `juicefs` in your `$PATH` for convenience. You can refer to ["Installation"](../getting-started/installation.md) for more information.
 :::
 
 :::note

--- a/docs/zh_cn/administration/upgrade.md
+++ b/docs/zh_cn/administration/upgrade.md
@@ -1,0 +1,51 @@
+# 客户端升级
+
+不同 JuiceFS 客户端的升级方式不同，以下分别介绍。
+
+## 挂载点
+
+JuiceFS 客户端只有一个二进制程序，升级新版只需用新版程序替换旧版程序即可。
+
+- **使用预编译客户端**：可以参照[「安装」](../getting-started/installation.md#安装预编译客户端)文档中相应系统的安装方法，下载最新的客户端，覆盖旧版客户端即可。
+- **手动编译客户端**：可以拉取最新的源代码重新编译，覆盖旧版客户端即可，具体请参考[「安装」](../getting-started/installation.md#手动编译客户端)文档。
+
+:::caution 注意
+对于已经使用旧版 JuiceFS 客户端挂载好的文件系统，需要先[卸载文件系统](../getting-started/for_distributed.md#7-卸载文件系统)，然后用新版 JuiceFS 客户端重新挂载。
+
+卸载文件系统时需确保没有任何应用正在访问，否则将会卸载失败。不可强行卸载文件系统，有可能造成应用无法继续正常访问。
+:::
+
+## Kubernetes CSI 驱动
+
+请参考[官方文档](https://juicefs.com/docs/zh/csi/upgrade-csi-driver)了解如何升级 JuiceFS CSI 驱动。
+
+## S3 网关
+
+与[挂载点](#挂载点)一样，升级 S3 网关也是使用新版程序替换旧版程序即可。
+
+如果是[通过 Kubernetes 部署](../deployment/s3_gateway.md#在-kubernetes-中部署-s3-网关)，则需要根据具体部署的方式来升级，以下详细介绍。
+
+### 通过 kubectl 升级
+
+下载并修改 S3 网关[部署 YAML](https://github.com/juicedata/juicefs/blob/main/deploy/juicefs-s3-gateway.yaml) 中的 `juicedata/juicefs-csi-driver` 镜像标签为想要升级的版本（关于所有版本的详细说明请参考[这里](https://github.com/juicedata/juicefs-csi-driver/releases)），然后运行以下命令：
+
+```shell
+kubectl apply -f ./juicefs-s3-gateway.yaml
+```
+
+### 通过 Helm 升级
+
+请依次运行以下命令以升级 S3 网关：
+
+```shell
+helm repo update
+helm upgrade juicefs-s3-gateway juicefs-s3-gateway/juicefs-s3-gateway -n kube-system -f ./values.yaml
+```
+
+## Hadoop Java SDK
+
+请参考[「安装与编译客户端」](../deployment/hadoop_java_sdk.md#安装与编译客户端)文档了解如何安装新版本的 Hadoop Java SDK，然后根据[「部署客户端」](../deployment/hadoop_java_sdk.md#部署客户端)的步骤重新部署新版本客户端即可完成升级。
+
+:::note 注意
+某些组件必须重启以后才能使用新版本的 Hadoop Java SDK，具体请参考[「重启服务」](../deployment/hadoop_java_sdk.md#重启服务)文档。
+:::

--- a/docs/zh_cn/deployment/hadoop_java_sdk.md
+++ b/docs/zh_cn/deployment/hadoop_java_sdk.md
@@ -39,7 +39,7 @@ JuiceFS Hadoop Java SDK 最多需要额外使用 4 * [`juicefs.memory-size`](#io
 
 ### 安装预编译客户端
 
-请参考[「安装与升级」](../getting-started/installation.md#安装预编译客户端)文档了解如何下载预编译的 JuiceFS Hadoop Java SDK。
+请参考[「安装」](../getting-started/installation.md#安装预编译客户端)文档了解如何下载预编译的 JuiceFS Hadoop Java SDK。
 
 ### 手动编译客户端
 

--- a/docs/zh_cn/getting-started/README.md
+++ b/docs/zh_cn/getting-started/README.md
@@ -10,7 +10,7 @@ JuiceFS 文件系统由[「对象存储」](../guide/how_to_setup_object_storage
 
 ## 安装客户端
 
-详情请参照[安装 & 升级](installation.md)。
+详情请参照[「安装」](installation.md)。
 
 不论你使用什么操作系统，当在终端输入并执行 `juicefs` 并返回了程序的帮助信息，就说明你成功安装了 JuiceFS 客户端。
 

--- a/docs/zh_cn/getting-started/for_distributed.md
+++ b/docs/zh_cn/getting-started/for_distributed.md
@@ -42,7 +42,7 @@ JuiceFS 目前支持的基于网络的数据库有：
 
 ### 1. 安装客户端
 
-在所有需要挂载文件系统的计算机上安装 JuiceFS 客户端，详情参照[「安装 & 升级」](installation.md)。
+在所有需要挂载文件系统的计算机上安装 JuiceFS 客户端，详情参照[「安装」](installation.md)。
 
 ### 2. 准备对象存储
 
@@ -151,7 +151,23 @@ redis://tom:mypassword@myjfs-sh-abc.redis.rds.aliyuncs.com:6379/1    /mnt/myjfs 
 默认情况下，CentOS 6 在系统启动时不会挂载网络文件系统，你需要执行命令开启网络文件系统的自动挂载支持：`sudo chkconfig --add netfs`
 :::
 
-### 6. 卸载文件系统
+### 6. 验证文件系统
+
+当挂载好文件系统以后可以通过 `juicefs bench` 命令对文件系统进行基础的性能测试和功能验证，确保 JuiceFS 文件系统能够正常访问且性能符合预期。
+
+:::info 说明
+`juicefs bench` 命令只能完成基础的性能测试，如果需要对 JuiceFS 进行更完整的评估，请参考[「JuiceFS 性能评估指南」](../benchmark/performance_evaluation_guide.md)。
+:::
+
+```shell
+juicefs bench ~/jfs
+```
+
+运行 `juicefs bench` 命令以后会根据指定的并发度（默认为 1）往 JuiceFS 文件系统中写入及读取 N 个大文件（默认为 1）及 N 个小文件（默认为 100），并统计读写的吞吐和单次操作的延迟，以及访问元数据引擎的延迟。
+
+如果在验证文件系统的过程中遇到任何问题，请先参考[「故障诊断和分析」](../administration/fault_diagnosis_and_analysis.md)文档进行问题排查。
+
+### 7. 卸载文件系统
 
 你可以通过 `juicefs umount` 命令卸载 JuiceFS 文件系统（假设挂载点路径是 `~/jfs`）：
 

--- a/docs/zh_cn/getting-started/installation.md
+++ b/docs/zh_cn/getting-started/installation.md
@@ -1,10 +1,10 @@
 ---
-sidebar_label: 安装 & 升级
+sidebar_label: 安装
 sidebar_position: 1
 slug: /installation
 ---
 
-# 安装与升级
+# 安装
 
 JuiceFS 有良好的跨平台能力，支持在几乎所有主流架构的各类操作系统上运行，包括且不限于 Linux、macOS、Windows 等。
 
@@ -273,18 +273,6 @@ make juicefs.exe
    ```shell
    make juicefs.linux
    ```
-
-
-## 客户端升级
-
-JuiceFS 客户端只有一个二进制程序，升级新版只需用新版程序替换旧版程序即可。
-
-- **使用预编译客户端**：可以参照本文档中相应系统的安装方法，下载最新的客户端，覆盖旧版客户端即可。
-- **手动编译客户端**：可以拉取最新的源代码重新编译，覆盖旧版客户端即可。
-
-:::caution 注意
-对于使用旧版 JuiceFS 客户端已经挂载好的文件系统，需要先[卸载文件系统](for_distributed.md#6-卸载文件系统)，然后用新版 JuiceFS 客户端重新挂载。
-:::
 
 ## 卸载客户端
 

--- a/docs/zh_cn/reference/command_reference.md
+++ b/docs/zh_cn/reference/command_reference.md
@@ -62,8 +62,8 @@ COPYRIGHT:
    Apache License 2.0
 ```
 
-:::tip 提示
-如果 `juicefs` 不在 `$PATH` 中，你需要指定程序所在的路径才能执行。例如，`juicefs` 如果在当前目录中，则可以使用 `./juicefs`。为了方便使用，建议将 `juicefs` 添加到  `$PATH` 中。可以参考 [安装&升级](../getting-started/installation.md) 了解安装相关内容。
+:::note 注意
+如果 `juicefs` 不在 `$PATH` 中，你需要指定程序所在的路径才能执行。例如，`juicefs` 如果在当前目录中，则可以使用 `./juicefs`。为了方便使用，建议将 `juicefs` 添加到  `$PATH` 中。可以参考[「安装」](../getting-started/installation.md)了解安装相关内容。
 :::
 
 :::note 注意
@@ -159,7 +159,7 @@ juicefs format [command options] META-URL NAME
 对象存储的 Secret Key (也可通过环境变量 `SECRET_KEY` 设置)
 
 `--session-token value`<br />
-对象存储的 session token 
+对象存储的 session token
 
 `--encrypt-rsa-key value`<br />
 RSA 私钥的路径 (PEM)


### PR DESCRIPTION
- The upgrade-related content is stripped from the "Installation" document and becomes a new document independently, and more client upgrade instructions are added.
- Added "Verify the file system" section to Quick Start Guide
