### PR TITLE
hadoop: do not use local uid/gid if global user/group specified

### DIFF
--- a/sdk/java/libjfs/guid.go
+++ b/sdk/java/libjfs/guid.go
@@ -95,11 +95,14 @@ func (m *mapping) lookupGroup(name string) uint32 {
 	return 0
 }
 
-func (m *mapping) lookupUserID(id uint32) string {
+func (m *mapping) lookupUserID(id uint32, lookupLocal bool) string {
 	m.Lock()
 	defer m.Unlock()
 	if name, ok := m.userIDs[id]; ok {
 		return name
+	}
+	if !lookupLocal {
+		return strconv.Itoa(int(id))
 	}
 	u, _ := user.LookupId(strconv.Itoa(int(id)))
 	if u == nil {
@@ -114,11 +117,14 @@ func (m *mapping) lookupUserID(id uint32) string {
 	return name
 }
 
-func (m *mapping) lookupGroupID(id uint32) string {
+func (m *mapping) lookupGroupID(id uint32, lookupLocal bool) string {
 	m.Lock()
 	defer m.Unlock()
 	if name, ok := m.groupIDs[id]; ok {
 		return name
+	}
+	if !lookupLocal {
+		return strconv.Itoa(int(id))
 	}
 	g, _ := user.LookupGroupId(strconv.Itoa(int(id)))
 	if g == nil {

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -187,7 +187,7 @@ func (w *wrapper) lookupGids(groups string) []uint32 {
 func (w *wrapper) uid2name(uid uint32) string {
 	name := w.superuser
 	if uid > 0 {
-		name = w.m.lookupUserID(uid, false)
+		name = w.m.lookupUserID(uid)
 	}
 	return name
 }
@@ -195,7 +195,7 @@ func (w *wrapper) uid2name(uid uint32) string {
 func (w *wrapper) gid2name(gid uint32) string {
 	group := w.supergroup
 	if gid > 0 {
-		group = w.m.lookupGroupID(gid, false)
+		group = w.m.lookupGroupID(gid)
 	}
 	return group
 }
@@ -567,7 +567,7 @@ func jfs_update_uid_grouping(h uintptr, uidstr *C.char, grouping *C.char) {
 		}
 		logger.Debugf("Update groups of %s to %s", w.user, strings.Join(groups, ","))
 	}
-	w.m.update(uids, gids)
+	w.m.update(uids, gids, false)
 
 	if w.isSuperuser(w.user, groups) {
 		w.ctx = meta.NewContext(uint32(os.Getpid()), 0, []uint32{0})

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -187,7 +187,7 @@ func (w *wrapper) lookupGids(groups string) []uint32 {
 func (w *wrapper) uid2name(uid uint32) string {
 	name := w.superuser
 	if uid > 0 {
-		name = w.m.lookupUserID(uid)
+		name = w.m.lookupUserID(uid, false)
 	}
 	return name
 }
@@ -195,7 +195,7 @@ func (w *wrapper) uid2name(uid uint32) string {
 func (w *wrapper) gid2name(gid uint32) string {
 	group := w.supergroup
 	if gid > 0 {
-		group = w.m.lookupGroupID(gid)
+		group = w.m.lookupGroupID(gid, false)
 	}
 	return group
 }

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -505,7 +505,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     LibraryLoader<Libjfs> libjfsLibraryLoader = LibraryLoader.create(Libjfs.class);
     libjfsLibraryLoader.failImmediately();
 
-    int soVer = 6;
+    int soVer = 7;
     String osId = "so";
     String archId = "amd64";
     String resourceFormat = "libjfs-%s.%s.gz";


### PR DESCRIPTION
SDK has two params ``juicefs.users`` and ``juicefs.groups`` to overwrite local guidmapping.
So when name2id mapping is overwrited. name2id should not lookup the local to avoid multiple uid to the same name confusion.