### PR TITLE
pkg/gateway: Support specifying umask for directories

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -59,7 +59,12 @@ func cmdGateway() *cli.Command {
 		&cli.StringFlag{
 			Name:  "umask",
 			Value: "022",
-			Usage: "umask for new file in octal",
+			Usage: "umask for new files in octal",
+		},
+		&cli.StringFlag{
+			Name:  "umask-dir",
+			Value: "022",
+			Usage: "umask for new directories in octal",
 		},
 	}
 
@@ -169,7 +174,21 @@ func (g *GateWay) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, er
 		logger.Fatalf("invalid umask %s: %s", c.String("umask"), err)
 	}
 
-	return jfsgateway.NewJFSGateway(jfs, conf, &jfsgateway.Config{MultiBucket: c.Bool("multi-buckets"), KeepEtag: c.Bool("keep-etag"), Mode: uint16(0777 &^ umask)})
+	umaskDir, err := strconv.ParseUint(c.String("umask-dir"), 8, 16)
+	if err != nil {
+		logger.Fatalf("invalid umask-dir %s: %s", c.String("umask-dir"), err)
+	}
+	
+	return jfsgateway.NewJFSGateway(
+		jfs,
+		conf,
+		&jfsgateway.Config{
+			MultiBucket: c.Bool("multi-buckets"),
+			KeepEtag: c.Bool("keep-etag"),
+			Mode: uint16(0777 &^ umask),
+			DirMode: uint16(0777 &^ umaskDir),
+		},
+	)
 }
 
 func initForSvc(c *cli.Context, mp string, metaUrl string) (*vfs.Config, *fs.FileSystem) {

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -59,12 +59,7 @@ func cmdGateway() *cli.Command {
 		&cli.StringFlag{
 			Name:  "umask",
 			Value: "022",
-			Usage: "umask for new files in octal",
-		},
-		&cli.StringFlag{
-			Name:  "umask-dir",
-			Value: "022",
-			Usage: "umask for new directories in octal",
+			Usage: "umask for new files and directories in octal",
 		},
 	}
 
@@ -174,19 +169,14 @@ func (g *GateWay) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, er
 		logger.Fatalf("invalid umask %s: %s", c.String("umask"), err)
 	}
 
-	umaskDir, err := strconv.ParseUint(c.String("umask-dir"), 8, 16)
-	if err != nil {
-		logger.Fatalf("invalid umask-dir %s: %s", c.String("umask-dir"), err)
-	}
-	
 	return jfsgateway.NewJFSGateway(
 		jfs,
 		conf,
 		&jfsgateway.Config{
 			MultiBucket: c.Bool("multi-buckets"),
 			KeepEtag: c.Bool("keep-etag"),
-			Mode: uint16(0777 &^ umask),
-			DirMode: uint16(0777 &^ umaskDir),
+			Mode: uint16(0666 &^ umask),
+			DirMode: uint16(0777 &^ umask),
 		},
 	)
 }


### PR DESCRIPTION
Currently, gateway does not respect the umask flag specified in the start command, instead, it hard codes 755 for all the directories it creates. I have added an option, umask-dir, which will dictate the umask for all the mkdir calls. I keep them as separate flags in case some users would like their umasks different for folders and directories.

The following screenshots show different behaviors when gateway is started with umask-dir 022 vs 000.
![image](https://user-images.githubusercontent.com/6692644/182369216-da1bd06d-b7d7-4f03-9b8b-4dcfc684f9ac.png)
