### PR TITLE
add / update fstab entry with --update-fstab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ libjfs.h
 .DS_Store
 docs/node_modules
 cmd/cmd
+*.dump
+*.out

--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBench(t *testing.T) {
-	mountTemp(t, nil, false)
+	mountTemp(t, nil, []string{"--trash-days=0"}, nil)
 	defer umountTemp(t)
 
 	os.Setenv("SKIP_DROP_CACHES", "true")

--- a/cmd/fsck_test.go
+++ b/cmd/fsck_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestFsck(t *testing.T) {
-	mountTemp(t, nil, true)
+	mountTemp(t, nil, nil, nil)
 	defer umountTemp(t)
 
 	for i := 0; i < 10; i++ {

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -65,7 +65,7 @@ func getFileCount(dir string) int {
 
 func TestGc(t *testing.T) {
 	var bucket string
-	mountTemp(t, &bucket, false)
+	mountTemp(t, &bucket, []string{"--trash-days=0"}, nil)
 	defer umountTemp(t)
 
 	if err := writeSmallBlocks(testMountPoint); err != nil {

--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -39,7 +39,7 @@ func TestInfo(t *testing.T) {
 			patches := gomonkey.ApplyGlobalVar(os.Stdout, *tmpFile)
 			defer patches.Reset()
 
-			mountTemp(t, nil, true)
+			mountTemp(t, nil, nil, nil)
 			defer umountTemp(t)
 
 			if err = os.MkdirAll(fmt.Sprintf("%s/dir1", testMountPoint), 0777); err != nil {

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -74,7 +74,7 @@ func startWebdav(t *testing.T) {
 }
 
 func TestIntegration(t *testing.T) {
-	mountTemp(t, nil, true)
+	mountTemp(t, nil, nil, nil)
 	defer umountTemp(t)
 	startGateway(t)
 	startWebdav(t)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,14 +76,17 @@ func Main(args []string) error {
 		},
 	}
 
-	// Called via mount or fstab.
-	if strings.HasSuffix(args[0], "/mount.juicefs") {
+	if calledViaMount(args) {
 		args = handleSysMountArgs(args)
 		if len(args) < 1 {
 			args = []string{"--help"}
 		}
 	}
 	return app.Run(reorderOptions(app, args))
+}
+
+func calledViaMount(args []string) bool {
+	return strings.HasSuffix(args[0], "/mount.juicefs")
 }
 
 func handleSysMountArgs(args []string) []string {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,7 @@ func handleSysMountArgs(args []string) []string {
 		opts := strings.Split(option, ",")
 		for _, opt := range opts {
 			opt = strings.TrimSpace(opt)
-			if opt == "" || utils.StringContains(sysOptions, opt) {
+			if opt == "" || opt == "background" || utils.StringContains(sysOptions, opt) {
 				continue
 			}
 			// Lower case option name is preferred, but if it's the same as flag name, we also accept it

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -25,7 +25,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -586,12 +585,9 @@ func mount(c *cli.Context) error {
 	logger.Infof("Data use %s", blob)
 
 	if c.Bool("update-fstab") {
-		user, err := user.Current()
-		if err != nil {
-			return err
-		}
-		if user.Uid != "0" {
-			logger.Warnf("--update-fstab should be used with root, not %s", user.Name)
+		uid:= os.Getuid()
+		if uid != 0 {
+			logger.Warnf("--update-fstab should be used with root")
 		}
 		if !calledViaMount(os.Args) {
 			if err = tryToInstallMountExec(); err != nil {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -409,7 +409,7 @@ func tellFstabOptions(c *cli.Context) string {
 		}
 		s = strings.TrimLeft(s, "-")
 		s = strings.Split(s, "=")[0]
-		if !c.IsSet(s) {
+		if !c.IsSet(s) || s == "update-fstab" || s == "background" || s == "d" {
 			continue
 		}
 		if s == "o" {

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,9 +163,9 @@ func TestUpdateFstab(t *testing.T) {
 		t.Fatalf("error reading mocked fstab: %s", err)
 	}
 	rv := "redis://127.0.0.1:6379/11 /tmp/jfs-unit-test juicefs _netdev,enable-xattr,entry-cache=2,max-uploads=3,max_read=99,no-usage-report,update-fstab,writeback 0 0"
-	lv := string(content)
+	lv := strings.TrimSpace(string(content))
 	if lv != rv {
-		t.Logf("incorrect fstab entry: %s", lv)
+		t.Fatalf("incorrect fstab entry: %s", lv)
 	}
 }
 

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -92,25 +94,29 @@ func resetTestMeta() *redis.Client { // using Redis
 	return rdb
 }
 
-func mountTemp(t *testing.T, bucket *string, trash bool) {
+func mountTemp(t *testing.T, bucket *string, extraFormatOpts []string, extraMountOpts []string) {
 	_ = resetTestMeta()
 	testDir := t.TempDir()
 	if bucket != nil {
 		*bucket = testDir
 	}
-	args := []string{"", "format", "--bucket", testDir, testMeta, testVolume}
-	if !trash {
-		args = append(args, "--trash-days=0")
+	formatArgs := []string{"", "format", "--bucket", testDir, testMeta, testVolume}
+	if extraFormatOpts != nil {
+		formatArgs = append(formatArgs, extraFormatOpts...)
 	}
-	if err := Main(args); err != nil {
+	if err := Main(formatArgs); err != nil {
 		t.Fatalf("format failed: %s", err)
 	}
 
 	// must do reset, otherwise will panic
 	ResetHttp()
 
+	mountArgs := []string{"", "mount", "--enable-xattr", testMeta, testMountPoint, "--no-usage-report"}
+	if extraMountOpts != nil {
+		mountArgs = append(mountArgs, extraMountOpts...)
+	}
 	go func() {
-		if err := Main([]string{"", "mount", "--enable-xattr", testMeta, testMountPoint, "--no-usage-report"}); err != nil {
+		if err := Main(mountArgs); err != nil {
 			t.Errorf("mount failed: %s", err)
 		}
 	}()
@@ -124,7 +130,7 @@ func umountTemp(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	mountTemp(t, nil, true)
+	mountTemp(t, nil, nil, nil)
 	defer umountTemp(t)
 
 	if err := os.WriteFile(fmt.Sprintf("%s/f1.txt", testMountPoint), []byte("test"), 0644); err != nil {
@@ -132,8 +138,38 @@ func TestMount(t *testing.T) {
 	}
 }
 
+func TestUpdateFstab(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.SkipNow()
+	}
+	mockFstab, err := ioutil.TempFile("/tmp", "fstab")
+	if err != nil {
+		t.Fatalf("cannot make temp file: %s", err)
+	}
+	defer os.Remove(mockFstab.Name())
+
+	patches := gomonkey.ApplyGlobalVar(&fstab, mockFstab.Name())
+	defer patches.Reset()
+	mountArgs := []string{"juicefs", "mount", "--enable-xattr", testMeta, testMountPoint, "--no-usage-report"}
+	mountOpts := []string{"--update-fstab", "--writeback", "--entry-cache=2", "--max-uploads", "3", "-o", "max_read=99"}
+	patches = gomonkey.ApplyGlobalVar(&os.Args, append(mountArgs, mountOpts...))
+	defer patches.Reset()
+	mountTemp(t, nil, nil, mountOpts)
+	defer umountTemp(t)
+
+	content, err := ioutil.ReadFile(mockFstab.Name())
+	if err != nil {
+		t.Fatalf("error reading mocked fstab: %s", err)
+	}
+	rv := "redis://127.0.0.1:6379/11 /tmp/jfs-unit-test juicefs _netdev,enable-xattr,entry-cache=2,max-uploads=3,max_read=99,no-usage-report,update-fstab,writeback 0 0"
+	lv := string(content)
+	if lv != rv {
+		t.Logf("incorrect fstab entry: %s", lv)
+	}
+}
+
 func TestUmount(t *testing.T) {
-	mountTemp(t, nil, true)
+	mountTemp(t, nil, nil, nil)
 	umountTemp(t)
 
 	inode, err := utils.GetFileInode(testMountPoint)

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -149,6 +149,7 @@ func TestUpdateFstab(t *testing.T) {
 	}
 	defer os.Remove(mockFstab.Name())
 
+	var fstab = "/etc/fstab"
 	patches := gomonkey.ApplyGlobalVar(&fstab, mockFstab.Name())
 	defer patches.Reset()
 	mountArgs := []string{"juicefs", "mount", "--enable-xattr", testMeta, testMountPoint, "--no-usage-report"}

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -138,7 +138,7 @@ func mount_flags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  "update-fstab",
-			Usage: "add / update entry in /etc/fstab",
+			Usage: "add / update entry in /etc/fstab, will create soft link /sbin/mount.juicefs if not exists",
 		},
 	}
 	return append(selfFlags, cacheFlags(1.0)...)

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -136,6 +136,10 @@ func mount_flags() []cli.Flag {
 			Name:  "enable-xattr",
 			Usage: "enable extended attributes (xattr)",
 		},
+		&cli.BoolFlag{
+			Name:  "update-fstab",
+			Usage: "add / update entry in /etc/fstab",
+		},
 	}
 	return append(selfFlags, cacheFlags(1.0)...)
 }

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -138,7 +138,7 @@ func mount_flags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  "update-fstab",
-			Usage: "add / update entry in /etc/fstab, will create soft link /sbin/mount.juicefs if not exists",
+			Usage: "add / update entry in /etc/fstab, will create symlink /sbin/mount.juicefs if not exists",
 		},
 	}
 	return append(selfFlags, cacheFlags(1.0)...)

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -138,7 +138,7 @@ func mount_flags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  "update-fstab",
-			Usage: "add / update entry in /etc/fstab, will create symlink /sbin/mount.juicefs if not exists",
+			Usage: "add / update entry in /etc/fstab, will create a symlink at /sbin/mount.juicefs if not existing",
 		},
 	}
 	return append(selfFlags, cacheFlags(1.0)...)

--- a/cmd/rmr_test.go
+++ b/cmd/rmr_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestRmr(t *testing.T) {
-	mountTemp(t, nil, true)
+	mountTemp(t, nil, nil, nil)
 	defer umountTemp(t)
 
 	paths := []string{"/dir1", "/dir2", "/dir3/dir2"}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -38,7 +38,7 @@ func TestStatus(t *testing.T) {
 			patches := gomonkey.ApplyGlobalVar(os.Stdout, *tmpFile)
 			defer patches.Reset()
 
-			mountTemp(t, nil, true)
+			mountTemp(t, nil, nil, nil)
 			defer umountTemp(t)
 
 			if err = Main([]string{"", "status", testMeta}); err != nil {

--- a/cmd/warmup_test.go
+++ b/cmd/warmup_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestWarmup(t *testing.T) {
-	mountTemp(t, nil, true)
+	mountTemp(t, nil, nil, nil)
 	defer umountTemp(t)
 
 	if err := os.WriteFile(fmt.Sprintf("%s/f1.txt", testMountPoint), []byte("test"), 0644); err != nil {


### PR DESCRIPTION
- [x] abs path check for sqlite and similars
- [x] correctly handle slice arguments, even though they don't exist in `juicefs mount` yet
- [x] do not run in containers
- [x] unit tests

PR code will produce the following result:

![image](https://user-images.githubusercontent.com/4319104/182520282-0c16f6b1-37cd-49e4-b266-60aaf64858ca.png)

permission denied behavior:

![image](https://user-images.githubusercontent.com/4319104/183869535-2b0074b4-a8a9-4dbf-8cdb-e19fad678f83.png)


closes https://github.com/juicedata/juicefs/issues/2432