### PR TITLE
upgrade docker cross build image's golang version to 1.18

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gythialy/golang-cross:v1.17.8
+FROM ghcr.io/gythialy/golang-cross:v1.18.5
 
 ARG APT_MIRROR
 RUN sed -i -e "s/deb.debian.org/${APT_MIRROR:-deb.debian.org}/g" \


### PR DESCRIPTION
This is the `Dockerfile` for [juicedata/golang-cross:latest](https://hub.docker.com/r/juicedata/golang-cross) image