### PR TITLE
hadoop: allow concat to empty file

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -1259,7 +1259,13 @@ public class JuiceFileSystemImpl extends FileSystem {
     }
     int r = lib.jfs_concat(Thread.currentThread().getId(), handle, normalizePath(dst), buf, bufsize);
     if (r < 0) {
-      // TODO: show correct path (one of srcs)
+      if (r == ENOENT) {
+        if (!exists(dst)) {
+          throw error(r, dst);
+        } else {
+          throw new FileNotFoundException("one of srcs is missing");
+        }
+      }
       throw error(r, dst);
     }
   }

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -1233,8 +1233,8 @@ public class JuiceFileSystemImpl extends FileSystem {
   @Override
   public void concat(final Path dst, final Path[] srcs) throws IOException {
     statistics.incrementWriteOps(1);
-    if (getFileStatus(dst).getLen() == 0) {
-      throw new IOException(dst + "is empty");
+    if (srcs.length == 0) {
+      throw new IllegalArgumentException("No sources given");
     }
     Path dp = dst.getParent();
     for (Path src : srcs) {
@@ -1244,7 +1244,6 @@ public class JuiceFileSystemImpl extends FileSystem {
                 + dst);
       }
     }
-    if (srcs.length == 0) { return; }
     byte[][] srcbytes = new byte[srcs.length][];
     int bufsize = 0;
     for (int i = 0; i < srcs.length; i++) {

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -511,6 +511,13 @@ public class JuiceFileSystemTest extends TestCase {
     // src should be deleted after concat
     assertFalse(fs.exists(src1));
     assertFalse(fs.exists(src2));
+
+    Path emptyFile = new Path("/tmp/concat_empty_file");
+    fs.create(emptyFile).close();
+    fs.concat(emptyFile, new Path[]{src1});
+    in = fs.open(emptyFile);
+    assertEquals("hello", IOUtils.toString(in));
+    in.close();
   }
 
   public void testList() throws Exception {

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -513,8 +513,12 @@ public class JuiceFileSystemTest extends TestCase {
     assertFalse(fs.exists(src2));
 
     Path emptyFile = new Path("/tmp/concat_empty_file");
+    Path src = new Path("/tmp/concat_empty_file_src");
+    FSDataOutputStream srcOu = fs.create(src);
+    srcOu.write("hello".getBytes());
+    srcOu.close();
     fs.create(emptyFile).close();
-    fs.concat(emptyFile, new Path[]{src1});
+    fs.concat(emptyFile, new Path[]{src});
     in = fs.open(emptyFile);
     assertEquals("hello", IOUtils.toString(in));
     in.close();


### PR DESCRIPTION
Compatible with hadoop3