### PR TITLE
fix LZ4 decompressing an empty input

### DIFF
--- a/pkg/compress/compress.go
+++ b/pkg/compress/compress.go
@@ -118,5 +118,8 @@ func (l LZ4) Compress(dst, src []byte) (int, error) {
 
 // Decompress using LZ4 algorithm
 func (l LZ4) Decompress(dst, src []byte) (int, error) {
+	if len(src) == 0 {
+		return 0, fmt.Errorf("decompress an empty input")
+	}
 	return lz4.DecompressSafe(src, dst)
 }


### PR DESCRIPTION
The LZ4 compressed result is not empty, we should check that before calling lz4.DecompressSafe, otherwise it will crash.

#2495 