### PR TITLE
/sbin/mount.juicefs: do not crash when called with no opts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,8 +79,10 @@ func Main(args []string) error {
 	// Called via mount or fstab.
 	if strings.HasSuffix(args[0], "/mount.juicefs") {
 		args = handleSysMountArgs(args)
+		if len(args) < 1 {
+			args = []string{"--help"}
+		}
 	}
-
 	return app.Run(reorderOptions(app, args))
 }
 
@@ -91,6 +93,9 @@ func handleSysMountArgs(args []string) []string {
 		"direntrycacheto": "dir-entry-cache",
 	}
 	newArgs := []string{"juicefs", "mount", "-d"}
+	if len(args) < 4 {
+		return nil
+	}
 	mountOptions := args[3:]
 	sysOptions := []string{"_netdev", "rw", "defaults", "remount"}
 	fuseOptions := make([]string, 0, 20)


### PR DESCRIPTION
```
$ /sbin/mount.juicefs mount
2022/08/12 16:13:18.700930 juicefs[5941] <WARNING>: [/sbin/mount.juicefs mount] [main.go:95]
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/juicedata/juicefs/cmd.reorderOptions(0xc000926340, 0x0, 0x0, 0x0, 0x0, 0x0, 0x19)
        /data/timfeirg/ce/cmd/main.go:174 +0xfb9
github.com/juicedata/juicefs/cmd.Main(0xc0008dbde0, 0x2, 0x2, 0x0, 0x0)
        /data/timfeirg/ce/cmd/main.go:84 +0x2054
main.main()
        /data/timfeirg/ce/main.go:29 +0x49
```