### PR TITLE
Revert "vfs: record plock owner and use it instead of the one from FUSE (#2649)"

### DIFF
--- a/pkg/vfs/handle.go
+++ b/pkg/vfs/handle.go
@@ -37,7 +37,6 @@ type handle struct {
 	// for file
 	locks      uint8
 	flockOwner uint64 // kernel 3.1- does not pass lock_owner in release()
-	plockOwner uint64 // plock owner may be different with OFD locks in flush()
 	reader     FileReader
 	writer     FileWriter
 	ops        []Context

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -730,7 +730,7 @@ func (v *VFS) Flush(ctx Context, ino Ino, fh uint64, lockOwner uint64) (err sysc
 		fh = v.getControlHandle(ctx.Pid())
 		defer v.releaseControlHandle(ctx.Pid())
 	}
-	defer func() { logit(ctx, "flush (%d,%d): %s", ino, fh, strerr(err)) }()
+	defer func() { logit(ctx, "flush (%d,%d,%016X): %s", ino, fh, lockOwner, strerr(err)) }()
 	h := v.findHandle(ino, fh)
 	if h == nil {
 		err = syscall.EBADF
@@ -762,10 +762,9 @@ func (v *VFS) Flush(ctx Context, ino Ino, fh uint64, lockOwner uint64) (err sysc
 
 	h.Lock()
 	locks := h.locks
-	owner := h.plockOwner
 	h.Unlock()
 	if locks&2 != 0 {
-		_ = v.Meta.Setlk(ctx, ino, owner, false, F_UNLCK, 0, 0x7FFFFFFFFFFFFFFF, 0)
+		_ = v.Meta.Setlk(ctx, ino, lockOwner, false, F_UNLCK, 0, 0x7FFFFFFFFFFFFFFF, 0)
 	}
 	return
 }

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -245,7 +245,6 @@ func (v *VFS) Setlk(ctx Context, ino Ino, fh uint64, owner uint64, start, end ui
 		h.Lock()
 		if typ != syscall.F_UNLCK {
 			h.locks |= 2
-			h.plockOwner = owner
 		}
 		h.Unlock()
 	}


### PR DESCRIPTION
This reverts commit 68a7168deb949d21e7a33243a3701d1ce4bd2cb1.

Failed LTP tests caused by the previous commit:
```
fcntl14    30  TFAIL  :  fcntl14.c:635: Test case 30, GETLK: type = 0, 2 was expected
fcntl14    31  TFAIL  :  fcntl14.c:669: Test case 30, GETLK: pid = 57008, should have remained 0
fcntl14    32  TFAIL  :  fcntl14.c:708: Attempt to set child NONBLOCKING lock failed
fcntl14    33  TFAIL  :  fcntl14.c:710: Test case 30, errno = 11
fcntl14    30  TFAIL  :  fcntl14.c:890: tchild returned status 0x100
fcntl14    31  TFAIL  :  fcntl14.c:895: testcase:30 FAILED
fcntl14    32  TFAIL  :  fcntl14.c:895: testcase:31 FAILED
fcntl14    33  TFAIL  :  fcntl14.c:895: testcase:32 FAILED
fcntl14    34  TFAIL  :  fcntl14.c:895: testcase:33 FAILED
fcntl14    35  TFAIL  :  fcntl14.c:895: testcase:34 FAILED
fcntl14    36  TFAIL  :  fcntl14.c:895: testcase:35 FAILED
fcntl14    37  TFAIL  :  fcntl14.c:895: testcase:36 FAILED
fcntl14    38  TFAIL  :  fcntl14.c:936: Block 1, test 1 FAILED
```

We cannot support OFD locks for now since FUSE ignores the `FL_OFDLCK` flag. See:
https://github.com/torvalds/linux/blob/v5.4/fs/locks.c#L2476-L2484
```
	case F_OFD_SETLK:
		error = -EINVAL;
		if (flock->l_pid != 0)
			goto out;

		cmd = F_SETLK;
		file_lock->fl_flags |= FL_OFDLCK;
		file_lock->fl_owner = filp;
		break;
```
and https://github.com/torvalds/linux/blob/v5.4/fs/fuse/file.c#L2341-L2349
```
	memset(inarg, 0, sizeof(*inarg));
	inarg->fh = ff->fh;
	inarg->owner = fuse_lock_owner_id(fc, fl->fl_owner);
	inarg->lk.start = fl->fl_start;
	inarg->lk.end = fl->fl_end;
	inarg->lk.type = fl->fl_type;
	inarg->lk.pid = pid;
	if (flock)
		inarg->lk_flags |= FUSE_LK_FLOCK;
```