### PR TITLE
close fd before interrupted

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -744,10 +744,8 @@ func (v *VFS) Flush(ctx Context, ino Ino, fh uint64, lockOwner uint64) (err sysc
 	}
 
 	if h.writer != nil {
-		if !h.Wlock(ctx) {
+		for !h.Wlock(ctx) {
 			h.cancelOp(ctx.Pid())
-			err = syscall.EINTR
-			return
 		}
 
 		err = h.writer.Flush(ctx)


### PR DESCRIPTION
Since a interrupted `close` will not be retried, and Linux kernel guarantee that the fd will be close even it's interrupted,  we should also do that, and try to not interrupt a `FLUSH` operation as much as possible. 

close #2744 