### PR TITLE
vfs: invalid entry cache after `rmr`

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -471,6 +471,9 @@ func Serve(v *vfs.VFS, options string, xattrs bool) error {
 	if err != nil {
 		return fmt.Errorf("fuse: %s", err)
 	}
+	v.RmrCB = func(parent Ino, name string) syscall.Errno {
+		return syscall.Errno(fssrv.EntryNotify(uint64(parent), name))
+	}
 
 	fssrv.Serve()
 	return nil

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -471,7 +471,7 @@ func Serve(v *vfs.VFS, options string, xattrs bool) error {
 	if err != nil {
 		return fmt.Errorf("fuse: %s", err)
 	}
-	v.RmrCB = func(parent Ino, name string) syscall.Errno {
+	v.InvalidateEntry = func(parent Ino, name string) syscall.Errno {
 		return syscall.Errno(fssrv.EntryNotify(uint64(parent), name))
 	}
 

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -251,11 +251,11 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 	switch cmd {
 	case meta.Rmr:
 		done := make(chan struct{})
+		inode := Ino(r.Get64())
+		name := string(r.Get(int(r.Get8())))
 		var count uint64
 		var st syscall.Errno
 		go func() {
-			inode := Ino(r.Get64())
-			name := string(r.Get(int(r.Get8())))
 			st = v.Meta.Remove(ctx, inode, name, &count)
 			if st != 0 {
 				logger.Errorf("remove %d/%s: %s", inode, name, st)
@@ -263,6 +263,11 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 			close(done)
 		}()
 		writeProgress(&count, nil, data, done)
+		if st == 0 && v.RmrCB != nil {
+			if st = v.RmrCB(inode, name); st != 0 {
+				logger.Errorf("Rmr callback %d/%s: %s", inode, name, st)
+			}
+		}
 		*data = append(*data, uint8(st))
 	case meta.Info:
 		var summary meta.Summary

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -263,9 +263,9 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 			close(done)
 		}()
 		writeProgress(&count, nil, data, done)
-		if st == 0 && v.RmrCB != nil {
-			if st = v.RmrCB(inode, name); st != 0 {
-				logger.Errorf("Rmr callback %d/%s: %s", inode, name, st)
+		if st == 0 && v.InvalidateEntry != nil {
+			if st = v.InvalidateEntry(inode, name); st != 0 {
+				logger.Errorf("Invalidate entry %d/%s: %s", inode, name, st)
 			}
 		}
 		*data = append(*data, uint8(st))

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -902,12 +902,12 @@ func (v *VFS) RemoveXattr(ctx Context, ino Ino, name string) (err syscall.Errno)
 var logger = utils.GetLogger("juicefs")
 
 type VFS struct {
-	Conf   *Config
-	Meta   meta.Meta
-	Store  chunk.ChunkStore
-	RmrCB  func(parent meta.Ino, name string) syscall.Errno
-	reader DataReader
-	writer DataWriter
+	Conf            *Config
+	Meta            meta.Meta
+	Store           chunk.ChunkStore
+	InvalidateEntry func(parent meta.Ino, name string) syscall.Errno
+	reader          DataReader
+	writer          DataWriter
 
 	handles map[Ino][]*handle
 	hanleM  sync.Mutex

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -905,6 +905,7 @@ type VFS struct {
 	Conf   *Config
 	Meta   meta.Meta
 	Store  chunk.ChunkStore
+	RmrCB  func(parent meta.Ino, name string) syscall.Errno
 	reader DataReader
 	writer DataWriter
 


### PR DESCRIPTION
close #2769 
close #2767 

`DeleteNotify` is not used for simplicity because the child inode can't be obtained directly.
See: https://github.com/juicedata/go-fuse/blob/master/fuse/server.go#L767