### PR TITLE
CI:rm load bagerdb test

### DIFF
--- a/.github/actions/load/action.yml
+++ b/.github/actions/load/action.yml
@@ -23,9 +23,9 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go
 
     - name: Build linux target
       run: |

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -116,20 +116,20 @@ jobs:
           load_file: "2M_emtpy_files.dump"
 
 
-  load-to-badgerdb:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: download data
-        run: |
-          wget -q https://s.juicefs.com/static/bench/2M_emtpy_files.dump.gz
-          gzip -dk  2M_emtpy_files.dump.gz
-      - run: sudo go get github.com/dgraph-io/badger/v3
-      - name: Test
-        uses: ./.github/actions/load
-        with:
-          meta_url: "badger://load_test"
-          load_file: "2M_emtpy_files.dump"    
+#  load-to-badgerdb:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: download data
+#        run: |
+#          wget -q https://s.juicefs.com/static/bench/2M_emtpy_files.dump.gz
+#          gzip -dk  2M_emtpy_files.dump.gz
+#      - run: sudo go get github.com/dgraph-io/badger/v3
+#      - name: Test
+#        uses: ./.github/actions/load
+#        with:
+#          meta_url: "badger://load_test"
+#          load_file: "2M_emtpy_files.dump"
 
 
   load-to-mariadb:

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -116,20 +116,20 @@ jobs:
           load_file: "2M_emtpy_files.dump"
 
 
-#  load-to-badgerdb:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: download data
-#        run: |
-#          wget -q https://s.juicefs.com/static/bench/2M_emtpy_files.dump.gz
-#          gzip -dk  2M_emtpy_files.dump.gz
-#      - run: sudo go get github.com/dgraph-io/badger/v3
-#      - name: Test
-#        uses: ./.github/actions/load
-#        with:
-#          meta_url: "badger://load_test"
-#          load_file: "2M_emtpy_files.dump"
+  load-to-badgerdb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: download data
+        run: |
+          wget -q https://s.juicefs.com/static/bench/2M_emtpy_files.dump.gz
+          gzip -dk  2M_emtpy_files.dump.gz
+      - run: sudo go get github.com/dgraph-io/badger/v3
+      - name: Test
+        uses: ./.github/actions/load
+        with:
+          meta_url: "badger://load_test"
+          load_file: "2M_emtpy_files.dump"
 
 
   load-to-mariadb:


### PR DESCRIPTION
The test of loading metadata in badgerdb has failed for a long time . Details may refer to https://github.com/juicedata/juicefs/actions/runs/3095075995 .