### PR TITLE
meta/badger: drop all keys directly to reset the database

### DIFF
--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -227,30 +227,10 @@ func (c *badgerClient) scan(prefix []byte, handler func(key []byte, value []byte
 }
 
 func (c *badgerClient) reset(prefix []byte) error {
-	for {
-		tx := c.client.NewTransaction(true)
-		defer tx.Discard()
-		it := tx.NewIterator(badger.IteratorOptions{
-			Prefix:       prefix,
-			PrefetchSize: 1024,
-		})
-		it.Rewind()
-		if !it.Valid() {
-			it.Close()
-			return nil
-		}
-		for ; it.Valid(); it.Next() {
-			if err := tx.Delete(it.Item().Key()); err == badger.ErrTxnTooBig {
-				break
-			} else if err != nil {
-				it.Close()
-				return err
-			}
-		}
-		it.Close()
-		if err := tx.Commit(); err != nil {
-			return err
-		}
+	if prefix == nil {
+		return c.client.DropAll()
+	} else {
+		return c.client.DropPrefix(prefix)
 	}
 }
 


### PR DESCRIPTION
close #2808 


Badger hangs here:
```
1 @ 0x42796e 0xc277eb 0x11555fc 0x11555fd 0x1130749 0x224df63 0x620f0a 0x61e8fe 0x225ca6d 0x225a4ca 0x2283b8e 0x44cf87 0x47eb61
#       0xc277ea        github.com/dgraph-io/badger/v3.(*Txn).modify+0x1ea                      /usr/local/go/pkg/mod/github.com/dgraph-io/badg
er/v3@v3.2103.2/txn.go:401
#       0x11555fb       github.com/dgraph-io/badger/v3.(*Txn).Delete+0x2fb                      /usr/local/go/pkg/mod/github.com/dgraph-io/badg
er/v3@v3.2103.2/txn.go:439
#       0x11555fc       github.com/juicedata/juicefs/pkg/meta.(*badgerClient).reset+0x2fc       /root/juicefs1/pkg/meta/tkv_badger.go:243
#       0x1130748       github.com/juicedata/juicefs/pkg/meta.(*kvMeta).Reset+0x28              /root/juicefs1/pkg/meta/tkv.go:383
#       0x224df62       github.com/juicedata/juicefs/cmd.destroy+0xfc2                          /root/juicefs1/cmd/destroy.go:207
#       0x620f09        github.com/urfave/cli/v2.(*Command).Run+0x649                           /usr/local/go/pkg/mod/github.com/urfave/cli/v2@
v2.4.0/command.go:163
#       0x61e8fd        github.com/urfave/cli/v2.(*App).RunContext+0x81d                        /usr/local/go/pkg/mod/github.com/urfave/cli/v2@
v2.4.0/app.go:313
#       0x225ca6c       github.com/urfave/cli/v2.(*App).Run+0x25cc                              /usr/local/go/pkg/mod/github.com/urfave/cli/v2@
v2.4.0/app.go:224
#       0x225a4c9       github.com/juicedata/juicefs/cmd.Main+0x29                              /root/juicefs1/cmd/main.go:86
#       0x2283b8d       main.main+0x2d                                                          /root/juicefs1/main.go:29
#       0x44cf86        runtime.main+0x226                                                      /usr/local/go/src/runtime/proc.go:255
```