### PR TITLE
support private region for KS3

### DIFF
--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -261,9 +261,14 @@ func newKS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	bucket := hostParts[0]
 	region := hostParts[1][3:]
 	region = strings.TrimLeft(region, "-")
-	if strings.HasSuffix(uri.Host, "ksyun.com") {
+	if strings.HasSuffix(uri.Host, "ksyun.com") || strings.HasSuffix(uri.Host, "ksyuncs.com") {
 		region = strings.TrimSuffix(region, "-internal")
 		region = ks3Regions[region]
+	} else if envRegion := os.Getenv("AWS_REGION"); envRegion != "" {
+		region = envRegion
+	}
+	if region == "" {
+		region = "us-east-1"
 	}
 
 	var err error
@@ -280,7 +285,7 @@ func newKS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		Endpoint:         strings.SplitN(uri.Host, ".", 2)[1],
 		DisableSSL:       !ssl,
 		HTTPClient:       httpClient,
-		S3ForcePathStyle: false,
+		S3ForcePathStyle: true,
 		Credentials:      credentials.NewStaticCredentials(accessKey, secretKey, token),
 	}
 


### PR DESCRIPTION
A private KS3 region may have different rule on endpoints, we can use `us-east-1` as the region for compatibility, which can also specified by AWS_REGION.