### PR TITLE
prepare for v1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ before_script:
   - go install github.com/minio/mc@RELEASE.2022-01-07T06-01-38Z && mc config host add local http://127.0.0.1:9000 testUser testUserPassword && mc mb local/testbucket
   - nohup /home/travis/.m2/rclone-v1.57.0-linux-amd64/rclone serve webdav local --addr 127.0.0.1:9007 >> rclone.log 2>&1 &
   - # nohup /home/travis/.m2/etcd-v3.5.2-linux-amd64/etcd --unsafe-no-fsync --listen-client-urls http://127.0.0.1:2389 --advertise-client-urls http://127.0.0.1:2389 &
-  - sudo chmod 777 /usr/local/maven-3.6.3/conf/settings.xml
-  - sudo sed -i "s?</settings>?<localRepository>/home/travis/.m2/repository</localRepository></settings>?" /usr/local/maven-3.6.3/conf/settings.xml
+  - sudo chmod 777 /usr/local/maven/conf/settings.xml
+  - sudo sed -i "s?</settings>?<localRepository>/home/travis/.m2/repository</localRepository></settings>?" /usr/local/maven/conf/settings.xml
   - docker run -d --name sftp -p 2222:22  juicedata/ci-sftp
   - make
   - sudo make -C fstests setup

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -59,7 +59,7 @@ func cmdGateway() *cli.Command {
 		&cli.StringFlag{
 			Name:  "umask",
 			Value: "022",
-			Usage: "umask for new file in octal",
+			Usage: "umask for new files and directories in octal",
 		},
 	}
 
@@ -169,7 +169,16 @@ func (g *GateWay) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, er
 		logger.Fatalf("invalid umask %s: %s", c.String("umask"), err)
 	}
 
-	return jfsgateway.NewJFSGateway(jfs, conf, &jfsgateway.Config{MultiBucket: c.Bool("multi-buckets"), KeepEtag: c.Bool("keep-etag"), Mode: uint16(0777 &^ umask)})
+	return jfsgateway.NewJFSGateway(
+		jfs,
+		conf,
+		&jfsgateway.Config{
+			MultiBucket: c.Bool("multi-buckets"),
+			KeepEtag: c.Bool("keep-etag"),
+			Mode: uint16(0666 &^ umask),
+			DirMode: uint16(0777 &^ umask),
+		},
+	)
 }
 
 func initForSvc(c *cli.Context, mp string, metaUrl string) (*vfs.Config, *fs.FileSystem) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,8 +79,10 @@ func Main(args []string) error {
 	// Called via mount or fstab.
 	if strings.HasSuffix(args[0], "/mount.juicefs") {
 		args = handleSysMountArgs(args)
+		if len(args) < 1 {
+			args = []string{"--help"}
+		}
 	}
-
 	return app.Run(reorderOptions(app, args))
 }
 
@@ -91,6 +93,9 @@ func handleSysMountArgs(args []string) []string {
 		"direntrycacheto": "dir-entry-cache",
 	}
 	newArgs := []string{"juicefs", "mount", "-d"}
+	if len(args) < 4 {
+		return nil
+	}
 	mountOptions := args[3:]
 	sysOptions := []string{"_netdev", "rw", "defaults", "remount"}
 	fuseOptions := make([]string, 0, 20)

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -153,7 +153,11 @@ func objbench(ctx *cli.Context) error {
 		failed = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, RED, failed, RESET_SEQ)
 	}
 
-	if !ctx.IsSet("skip-functional-tests") {
+	if ctx.Bool("skip-functional-tests") {
+		if err := blob.Create(); err != nil {
+			return fmt.Errorf("can't create bucket: %s", err)
+		}
+	} else {
 		var result [][]string
 		result = append(result, []string{"CATEGORY", "TEST", "RESULT"})
 		fmt.Println("Start Functional Testing ...")

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -34,7 +34,6 @@ import (
 	"github.com/juicedata/juicefs/pkg/object"
 	osync "github.com/juicedata/juicefs/pkg/sync"
 	"github.com/juicedata/juicefs/pkg/utils"
-	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -145,9 +144,9 @@ func objbench(ctx *cli.Context) error {
 	bCount := int(math.Ceil(float64(fsize) / float64(bSize)))
 	sCount := int(ctx.Uint("small-objects"))
 	threads := int(ctx.Uint("threads"))
-	tty := isatty.IsTerminal(os.Stdout.Fd())
-	progress := utils.NewProgress(!tty, false)
-	if tty {
+	colorful := utils.SupportANSIColor(os.Stdout.Fd())
+	progress := utils.NewProgress(false, false)
+	if colorful {
 		nspt = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, YELLOW, nspt, RESET_SEQ)
 		skipped = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, YELLOW, skipped, RESET_SEQ)
 		pass = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, GREEN, pass, RESET_SEQ)
@@ -158,8 +157,8 @@ func objbench(ctx *cli.Context) error {
 		var result [][]string
 		result = append(result, []string{"CATEGORY", "TEST", "RESULT"})
 		fmt.Println("Start Functional Testing ...")
-		functionalTesting(blob, &result, tty)
-		printResult(result, -1, tty)
+		functionalTesting(blob, &result, colorful)
+		printResult(result, -1, colorful)
 		fmt.Println()
 	}
 	fmt.Println("Start Performance Testing ...")
@@ -174,7 +173,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("smallput", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("smallput", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -187,7 +186,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("smallget", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("smallget", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -201,7 +200,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("put", float64(bSize>>20*bCount)/cost, cost*1000/float64(bCount), 2, tty)
+					line[1], line[2] = colorize("put", float64(bSize>>20*bCount)/cost, cost*1000/float64(bCount), 2, colorful)
 					line[1] += " MiB/s"
 					line[2] += " ms/object"
 				}
@@ -220,7 +219,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("get", float64(bSize>>20*bCount)/cost, cost*1000/float64(bCount), 2, tty)
+					line[1], line[2] = colorize("get", float64(bSize>>20*bCount)/cost, cost*1000/float64(bCount), 2, colorful)
 					line[1] += " MiB/s"
 					line[2] += " ms/object"
 				}
@@ -233,7 +232,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("list", float64(sCount)*100/cost, cost*10, 2, tty)
+					line[1], line[2] = colorize("list", float64(sCount)*100/cost, cost*10, 2, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/op"
 				}
@@ -246,7 +245,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("head", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("head", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -259,7 +258,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("chtimes", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("chtimes", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -272,7 +271,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("chmod", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("chmod", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -285,7 +284,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("chown", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("chown", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -298,7 +297,7 @@ func objbench(ctx *cli.Context) error {
 			getResult: func(cost float64) []string {
 				line := []string{"", nspt, nspt}
 				if cost > 0 {
-					line[1], line[2] = colorize("delete", float64(sCount)/cost, cost*1000/float64(sCount), 1, tty)
+					line[1], line[2] = colorize("delete", float64(sCount)/cost, cost*1000/float64(sCount), 1, colorful)
 					line[1] += " objects/s"
 					line[2] += " ms/object"
 				}
@@ -333,7 +332,7 @@ func objbench(ctx *cli.Context) error {
 	pResult[1], pResult[3] = pResult[3], pResult[1]
 	pResult[2], pResult[4] = pResult[4], pResult[2]
 	pResult[7], pResult[10] = pResult[10], pResult[7]
-	printResult(pResult, -1, tty)
+	printResult(pResult, -1, colorful)
 	return nil
 }
 
@@ -351,10 +350,10 @@ var resultRangeForObj = map[string][4]float64{
 	"chtimes":      {10, 30, 30, 100},
 }
 
-func colorize(item string, value, cost float64, prec int, isatty bool) (string, string) {
+func colorize(item string, value, cost float64, prec int, colorful bool) (string, string) {
 	svalue := strconv.FormatFloat(value, 'f', prec, 64)
 	scost := strconv.FormatFloat(cost, 'f', 2, 64)
-	if isatty {
+	if colorful {
 		r, ok := resultRangeForObj[item]
 		if !ok {
 			logger.Fatalf("Invalid item: %s", item)
@@ -582,14 +581,14 @@ var syncTests = map[string]bool{
 	"multipart upload":    true,
 }
 
-func functionalTesting(blob object.ObjectStorage, result *[][]string, tty bool) {
+func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful bool) {
 	runCase := func(title string, fn func(blob object.ObjectStorage) error) {
 		r := pass
 		if err := fn(blob); err == utils.ENOTSUP {
 			r = nspt
 		} else if err != nil {
 			r = err.Error()
-			if tty {
+			if colorful {
 				r = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, RED, r, RESET_SEQ)
 			}
 			logger.Debug(err.Error())
@@ -600,7 +599,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, tty bool) 
 			category = "sync"
 		}
 
-		if tty {
+		if colorful {
 			title = fmt.Sprintf("%s%sm%s%s", COLOR_SEQ, DEFAULT, title, RESET_SEQ)
 		}
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
-	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -86,7 +85,7 @@ var findDigits = regexp.MustCompile(`\d+`)
 type profiler struct {
 	file      *os.File
 	replay    bool
-	tty       bool
+	colorful  bool
 	interval  time.Duration
 	uids      []string
 	gids      []string
@@ -246,8 +245,8 @@ func (p *profiler) fastCounter() {
 	p.printTime <- last
 }
 
-func printLines(lines []string, tty bool) {
-	if tty {
+func printLines(lines []string, colorful bool) {
+	if colorful {
 		fmt.Print("\033[2J\033[1;1H") // clear screen
 		fmt.Printf("\033[92m%s\n\033[0m", lines[0])
 		fmt.Printf("\033[97m%s\n\033[0m", lines[1])
@@ -286,7 +285,7 @@ func (p *profiler) flush(timeStamp time.Time, keyStats []keyStat, done bool) {
 	if p.replay {
 		output[1] = fmt.Sprintln("\n[enter]Pause/Continue")
 	}
-	printLines(output, p.tty)
+	printLines(output, p.colorful)
 }
 
 func (p *profiler) flusher() {
@@ -364,7 +363,7 @@ func profile(ctx *cli.Context) error {
 	prof := profiler{
 		file:      file,
 		replay:    replay,
-		tty:       isatty.IsTerminal(os.Stdout.Fd()),
+		colorful:  utils.SupportANSIColor(os.Stdout.Fd()),
 		interval:  time.Second * time.Duration(ctx.Int64("interval")),
 		uids:      strings.Split(ctx.String("uid"), ","),
 		gids:      strings.Split(ctx.String("gid"), ","),
@@ -402,7 +401,7 @@ func profile(ctx *cli.Context) error {
 	var input string
 	for {
 		_, _ = fmt.Scanln(&input)
-		if prof.tty {
+		if prof.colorful {
 			fmt.Print("\033[1A\033[K") // move cursor back
 		}
 		if prof.replay {

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/juicedata/juicefs/pkg/utils"
-	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -88,7 +87,7 @@ const (
 )
 
 type statsWatcher struct {
-	tty      bool
+	colorful bool
 	interval uint
 	path     string
 	header   string
@@ -96,7 +95,7 @@ type statsWatcher struct {
 }
 
 func (w *statsWatcher) colorize(msg string, color int, dark bool, underline bool) string {
-	if !w.tty || msg == "" || msg == " " {
+	if !w.colorful || msg == "" || msg == " " {
 		return msg
 	}
 	var cseq, useq string
@@ -293,7 +292,7 @@ func (w *statsWatcher) formatCPU(v float64, dark bool) string {
 }
 
 func (w *statsWatcher) printDiff(left, right map[string]float64, dark bool) {
-	if !w.tty && dark {
+	if !w.colorful && dark {
 		return
 	}
 	values := make([]string, len(w.sections))
@@ -333,7 +332,7 @@ func (w *statsWatcher) printDiff(left, right map[string]float64, dark bool) {
 		}
 		values[i] = strings.Join(vals, " ")
 	}
-	if w.tty && dark {
+	if w.colorful && dark {
 		fmt.Printf("%s\r", strings.Join(values, w.colorize("|", BLUE, true, false)))
 	} else {
 		fmt.Printf("%s\n", strings.Join(values, w.colorize("|", BLUE, true, false)))
@@ -378,7 +377,7 @@ func stats(ctx *cli.Context) error {
 	}
 
 	watcher := &statsWatcher{
-		tty:      !ctx.Bool("no-color") && isatty.IsTerminal(os.Stdout.Fd()),
+		colorful: !ctx.Bool("no-color") && utils.SupportANSIColor(os.Stdout.Fd()),
 		interval: ctx.Uint("interval"),
 		path:     path.Join(mp, ".stats"),
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -313,8 +313,16 @@ func doSync(c *cli.Context) error {
 	go func() { _ = http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", config.HTTPPort), nil) }()
 
 	// Windows support `\` and `/` as its separator, Unix only use `/`
-	srcURL := strings.Replace(c.Args().Get(0), "\\", "/", -1)
-	dstURL := strings.Replace(c.Args().Get(1), "\\", "/", -1)
+	srcURL := c.Args().Get(0)
+	dstURL := c.Args().Get(1)
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(srcURL, "://") {
+			srcURL = strings.Replace(srcURL, "\\", "/", -1)
+		}
+		if !strings.Contains(dstURL, "://") {
+			dstURL = strings.Replace(dstURL, "\\", "/", -1)
+		}
+	}
 	if strings.HasSuffix(srcURL, "/") != strings.HasSuffix(dstURL, "/") {
 		logger.Fatalf("SRC and DST should both end with path separator or not!")
 	}

--- a/docs/en/deployment/hadoop_java_sdk.md
+++ b/docs/en/deployment/hadoop_java_sdk.md
@@ -33,7 +33,7 @@ If you want to use JuiceFS in a distributed environment, when creating a file sy
 
 ### 4. Memory
 
-JuiceFS Hadoop Java SDK need extra 4 * [`juicefs.memory-size`](#io-configurations) off-heap memory at most. By default, up to 1.2 GB of additional memory is required (depends on write load).
+Depending on the read and write load of computing tasks (such as Spark executor), JuiceFS Hadoop Java SDK may require an additional 4 * [`juicefs.memory-size`](#io-configurations) off-heap memory to speed up read and write performance. By default, it is recommended to configure at least 1.2GB of off-heap memory for compute tasks.
 
 ## Install and compile the client
 
@@ -350,6 +350,10 @@ Before restart, you need to confirm JuiceFS related configuration has been writt
 HDFS, Hue, ZooKeeper and other services don't need to be restarted.
 
 When `Class io.juicefs.JuiceFileSystem not found` or `No FilesSystem for scheme: jfs` exceptions was occurred after restart, reference [FAQ](#faq).
+
+### Trash
+
+JuiceFS Hadoop Java SDK also has the same trash function as HDFS, which needs to be enabled by setting `fs.trash.interval` and `fs.trash.checkpoint.interval`, please refer to [HDFS documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html#File_Deletes_and_Undeletes) for more information.
 
 ## Environmental Verification
 

--- a/docs/en/guide/how_to_set_up_metadata_engine.md
+++ b/docs/en/guide/how_to_set_up_metadata_engine.md
@@ -140,14 +140,14 @@ When using PostgreSQL as the metadata storage engine, you need to create a datab
   <TabItem value="tcp" label="TCP">
 
 ```
-postgres://<username>[:<password>]@<host>[:5432]/<database-name>[?parameters]
+postgres://[username][:<password>]@<host>[:5432]/<database-name>[?parameters]
 ```
 
   </TabItem>
   <TabItem value="unix-socket" label="Unix socket">
 
 ```
-postgres:///<database-name>?host=<socket-directories-path>[&user=<user>&password=<password>]
+postgres://[username][:<password>]@/<database-name>?host=<socket-directories-path>[&parameters]
 ```
 
   </TabItem>

--- a/docs/zh_cn/deployment/hadoop_java_sdk.md
+++ b/docs/zh_cn/deployment/hadoop_java_sdk.md
@@ -33,7 +33,7 @@ JuiceFS 默认使用本地的 `用户` 和 `UID` 映射，在分布式环境下�
 
 ### 4. 内存资源
 
-JuiceFS Hadoop Java SDK 最多需要额外使用 4 * [`juicefs.memory-size`](#io-配置) 的 off-heap 内存用来加速读写性能，默认情况下，最多需要额外 1.2GB 内存（取决于写入负载）。
+根据计算任务（如 Spark executor）的读写负载，JuiceFS Hadoop Java SDK 可能需要额外使用 4 * [`juicefs.memory-size`](#io-配置) 的堆外内存用来加速读写性能。默认情况下，建议为计算任务至少配置 1.2GB 的堆外内存。
 
 ## 安装与编译客户端
 
@@ -351,6 +351,10 @@ JuiceFS 适合存储 HBase 的 HFile，但不适合用来保存它的事务日�
 HDFS、Hue、ZooKeeper 等服务无需重启。
 
 若访问 JuiceFS 出现 `Class io.juicefs.JuiceFileSystem not found` 或 `No FilesSystem for scheme: jfs` 错误，请参考 [FAQ](#faq)。
+
+### 回收站
+
+JuiceFS Hadoop Java SDK 同样也有和 HDFS 一样的回收站功能，需要通过设置 `fs.trash.interval` 和 `fs.trash.checkpoint.interval` 开启，请参考 [HDFS 文档](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html#File_Deletes_and_Undeletes)了解更多信息。
 
 ## 环境验证
 

--- a/docs/zh_cn/guide/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/guide/how_to_set_up_metadata_engine.md
@@ -140,14 +140,14 @@ KeyDB 的数据复制是异步的，使用 Active Active（双活）功能可能
   <TabItem value="tcp" label="TCP">
 
 ```
-postgres://<username>[:<password>]@<host>[:5432]/<database-name>[?parameters]
+postgres://[username][:<password>]@<host>[:5432]/<database-name>[?parameters]
 ```
 
   </TabItem>
   <TabItem value="unix-socket" label="Unix socket">
 
 ```
-postgres:///<database-name>?host=<socket-directories-path>[&user=<user>&password=<password>]
+postgres://[username][:<password>]@/<database-name>?host=<socket-directories-path>[&parameters]
 ```
 
   </TabItem>

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -79,3 +79,33 @@ func BenchmarkLoadUncached(b *testing.B) {
 		}
 	}
 }
+
+func TestCheckPath(t *testing.T) {
+	cases := []struct {
+		path     string
+		expected bool
+	}{
+		// unix path style
+		{path: "chunks/111/222/3333_3333_3333", expected: true},
+		{path: "chunks/111/222/3333_3333_0", expected: true},
+		{path: "chunks/0/0/0_0_0", expected: true},
+		{path: "chunks/01/10/0_01_0", expected: true},
+		{path: "achunks/111/222/3333_3333_3333", expected: false},
+		{path: "chunksa/111/222/3333_3333_3333", expected: false},
+		{path: "chunksa", expected: false},
+		{path: "chunks/111", expected: false},
+		{path: "chunks/111/2222", expected: false},
+		{path: "chunks/111/2222/3", expected: false},
+		{path: "chunks/111/2222/3333_3333", expected: false},
+		{path: "chunks/111/2222/3333_3333_3333_4444", expected: false},
+		{path: "chunks/111/2222/3333_3333_3333/4444", expected: false},
+		{path: "chunks/111_/2222/3333_3333_3333", expected: false},
+		{path: "chunks/111/22_22/3333_3333_3333", expected: false},
+		{path: "chunks/111/22_22/3333_3333_3333", expected: false},
+	}
+	for _, c := range cases {
+		if res := pathReg.MatchString(c.path); res != c.expected {
+			t.Fatalf("check path %s expected %v but got %v", c.path, c.expected, res)
+		}
+	}
+}

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -464,6 +464,9 @@ func Serve(v *vfs.VFS, options string, xattrs bool) error {
 	if err != nil {
 		return fmt.Errorf("fuse: %s", err)
 	}
+	v.InvalidateEntry = func(parent Ino, name string) syscall.Errno {
+		return syscall.Errno(fssrv.EntryNotify(uint64(parent), name))
+	}
 
 	fssrv.Serve()
 	return nil

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -464,8 +464,10 @@ func Serve(v *vfs.VFS, options string, xattrs bool) error {
 	if err != nil {
 		return fmt.Errorf("fuse: %s", err)
 	}
-	v.InvalidateEntry = func(parent Ino, name string) syscall.Errno {
-		return syscall.Errno(fssrv.EntryNotify(uint64(parent), name))
+	if runtime.GOOS == "linux" {
+		v.InvalidateEntry = func(parent Ino, name string) syscall.Errno {
+			return syscall.Errno(fssrv.EntryNotify(uint64(parent), name))
+		}
 	}
 
 	fssrv.Serve()

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -450,12 +450,15 @@ func (n *jfsObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBu
 	}
 	tmp := n.tpath(dstBucket, "tmp", minio.MustGetUUID())
 	_ = n.mkdirAll(ctx, path.Dir(tmp), os.FileMode(n.gConf.DirMode))
-	_, eno := n.fs.Create(mctx, tmp, n.gConf.Mode)
+	f, eno := n.fs.Create(mctx, tmp, n.gConf.Mode)
 	if eno != 0 {
 		logger.Errorf("create %s: %s", tmp, eno)
 		return
 	}
-	defer func() { _ = n.fs.Delete(mctx, tmp) }()
+	defer func() {
+		_ = f.Close(mctx)
+		_ = n.fs.Delete(mctx, tmp)
+	}()
 
 	_, eno = n.fs.CopyFileRange(mctx, src, 0, tmp, 0, 1<<63)
 	if eno != 0 {
@@ -841,12 +844,15 @@ func (n *jfsObjects) CompleteMultipartUpload(ctx context.Context, bucket, object
 
 	tmp := n.ppath(bucket, uploadID, "complete")
 	_ = n.fs.Delete(mctx, tmp)
-	_, eno := n.fs.Create(mctx, tmp, n.gConf.Mode)
+	f, eno := n.fs.Create(mctx, tmp, n.gConf.Mode)
 	if eno != 0 {
 		err = jfsToObjectErr(ctx, eno, bucket, object, uploadID)
 		logger.Errorf("create complete: %s", err)
 		return
 	}
+	defer func() {
+		_ = f.Close(mctx)
+	}()
 	var total uint64
 	for _, part := range parts {
 		p := n.ppath(bucket, uploadID, strconv.Itoa(part.PartNumber))

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -372,7 +372,7 @@ func setPasswordFromEnv(uri string) (string, error) {
 	dIndex := strings.Index(uri, "://") + 3
 	s := strings.Split(uri[dIndex:atIndex], ":")
 
-	if len(s) > 2 || s[0] == "" {
+	if len(s) > 2 {
 		return "", fmt.Errorf("invalid uri: %s", uri)
 	}
 

--- a/pkg/meta/interface_test.go
+++ b/pkg/meta/interface_test.go
@@ -41,13 +41,14 @@ func Test_setPasswordFromEnv(t *testing.T) {
 			args: "mysql://root@(127.0.0.1:3306)/juicefs",
 			want: "mysql://root:dbPasswd@(127.0.0.1:3306)/juicefs",
 		},
+		// no user is ok
 		{
-			args: "mysql://(127.0.0.1:3306)/juicefs",
-			want: "",
+			args: "mysql://:@(127.0.0.1:3306)/juicefs",
+			want: "mysql://:dbPasswd@(127.0.0.1:3306)/juicefs",
 		},
 		{
 			args: "mysql://:pwd@(127.0.0.1:3306)/juicefs",
-			want: "",
+			want: "mysql://:pwd@(127.0.0.1:3306)/juicefs",
 		},
 		{
 			args: "mysql://a:b:c:@(127.0.0.1:3306)/juicefs",
@@ -65,6 +66,14 @@ func Test_setPasswordFromEnv(t *testing.T) {
 		{
 			args: "postgres://root@192.168.1.6:5432/juicefs",
 			want: "postgres://root:dbPasswd@192.168.1.6:5432/juicefs",
+		},
+		{
+			args: "postgres://root@/pgtest?host=/tmp/pgsocket/&port=5433",
+			want: "postgres://root:dbPasswd@/pgtest?host=/tmp/pgsocket/&port=5433",
+		},
+		{
+			args: "postgres://@/pgtest?host=/tmp/pgsocket/&port=5433&user=pguser",
+			want: "postgres://:dbPasswd@/pgtest?host=/tmp/pgsocket/&port=5433&user=pguser",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -227,30 +227,10 @@ func (c *badgerClient) scan(prefix []byte, handler func(key []byte, value []byte
 }
 
 func (c *badgerClient) reset(prefix []byte) error {
-	for {
-		tx := c.client.NewTransaction(true)
-		defer tx.Discard()
-		it := tx.NewIterator(badger.IteratorOptions{
-			Prefix:       prefix,
-			PrefetchSize: 1024,
-		})
-		it.Rewind()
-		if !it.Valid() {
-			it.Close()
-			return nil
-		}
-		for ; it.Valid(); it.Next() {
-			if err := tx.Delete(it.Item().Key()); err == badger.ErrTxnTooBig {
-				break
-			} else if err != nil {
-				it.Close()
-				return err
-			}
-		}
-		it.Close()
-		if err := tx.Commit(); err != nil {
-			return err
-		}
+	if prefix == nil {
+		return c.client.DropAll()
+	} else {
+		return c.client.DropPrefix(prefix)
 	}
 }
 

--- a/pkg/object/etcd.go
+++ b/pkg/object/etcd.go
@@ -156,8 +156,8 @@ func buildTlsConfig(u *url.URL) (*tls.Config, error) {
 }
 
 func newEtcd(addr, user, passwd, token string) (ObjectStorage, error) {
-	if !strings.Contains(addr, "://") {
-		addr = "http://" + addr
+	if !strings.HasPrefix(addr, "etcd://") {
+		addr = "etcd://" + addr
 	}
 	u, err := url.Parse(addr)
 	if err != nil {

--- a/pkg/object/file_unix.go
+++ b/pkg/object/file_unix.go
@@ -40,8 +40,11 @@ func userName(uid int) string {
 	if !ok {
 		if u, err := user.LookupId(strconv.Itoa(uid)); err == nil {
 			name = u.Username
-			uids[uid] = name
+		} else {
+			logger.Warnf("lookup uid %d: %s", uid, err)
+			name = strconv.Itoa(uid)
 		}
+		uids[uid] = name
 	}
 	return name
 }
@@ -51,8 +54,11 @@ func groupName(gid int) string {
 	if !ok {
 		if g, err := user.LookupGroupId(strconv.Itoa(gid)); err == nil {
 			name = g.Name
-			gids[gid] = name
+		} else {
+			logger.Warnf("lookup gid %d: %s", gid, err)
+			name = strconv.Itoa(gid)
 		}
+		gids[gid] = name
 	}
 	return name
 }
@@ -81,6 +87,12 @@ func lookupUser(name string) int {
 	var uid = -1
 	if u, err := user.Lookup(name); err == nil {
 		uid, _ = strconv.Atoi(u.Uid)
+	} else {
+		if g, e := strconv.Atoi(name); e == nil {
+			uid = g
+		} else {
+			logger.Warnf("lookup user %s: %s", name, err)
+		}
 	}
 	users[name] = uid
 	return uid
@@ -95,6 +107,12 @@ func lookupGroup(name string) int {
 	var gid = -1
 	if u, err := user.LookupGroup(name); err == nil {
 		gid, _ = strconv.Atoi(u.Gid)
+	} else {
+		if g, e := strconv.Atoi(name); e == nil {
+			gid = g
+		} else {
+			logger.Warnf("lookup group %s: %s", name, err)
+		}
 	}
 	groups[name] = gid
 	return gid

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -261,9 +261,14 @@ func newKS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	bucket := hostParts[0]
 	region := hostParts[1][3:]
 	region = strings.TrimLeft(region, "-")
-	if strings.HasSuffix(uri.Host, "ksyun.com") {
+	if strings.HasSuffix(uri.Host, "ksyun.com") || strings.HasSuffix(uri.Host, "ksyuncs.com") {
 		region = strings.TrimSuffix(region, "-internal")
 		region = ks3Regions[region]
+	} else if envRegion := os.Getenv("AWS_REGION"); envRegion != "" {
+		region = envRegion
+	}
+	if region == "" {
+		region = "us-east-1"
 	}
 
 	var err error
@@ -280,7 +285,7 @@ func newKS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		Endpoint:         strings.SplitN(uri.Host, ".", 2)[1],
 		DisableSSL:       !ssl,
 		HTTPClient:       httpClient,
-		S3ForcePathStyle: false,
+		S3ForcePathStyle: true,
 		Credentials:      credentials.NewStaticCredentials(accessKey, secretKey, token),
 	}
 

--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -48,8 +48,12 @@ func newMinio(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		return nil, fmt.Errorf("Invalid endpoint %s: %s", endpoint, err)
 	}
 	ssl := strings.ToLower(uri.Scheme) == "https"
+	region := os.Getenv("MINIO_REGION")
+	if region == "" {
+		region = awsDefaultRegion
+	}
 	awsConfig := &aws.Config{
-		Region:           aws.String(awsDefaultRegion),
+		Region:           aws.String(region),
 		Endpoint:         &uri.Host,
 		DisableSSL:       aws.Bool(!ssl),
 		S3ForcePathStyle: aws.Bool(true),

--- a/pkg/object/sql.go
+++ b/pkg/object/sql.go
@@ -183,22 +183,22 @@ func newSQLStore(driver, addr, user, password string) (ObjectStorage, error) {
 	return &sqlStore{DefaultObjectStorage{}, engine, addr}, nil
 }
 
+func removeScheme(addr string) string {
+	p := strings.Index(addr, "://")
+	if p > 0 {
+		addr = addr[p+3:]
+	}
+	return addr
+}
+
 func init() {
 	Register("sqlite3", func(addr, user, pass, token string) (ObjectStorage, error) {
-		p := strings.Index(addr, "://")
-		if p > 0 {
-			addr = addr[p+3:]
-		}
-		return newSQLStore("sqlite3", addr, user, pass)
+		return newSQLStore("sqlite3", removeScheme(addr), user, pass)
 	})
 	Register("mysql", func(addr, user, pass, token string) (ObjectStorage, error) {
-		p := strings.Index(addr, "://")
-		if p > 0 {
-			addr = addr[p+3:]
-		}
-		return newSQLStore("mysql", addr, user, pass)
+		return newSQLStore("mysql", removeScheme(addr), user, pass)
 	})
 	Register("postgres", func(addr, user, pass, token string) (ObjectStorage, error) {
-		return newSQLStore("postgres", addr, user, pass)
+		return newSQLStore("postgres", removeScheme(addr), user, pass)
 	})
 }

--- a/pkg/object/tikv.go
+++ b/pkg/object/tikv.go
@@ -127,7 +127,10 @@ func newTiKV(endpoint, accesskey, secretkey, token string) (ObjectStorage, error
 	l, prop, _ := plog.InitLogger(&plog.Config{Level: plvl})
 	plog.ReplaceGlobals(l, prop)
 
-	tUrl, err := url.Parse("tikv://" + endpoint)
+	if !strings.HasPrefix(endpoint, "tikv://") {
+		endpoint = "tikv://" + endpoint
+	}
+	tUrl, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -87,7 +87,7 @@ func newLogger(name string) *logHandle {
 	l := &logHandle{Logger: *logrus.New(), name: name, colorful: SupportANSIColor(os.Stderr.Fd())}
 	l.Formatter = l
 	if syslogHook != nil {
-		l.Hooks.Add(syslogHook)
+		l.AddHook(syslogHook)
 	}
 	l.SetReportCaller(true)
 	return l
@@ -108,12 +108,16 @@ func GetLogger(name string) *logHandle {
 
 // SetLogLevel sets Level to all the loggers in the map
 func SetLogLevel(lvl logrus.Level) {
+	mu.Lock()
+	defer mu.Unlock()
 	for _, logger := range loggers {
 		logger.Level = lvl
 	}
 }
 
 func DisableLogColor() {
+	mu.Lock()
+	defer mu.Unlock()
 	for _, logger := range loggers {
 		logger.colorful = false
 	}
@@ -124,6 +128,8 @@ func SetOutFile(name string) {
 	if err != nil {
 		return
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	for _, logger := range loggers {
 		logger.SetOutput(file)
 		logger.colorful = false
@@ -131,6 +137,8 @@ func SetOutFile(name string) {
 }
 
 func SetOutput(w io.Writer) {
+	mu.Lock()
+	defer mu.Unlock()
 	for _, logger := range loggers {
 		logger.SetOutput(w)
 	}

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 )
 
@@ -85,7 +84,7 @@ func (l *logHandle) Log(args ...interface{}) {
 }
 
 func newLogger(name string) *logHandle {
-	l := &logHandle{Logger: *logrus.New(), name: name, colorful: isatty.IsTerminal(os.Stderr.Fd())}
+	l := &logHandle{Logger: *logrus.New(), name: name, colorful: SupportANSIColor(os.Stderr.Fd())}
 	l.Formatter = l
 	if syslogHook != nil {
 		l.Hooks.Add(syslogHook)

--- a/pkg/utils/logger_syslog.go
+++ b/pkg/utils/logger_syslog.go
@@ -70,7 +70,7 @@ func InitLoggers(logToSyslog bool) {
 		syslogHook = &SyslogHook{hook}
 
 		for _, l := range loggers {
-			l.Hooks.Add(syslogHook)
+			l.AddHook(syslogHook)
 		}
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,8 +22,11 @@ import (
 	"net"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mattn/go-isatty"
 )
 
 // Min returns min of 2 int
@@ -123,4 +126,8 @@ func FormatBytes(n uint64) string {
 		m = m >> 10
 	}
 	return fmt.Sprintf("%.2f %siB (%d Bytes)", float64(m)/1024.0, units[i], n)
+}
+
+func SupportANSIColor(fd uintptr) bool {
+	return isatty.IsTerminal(fd) && runtime.GOOS != "windows"
 }

--- a/pkg/vfs/backup.go
+++ b/pkg/vfs/backup.go
@@ -76,12 +76,11 @@ func Backup(m meta.Meta, blob object.ObjectStorage, interval time.Duration) {
 
 func backup(m meta.Meta, blob object.ObjectStorage, now time.Time) error {
 	name := "dump-" + now.UTC().Format("2006-01-02-150405") + ".json.gz"
-	fpath := "/tmp/juicefs-meta-" + name
-	fp, err := os.OpenFile(fpath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0444)
+	fp, err := os.CreateTemp("", "juicefs-meta-*")
 	if err != nil {
 		return err
 	}
-	defer os.Remove(fpath)
+	defer os.Remove(fp.Name())
 	defer fp.Close()
 	zw := gzip.NewWriter(fp)
 	err = m.DumpMeta(zw, 0) // force dump the whole tree

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -684,7 +684,7 @@ func NewDataReader(conf *Config, m meta.Meta, store chunk.ChunkStore) DataReader
 	var readAheadTotal = 256 << 20
 	var readAheadMax = conf.Chunk.BlockSize * 8
 	if conf.Chunk.BufferSize > 0 {
-		readAheadTotal = conf.Chunk.BufferSize * 8 / 10 // 80% of total buffer
+		readAheadTotal = conf.Chunk.BufferSize / 10 * 8 // 80% of total buffer
 	}
 	if conf.Chunk.Readahead > 0 {
 		readAheadMax = conf.Chunk.Readahead

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -902,11 +902,12 @@ func (v *VFS) RemoveXattr(ctx Context, ino Ino, name string) (err syscall.Errno)
 var logger = utils.GetLogger("juicefs")
 
 type VFS struct {
-	Conf   *Config
-	Meta   meta.Meta
-	Store  chunk.ChunkStore
-	reader DataReader
-	writer DataWriter
+	Conf            *Config
+	Meta            meta.Meta
+	Store           chunk.ChunkStore
+	InvalidateEntry func(parent meta.Ino, name string) syscall.Errno
+	reader          DataReader
+	writer          DataWriter
 
 	handles map[Ino][]*handle
 	hanleM  sync.Mutex

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -744,10 +744,8 @@ func (v *VFS) Flush(ctx Context, ino Ino, fh uint64, lockOwner uint64) (err sysc
 	}
 
 	if h.writer != nil {
-		if !h.Wlock(ctx) {
+		for !h.Wlock(ctx) {
 			h.cancelOp(ctx.Pid())
-			err = syscall.EINTR
-			return
 		}
 
 		err = h.writer.Flush(ctx)

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -271,7 +271,7 @@ public class JuiceFileSystemImpl extends FileSystem {
       throw new IOException("name is required");
     }
 
-    blocksize = conf.getLong("juicefs.block.size", conf.getLong("dfs.blocksize", 128 << 20));
+    blocksize = conf.getLongBytes("juicefs.block.size", conf.getLongBytes("dfs.blocksize", 128 << 20));
     minBufferSize = conf.getInt("juicefs.min-buffer-size", 128 << 10);
     cacheReplica = Integer.parseInt(getConf(conf, "cache-replica", "1"));
     fileChecksumEnabled = Boolean.parseBoolean(getConf(conf, "file.checksum", "false"));

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -1111,9 +1111,8 @@ public class JuiceFileSystemImpl extends FileSystem {
       int fd = lib.jfs_create(Thread.currentThread().getId(), handle, normalizePath(f), permission.toShort());
       if (fd == ENOENT) {
         Path parent = makeQualified(f).getParent();
-        FsPermission perm = FsPermission.getDirDefault().applyUMask(FsPermission.getUMask(getConf()));
         try {
-          mkdirs(parent, perm);
+          mkdirs(parent, FsPermission.getDirDefault());
         } catch (FileAlreadyExistsException e) {
         }
         continue;

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -184,12 +184,13 @@ public class JuiceFileSystemImpl extends FileSystem {
   static int MODE_MASK_X = 1;
 
   private IOException error(int errno, Path p) {
+    String pStr = p == null ? "" : p.toString();
     if (errno == EPERM) {
-      return new PathPermissionException(p.toString());
+      return new PathPermissionException(pStr);
     } else if (errno == ENOTDIR) {
       return new ParentNotDirectoryException();
     } else if (errno == ENOENT) {
-      return new FileNotFoundException(p.toString() + ": not found");
+      return new FileNotFoundException(pStr+ ": not found");
     } else if (errno == EACCESS) {
       try {
         String user = ugi.getShortUserName();
@@ -202,25 +203,25 @@ public class JuiceFileSystemImpl extends FileSystem {
       } catch (Exception e) {
         LOG.warn("fail to generate better error message", e);
       }
-      return new AccessControlException("Permission denied: " + p.toString());
+      return new AccessControlException("Permission denied: " + pStr);
     } else if (errno == EEXIST) {
       return new FileAlreadyExistsException();
     } else if (errno == EINVAL) {
       return new InvalidRequestException("Invalid parameter");
     } else if (errno == ENOTEMPTY) {
-      return new PathIsNotEmptyDirectoryException(p.toString());
+      return new PathIsNotEmptyDirectoryException(pStr);
     } else if (errno == EINTR) {
       return new InterruptedIOException();
     } else if (errno == ENOTSUP) {
-      return new PathOperationException(p.toString());
+      return new PathOperationException(pStr);
     } else if (errno == ENOSPACE) {
       return new IOException("No space");
     } else if (errno == EROFS) {
       return new IOException("Read-only Filesystem");
     } else if (errno == EIO) {
-      return new IOException(p.toString());
+      return new IOException(pStr);
     } else {
-      return new IOException("errno: " + errno + " " + p.toString());
+      return new IOException("errno: " + errno + " " + pStr);
     }
   }
 
@@ -1107,7 +1108,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     while (true) {
       int fd = lib.jfs_create(Thread.currentThread().getId(), handle, normalizePath(f), permission.toShort());
       if (fd == ENOENT) {
-        Path parent = f.getParent();
+        Path parent = makeQualified(f).getParent();
         FsPermission perm = FsPermission.getDirDefault().applyUMask(FsPermission.getUMask(getConf()));
         try {
           mkdirs(parent, perm);
@@ -1123,7 +1124,7 @@ public class JuiceFileSystemImpl extends FileSystem {
         continue;
       }
       if (fd < 0) {
-        throw error(fd, f.getParent());
+        throw error(fd, makeQualified(f).getParent());
       }
       return createFsDataOutputStream(f, bufferSize, fd, 0L);
     }
@@ -1150,7 +1151,7 @@ public class JuiceFileSystemImpl extends FileSystem {
       fd = lib.jfs_create(Thread.currentThread().getId(), handle, normalizePath(f), permission.toShort());
     }
     if (fd < 0) {
-      throw error(fd, f.getParent());
+      throw error(fd, makeQualified(f).getParent());
     }
     return createFsDataOutputStream(f, bufferSize, fd, 0L);
   }
@@ -1236,12 +1237,12 @@ public class JuiceFileSystemImpl extends FileSystem {
     if (getFileStatus(dst).getLen() == 0) {
       throw new IOException(dst + "is empty");
     }
-    Path dp = dst.getParent();
+    Path dp = makeQualified(dst).getParent();
     for (Path src : srcs) {
-      if (!src.getParent().equals(dp)) {
-        throw new HadoopIllegalArgumentException("Source file " + src
+      if (!makeQualified(src).getParent().equals(dp)) {
+        throw new HadoopIllegalArgumentException("Source file " + normalizePath(src)
                 + " is not in the same directory with the target "
-                + dst);
+                + normalizePath(dst));
       }
     }
     if (srcs.length == 0) { return; }
@@ -1429,7 +1430,6 @@ public class JuiceFileSystemImpl extends FileSystem {
     if (f == null) {
       throw new IllegalArgumentException("mkdirs path arg is null");
     }
-    f = makeQualified(f);
     String path = normalizePath(f);
     if ("/".equals(path))
       return true;
@@ -1437,12 +1437,12 @@ public class JuiceFileSystemImpl extends FileSystem {
     if (r == 0 || r == EEXIST && !isFile(f)) {
       return true;
     } else if (r == ENOENT) {
-      Path parent = f.getParent();
+      Path parent = makeQualified(f).getParent();
       if (parent != null) {
         return mkdirs(parent, permission) && mkdirs(f, permission);
       }
     }
-    throw error(r, f.getParent());
+    throw error(r, makeQualified(f).getParent());
   }
 
   @Override

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -1429,6 +1429,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     if (f == null) {
       throw new IllegalArgumentException("mkdirs path arg is null");
     }
+    f = makeQualified(f);
     String path = normalizePath(f);
     if ("/".equals(path))
       return true;

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -624,6 +624,17 @@ public class JuiceFileSystemTest extends TestCase {
     assertEquals(FsPermission.createImmutable((short) 0777), newFs.getFileStatus(new Path("/test_umask")).getPermission());
     assertEquals(FsPermission.createImmutable((short) 0777), newFs.getFileStatus(new Path("/test_umask/dir")).getPermission());
     assertEquals(FsPermission.createImmutable((short) 0666), newFs.getFileStatus(new Path("/test_umask/dir/f")).getPermission());
+
+    conf.set("juicefs.umask", "022");
+    conf.set("fs.permissions.umask-mode", "077");
+    Path p = new Path("/test_umask/u_parent/f");
+    newFs = createNewFs(conf, currentUser.getShortUserName(), currentUser.getGroupNames());
+    newFs.delete(p.getParent());
+    FSDataOutputStream out = newFs.create(p, true);
+    out.close();
+    assertEquals(FsPermission.createImmutable((short) 0755), fs.getFileStatus(p.getParent()).getPermission());
+    assertEquals(FsPermission.createImmutable((short) 0644), fs.getFileStatus(p).getPermission());
+
     newFs.close();
   }
 

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -662,4 +662,11 @@ public class JuiceFileSystemTest extends TestCase {
     trash.expungeImmediately();
     assertEquals(0, fs.listStatus(fs.getTrashRoot(trashFile)).length);
   }
+
+  public void testBlockSize() throws Exception {
+    Configuration newConf = new Configuration(cfg);
+    newConf.set("dfs.blocksize", "256m");
+    FileSystem newFs = FileSystem.newInstance(newConf);
+    assertEquals(256 << 20, newFs.getDefaultBlockSize(new Path("/")));
+  }
 }


### PR DESCRIPTION
Backported 30 commits (65f013a8 and a21e6582 have already been picked to release-1.0):
eba3200b pkg/gateway: Support specifying umask for directories (#2445)
65f013a8 fix LZ4 decompressing an empty input (#2499)
3b1c216b chunk: init metrics before creating cache manager (#2503)
3de650d1 cmd/sync: sync uid/gid for not existed user/group (#2502)
d31cca45 /sbin/mount.juicefs: do not crash when called with no opts (#2515)
2a067475 hadoop: use superuser for trash emptier (#2512)
c06b41f3 hadoop: compatible with hdfs for dfs.blocksize (#2555)
a21e6582 hadoop-action: update spark download url (#2557)
6548a538 fix windows color print (#2567)
bb841274 meta/pg:fix pg socket connection (#2607)
d4928e5b close created file in gateway (#2661)
d89867f4 feat: set minion region via env (#2673)
eca9f9be pkg/cache: ignore invalid file in cache dir (#2686)
4963abdb hadoop: qualify relative path for mkdirs (#2696)
4498065f fix thread safety in logger (#2706)
83095269 vfs/backup: use OS temp file instead of /tmp (#2707)
4fd0094d align 64bit counters in 32bit system (#2703)
e594cac7 hadoop: qualify all relative path (#2709)
fb68435c fix calculate readAheadTotal overflow on 32bit system (#2726)
d3757c81 meta/sql: fix get session (#2732)
b08a7f61 vfs: close fd before interrupted (#2745)
9baab779 hadoop: support nest juicefs-hadoop.jar in spring-boot (#2756)
3365d84d cmd/format: ignore bucket schema (#2749)
07aa2296 create bucket first when run objebench with skip-functional-tests (#2773)
8b94a160 vfs: invalid entry cache after `rmr` (#2776)
391a7303 sync: make special char behavior consistent with aws (#2778)
60bec429 meta/badger: drop all keys directly to reset the database (#2811)
7c95af79 support private region for KS3 (#2812)
63981b05 hadoop: apply juicefs.umask when create parent dir (#2833)
5ef1acec fuse: register InvalidateEntry only for Linux (#2838)

More commits to fix tests:
02923d1 hadoop: update mvn version