### PR TITLE
CI: add cache for tiup.

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -91,6 +91,13 @@ jobs:
         with: 
           target: ${{steps.vars.outputs.target}}
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.tiup
+          key: ${{ runner.os }}-tiup
+          restore-keys: |
+            ${{ runner.os }}-tiup
+            
       - name: Start meta
         run: | 
           sudo chmod +x .github/scripts/start_meta_engine.sh

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -45,6 +45,13 @@ jobs:
         with: 
           target: ${{steps.vars.outputs.target}}
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.tiup
+          key: ${{ runner.os }}-tiup
+          restore-keys: |
+            ${{ runner.os }}-tiup
+
       - name: Prepare meta db
         run: | 
           chmod +x .github/scripts/start_meta_engine.sh

--- a/.github/workflows/pjdfstest.yml
+++ b/.github/workflows/pjdfstest.yml
@@ -32,7 +32,8 @@ jobs:
           if [ "${{github.event_name}}" == "schedule"  ]; then
             echo '::set-output name=meta_matrix::["sqlite3", "redis", "mysql", "tikv", "tidb", "postgres", "badger", "mariadb", "fdb"]'
           else
-            echo '::set-output name=meta_matrix::["redis"]'
+            # echo '::set-output name=meta_matrix::["redis"]'
+            echo '::set-output name=meta_matrix::["sqlite3", "redis", "mysql", "tikv", "tidb", "postgres", "badger", "mariadb", "fdb"]'
           fi
     outputs:
       meta_matrix: ${{ steps.set-matrix.outputs.meta_matrix }}

--- a/.github/workflows/pjdfstest.yml
+++ b/.github/workflows/pjdfstest.yml
@@ -81,6 +81,13 @@ jobs:
         with: 
           target: ${{steps.vars.outputs.target}}
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.tiup
+          key: ${{ runner.os }}-tiup
+          restore-keys: |
+            ${{ runner.os }}-tiup
+
       - name: Prepare meta db
         run: | 
           chmod +x .github/scripts/start_meta_engine.sh

--- a/.github/workflows/pjdfstest.yml
+++ b/.github/workflows/pjdfstest.yml
@@ -32,8 +32,8 @@ jobs:
           if [ "${{github.event_name}}" == "schedule"  ]; then
             echo '::set-output name=meta_matrix::["sqlite3", "redis", "mysql", "tikv", "tidb", "postgres", "badger", "mariadb", "fdb"]'
           else
-            # echo '::set-output name=meta_matrix::["redis"]'
-            echo '::set-output name=meta_matrix::["sqlite3", "redis", "mysql", "tikv", "tidb", "postgres", "badger", "mariadb", "fdb"]'
+            echo '::set-output name=meta_matrix::["redis"]'
+            # echo '::set-output name=meta_matrix::["sqlite3", "redis", "mysql", "tikv", "tidb", "postgres", "badger", "mariadb", "fdb"]'
           fi
     outputs:
       meta_matrix: ${{ steps.set-matrix.outputs.meta_matrix }}

--- a/.github/workflows/rmfiles.yml
+++ b/.github/workflows/rmfiles.yml
@@ -46,6 +46,13 @@ jobs:
         with: 
           target: ${{steps.vars.outputs.target}}
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.tiup
+          key: ${{ runner.os }}-tiup
+          restore-keys: |
+            ${{ runner.os }}-tiup
+
       - name: Prepare meta db
         run: | 
           sudo chmod +x .github/scripts/start_meta_engine.sh

--- a/.github/workflows/vdbench.yml
+++ b/.github/workflows/vdbench.yml
@@ -44,6 +44,13 @@ jobs:
         with: 
           target: ${{steps.vars.outputs.target}}    
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.tiup
+          key: ${{ runner.os }}-tiup
+          restore-keys: |
+            ${{ runner.os }}-tiup
+
       - name: Prepare meta db
         run: | 
           chmod +x .github/scripts/start_meta_engine.sh

--- a/.github/workflows/version_compatible_hypo.yml
+++ b/.github/workflows/version_compatible_hypo.yml
@@ -95,6 +95,13 @@ jobs:
           fi
           cd -
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.tiup
+          key: ${{ runner.os }}-tiup
+          restore-keys: |
+            ${{ runner.os }}-tiup
+
       - name: Prepare meta database
         run: | 
           meta=${{matrix.meta}}


### PR DESCRIPTION
tiup mirror is not stable,  it will failed to fetch some files, we add cache as a work round

https://github.com/juicedata/juicefs/actions/runs/3214726165/jobs/5255311152
Playground Bootstrapping...
Error: Playground bootstrapping failed: fetch /2551.pd.json from mirror(https://tiup-mirrors.pingcap.com/) failed: url https://tiup-mirrors.pingcap.com/2551.pd.json: not found

