### PR TITLE
chunk/cache: disable refreshCacheKeys if interval < 0

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -135,6 +135,9 @@ func (cache *cacheStore) checkFreeSpace() {
 }
 
 func (cache *cacheStore) refreshCacheKeys() {
+	if cache.scanInterval < 0 {
+		return
+	}
 	cache.scanCached()
 	if cache.scanInterval > 0 {
 		for {


### PR DESCRIPTION
This is a very special case, which will totally disable building index for the cached keys. Users have to be make sure by themselves that there is at lease one client building this index, so that it can upload staging blocks (if `writeback` is enabled) and do the cleanup of cache directory.