### PR TITLE
obj/tos: fix TOS region parse bug

### DIFF
--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -229,7 +229,7 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	credentials.WithSecurityToken(token)
 	cli, err := tos.NewClientV2(
 		hostParts[1]+"."+hostParts[2],
-		tos.WithRegion(strings.TrimSuffix("tos-", hostParts[1])),
+		tos.WithRegion(strings.TrimSuffix(hostParts[1], "tos-")),
 		tos.WithCredentials(credentials))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using tos storage without beijing region, failed.

because :

![image](https://user-images.githubusercontent.com/12098947/197931625-440f43b0-3bf4-4fdb-9f29-9a6f1364f952.png)

close #2910