### PR TITLE
mode of symlink should be 0777

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -737,7 +737,8 @@ func (m *baseMeta) Mkdir(ctx Context, parent Ino, name string, mode uint16, cuma
 }
 
 func (m *baseMeta) Symlink(ctx Context, parent Ino, name string, path string, inode *Ino, attr *Attr) syscall.Errno {
-	return m.Mknod(ctx, parent, name, TypeSymlink, 0644, 022, 0, path, inode, attr)
+	// mode of symlink is ignored in POSIX
+	return m.Mknod(ctx, parent, name, TypeSymlink, 0777, 0, 0, path, inode, attr)
 }
 
 func (m *baseMeta) Link(ctx Context, inode, parent Ino, name string, attr *Attr) syscall.Errno {

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -351,6 +351,9 @@ func testMetaClient(t *testing.T, m Meta) {
 	if st := m.Symlink(ctx, 1, "s", "/f", &inode, attr); st != 0 {
 		t.Fatalf("symlink s -> /f: %s", st)
 	}
+	if attr.Mode&0777 != 0777 {
+		t.Fatalf("mode of symlink should be 0777")
+	}
 	defer m.Unlink(ctx, 1, "s")
 	var target1, target2 []byte
 	if st := m.ReadLink(ctx, inode, &target1); st != 0 {


### PR DESCRIPTION
Mode of symlink is ignored in POSIX, but mac and bsd may check the read permission in readlink(). We follow the behavior in POSIX.

link: https://superuser.com/questions/303040/how-do-file-permissions-apply-to-symlinks

close #2915 