### PR TITLE
mount: ignore command when mount point is already mounted by the same juicefs

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -141,6 +141,11 @@ func mount_flags() []cli.Flag {
 			Usage: "enable ioctl (support GETFLAGS/SETFLAGS only)",
 		},
 		&cli.BoolFlag{
+			Name:    "f",
+			Aliases: []string{"force"},
+			Usage:   "force to mount even if the mount point is already mounted by the same filesystem",
+		},
+		&cli.BoolFlag{
 			Name:  "update-fstab",
 			Usage: "add / update entry in /etc/fstab, will create a symlink at /sbin/mount.juicefs if not existing",
 		},


### PR DESCRIPTION
Signed-off-by: xixi <i@hexilee.me>

Close #2840

- Ignore `mount` when the mount point is already mounted by the same juicefs
- Add `force` flag for the `mount` subcommand to mount the same mount point forcibly