### PR TITLE
object:fix tls-insecure-skip-verify does not effect on some object stores

### DIFF
--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
+	"net/http"
 	"os"
 	"reflect"
 	"sort"
@@ -768,5 +770,6 @@ func TestMain(m *testing.M) {
 			}
 		}
 	}
+	httpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: false}
 	m.Run()
 }

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -335,7 +335,7 @@ func newOBS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	// Empty proxy url string has no effect
 	// there is a bug in the retry of PUT (did not call Seek(0,0) before retry), so disable the retry here
 	c, err := obs.New(accessKey, secretKey, endpoint, obs.WithSecurityToken(token),
-		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0))
+		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithHttpTransport(httpClient.Transport.(*http.Transport)))
 	if err != nil {
 		return nil, fmt.Errorf("fail to initialize OBS: %q", err)
 	}

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -374,7 +374,8 @@ func newOSS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		logger.Debugf("Use endpoint %q", domain)
 	}
 
-	client, err := oss.New(domain, accessKey, secretKey, oss.SecurityToken(token))
+	client, err := oss.New(domain, accessKey, secretKey, oss.SecurityToken(token),
+		oss.InsecureSkipVerify(httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify))
 	if err != nil {
 		return nil, fmt.Errorf("Cannot create OSS client with endpoint %s: %s", endpoint, err)
 	}

--- a/pkg/object/redis.go
+++ b/pkg/object/redis.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"sort"
@@ -200,7 +199,6 @@ func newRedis(uri, user, passwd, token string) (ObjectStorage, error) {
 	if opt.MaxRetries == 0 {
 		opt.MaxRetries = -1 // Redis use -1 to disable retries
 	}
-	opt.TLSConfig.InsecureSkipVerify = httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify
 	var rdb redis.UniversalClient
 	if strings.Contains(hosts, ",") && strings.Index(hosts, ",") < strings.Index(hosts, ":") {
 		var fopt redis.FailoverOptions

--- a/pkg/object/redis.go
+++ b/pkg/object/redis.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"sort"
@@ -199,6 +200,7 @@ func newRedis(uri, user, passwd, token string) (ObjectStorage, error) {
 	if opt.MaxRetries == 0 {
 		opt.MaxRetries = -1 // Redis use -1 to disable retries
 	}
+	opt.TLSConfig.InsecureSkipVerify = httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify
 	var rdb redis.UniversalClient
 	if strings.Contains(hosts, ",") && strings.Index(hosts, ",") < strings.Index(hosts, ":") {
 		var fopt redis.FailoverOptions

--- a/pkg/object/swift.go
+++ b/pkg/object/swift.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -144,6 +145,7 @@ func newSwiftOSS(endpoint, username, apiKey, token string) (ObjectStorage, error
 		ApiKey:    apiKey,
 		AuthToken: token,
 		AuthUrl:   authURL,
+		Transport: httpClient.Transport.(*http.Transport),
 	}
 	err = conn.Authenticate()
 	if err != nil {

--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -240,7 +240,8 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	cli, err := tos.NewClientV2(
 		hostParts[1]+"."+hostParts[2],
 		tos.WithRegion(strings.TrimSuffix(hostParts[1], "tos-")),
-		tos.WithCredentials(credentials))
+		tos.WithCredentials(credentials),
+		tos.WithEnableVerifySSL(httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/object/upyun.go
+++ b/pkg/object/upyun.go
@@ -151,7 +151,9 @@ func newUpyun(endpoint, user, passwd, token string) (ObjectStorage, error) {
 	if strings.Contains(uri.Host, ".") {
 		cfg.Hosts["v0.api.upyun.com"] = strings.SplitN(uri.Host, ".", 2)[1]
 	}
-	return &up{c: upyun.NewUpYun(cfg)}, nil
+	upYun := upyun.NewUpYun(cfg)
+	upYun.SetHTTPClient(httpClient)
+	return &up{c: upYun}, nil
 }
 
 func init() {

--- a/pkg/object/webdav.go
+++ b/pkg/object/webdav.go
@@ -282,7 +282,7 @@ func newWebDAV(endpoint, user, passwd, token string) (ObjectStorage, error) {
 	}
 	uri.User = url.UserPassword(user, passwd)
 	c := gowebdav.NewClient(uri.String(), user, passwd)
-
+	c.SetTransport(httpClient.Transport)
 	return &webdav{endpoint: uri, c: c}, nil
 }
 


### PR DESCRIPTION
The `tls-insecure-skip-verify` no work on `gs` and `ibmcos`  also.
Since they are directly replacing http client, it is risky, so we should try to fix it when we have user feedback.

Redis
```
=== RUN   TestRedis
    object_storage_test.go:95: PUT failed: context deadline exceeded
    object_storage_test.go:82: delete failed: context deadline exceeded
--- FAIL: TestRedis (25.00s)
```
If redis is modified, the test will fail. Do not change it for now.