### PR TITLE
meta/sql: do not use the number of affected rows returned by update

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -607,6 +607,15 @@ func testLocks(t *testing.T, m Meta) {
 	}
 	// flock
 	o1 := uint64(0xF000000000000001)
+	if st := m.Flock(ctx, inode, o1, syscall.F_WRLCK, false); st != 0 {
+		t.Fatalf("flock wlock: %s", st)
+	}
+	if st := m.Flock(ctx, inode, o1, syscall.F_WRLCK, false); st != 0 {
+		t.Fatalf("flock wlock: %s", st)
+	}
+	if st := m.Flock(ctx, inode, o1, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("flock unlock: %s", st)
+	}
 	if st := m.Flock(ctx, inode, o1, syscall.F_RDLCK, false); st != 0 {
 		t.Fatalf("flock rlock: %s", st)
 	}
@@ -644,6 +653,9 @@ func testLocks(t *testing.T, m Meta) {
 	// POSIX locks
 	if st := m.Setlk(ctx, inode, o1, false, syscall.F_UNLCK, 0, 0xFFFF, 1); st != 0 {
 		t.Fatalf("plock unlock: %s", st)
+	}
+	if st := m.Setlk(ctx, inode, o1, false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("plock rlock: %s", st)
 	}
 	if st := m.Setlk(ctx, inode, o1, false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
 		t.Fatalf("plock rlock: %s", st)

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1947,10 +1947,11 @@ func (m *dbMeta) doFindStaleSessions(limit int) ([]uint64, error) {
 func (m *dbMeta) doRefreshSession() {
 	_ = m.txn(func(ses *xorm.Session) error {
 		expireTime := m.expireTime()
-		var n int64
 		var err error
+		var ok bool
 		s := session2{Sid: m.sid}
-		if ok, err := ses.ForUpdate().Get(&s); ok {
+		if ok, err = ses.ForUpdate().Get(&s); ok {
+			var n int64
 			if s.Expire != expireTime {
 				n, err = ses.Cols("Expire").Update(&session2{Expire: expireTime}, &session2{Sid: m.sid})
 			} else {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1946,11 +1946,11 @@ func (m *dbMeta) doFindStaleSessions(limit int) ([]uint64, error) {
 
 func (m *dbMeta) doRefreshSession() {
 	_ = m.txn(func(ses *xorm.Session) error {
-		expireTime := m.expireTime()
 		var err error
 		var ok bool
 		s := session2{Sid: m.sid}
 		if ok, err = ses.ForUpdate().Get(&s); ok {
+			expireTime := m.expireTime()
 			var n int64
 			if s.Expire != expireTime {
 				n, err = ses.Cols("Expire").Update(&session2{Expire: expireTime}, &session2{Sid: m.sid})


### PR DESCRIPTION
Do not use the number of affected rows returned by update to determine whether the update is successful