### PR TITLE
info: show locks of a certain file

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -118,10 +118,6 @@ func info(ctx *cli.Context) error {
 		if err != nil {
 			logger.Fatalf("write message: %s", err)
 		}
-		err = f.Sync()
-		if err != nil {
-			logger.Fatalf("sync control file: %s", err)
-		}
 		var resp vfs.InfoResponse
 		err = resp.Decode(f)
 		_ = f.Close()

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -174,7 +174,7 @@ func info(ctx *cli.Context) error {
 			printResult(results, 1, false)
 		}
 		if len(resp.FLocks) > 0 {
-			fmt.Println("  flocks:")
+			fmt.Println(" flocks:")
 			results := make([][]string, 0, 1+len(resp.FLocks))
 			results = append(results, []string{"Sid", "Owner", "Type"})
 			for _, l := range resp.FLocks {
@@ -187,7 +187,7 @@ func info(ctx *cli.Context) error {
 			printResult(results, 0, false)
 		}
 		if len(resp.PLocks) > 0 {
-			fmt.Println("  plocks:")
+			fmt.Println(" plocks:")
 			results := make([][]string, 0, 1+len(resp.PLocks))
 			results = append(results, []string{"Sid", "Owner", "Type", "Pid", "Start", "End"})
 			for _, l := range resp.PLocks {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -133,6 +133,11 @@ func info(ctx *cli.Context) error {
 		if err != nil {
 			logger.Fatalf("read info: %s", err)
 		}
+
+		if resp.Failed {
+			logger.Fatalf("failed to get info: %s", resp.Reason)
+		}
+
 		fmt.Println(path, ":")
 		fmt.Printf("  inode: %d\n", resp.Ino)
 		fmt.Printf("  files: %d\n", resp.Summary.Files)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -240,7 +240,7 @@ func legacyInfo(d, path string, inode uint64, recursive, raw uint8) {
 	}
 
 	wb := utils.NewBuffer(8 + 10)
-	wb.Put32(meta.Info)
+	wb.Put32(meta.LegacyInfo)
 	wb.Put32(10)
 	wb.Put64(inode)
 	wb.Put8(recursive)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -161,9 +161,49 @@ func info(ctx *cli.Context) error {
 			}
 			printChunks(buf.String(), false)
 		}
+		if len(resp.FLocks) > 0 {
+			fmt.Println("  flocks:")
+			results := make([][]string, 0, 1+len(resp.FLocks))
+			results = append(results, []string{"Sid", "Owner", "Type"})
+			for _, l := range resp.FLocks {
+				results = append(results, []string{
+					strconv.FormatUint(l.Sid, 10),
+					strconv.FormatUint(l.Owner, 10),
+					l.Type,
+				})
+			}
+			printResult(results, 0, false)
+		}
+		if len(resp.PLocks) > 0 {
+			fmt.Println("  plocks:")
+			results := make([][]string, 0, 1+len(resp.PLocks))
+			results = append(results, []string{"Sid", "Owner", "Type", "Pid", "Start", "End"})
+			for _, l := range resp.PLocks {
+				results = append(results, []string{
+					strconv.FormatUint(l.Sid, 10),
+					strconv.FormatUint(l.Owner, 10),
+					ltypeToString(l.Type),
+					strconv.FormatUint(uint64(l.Pid), 10),
+					strconv.FormatUint(l.Start, 10),
+					strconv.FormatUint(l.End, 10),
+				})
+			}
+			printResult(results, 0, false)
+		}
 	}
 
 	return nil
+}
+
+func ltypeToString(t uint32) string {
+	switch t {
+	case meta.F_RDLCK:
+		return "R"
+	case meta.F_WRLCK:
+		return "W"
+	default:
+		return "UNKNOWN"
+	}
 }
 
 func printChunks(resp string, raw bool) {

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -598,7 +598,7 @@ func testStickyBit(t *testing.T, m Meta) {
 }
 
 func testListLocks(t *testing.T, m Meta) {
-	_ = m.Init(Format{Name: "test"}, false)
+	_ = m.Init(&Format{Name: "test"}, false)
 	ctx := Background
 	var inode Ino
 	var attr = &Attr{}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -64,6 +64,7 @@ func testMeta(t *testing.T, m Meta) {
 	testRemove(t, m)
 	testStickyBit(t, m)
 	testLocks(t, m)
+	testListLocks(t, m)
 	testConcurrentWrite(t, m)
 	testCompaction(t, m, false)
 	time.Sleep(time.Second)
@@ -593,6 +594,81 @@ func testStickyBit(t *testing.T, m Meta) {
 	}
 	if e := m.Rmdir(ctxA, sticky, "d3"); e != 0 {
 		t.Fatalf("rmdir d3: %s", e)
+	}
+}
+
+func testListLocks(t *testing.T, m Meta) {
+	_ = m.Init(Format{Name: "test"}, false)
+	ctx := Background
+	var inode Ino
+	var attr = &Attr{}
+	defer m.Unlink(ctx, 1, "f")
+	if st := m.Create(ctx, 1, "f", 0644, 0, 0, &inode, attr); st != 0 {
+		t.Fatalf("create f: %s", st)
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+
+	// flock
+	o1 := uint64(0xF000000000000001)
+	if st := m.Flock(ctx, inode, o1, syscall.F_WRLCK, false); st != 0 {
+		t.Fatalf("flock wlock: %s", st)
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 1 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+	if st := m.Flock(ctx, inode, o1, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("flock unlock: %s", st)
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+	for i := 2; i < 10; i++ {
+		if st := m.Flock(ctx, inode, uint64(i), syscall.F_RDLCK, false); st != 0 {
+			t.Fatalf("flock wlock: %s", st)
+		}
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 8 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+	for i := 2; i < 10; i++ {
+		if st := m.Flock(ctx, inode, uint64(i), syscall.F_UNLCK, false); st != 0 {
+			t.Fatalf("flock unlock: %s", st)
+		}
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+
+	// plock
+	if st := m.Setlk(ctx, inode, o1, false, syscall.F_WRLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("plock rlock: %s", st)
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 1 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+	if st := m.Setlk(ctx, inode, o1, false, syscall.F_UNLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("plock unlock: %s", st)
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+	for i := 2; i < 10; i++ {
+		if st := m.Setlk(ctx, inode, uint64(i), false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
+			t.Fatalf("plock rlock: %s", st)
+		}
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 8 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
+	}
+	for i := 2; i < 10; i++ {
+		if st := m.Setlk(ctx, inode, uint64(i), false, syscall.F_UNLCK, 0, 0xFFFF, 1); st != 0 {
+			t.Fatalf("plock unlock: %s", st)
+		}
+	}
+	if plocks, flocks, err := m.ListLocks(ctx, inode); err != nil || len(plocks) != 0 || len(flocks) != 0 {
+		t.Fatalf("list locks: %v %v %v", plocks, flocks, err)
 	}
 }
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -42,8 +42,8 @@ const (
 	CompactChunk = 1001
 	// Rmr is a message to remove a directory recursively.
 	Rmr = 1002
-	// Deprecated: Info is a message to get the internal info for file or directory.
-	Info = 1003
+	// LegacyInfo is a message to get the internal info for file or directory.
+	LegacyInfo = 1003
 	// FillCache is a message to build cache for target directories/files
 	FillCache = 1004
 	// InfoV2 is a message to get the internal info for file or directory.

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -42,10 +42,12 @@ const (
 	CompactChunk = 1001
 	// Rmr is a message to remove a directory recursively.
 	Rmr = 1002
-	// Info is a message to get the internal info for file or directory.
+	// Deprecated: Info is a message to get the internal info for file or directory.
 	Info = 1003
 	// FillCache is a message to build cache for target directories/files
 	FillCache = 1004
+	// InfoV2 is a message to get the internal info for file or directory.
+	InfoV2 = 1005
 )
 
 const (

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -267,6 +267,8 @@ type Meta interface {
 	GetSession(sid uint64, detail bool) (*Session, error)
 	// ListSessions returns all client sessions.
 	ListSessions() ([]*Session, error)
+	// ListLocks returns all locks of a inode.
+	ListLocks(ctx context.Context, inode Ino) ([]PLockItem, []FLockItem, error)
 	// Statistic scan metadata by visitors.
 	Statistic(ctx context.Context, slicesDelayedScan func(Slice) error, fileDelayedScan func(ino Ino, size uint64) error) error
 	// CleanStaleSessions cleans up sessions not active for more than 5 minutes

--- a/pkg/meta/redis_lock.go
+++ b/pkg/meta/redis_lock.go
@@ -20,6 +20,7 @@
 package meta
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"syscall"
@@ -205,4 +206,36 @@ func (r *redisMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltyp
 		}
 	}
 	return errno(err)
+}
+
+func (r *redisMeta) ListLocks(ctx context.Context, inode Ino) ([]PLockItem, []FLockItem, error) {
+	fKey := r.flockKey(inode)
+	pKey := r.plockKey(inode)
+
+	rawFLocks, err := r.rdb.HGetAll(ctx, fKey).Result()
+	if err != nil {
+		return nil, nil, err
+	}
+	flocks := make([]FLockItem, 0, len(rawFLocks))
+	for k, v := range rawFLocks {
+		owner, err := parseOwnerKey(k)
+		if err != nil {
+			return nil, nil, err
+		}
+		flocks = append(flocks, FLockItem{*owner, v})
+	}
+
+	rawPLocks, err := r.rdb.HGetAll(ctx, pKey).Result()
+	plocks := make([]PLockItem, 0)
+	for k, d := range rawPLocks {
+		owner, err := parseOwnerKey(k)
+		if err != nil {
+			return nil, nil, err
+		}
+		ls := loadLocks([]byte(d))
+		for _, l := range ls {
+			plocks = append(plocks, PLockItem{*owner, l})
+		}
+	}
+	return plocks, flocks, nil
 }

--- a/pkg/meta/redis_lock.go
+++ b/pkg/meta/redis_lock.go
@@ -226,6 +226,9 @@ func (r *redisMeta) ListLocks(ctx context.Context, inode Ino) ([]PLockItem, []FL
 	}
 
 	rawPLocks, err := r.rdb.HGetAll(ctx, pKey).Result()
+	if err != nil {
+		return nil, nil, err
+	}
 	plocks := make([]PLockItem, 0)
 	for k, d := range rawPLocks {
 		owner, err := parseOwnerKey(k)

--- a/pkg/meta/tkv_lock.go
+++ b/pkg/meta/tkv_lock.go
@@ -17,6 +17,7 @@
 package meta
 
 import (
+	"context"
 	"syscall"
 	"time"
 
@@ -220,4 +221,30 @@ func (m *kvMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype u
 		}
 	}
 	return errno(err)
+}
+
+func (m *kvMeta) ListLocks(ctx context.Context, inode Ino) ([]PLockItem, []FLockItem, error) {
+	fKey := m.flockKey(inode)
+	pKey := m.plockKey(inode)
+
+	var flocks []FLockItem
+	var plocks []PLockItem
+	err := m.txn(func(tx kvTxn) error {
+		fv := tx.get(fKey)
+		fs := unmarshalFlock(fv)
+		for k, t := range fs {
+			flocks = append(flocks, FLockItem{ownerKey{k.sid, k.owner}, string(t)})
+		}
+
+		pv := tx.get(pKey)
+		owners := unmarshalPlock(pv)
+		for k, records := range owners {
+			ls := loadLocks(records)
+			for _, l := range ls {
+				plocks = append(plocks, PLockItem{ownerKey{k.sid, k.owner}, l})
+			}
+		}
+		return nil
+	})
+	return plocks, flocks, err
 }

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"runtime/debug"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -132,6 +133,37 @@ type plockRecord struct {
 	Pid   uint32
 	Start uint64
 	End   uint64
+}
+
+type ownerKey struct {
+	Sid   uint64
+	Owner uint64
+}
+
+type PLockItem struct {
+	ownerKey
+	plockRecord
+}
+
+type FLockItem struct {
+	ownerKey
+	Type string
+}
+
+func parseOwnerKey(key string) (*ownerKey, error) {
+	pair := strings.Split(key, "_")
+	if len(pair) != 2 {
+		return nil, fmt.Errorf("invalid owner key: %s", key)
+	}
+	sid, err := strconv.ParseUint(pair[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	owner, err := strconv.ParseUint(pair[1], 16, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &ownerKey{sid, owner}, nil
 }
 
 func loadLocks(d []byte) []plockRecord {

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"bytes"
+	"fmt"
 	"net/url"
 	"runtime/debug"
 	"sort"

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -18,7 +18,9 @@ package vfs
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -247,6 +249,54 @@ func (v *VFS) caclObjects(id uint64, size, offset, length uint32) []*obj {
 	return objs
 }
 
+type InfoResponse struct {
+	Ino     Ino
+	Success bool
+	Reason  string
+	Summary meta.Summary
+	Paths   []string
+	Chunks  []*chunkSlice
+	Objects []*chunkObj
+}
+
+type chunkSlice struct {
+	ChunkIndex uint64
+	meta.Slice
+}
+
+type chunkObj struct {
+	ChunkIndex     uint64
+	Key            string
+	Size, Off, Len uint32
+}
+
+func (r *InfoResponse) Encode() []byte {
+	resp, _ := json.Marshal(r)
+	buffer := utils.NewBuffer(4 + uint32(len(resp)))
+	buffer.Put32(uint32(len(resp)))
+	buffer.Put(resp)
+	return buffer.Bytes()
+}
+
+func (r *InfoResponse) Decode(reader io.Reader) error {
+	sizeBuf := make([]byte, 4)
+	n := 0
+	for n != 4 {
+		i, err := reader.Read(sizeBuf[n:])
+		if err != nil && err != io.EOF {
+			return err
+		}
+		n += i
+	}
+
+	size := utils.ReadBuffer(sizeBuf).Get32()
+	respBuf := make([]byte, size)
+	if _, err := io.ReadFull(reader, respBuf); err != nil {
+		return err
+	}
+	return json.Unmarshal(respBuf, r)
+}
+
 func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, data *[]byte) {
 	switch cmd {
 	case meta.Rmr:
@@ -270,8 +320,11 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 		}
 		*data = append(*data, uint8(st))
 	case meta.Info:
-		var summary meta.Summary
 		inode := Ino(r.Get64())
+		info := &InfoResponse{
+			Ino: inode,
+		}
+
 		var recursive uint8 = 1
 		if r.HasMore() {
 			recursive = r.Get8()
@@ -281,54 +334,32 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 			raw = r.Get8() != 0
 		}
 
-		wb := utils.NewBuffer(4)
-		r := meta.GetSummary(v.Meta, ctx, inode, &summary, recursive != 0)
+		fmt.Printf("ino %d, recursive %d, raw %v\n", inode, recursive, raw)
+		r := meta.GetSummary(v.Meta, ctx, inode, &info.Summary, recursive != 0)
 		if r != 0 {
-			msg := r.Error()
-			wb.Put32(uint32(len(msg)))
-			*data = append(*data, append(wb.Bytes(), msg...)...)
+			info.Success = true
+			info.Reason = r.Error()
+			*data = info.Encode()
 			return
 		}
-		var w = bytes.NewBuffer(nil)
-		fmt.Fprintf(w, "  inode: %d\n", inode)
-		fmt.Fprintf(w, "  files: %d\n", summary.Files)
-		fmt.Fprintf(w, "   dirs: %d\n", summary.Dirs)
-		fmt.Fprintf(w, " length: %s\n", utils.FormatBytes(summary.Length))
-		fmt.Fprintf(w, "   size: %s\n", utils.FormatBytes(summary.Size))
-		ps := v.Meta.GetPaths(ctx, inode)
-		switch len(ps) {
-		case 0:
-			fmt.Fprintf(w, "   path: %s\n", "unknown")
-		case 1:
-			fmt.Fprintf(w, "   path: %s\n", ps[0])
-		default:
-			fmt.Fprintf(w, "  paths:\n")
-			for _, p := range ps {
-				fmt.Fprintf(w, "\t%s\n", p)
-			}
-		}
-		if summary.Files == 1 && summary.Dirs == 0 {
-			if raw {
-				fmt.Fprintf(w, " chunks:\n")
-			} else {
-				fmt.Fprintf(w, "objects:\n")
-			}
-			for indx := uint64(0); indx*meta.ChunkSize < summary.Length; indx++ {
+
+		info.Paths = v.Meta.GetPaths(ctx, inode)
+		if info.Summary.Files == 1 && info.Summary.Dirs == 0 {
+			for indx := uint64(0); indx*meta.ChunkSize < info.Summary.Length; indx++ {
 				var cs []meta.Slice
 				_ = v.Meta.Read(ctx, inode, uint32(indx), &cs)
 				for _, c := range cs {
 					if raw {
-						fmt.Fprintf(w, "\t%d:\t%d\t%d\t%d\t%d\n", indx, c.Id, c.Size, c.Off, c.Len)
+						info.Chunks = append(info.Chunks, &chunkSlice{indx, c})
 					} else {
 						for _, o := range v.caclObjects(c.Id, c.Size, c.Off, c.Len) {
-							fmt.Fprintf(w, "\t%d:\t%s\t%d\t%d\t%d\n", indx, o.key, o.size, o.off, o.len)
+							info.Objects = append(info.Objects, &chunkObj{indx, o.key, o.size, o.off, o.len})
 						}
 					}
 				}
 			}
 		}
-		wb.Put32(uint32(w.Len()))
-		*data = append(*data, append(wb.Bytes(), w.Bytes()...)...)
+		*data = append(*data, info.Encode()...)
 	case meta.FillCache:
 		paths := strings.Split(string(r.Get(int(r.Get32()))), "\n")
 		concurrent := r.Get16()

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -324,7 +324,7 @@ func (v *VFS) handleInternalMsg(ctx meta.Context, cmd uint32, r *utils.Buffer, d
 			}
 		}
 		*data = append(*data, uint8(st))
-	case meta.Info:
+	case meta.LegacyInfo:
 		inode := Ino(r.Get64())
 		info := &InfoResponse{
 			Ino:    inode,

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -273,7 +273,7 @@ type chunkObj struct {
 }
 
 func (r *InfoResponse) Encode() []byte {
-	resp, _ := json.MarshalIndent(r, "", "  ")
+	resp, _ := json.Marshal(r)
 	buffer := utils.NewBuffer(4 + uint32(len(resp)))
 	buffer.Put32(uint32(len(resp)))
 	buffer.Put(resp)

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -17,6 +17,7 @@
 package vfs
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"reflect"
@@ -737,21 +738,40 @@ func TestInternalFile(t *testing.T) {
 	} else {
 		off += uint64(n)
 	}
-	// info
+	// legacy info
 	buf = make([]byte, 4+4+8)
 	w = utils.FromBuffer(buf)
 	w.Put32(meta.LegacyInfo)
 	w.Put32(8)
 	w.Put64(1)
 	if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {
-		t.Fatalf("write info: %s", e)
+		t.Fatalf("write legacy info: %s", e)
 	}
 	off += uint64(len(buf))
 	buf = make([]byte, 1024*10)
 	if n, e = readControl(buf, &off); e != 0 {
 		t.Fatalf("read result: %s %d", e, n)
 	} else if !strings.Contains(string(buf[:n]), "dirs:") {
-		t.Fatalf("info result: %s", string(buf[:n]))
+		t.Fatalf("legacy info result: %s", string(buf[:n]))
+	} else {
+		off += uint64(n)
+	}
+	// info v2
+	buf = make([]byte, 4+4+8)
+	w = utils.FromBuffer(buf)
+	w.Put32(meta.InfoV2)
+	w.Put32(8)
+	w.Put64(1)
+	if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {
+		t.Fatalf("write info v2: %s", e)
+	}
+	off += uint64(len(buf))
+	buf = make([]byte, 1024*10)
+	var infoResp InfoResponse
+	if n, e = readControl(buf, &off); e != 0 {
+		t.Fatalf("read result: %s %d", e, n)
+	} else if infoResp.Decode(bytes.NewBuffer(buf[:n])) != nil {
+		t.Fatalf("info v2 result: %s", string(buf[:n]))
 	} else {
 		off += uint64(n)
 	}

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -740,7 +740,7 @@ func TestInternalFile(t *testing.T) {
 	// info
 	buf = make([]byte, 4+4+8)
 	w = utils.FromBuffer(buf)
-	w.Put32(meta.InfoV2)
+	w.Put32(meta.LegacyInfo)
 	w.Put32(8)
 	w.Put64(1)
 	if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -740,7 +740,7 @@ func TestInternalFile(t *testing.T) {
 	// info
 	buf = make([]byte, 4+4+8)
 	w = utils.FromBuffer(buf)
-	w.Put32(meta.Info)
+	w.Put32(meta.InfoV2)
 	w.Put32(8)
 	w.Put64(1)
 	if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {


### PR DESCRIPTION
Close https://github.com/juicedata/juicefs/issues/2625

```bash
> ./juicefs info /mnt/jfs/example
/mnt/jfs/example :
  inode: 55
  files: 1
   dirs: 0
 length: 1.56 KiB (1596 Bytes)
   size: 4.00 KiB (4096 Bytes)
   path: /mnt/jfs/example
 objects:
+------------+----------------------------+------+--------+--------+
| chunkIndex |         objectName         | size | offset | length |
+------------+----------------------------+------+--------+--------+
|          0 | myjfs/chunks/0/0/34_0_1596 | 1596 |      0 |   1596 |
+------------+----------------------------+------+--------+--------+
  flocks:
+-----+---------------------+------+
| Sid |        Owner        | Type |
+-----+---------------------+------+
| 49  | 4848886172199279596 |    W |
+-----+---------------------+------+
```
