### PR TITLE
modify current limit parameters dynamically (volume dimension)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -95,6 +95,16 @@ $ juicefs config redis://localhost --min-client-version 1.0.0 --max-client-versi
 				Name:  "force",
 				Usage: "skip sanity check and force update the configurations",
 			},
+			&cli.Int64Flag{
+				Name:  "default-upload-limit",
+				Value: 0,
+				Usage: "bandwidth limit for upload in Mbps, volume level configuration, priority is lower than mount",
+			},
+			&cli.Int64Flag{
+				Name:  "default-download-limit",
+				Value: 0,
+				Usage: "bandwidth limit for download in Mbps, volume level configuration, priority is lower than mount",
+			},
 		},
 	}
 }
@@ -208,6 +218,22 @@ func config(ctx *cli.Context) error {
 				msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", flag, format.MaxClientVersion, new))
 				format.MaxClientVersion = new
 				clientVer = true
+			}
+		case "default-upload-limit":
+			if new := ctx.Int64(flag) * 1e6 / 8; new != format.DefaultUpLimit {
+				if new < 0 {
+					return fmt.Errorf("Invalid DefaultUpLimit: %d", new)
+				}
+				msg.WriteString(fmt.Sprintf("%s: %d -> %d\n", flag, format.DefaultUpLimit, new))
+				format.DefaultUpLimit = new
+			}
+		case "default-download-limit":
+			if new := ctx.Int64(flag) * 1e6 / 8; new != format.DefaultDownLimit {
+				if new < 0 {
+					return fmt.Errorf("Invalid DefaultDownLimit: %d", new)
+				}
+				msg.WriteString(fmt.Sprintf("%s: %d -> %d\n", flag, format.DefaultDownLimit, new))
+				format.DefaultDownLimit = new
 			}
 		}
 	}

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -216,6 +216,10 @@ func initForSvc(c *cli.Context, mp string, metaUrl string) (*vfs.Config, *fs.Fil
 	vfsConf.DirEntryTimeout = time.Millisecond * time.Duration(c.Float64("dir-entry-cache")*1000)
 
 	initBackgroundTasks(c, vfsConf, metaConf, metaCli, blob, registerer, registry)
+
+	setRateLimitPriority(c)
+	NewReloadRateLimit(format, metaCli, store)
+
 	jfs, err := fs.NewFileSystem(vfsConf, metaCli, store)
 	if err != nil {
 		logger.Fatalf("Initialize failed: %s", err)

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -217,8 +217,7 @@ func initForSvc(c *cli.Context, mp string, metaUrl string) (*vfs.Config, *fs.Fil
 
 	initBackgroundTasks(c, vfsConf, metaConf, metaCli, blob, registerer, registry)
 
-	setRateLimitPriority(c)
-	NewReloadRateLimit(format, metaCli, store)
+	NewReloadRateLimit(format, metaCli, store, chunkConf)
 
 	jfs, err := fs.NewFileSystem(vfsConf, metaCli, store)
 	if err != nil {

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -795,25 +795,25 @@ func NewCachedStore(storage object.ObjectStorage, config Config, reg prometheus.
 func (store *cachedStore) UpdateCachedStoreRateLimit(limit int64, lastLimit int64, limitType string) {
 	switch limitType {
 	case "upLimit":
-		if (store.upLimit == nil || lastLimit == 0) && limit > 0 {
+		if store.upLimit == nil && limit > 0 {
 			store.upLimit = rate.NewLimiter(rate.Limit(float64(limit)*0.85), int(limit))
 		} else if store.upLimit != nil && limit != lastLimit {
-			if lastLimit > 0 && limit > 0 {
+			if limit > 0 {
 				store.upLimit.SetLimit(rate.Limit(float64(limit) * 0.85))
 				store.upLimit.SetBurst(int(limit))
 			} else if lastLimit > 0 && limit == 0 {
-				store.upLimit = nil
+				store.upLimit.SetLimit(rate.Inf)
 			}
 		}
 	case "downLimit":
-		if (store.downLimit == nil || lastLimit == 0) && limit > 0 {
+		if store.downLimit == nil && limit > 0 {
 			store.downLimit = rate.NewLimiter(rate.Limit(float64(limit)*0.85), int(limit))
 		} else if store.downLimit != nil && limit != lastLimit {
-			if lastLimit > 0 && limit > 0 {
+			if limit > 0 {
 				store.downLimit.SetLimit(rate.Limit(float64(limit) * 0.85))
 				store.downLimit.SetBurst(int(limit))
 			} else if lastLimit > 0 && limit == 0 {
-				store.downLimit = nil
+				store.downLimit.SetLimit(rate.Inf)
 			}
 		}
 	default:

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -40,4 +40,5 @@ type ChunkStore interface {
 	Remove(id uint64, length int) error
 	FillCache(id uint64, length uint32) error
 	UsedMemory() int64
+	UpdateCachedStoreRateLimit(limit int64, lastLimit int64, limitType string)
 }

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -64,6 +64,8 @@ type Format struct {
 	MetaVersion      int    `json:",omitempty"`
 	MinClientVersion string `json:",omitempty"`
 	MaxClientVersion string `json:",omitempty"`
+	DefaultUpLimit   int64 // bytes per second
+	DefaultDownLimit int64 // bytes per second
 }
 
 func (f *Format) update(old *Format, force bool) error {


### PR DESCRIPTION
Modify juicefs client upload/download limit parameters dynamically.

Add parameters(flags) in format settings, and modify the value through the 'juicefs config' to dynamically modify the traffiic(object storage) limiting bucket setting, which acts on the volume level.

The priority of new configuration is lower than the mount parameter.

The commit use official rate package(golang) , And allow control of timeout, but it seems that there is no high necessity., in order to make the use easier, all case set to no timeout.

Test Result:

1. Unlimited upload/download
default 0 in format setting

`./juicefs bench /tmp/zmc-1112 -p 4`
![image](https://user-images.githubusercontent.com/39403809/204121796-0b67dbb9-cb07-4a8e-8217-1091e41b7ff8.png)

2. Update upload/download limit(480 Mbps = 60MB, 960 Mbps = 120 MB)
`./juicefs config tikv://xxx:2379/zmc-1112 --default-upload-limit 480 --default-download-limit 960`
<img width="747" alt="image" src="https://user-images.githubusercontent.com/39403809/204121888-881b7492-a878-4b91-b223-1c7114fd3aa4.png">

3. Update upload/download limit
`./juicefs config tikv://1xxx:2379/zmc-1112 --default-upload-limit 480 --default-download-limit 480`
<img width="761" alt="image" src="https://user-images.githubusercontent.com/39403809/204121946-e392b96c-018f-4943-a8f2-a0b9b0de1643.png">

4. Close upload/download limit
`./juicefs config tikv://xxx:2379/zmc-1112 --default-upload-limit 0 --default-download-limit 0` 
<img width="738" alt="image" src="https://user-images.githubusercontent.com/39403809/204121989-4f99d9f5-f87f-4e95-8582-ddcb60fd567b.png">


