### PR TITLE
fix runner hosts version

### DIFF
--- a/.github/workflows/aitests.yml
+++ b/.github/workflows/aitests.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   aitests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/aitests_limitcache.yml
+++ b/.github/workflows/aitests_limitcache.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   aitestslimitcache:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -18,7 +18,7 @@ on:
   
 jobs:
   config-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       redis:
         # Docker Hub image

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3

--- a/.github/workflows/elastictest.yml
+++ b/.github/workflows/elastictest.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   elastictest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/encoding_mysql.yml
+++ b/.github/workflows/encoding_mysql.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   mysql-encoding-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/filebench.yml
+++ b/.github/workflows/filebench.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         workload: [ 'varmail', 'webserver', 'videoserver']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/fio_benchmark.yml
+++ b/.github/workflows/fio_benchmark.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   big-file-sequential-read:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
 
   big-file-sequential-write:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
 
   big-file-multi-read-1:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
 
   big-file-multi-read-4:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
 
   big-file-multi-read-16:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
 
   big-file-multi-write-1:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
 
   big-file-multi-write-4:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -113,7 +113,7 @@ jobs:
 
   big-file-multi-write-16:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
 
   big-file-rand-read-4k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -144,7 +144,7 @@ jobs:
         
   big-file-rand-read-256k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -160,7 +160,7 @@ jobs:
 
   big-file-random-write-16k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -175,7 +175,7 @@ jobs:
 
   big-file-random-write-256k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -190,7 +190,7 @@ jobs:
 
   small-file-seq-read-4k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -206,7 +206,7 @@ jobs:
 
   small-file-seq-read-256k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -222,7 +222,7 @@ jobs:
         
   small-file-seq-write-4k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -237,7 +237,7 @@ jobs:
 
   small-file-seq-write-256k:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -252,7 +252,7 @@ jobs:
 
   small-file-multi-read-1:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -267,7 +267,7 @@ jobs:
 
   small-file-multi-read-4:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -282,7 +282,7 @@ jobs:
 
   small-file-multi-read-16:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -297,7 +297,7 @@ jobs:
 
   small-file-multi-write-1:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -312,7 +312,7 @@ jobs:
 
   small-file-multi-write-4:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -327,7 +327,7 @@ jobs:
 
   small-file-multi-write-16:
     if: github.repository == 'juicedata/juicefs'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ on:
   
 jobs:
   format-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       redis:
         # Docker Hub image

--- a/.github/workflows/fsrand.yml
+++ b/.github/workflows/fsrand.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # meta: [ 'sqlite3', 'redis', 'mysql', 'tikv', 'tidb', 'postgres', 'mariadb', 'badger', 'fdb']
         meta: ['redis', 'mysql', 'tikv']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -61,7 +61,7 @@ jobs:
             file_size: '100M'
             isolation_level: "repeatable read"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps: 
       - name: Checkout

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -21,7 +21,7 @@ on:
         default: false  
 jobs:
   gc-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       redis:
         # Docker Hub image

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         meta: [ 'sqlite3', 'redis', 'mysql', 'tikv', 'tidb', 'postgres', 'mariadb', 'badger', 'fdb']
         # meta: ['redis']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/ltpfs.yml
+++ b/.github/workflows/ltpfs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   ltpfs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ltpsyscallshead.yml
+++ b/.github/workflows/ltpsyscallshead.yml
@@ -24,7 +24,7 @@ jobs:
         # meta: [ 'sqlite3', 'redis', 'mysql', 'tikv', 'tidb', 'postgres', 'mariadb', 'badger', 'fdb']
         meta: ['redis']
         type: [ 'head', 'middle', 'tail']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/mongodb_mmap.yml
+++ b/.github/workflows/mongodb_mmap.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   mongodb_mmap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/mutate-test.yml
+++ b/.github/workflows/mutate-test.yml
@@ -27,7 +27,7 @@ on:
 jobs:
 
   build-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         test_file: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       pull-requests: write
     steps:
@@ -241,7 +241,7 @@ jobs:
         uses: lhotari/action-upterm@v1
 
   success-all-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build-matrix, mutate-test]
     if: always()
     steps:

--- a/.github/workflows/mysqltest_bigtable.yml
+++ b/.github/workflows/mysqltest_bigtable.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         size: [ 'big', 'small' ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pjdfstest.yml
+++ b/.github/workflows/pjdfstest.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - id: set-matrix
         run: |
@@ -54,7 +54,7 @@ jobs:
       matrix:
         # [ 'sqlite3', 'redis', 'mysql', 'tikv', 'tidb', 'postgres', 'badger', 'mariadb', 'fdb']
         meta: ${{ fromJson(needs.build-matrix.outputs.meta_matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: shogo82148/actions-setup-perl@v1

--- a/.github/workflows/redis_compile.yml
+++ b/.github/workflows/redis_compile.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   rediscompile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   releaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/rmfiles.yml
+++ b/.github/workflows/rmfiles.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         meta: [ 'sqlite3', 'redis', 'mysql',  'postgres', 'tikv', 'fdb', 'badger', 'etcd']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/sdktest.yml
+++ b/.github/workflows/sdktest.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   sdktest:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   compare-with-rsync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       redis:
         # Docker Hub image
@@ -95,7 +95,7 @@ jobs:
 
 
   compare-with-rsync-randomly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -140,7 +140,7 @@ jobs:
       #   uses: lhotari/action-upterm@v1
 
   file-head-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/sysbench.yml
+++ b/.github/workflows/sysbench.yml
@@ -19,7 +19,7 @@ jobs:
           - meta: 'redis'
             compress: 'none'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
   
     steps:
       - name: Checkout

--- a/.github/workflows/tpch_clickhouse.yml
+++ b/.github/workflows/tpch_clickhouse.yml
@@ -24,7 +24,7 @@ jobs:
         type: [ 'normal', 'limitcache']
         # type: ['local']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   unittests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MINIO_TEST_BUCKET: 127.0.0.1:9000/testbucket
       MINIO_ACCESS_KEY: testUser

--- a/.github/workflows/vdbench.yml
+++ b/.github/workflows/vdbench.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         meta: [ 'sqlite3', 'redis', 'mysql', 'tikv', 'tidb', 'postgres', 'mariadb', 'fdb']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:        
       - name: Checkout

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -32,7 +32,7 @@ jobs:
         with:
           version: v1.49.0
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/version_compatible_hypo.yml
+++ b/.github/workflows/version_compatible_hypo.yml
@@ -39,7 +39,7 @@ jobs:
             meta: 'redis'
             storage: 'minio'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
```
Building fileop for Linux

cc -Wall -c -O3  fileop.c -o fileop_linux.o

Building the pit_server

cc -c   pit_server.c  -o pit_server.o 
cc  -O3  iozone_linux.o libasync.o libbif.o -lpthread \
	-lrt -o iozone
/usr/bin/ld: libbif.o:(.bss+0x8): multiple definition of `junk'; iozone_linux.o:(.bss+0x340e0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [makefile:169: linux] Error 1
make[2]: Leaving directory '/home/runner/work/juicefs/juicefs/integration/secfs.test/iozone/src/current'
make[1]: *** [Makefile:59: tools/bin/iozone] Error 2
make[1]: Leaving directory '/home/runner/work/juicefs/juicefs/integration/secfs.test'
```