### PR TITLE
object: increase buffer size from 4KB to 32KB

### DIFF
--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -46,6 +46,8 @@ func init() {
 			ResponseHeaderTimeout: time.Second * 30,
 			IdleConnTimeout:       time.Second * 300,
 			MaxIdleConnsPerHost:   500,
+			ReadBufferSize:        32 << 10,
+			WriteBufferSize:       32 << 10,
 			Dial: func(network string, address string) (net.Conn, error) {
 				separator := strings.LastIndex(address, ":")
 				host := address[:separator]


### PR DESCRIPTION
The default buffer size of HTTP connection is 4KB, which is too small that lots of CPU spent in syscalls.