### PR TITLE
status: rename DeletedSlice to TrashSlice and DeletedFile to PendingDeletedFile

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -70,8 +70,8 @@ type statistic struct {
 	AvailableInodes         uint64
 	TrashSliceCount         int64 `json:",omitempty"`
 	TrashSliceSize          int64 `json:",omitempty"`
-	DelayedDeletedFileCount int64 `json:",omitempty"`
-	DelayedDeletedFileSize  int64 `json:",omitempty"`
+	PendingDeletedFileCount int64 `json:",omitempty"`
+	PendingDeletedFileSize  int64 `json:",omitempty"`
 }
 
 func printJson(v interface{}) {
@@ -117,7 +117,7 @@ func status(ctx *cli.Context) error {
 		progress := utils.NewProgress(false, false)
 		slicesSpinner := progress.AddDoubleSpinner("Trash Slices")
 		defer slicesSpinner.Done()
-		fileSpinner := progress.AddDoubleSpinner("Delayed Deleted Files")
+		fileSpinner := progress.AddDoubleSpinner("Pending Deleted Files")
 		defer fileSpinner.Done()
 
 		err = m.ScanDeletedObject(
@@ -138,7 +138,7 @@ func status(ctx *cli.Context) error {
 			return err
 		}
 		stat.TrashSliceCount, stat.TrashSliceSize = slicesSpinner.Current()
-		stat.DelayedDeletedFileCount, stat.DelayedDeletedFileSize = fileSpinner.Current()
+		stat.PendingDeletedFileCount, stat.PendingDeletedFileSize = fileSpinner.Current()
 	}
 
 	printJson(&sections{format, sessions, stat})

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -64,14 +64,14 @@ type sections struct {
 }
 
 type statistic struct {
-	UsedSpace        uint64
-	AvailableSpace   uint64
-	UsedInodes       uint64
-	AvailableInodes  uint64
-	TrashSliceCount  int64 `json:",omitempty"`
-	TrashSliceSize   int64 `json:",omitempty"`
-	DeletedFileCount int64 `json:",omitempty"`
-	DeletedFileSize  int64 `json:",omitempty"`
+	UsedSpace               uint64
+	AvailableSpace          uint64
+	UsedInodes              uint64
+	AvailableInodes         uint64
+	TrashSliceCount         int64 `json:",omitempty"`
+	TrashSliceSize          int64 `json:",omitempty"`
+	DelayedDeletedFileCount int64 `json:",omitempty"`
+	DelayedDeletedFileSize  int64 `json:",omitempty"`
 }
 
 func printJson(v interface{}) {
@@ -117,7 +117,7 @@ func status(ctx *cli.Context) error {
 		progress := utils.NewProgress(false, false)
 		slicesSpinner := progress.AddDoubleSpinner("Trash Slices")
 		defer slicesSpinner.Done()
-		fileSpinner := progress.AddDoubleSpinner("Deleted Files")
+		fileSpinner := progress.AddDoubleSpinner("Delayed Deleted Files")
 		defer fileSpinner.Done()
 
 		err = m.ScanDeletedObject(
@@ -138,7 +138,7 @@ func status(ctx *cli.Context) error {
 			return err
 		}
 		stat.TrashSliceCount, stat.TrashSliceSize = slicesSpinner.Current()
-		stat.DeletedFileCount, stat.DeletedFileSize = fileSpinner.Current()
+		stat.DelayedDeletedFileCount, stat.DelayedDeletedFileSize = fileSpinner.Current()
 	}
 
 	printJson(&sections{format, sessions, stat})

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -64,14 +64,14 @@ type sections struct {
 }
 
 type statistic struct {
-	UsedSpace         uint64
-	AvailableSpace    uint64
-	UsedInodes        uint64
-	AvailableInodes   uint64
-	DeletedSliceCount int64 `json:",omitempty"`
-	DeletedSliceSize  int64 `json:",omitempty"`
-	DeletedFileCount  int64 `json:",omitempty"`
-	DeletedFileSize   int64 `json:",omitempty"`
+	UsedSpace        uint64
+	AvailableSpace   uint64
+	UsedInodes       uint64
+	AvailableInodes  uint64
+	TrashSliceCount  int64 `json:",omitempty"`
+	TrashSliceSize   int64 `json:",omitempty"`
+	DeletedFileCount int64 `json:",omitempty"`
+	DeletedFileSize  int64 `json:",omitempty"`
 }
 
 func printJson(v interface{}) {
@@ -115,9 +115,9 @@ func status(ctx *cli.Context) error {
 
 	if ctx.Bool("more") {
 		progress := utils.NewProgress(false, false)
-		slicesSpinner := progress.AddDoubleSpinner("Delayed Slices")
+		slicesSpinner := progress.AddDoubleSpinner("Trash Slices")
 		defer slicesSpinner.Done()
-		fileSpinner := progress.AddDoubleSpinner("Delayed Files")
+		fileSpinner := progress.AddDoubleSpinner("Deleted Files")
 		defer fileSpinner.Done()
 
 		err = m.ScanDeletedObject(
@@ -137,7 +137,7 @@ func status(ctx *cli.Context) error {
 			logger.Fatalf("statistic: %s", err)
 			return err
 		}
-		stat.DeletedSliceCount, stat.DeletedSliceSize = slicesSpinner.Current()
+		stat.TrashSliceCount, stat.TrashSliceSize = slicesSpinner.Current()
 		stat.DeletedFileCount, stat.DeletedFileSize = fileSpinner.Current()
 	}
 


### PR DESCRIPTION
Signed-off-by: xixi <hexilee@juicedata.io>

In current implementation, `delfile` means files that were deleted delayed and could be cleaned immediately, while the `delslice` means slices that were swept into trash and should be cleaned according to `trash-days`.

In this PR, we renamed them more appropriately.