### PR TITLE
Migrate setup-java action to use Temurin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '8'
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.github/workflows/sdktest.yml
+++ b/.github/workflows/sdktest.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
 
       - name: Run Redis

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
 
       - name: Checkout


### PR DESCRIPTION
AdoptOpenJDK has moved to the Eclipse Foundation and now distributes binaries under the new name "Eclipse Temurin"