### PR TITLE
Add internal-inodes-prefix option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ltmain.sh
 .deps
 .dirstamp
 .vscode
+.devcontainer
 .idea
 fstests/secfs.test
 fstests/flock

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -200,6 +200,11 @@ func clientFlags() []cli.Flag {
 			Name:  "subdir",
 			Usage: "mount a sub-directory as root",
 		},
+		&cli.StringFlag{
+			Name:  "internal-inodes-prefix",
+			Value: "",
+			Usage: "prefix for internal inodes (.accesslog, .config, etc.)",
+		},
 	}
 }
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -360,6 +360,7 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 		Heartbeat:  duration(c.String("heartbeat")),
 		MountPoint: mp,
 		Subdir:     c.String("subdir"),
+		IntPrefix:  c.String("internal-inodes-prefix"),
 	}
 	if cfg.Heartbeat < time.Second {
 		logger.Warnf("heartbeat should not be less than 1 second")

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -370,10 +370,6 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 		logger.Warnf("heartbeat shouldd not be greater than 10 minutes")
 		cfg.Heartbeat = time.Minute * 10
 	}
-	if cfg.IntPrefix != "" && cfg.IntPrefix[0] != '.' { // todo: verify the prefix is alpha-numeric
-		logger.Warnf("internal-inodes-prefix should start with a dot (.)")
-		cfg.IntPrefix = "." + cfg.IntPrefix
-	}
 	return cfg
 }
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -370,6 +370,10 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 		logger.Warnf("heartbeat shouldd not be greater than 10 minutes")
 		cfg.Heartbeat = time.Minute * 10
 	}
+	if cfg.IntPrefix != "" && cfg.IntPrefix[0] != '.' { // todo: verify the prefix is alpha-numeric
+		logger.Warnf("internal-inodes-prefix should start with a dot (.)")
+		cfg.IntPrefix = "." + cfg.IntPrefix
+	}
 	return cfg
 }
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -245,12 +245,13 @@ func expandPathForEmbedded(addr string) string {
 
 func getVfsConf(c *cli.Context, metaConf *meta.Config, format *meta.Format, chunkConf *chunk.Config) *vfs.Config {
 	cfg := &vfs.Config{
-		Meta:       metaConf,
-		Format:     format,
-		Version:    version.Version(),
-		Chunk:      chunkConf,
-		BackupMeta: duration(c.String("backup-meta")),
-		Port:       &vfs.Port{DebugAgent: debugAgent, PyroscopeAddr: c.String("pyroscope")},
+		Meta:                metaConf,
+		Format:              format,
+		Version:             version.Version(),
+		Chunk:               chunkConf,
+		BackupMeta:          duration(c.String("backup-meta")),
+		Port:                &vfs.Port{DebugAgent: debugAgent, PyroscopeAddr: c.String("pyroscope")},
+		InternalInodePrefix: c.String("internal-inodes-prefix"),
 	}
 	if cfg.BackupMeta > 0 && cfg.BackupMeta < time.Minute*5 {
 		logger.Fatalf("backup-meta should not be less than 5 minutes: %s", cfg.BackupMeta)
@@ -360,7 +361,6 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 		Heartbeat:  duration(c.String("heartbeat")),
 		MountPoint: mp,
 		Subdir:     c.String("subdir"),
-		IntPrefix:  c.String("internal-inodes-prefix"),
 	}
 	if cfg.Heartbeat < time.Second {
 		logger.Warnf("heartbeat should not be less than 1 second")

--- a/docs/en/reference/command_reference.md
+++ b/docs/en/reference/command_reference.md
@@ -325,6 +325,9 @@ delayed duration for uploading objects ("s", "m", "h") (default: 0s)
 `--no-bgjob`<br />
 disable background jobs (clean-up, backup, etc.) (default: false)
 
+`--internal-inodes-prefix value`<br />
+prefix for internal inodes (virtual files - .accesslog, .config, etc.) (default: "")
+
 #### Examples
 
 ```bash

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/juicedata/juicefs/pkg/version"
@@ -42,7 +41,6 @@ type Config struct {
 	Heartbeat   time.Duration
 	MountPoint  string
 	Subdir      string
-	IntPrefix   string // prefix for internal inodes (.accesslog, .config, etc.)
 }
 
 type Format struct {
@@ -66,19 +64,6 @@ type Format struct {
 	MetaVersion      int    `json:",omitempty"`
 	MinClientVersion string `json:",omitempty"`
 	MaxClientVersion string `json:",omitempty"`
-}
-
-func (c *Config) SanitizePrefix() {
-	if c.IntPrefix != "" {
-		if c.IntPrefix[0] != '.' {
-			logger.Warnf("Internal inodes prefix should start with a dot, changing %s -> %s", c.IntPrefix, "."+c.IntPrefix)
-			c.IntPrefix = "." + c.IntPrefix
-		}
-		if strings.Contains(c.IntPrefix, "/") {
-			logger.Warnf("Internal inodes prefix should not contain slashes, changing %s -> %s", c.IntPrefix, strings.ReplaceAll(c.IntPrefix, "/", ""))
-			c.IntPrefix = strings.ReplaceAll(c.IntPrefix, "/", "")
-		}
-	}
 }
 
 func (f *Format) update(old *Format, force bool) error {

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	Heartbeat   time.Duration
 	MountPoint  string
 	Subdir      string
+	IntPrefix   string // prefix for internal inodes (.accesslog, .config, etc.)
 }
 
 type Format struct {

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/juicedata/juicefs/pkg/version"
@@ -65,6 +66,19 @@ type Format struct {
 	MetaVersion      int    `json:",omitempty"`
 	MinClientVersion string `json:",omitempty"`
 	MaxClientVersion string `json:",omitempty"`
+}
+
+func (c *Config) SanitizePrefix() {
+	if c.IntPrefix != "" {
+		if c.IntPrefix[0] != '.' {
+			logger.Warnf("Internal inodes prefix should start with a dot, changing %s -> %s", c.IntPrefix, "."+c.IntPrefix)
+			c.IntPrefix = "." + c.IntPrefix
+		}
+		if strings.Contains(c.IntPrefix, "/") {
+			logger.Warnf("Internal inodes prefix should not contain slashes, changing %s -> %s", c.IntPrefix, strings.ReplaceAll(c.IntPrefix, "/", ""))
+			c.IntPrefix = strings.ReplaceAll(c.IntPrefix, "/", "")
+		}
+	}
 }
 
 func (f *Format) update(old *Format, force bool) error {

--- a/pkg/vfs/backup_test.go
+++ b/pkg/vfs/backup_test.go
@@ -68,7 +68,7 @@ func TestRotate(t *testing.T) {
 }
 
 func TestBackup(t *testing.T) {
-	v, blob := createTestVFS()
+	v, blob := createTestVFS("")
 	go Backup(v.Meta, blob, time.Millisecond*100)
 	time.Sleep(time.Millisecond * 100)
 

--- a/pkg/vfs/backup_test.go
+++ b/pkg/vfs/backup_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/object"
 	osync "github.com/juicedata/juicefs/pkg/sync"
 )
@@ -68,7 +69,11 @@ func TestRotate(t *testing.T) {
 }
 
 func TestBackup(t *testing.T) {
-	v, blob := createTestVFS("")
+	v, blob := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
 	go Backup(v.Meta, blob, time.Millisecond*100)
 	time.Sleep(time.Millisecond * 100)
 

--- a/pkg/vfs/backup_test.go
+++ b/pkg/vfs/backup_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/object"
 	osync "github.com/juicedata/juicefs/pkg/sync"
 )
@@ -69,11 +68,7 @@ func TestRotate(t *testing.T) {
 }
 
 func TestBackup(t *testing.T) {
-	v, blob := createTestVFS(&meta.Config{
-		Retries:    10,
-		Strict:     true,
-		MountPoint: "/jfs",
-	})
+	v, blob := createTestVFS("")
 	go Backup(v.Meta, blob, time.Millisecond*100)
 	time.Sleep(time.Millisecond * 100)
 

--- a/pkg/vfs/fill_test.go
+++ b/pkg/vfs/fill_test.go
@@ -24,7 +24,11 @@ import (
 )
 
 func TestFill(t *testing.T) {
-	v, _ := createTestVFS("")
+	v, _ := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
 	ctx := NewLogContext(meta.Background)
 	entry, _ := v.Mkdir(ctx, 1, "test", 0777, 022)
 	fe, fh, _ := v.Create(ctx, entry.Inode, "file", 0644, 0, uint32(os.O_WRONLY))

--- a/pkg/vfs/fill_test.go
+++ b/pkg/vfs/fill_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestFill(t *testing.T) {
-	v, _ := createTestVFS()
+	v, _ := createTestVFS("")
 	ctx := NewLogContext(meta.Background)
 	entry, _ := v.Mkdir(ctx, 1, "test", 0777, 022)
 	fe, fh, _ := v.Create(ctx, entry.Inode, "file", 0644, 0, uint32(os.O_WRONLY))

--- a/pkg/vfs/fill_test.go
+++ b/pkg/vfs/fill_test.go
@@ -24,11 +24,7 @@ import (
 )
 
 func TestFill(t *testing.T) {
-	v, _ := createTestVFS(&meta.Config{
-		Retries:    10,
-		Strict:     true,
-		MountPoint: "/jfs",
-	})
+	v, _ := createTestVFS("")
 	ctx := NewLogContext(meta.Background)
 	entry, _ := v.Mkdir(ctx, 1, "test", 0777, 022)
 	fe, fh, _ := v.Create(ctx, entry.Inode, "file", 0644, 0, uint32(os.O_WRONLY))

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -71,16 +71,17 @@ func (v *VFS) releaseControlHandle(pid uint32) {
 
 type internalNode struct {
 	inode Ino
+	base  string
 	name  string
 	attr  *Attr
 }
 
 var internalNodes = []*internalNode{
-	{controlInode, ".control", &Attr{Mode: 0666}},
-	{logInode, ".accesslog", &Attr{Mode: 0400}},
-	{statsInode, ".stats", &Attr{Mode: 0444}},
-	{configInode, ".config", &Attr{Mode: 0400}},
-	{trashInode, meta.TrashName, &Attr{Mode: 0555}},
+	{controlInode, ".control", "", &Attr{Mode: 0666}},
+	{logInode, ".accesslog", "", &Attr{Mode: 0400}},
+	{statsInode, ".stats", "", &Attr{Mode: 0444}},
+	{configInode, ".config", "", &Attr{Mode: 0400}},
+	{trashInode, meta.TrashName, "", &Attr{Mode: 0555}},
 }
 
 func init() {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -946,17 +946,17 @@ func NewVFS(conf *Config, m meta.Meta, store chunk.ChunkStore, registerer promet
 		registry:   registry,
 	}
 
+	v.Conf.Meta.SanitizePrefix()
+	for _, n := range internalNodes {
+		n.name = conf.Meta.IntPrefix + n.base
+	}
+
 	n := getInternalNode(configInode)
 	v.Conf.Format.RemoveSecret()
 	data, _ := json.MarshalIndent(v.Conf, "", " ")
 	n.attr.Length = uint64(len(data))
 	if conf.Meta.Subdir != "" { // don't show trash directory
 		internalNodes = internalNodes[:len(internalNodes)-1]
-	}
-	if conf.Meta.IntPrefix != "" { // add prefix to internal nodes
-		for _, n := range internalNodes {
-			n.name = conf.Meta.IntPrefix + n.name
-		}
 	}
 
 	go v.cleanupModified()

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -953,6 +953,11 @@ func NewVFS(conf *Config, m meta.Meta, store chunk.ChunkStore, registerer promet
 	if conf.Meta.Subdir != "" { // don't show trash directory
 		internalNodes = internalNodes[:len(internalNodes)-1]
 	}
+	if conf.Meta.IntPrefix != "" { // add prefix to internal nodes
+		for _, n := range internalNodes {
+			n.name = conf.Meta.IntPrefix + n.name
+		}
+	}
 
 	go v.cleanupModified()
 	initVFSMetrics(v, writer, registerer)

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -37,14 +37,7 @@ import (
 
 // nolint:errcheck
 
-func createTestVFS(intPrefix string) (*VFS, object.ObjectStorage) {
-	mp := "/jfs"
-	metaConf := &meta.Config{
-		Retries:    10,
-		Strict:     true,
-		MountPoint: mp,
-		IntPrefix:  intPrefix,
-	}
+func createTestVFS(metaConf *meta.Config) (*VFS, object.ObjectStorage) {
 	m := meta.NewClient("memkv://", metaConf)
 	format := &meta.Format{
 		Name:        "test",
@@ -74,13 +67,17 @@ func createTestVFS(intPrefix string) (*VFS, object.ObjectStorage) {
 	blob, _ := object.CreateStorage("mem", "", "", "", "")
 	registry := prometheus.NewRegistry() // replace default so only JuiceFS metrics are exposed
 	registerer := prometheus.WrapRegistererWithPrefix("juicefs_",
-		prometheus.WrapRegistererWith(prometheus.Labels{"mp": mp, "vol_name": format.Name}, registry))
+		prometheus.WrapRegistererWith(prometheus.Labels{"mp": metaConf.MountPoint, "vol_name": format.Name}, registry))
 	store := chunk.NewCachedStore(blob, *conf.Chunk, registry)
 	return NewVFS(conf, m, store, registerer, registry), blob
 }
 
 func TestVFSBasic(t *testing.T) {
-	v, _ := createTestVFS("")
+	v, _ := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
 	ctx := NewLogContext(meta.NewContext(10, 1, []uint32{2}))
 
 	if st, e := v.StatFS(ctx, 1); e != 0 {
@@ -189,7 +186,11 @@ func TestVFSBasic(t *testing.T) {
 }
 
 func TestVFSIO(t *testing.T) {
-	v, _ := createTestVFS("")
+	v, _ := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
 	ctx := NewLogContext(meta.Background)
 	fe, fh, e := v.Create(ctx, 1, "file", 0755, 0, syscall.O_RDWR)
 	if e != 0 {
@@ -354,7 +355,11 @@ func TestVFSIO(t *testing.T) {
 }
 
 func TestVFSXattrs(t *testing.T) {
-	v, _ := createTestVFS("")
+	v, _ := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
 	ctx := NewLogContext(meta.Background)
 	fe, e := v.Mkdir(ctx, 1, "xattrs", 0755, 0)
 	if e != 0 {
@@ -496,7 +501,11 @@ func TestSetattrStr(t *testing.T) {
 }
 
 func TestVFSLocks(t *testing.T) {
-	v, _ := createTestVFS("")
+	v, _ := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
 	ctx := NewLogContext(meta.Background)
 	fe, fh, e := v.Create(ctx, 1, "flock", 0644, 0, syscall.O_RDWR)
 	if e != 0 {
@@ -597,244 +606,236 @@ func TestVFSLocks(t *testing.T) {
 }
 
 func TestInternalFile(t *testing.T) {
-	var tests = []struct {
-		prefix                            string
-		config, stats, accesslog, control string
-	}{
-		{"", ".config", ".stats", ".accesslog", ".control"},
-		{".jfs", ".jfs.config", ".jfs.stats", ".jfs.accesslog", ".jfs.control"},
+	v, _ := createTestVFS(&meta.Config{
+		Retries:    10,
+		Strict:     true,
+		MountPoint: "/jfs",
+	})
+	ctx := NewLogContext(meta.Background)
+	// list internal files
+	fh, _ := v.Opendir(ctx, 1)
+	entries, _, e := v.Readdir(ctx, 1, 1024, 0, fh, true)
+	if e != 0 {
+		t.Fatalf("readdir 1: %s", e)
+	}
+	internalFiles := make(map[string]bool)
+	for _, e := range entries {
+		if IsSpecialName(string(e.Name)) && e.Attr.Typ == meta.TypeFile {
+			internalFiles[string(e.Name)] = true
+		}
+	}
+	if len(internalFiles) != 3 {
+		t.Fatalf("there should be 3 internal files but got %d", len(internalFiles))
+	}
+	v.Releasedir(ctx, 1, fh)
+
+	// .config
+	ctx2 := NewLogContext(meta.NewContext(10, 111, []uint32{222}))
+	fe, e := v.Lookup(ctx2, 1, ".config")
+	if e != 0 {
+		t.Fatalf("lookup .config: %s", e)
+	}
+	if e := v.Access(ctx2, fe.Inode, unix.R_OK); e != syscall.EACCES { // other user can't access .config
+		t.Fatalf("access .config: %s", e)
+	}
+	if _, e := v.GetAttr(ctx, fe.Inode, 0); e != 0 {
+		t.Fatalf("getattr .config: %s", e)
+	}
+	// ignore setattr on internal files
+	if fe2, e := v.SetAttr(ctx, fe.Inode, meta.SetAttrUID, 0, 0, ctx2.Uid(), 0, 0, 0, 0, 0, 0); e != 0 || fe2.Attr.Uid != fe.Attr.Uid {
+		t.Fatalf("can't setattr on internal files")
+	}
+	if e = v.Unlink(ctx, 1, ".config"); e != syscall.EPERM {
+		t.Fatalf("should not unlink internal file")
+	}
+	if _, _, e = v.Open(ctx, fe.Inode, syscall.O_WRONLY); e != syscall.EACCES {
+		t.Fatalf("write .config: %s", e)
+	}
+	_, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDONLY)
+	if e != 0 {
+		t.Fatalf("open .config: %s", e)
+	}
+	buf := make([]byte, 10240)
+	if _, e := v.Read(ctx, fe.Inode, buf, 0, 0); e != syscall.EBADF {
+		t.Fatalf("read .config: %s", e)
+	}
+	if n, e := v.Read(ctx, fe.Inode, buf, 0, fh); e != 0 {
+		t.Fatalf("read .config: %s", e)
+	} else if !strings.Contains(string(buf[:n]), v.Conf.Format.UUID) {
+		t.Fatalf("invalid config: %q", string(buf[:n]))
 	}
 
-	for _, test := range tests {
-		t.Run(test.prefix, func(t *testing.T) {
-			v, _ := createTestVFS(test.prefix)
-			ctx := NewLogContext(meta.Background)
-			// list internal files
-			fh, _ := v.Opendir(ctx, 1)
-			entries, _, e := v.Readdir(ctx, 1, 1024, 0, fh, true)
-			if e != 0 {
-				t.Fatalf("readdir 1: %s", e)
-			}
-			internalFiles := make(map[string]bool)
-			for _, e := range entries {
-				if IsSpecialName(string(e.Name)) && e.Attr.Typ == meta.TypeFile {
-					internalFiles[string(e.Name)] = true
-				}
-			}
-			if len(internalFiles) != 3 {
-				t.Fatalf("there should be 3 internal files but got %d", len(internalFiles))
-			}
-			v.Releasedir(ctx, 1, fh)
+	// .stats
+	fe, e = v.Lookup(ctx, 1, ".stats")
+	if e != 0 {
+		t.Fatalf("lookup .stats: %s", e)
+	}
+	if e := v.Access(ctx, fe.Inode, unix.W_OK); e != 0 { // root can do everything
+		t.Fatalf("access .stats: %s", e)
+	}
+	fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDONLY)
+	if e != 0 {
+		t.Fatalf("open .stats: %s", e)
+	}
+	defer v.Release(ctx, fe.Inode, fh)
+	defer v.Flush(ctx, fe.Inode, fh, 0)
+	buf = make([]byte, 128<<10)
+	n, e := v.Read(ctx, fe.Inode, buf[:4<<10], 0, fh)
+	if e != 0 {
+		t.Fatalf("read .stats: %s", e)
+	}
+	if n == 4<<10 {
+		if n2, e := v.Read(ctx, fe.Inode, buf[n:], uint64(n), fh); e != 0 {
+			t.Fatalf("read .stats 2: %s", e)
+		} else {
+			n += n2
+		}
+	}
+	if !strings.Contains(string(buf[:n]), "fuse_open_handlers") {
+		t.Fatalf(".stats should contains `memory`, but got %s", string(buf[:n]))
+	}
+	if e = v.Truncate(ctx, fe.Inode, 0, 1, &meta.Attr{}); e != syscall.EPERM {
+		t.Fatalf("truncate .config: %s", e)
+	}
 
-			// .config
-			ctx2 := NewLogContext(meta.NewContext(10, 111, []uint32{222}))
-			fe, e := v.Lookup(ctx2, 1, test.config)
-			if e != 0 {
-				t.Fatalf("lookup .config: %s", e)
-			}
-			if e := v.Access(ctx2, fe.Inode, unix.R_OK); e != syscall.EACCES { // other user can't access .config
-				t.Fatalf("access .config: %s", e)
-			}
-			if _, e := v.GetAttr(ctx, fe.Inode, 0); e != 0 {
-				t.Fatalf("getattr .config: %s", e)
-			}
-			// ignore setattr on internal files
-			if fe2, e := v.SetAttr(ctx, fe.Inode, meta.SetAttrUID, 0, 0, ctx2.Uid(), 0, 0, 0, 0, 0, 0); e != 0 || fe2.Attr.Uid != fe.Attr.Uid {
-				t.Fatalf("can't setattr on internal files")
-			}
-			if e = v.Unlink(ctx, 1, test.config); e != syscall.EPERM {
-				t.Fatalf("should not unlink internal file")
-			}
-			if _, _, e = v.Open(ctx, fe.Inode, syscall.O_WRONLY); e != syscall.EACCES {
-				t.Fatalf("write .config: %s", e)
-			}
-			_, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDONLY)
-			if e != 0 {
-				t.Fatalf("open .config: %s", e)
-			}
-			buf := make([]byte, 10240)
-			if _, e := v.Read(ctx, fe.Inode, buf, 0, 0); e != syscall.EBADF {
-				t.Fatalf("read .config: %s", e)
-			}
-			if n, e := v.Read(ctx, fe.Inode, buf, 0, fh); e != 0 {
-				t.Fatalf("read .config: %s", e)
-			} else if !strings.Contains(string(buf[:n]), v.Conf.Format.UUID) {
-				t.Fatalf("invalid config: %q", string(buf[:n]))
-			}
+	// accesslog
+	fe, e = v.Lookup(ctx, 1, ".accesslog")
+	if e != 0 {
+		t.Fatalf("lookup .accesslog: %s", e)
+	}
+	fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDONLY)
+	if e != 0 {
+		t.Fatalf("open .accesslog: %s", e)
+	}
+	if n, e = v.Read(ctx, fe.Inode, buf, 0, fh); e != 0 {
+		t.Fatalf("read .accesslog: %s", e)
+	} else if !strings.Contains(string(buf[:n]), "open (9223372032559808513)") {
+		t.Fatalf("invalid access log: %q", string(buf[:n]))
+	}
+	_ = v.Flush(ctx, fe.Inode, fh, 0)
+	v.Release(ctx, fe.Inode, fh)
 
-			// .stats
-			fe, e = v.Lookup(ctx, 1, test.stats)
-			if e != 0 {
-				t.Fatalf("lookup .stats: %s", e)
-			}
-			if e := v.Access(ctx, fe.Inode, unix.W_OK); e != 0 { // root can do everything
-				t.Fatalf("access .stats: %s", e)
-			}
-			fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDONLY)
-			if e != 0 {
-				t.Fatalf("open .stats: %s", e)
-			}
-			defer v.Release(ctx, fe.Inode, fh)
-			defer v.Flush(ctx, fe.Inode, fh, 0)
-			buf = make([]byte, 128<<10)
-			n, e := v.Read(ctx, fe.Inode, buf[:4<<10], 0, fh)
-			if e != 0 {
-				t.Fatalf("read .stats: %s", e)
-			}
-			if n == 4<<10 {
-				if n2, e := v.Read(ctx, fe.Inode, buf[n:], uint64(n), fh); e != 0 {
-					t.Fatalf("read .stats 2: %s", e)
-				} else {
-					n += n2
-				}
-			}
-			if !strings.Contains(string(buf[:n]), "fuse_open_handlers") {
-				t.Fatalf(".stats should contains `memory`, but got %s", string(buf[:n]))
-			}
-			if e = v.Truncate(ctx, fe.Inode, 0, 1, &meta.Attr{}); e != syscall.EPERM {
-				t.Fatalf("truncate .config: %s", e)
-			}
-
-			// accesslog
-			fe, e = v.Lookup(ctx, 1, test.accesslog)
-			if e != 0 {
-				t.Fatalf("lookup .accesslog: %s", e)
-			}
-			fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDONLY)
-			if e != 0 {
-				t.Fatalf("open .accesslog: %s", e)
-			}
-			if n, e = v.Read(ctx, fe.Inode, buf, 0, fh); e != 0 {
-				t.Fatalf("read .accesslog: %s", e)
-			} else if !strings.Contains(string(buf[:n]), "open (9223372032559808513)") {
-				t.Fatalf("invalid access log: %q", string(buf[:n]))
-			}
-			_ = v.Flush(ctx, fe.Inode, fh, 0)
-			v.Release(ctx, fe.Inode, fh)
-
-			// control messages
-			fe, e = v.Lookup(ctx, 1, test.control)
-			if e != 0 {
-				t.Fatalf("lookup .control: %s", e)
-			}
-			fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDWR)
-			if e != 0 {
-				t.Fatalf("open .stats: %s", e)
-			}
-			readControl := func(resp []byte, off *uint64) (int, syscall.Errno) {
-				for {
-					if n, errno := v.Read(ctx, fe.Inode, resp, *off, fh); n == 0 {
-						time.Sleep(time.Millisecond * 300)
-					} else if n%17 == 0 {
-						*off += uint64(n)
-						continue
-					} else if n%17 == 1 {
-						*off += uint64(n / 17 * 17)
-						resp[0] = resp[n-1]
-						return 1, errno
-					} else {
-						return n, errno
-					}
-				}
-			}
-
-			// rmr
-			buf = make([]byte, 4+4+8+1+4)
-			w := utils.FromBuffer(buf)
-			w.Put32(meta.Rmr)
-			w.Put32(13)
-			w.Put64(1)
-			w.Put8(4)
-			w.Put([]byte("file"))
-			if e := v.Write(ctx, fe.Inode, w.Bytes(), 0, fh); e != 0 {
-				t.Fatalf("write info: %s", e)
-			}
-			var off uint64 = uint64(len(buf))
-			resp := make([]byte, 1024*10)
-			if n, e := readControl(resp, &off); e != 0 || n != 1 {
-				t.Fatalf("read result: %s %d", e, n)
-			} else if resp[0] != byte(syscall.ENOENT) {
-				t.Fatalf("rmr result: %s", string(buf[:n]))
+	// control messages
+	fe, e = v.Lookup(ctx, 1, ".control")
+	if e != 0 {
+		t.Fatalf("lookup .control: %s", e)
+	}
+	fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDWR)
+	if e != 0 {
+		t.Fatalf("open .stats: %s", e)
+	}
+	readControl := func(resp []byte, off *uint64) (int, syscall.Errno) {
+		for {
+			if n, errno := v.Read(ctx, fe.Inode, resp, *off, fh); n == 0 {
+				time.Sleep(time.Millisecond * 300)
+			} else if n%17 == 0 {
+				*off += uint64(n)
+				continue
+			} else if n%17 == 1 {
+				*off += uint64(n / 17 * 17)
+				resp[0] = resp[n-1]
+				return 1, errno
 			} else {
-				off += uint64(n)
+				return n, errno
 			}
-			// legacy info
-			buf = make([]byte, 4+4+8)
-			w = utils.FromBuffer(buf)
-			w.Put32(meta.LegacyInfo)
-			w.Put32(8)
-			w.Put64(1)
-			if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {
-				t.Fatalf("write legacy info: %s", e)
-			}
-			off += uint64(len(buf))
-			buf = make([]byte, 1024*10)
-			if n, e = readControl(buf, &off); e != 0 {
-				t.Fatalf("read result: %s %d", e, n)
-			} else if !strings.Contains(string(buf[:n]), "dirs:") {
-				t.Fatalf("legacy info result: %s", string(buf[:n]))
-			} else {
-				off += uint64(n)
-			}
-			// info v2
-			buf = make([]byte, 4+4+8)
-			w = utils.FromBuffer(buf)
-			w.Put32(meta.InfoV2)
-			w.Put32(8)
-			w.Put64(1)
-			if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {
-				t.Fatalf("write info v2: %s", e)
-			}
-			off += uint64(len(buf))
-			buf = make([]byte, 1024*10)
-			var infoResp InfoResponse
-			if n, e = readControl(buf, &off); e != 0 {
-				t.Fatalf("read result: %s %d", e, n)
-			} else if infoResp.Decode(bytes.NewBuffer(buf[:n])) != nil {
-				t.Fatalf("info v2 result: %s", string(buf[:n]))
-			} else {
-				off += uint64(n)
-			}
-			// fill
-			buf = make([]byte, 4+4+8+1+1+2+1)
-			w = utils.FromBuffer(buf)
-			w.Put32(meta.FillCache)
-			w.Put32(13)
-			w.Put64(1)
-			w.Put8(1)
-			w.Put([]byte("/"))
-			w.Put16(2)
-			w.Put8(0)
-			if e := v.Write(ctx, fe.Inode, w.Bytes()[:10], 0, fh); e != 0 {
-				t.Fatalf("write fill 1: %s", e)
-			}
-			if e := v.Write(ctx, fe.Inode, w.Bytes()[10:], 0, fh); e != 0 {
-				t.Fatalf("write fill 2: %s", e)
-			}
-			off += uint64(len(buf))
-			resp = make([]byte, 1024*10)
-			if n, e = readControl(resp, &off); e != 0 || n != 1 {
-				t.Fatalf("read result: %s %d", e, n)
-			} else if resp[0] != 0 {
-				t.Fatalf("fill result: %s", string(buf[:n]))
-			}
-			off += uint64(n)
+		}
+	}
 
-			// invalid msg
-			buf = make([]byte, 4+4+2)
-			w = utils.FromBuffer(buf)
-			w.Put32(meta.Rmr)
-			w.Put32(0)
-			if e := v.Write(ctx, fe.Inode, buf, off, fh); e != 0 {
-				t.Fatalf("write info: %s", e)
-			}
-			off += uint64(len(buf))
-			resp = make([]byte, 1024)
-			if n, e := v.Read(ctx, fe.Inode, resp, off, fh); e != 0 || n != 1 {
-				t.Fatalf("read result: %s %d", e, n)
-			} else if resp[0] != uint8(syscall.EIO) {
-				t.Fatalf("result: %s", string(resp[:n]))
-			}
-		})
+	// rmr
+	buf = make([]byte, 4+4+8+1+4)
+	w := utils.FromBuffer(buf)
+	w.Put32(meta.Rmr)
+	w.Put32(13)
+	w.Put64(1)
+	w.Put8(4)
+	w.Put([]byte("file"))
+	if e := v.Write(ctx, fe.Inode, w.Bytes(), 0, fh); e != 0 {
+		t.Fatalf("write info: %s", e)
+	}
+	var off uint64 = uint64(len(buf))
+	resp := make([]byte, 1024*10)
+	if n, e := readControl(resp, &off); e != 0 || n != 1 {
+		t.Fatalf("read result: %s %d", e, n)
+	} else if resp[0] != byte(syscall.ENOENT) {
+		t.Fatalf("rmr result: %s", string(buf[:n]))
+	} else {
+		off += uint64(n)
+	}
+	// legacy info
+	buf = make([]byte, 4+4+8)
+	w = utils.FromBuffer(buf)
+	w.Put32(meta.LegacyInfo)
+	w.Put32(8)
+	w.Put64(1)
+	if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {
+		t.Fatalf("write legacy info: %s", e)
+	}
+	off += uint64(len(buf))
+	buf = make([]byte, 1024*10)
+	if n, e = readControl(buf, &off); e != 0 {
+		t.Fatalf("read result: %s %d", e, n)
+	} else if !strings.Contains(string(buf[:n]), "dirs:") {
+		t.Fatalf("legacy info result: %s", string(buf[:n]))
+	} else {
+		off += uint64(n)
+	}
+	// info v2
+	buf = make([]byte, 4+4+8)
+	w = utils.FromBuffer(buf)
+	w.Put32(meta.InfoV2)
+	w.Put32(8)
+	w.Put64(1)
+	if e := v.Write(ctx, fe.Inode, w.Bytes(), off, fh); e != 0 {
+		t.Fatalf("write info v2: %s", e)
+	}
+	off += uint64(len(buf))
+	buf = make([]byte, 1024*10)
+	var infoResp InfoResponse
+	if n, e = readControl(buf, &off); e != 0 {
+		t.Fatalf("read result: %s %d", e, n)
+	} else if infoResp.Decode(bytes.NewBuffer(buf[:n])) != nil {
+		t.Fatalf("info v2 result: %s", string(buf[:n]))
+	} else {
+		off += uint64(n)
+	}
+	// fill
+	buf = make([]byte, 4+4+8+1+1+2+1)
+	w = utils.FromBuffer(buf)
+	w.Put32(meta.FillCache)
+	w.Put32(13)
+	w.Put64(1)
+	w.Put8(1)
+	w.Put([]byte("/"))
+	w.Put16(2)
+	w.Put8(0)
+	if e := v.Write(ctx, fe.Inode, w.Bytes()[:10], 0, fh); e != 0 {
+		t.Fatalf("write fill 1: %s", e)
+	}
+	if e := v.Write(ctx, fe.Inode, w.Bytes()[10:], 0, fh); e != 0 {
+		t.Fatalf("write fill 2: %s", e)
+	}
+	off += uint64(len(buf))
+	resp = make([]byte, 1024*10)
+	if n, e = readControl(resp, &off); e != 0 || n != 1 {
+		t.Fatalf("read result: %s %d", e, n)
+	} else if resp[0] != 0 {
+		t.Fatalf("fill result: %s", string(buf[:n]))
+	}
+	off += uint64(n)
+
+	// invalid msg
+	buf = make([]byte, 4+4+2)
+	w = utils.FromBuffer(buf)
+	w.Put32(meta.Rmr)
+	w.Put32(0)
+	if e := v.Write(ctx, fe.Inode, buf, off, fh); e != 0 {
+		t.Fatalf("write info: %s", e)
+	}
+	off += uint64(len(buf))
+	resp = make([]byte, 1024)
+	if n, e := v.Read(ctx, fe.Inode, resp, off, fh); e != 0 || n != 1 {
+		t.Fatalf("read result: %s %d", e, n)
+	} else if resp[0] != uint8(syscall.EIO) {
+		t.Fatalf("result: %s", string(resp[:n]))
 	}
 }


### PR DESCRIPTION
A proposed change to fix #3120. Implements a new string flag to `juicefs mount`, named `--internal-inodes-prefix`. If provided, it will be prepended to the names of all the internal inodes.

Regular mounting (without this flag, identical to current behavior):

```
$ juicefs mount -d redis://127.0.0.1/1 /mnt/jfs
$ ls -la /mnt/jfs
total 10
drwxrwxrwx    2 root     root          4096 Dec 23 08:42 .
drwxr-xr-x    4 root     root          4096 Dec 21 10:53 ..
-r--------    1 user     user             0 Dec 23 11:19 .accesslog
-r--------    1 user     user          1362 Dec 23 11:19 .config
-rw-r--r--    1 root     root             0 Dec 23 08:56 .juicefs
-r--r--r--    1 user     user             0 Dec 23 11:19 .stats
```

With this proposed flag:

```
$ juicefs mount -d --internal-inodes-prefix .jfs redis://127.0.0.1/1 /mnt/jfs
$ ls -la /mnt/jfs
total 10
drwxrwxrwx    2 root     root          4096 Dec 23 08:42 .
drwxr-xr-x    4 root     root          4096 Dec 21 10:53 ..
-r--------    1 user     user             0 Dec 23 11:19 .jfs.accesslog
-r--------    1 user     user          1362 Dec 23 11:19 .jfs.config
-rw-r--r--    1 root     root             0 Dec 23 08:56 .juicefs
-r--r--r--    1 user     user             0 Dec 23 11:19 .jfs.stats
```

I haven't added any unit-tests, as I'm not thoroughly familiar with either Go, or this code base. If you'll be so kind as to direct me to the relevant files, I'll be happy to oblige.

Furthermore, I only updated the English documentation, as I don't speak Chinese.

I'm aware that this solution (changing the inode names after they are initialized) is a bit hacky, but I don't see any other approach that allows using command flags without fundamentally changing the VFS logic. Also, the `.trash` node is modified in a similar fashion, so I guess it's not too bad.

Finally, my modifications are localized to the `mount` command, since this is the command I'm familiar with and use personally. It's possible that it would be relevant to additional commands - help in that regard is appreciated.