### PR TITLE
Docs: fixed descriptions

### DIFF
--- a/docs/en/administration/fault_diagnosis_and_analysis.md
+++ b/docs/en/administration/fault_diagnosis_and_analysis.md
@@ -2,6 +2,7 @@
 title: Troubleshooting Methods
 sidebar_position: 5
 slug: /fault_diagnosis_and_analysis
+description: This article describes how to view and interpret logs in various operating systems for JuiceFS FUSE, CSI Driver, Hadoop Java SDK S3 gateway, S3 gateway clients.
 ---
 # Fault Diagnosis and Analysis
 

--- a/docs/en/administration/monitoring.md
+++ b/docs/en/administration/monitoring.md
@@ -1,6 +1,7 @@
 ---
 title: Monitoring and Data Visualization
 sidebar_position: 3
+description: This article describes how to visualize JuiceFS status monitoring with third-party tools such as Prometheus, Grafana, etc.
 ---
 
 As a distributed file system hosting massive data storage, it is important for users to directly view the status changes of the entire system in terms of capacity, files, CPU load, disk IO, cache, etc. JuiceFS provides real-time status data externally through the Prometheus-oriented API to achieve the visualization of JuiceFS monitoring with ease, and you only need to expose it to your own Prometheus Server to visualize time series data with tools like Grafana.

--- a/docs/en/benchmark/benchmark.md
+++ b/docs/en/benchmark/benchmark.md
@@ -2,6 +2,7 @@
 title: Performance Benchmark
 sidebar_position: 1
 slug: .
+description: This article describes benchmarking the file system using FIO, mdtest, and the bench command that comes with JuiceFS.
 ---
 
 ## Basic benchmark

--- a/docs/en/benchmark/metadata_engines_benchmark.md
+++ b/docs/en/benchmark/metadata_engines_benchmark.md
@@ -2,6 +2,7 @@
 title: Metadata Engines Benchmark
 sidebar_position: 6
 slug: /metadata_engines_benchmark
+description: This article describes how to test and evaluate the performance of various metadata engines for JuiceFS using a real-world environment.
 ---
 
 Conclusion first:

--- a/docs/en/benchmark/operations_profiling.md
+++ b/docs/en/benchmark/operations_profiling.md
@@ -2,6 +2,7 @@
 title: Operations Profiling
 sidebar_position: 3
 slug: /operations_profiling
+description: JuiceFS profile is to aggregate all logs in the past interval and display statistics periodically, includes real time and replay modes。
 ---
 
 ## Introduction

--- a/docs/en/deployment/production_deployment_recommendations.md
+++ b/docs/en/deployment/production_deployment_recommendations.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /production_deployment_recommendations
+description: This article is intended as a reference for users who are about to deploy JuiceFS to a production environment and provides a series of environment configuration recommendations.
 ---
 
 # Production Deployment Recommendations

--- a/docs/en/development/contributing_guide.md
+++ b/docs/en/development/contributing_guide.md
@@ -1,6 +1,7 @@
 ---
 title: Contributing Guide
 sidebar_position: 1
+description: JuiceFS is open source software and the code is contributed and maintained by developers worldwide. Please refer to this article for participating.
 ---
 
 ## Guidelines

--- a/docs/en/development/data_structures.md
+++ b/docs/en/development/data_structures.md
@@ -2,6 +2,7 @@
 title: Internals
 sidebar_position: 4
 slug: /internals
+description: This article introduces the main implementation details of JuiceFS, which is used as a reference for developers to understand and contribute open source code.
 ---
 
 ## 1. Introduction

--- a/docs/en/getting-started/for_distributed.md
+++ b/docs/en/getting-started/for_distributed.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Quick Start (Distributed Mode)
 sidebar_position: 3
+description: This article will guide you through building a distributed, shared-access JuiceFS file system using cloud-based object storage and database.
 ---
 
 # Quick Start Guide for Distributed Mode

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -3,6 +3,7 @@ title: Installation
 sidebar_position: 1
 slug: /installation
 pagination_prev: introduction/comparison/juicefs_vs_s3ql
+description: This article describes how to install JuiceFS on Linux, macOS and Windows, including one-click installation, compiled and containerized.
 ---
 
 JuiceFS has good cross-platform capability and supports running on all kinds of operating systems of almost all major architectures, including and not limited to Linux, macOS, Windows, etc.

--- a/docs/en/guide/how_to_set_up_metadata_engine.md
+++ b/docs/en/guide/how_to_set_up_metadata_engine.md
@@ -2,6 +2,7 @@
 title: How to Set Up Metadata Engine
 sidebar_position: 1
 slug: /databases_for_metadata
+description: JuiceFS supports Redis, TiKV, PostgreSQL, MySQL and other databases as metadata engines, and this article describes how to set up and use them.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/en/guide/how_to_set_up_object_storage.md
+++ b/docs/en/guide/how_to_set_up_object_storage.md
@@ -2,6 +2,7 @@
 title: How to Set Up Object Storage
 sidebar_position: 2
 slug: /how_to_setup_object_storage
+description: This article introduces the object storages supported by JuiceFS and how to configure and use it.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/en/introduction/architecture.md
+++ b/docs/en/introduction/architecture.md
@@ -2,6 +2,7 @@
 title: Architecture
 sidebar_position: 2
 slug: /architecture
+description: This article introduces the technical architecture of JuiceFS and the resulting technical advantages, as well as the file storage principles of JuiceFS.
 ---
 
 The JuiceFS file system consists of three parts:

--- a/docs/en/introduction/architecture.md
+++ b/docs/en/introduction/architecture.md
@@ -2,7 +2,7 @@
 title: Architecture
 sidebar_position: 2
 slug: /architecture
-description: This article introduces the technical architecture of JuiceFS and the resulting technical advantages, as well as the file storage principles of JuiceFS.
+description: This article introduces the technical architecture of JuiceFS and its technical advantages.
 ---
 
 The JuiceFS file system consists of three parts:

--- a/docs/en/introduction/comparison/juicefs_vs_cephfs.md
+++ b/docs/en/introduction/comparison/juicefs_vs_cephfs.md
@@ -1,5 +1,6 @@
 ---
 slug: /comparison/juicefs_vs_cephfs
+description: Ceph is a unified system that provides object storage, block storage and file storage. This article compares the similarities and differences between JuiceFS and Ceph.
 ---
 
 # JuiceFS vs. CephFS

--- a/docs/en/introduction/io_processing.md
+++ b/docs/en/introduction/io_processing.md
@@ -2,7 +2,7 @@
 sidebar_label: Data Processing Workflow
 sidebar_position: 3
 slug: /internals/io_processing
-description: This article introduces the read and write processes of JuiceFS respectively, and the process of implementing JuiceFS read-write chunking technology.
+description: This article introduces read and write implementation of JuiceFS, including how it split file into chunks.
 ---
 # An introduction to the workflow of processing read and write
 

--- a/docs/en/introduction/io_processing.md
+++ b/docs/en/introduction/io_processing.md
@@ -2,6 +2,7 @@
 sidebar_label: Data Processing Workflow
 sidebar_position: 3
 slug: /internals/io_processing
+description: This article introduces the read and write processes of JuiceFS respectively, and the process of implementing JuiceFS read-write chunking technology.
 ---
 # An introduction to the workflow of processing read and write
 

--- a/docs/en/reference/command_reference.md
+++ b/docs/en/reference/command_reference.md
@@ -2,6 +2,7 @@
 title: Command Reference
 sidebar_position: 1
 slug: /command_reference
+description: This article provides descriptions, usage and examples of all commands and options included in JuiceFS.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/zh_cn/administration/fault_diagnosis_and_analysis.md
+++ b/docs/zh_cn/administration/fault_diagnosis_and_analysis.md
@@ -2,6 +2,7 @@
 title: 问题排查方法
 sidebar_position: 5
 slug: /fault_diagnosis_and_analysis
+description: 本文介绍 JuiceFS FUSE、CSI Driver、Hadoop Java SDK S3 gateway、S3 gateway 等客户端在各类操作系统中的日志获取和解读方法。
 ---
 
 # 故障诊断和分析

--- a/docs/zh_cn/administration/monitoring.md
+++ b/docs/zh_cn/administration/monitoring.md
@@ -1,6 +1,7 @@
 ---
 title: 监控与数据可视化
 sidebar_position: 3
+description: 本文介绍如何搭配 Prometheus、Grafana 等第三方工具可视化 JuiceFS 状态监控。
 ---
 
 作为承载海量数据存储的分布式文件系统，用户通常需要直观地了解整个系统的容量、文件数量、CPU 负载、磁盘 IO、缓存等指标的变化。JuiceFS 通过 Prometheus 兼容的 API 对外提供实时的状态数据，只需将其添加到用户自建的 Prometheus Server 建立时序数据，然后通过 Grafana 等工具即可轻松实现 JucieFS 文件系统的可视化监控。

--- a/docs/zh_cn/benchmark/benchmark.md
+++ b/docs/zh_cn/benchmark/benchmark.md
@@ -2,6 +2,7 @@
 title: 常规测试
 sidebar_position: 1
 slug: .
+description: 本文介绍使用 FIO、mdtest 以及 JuiceFS 自带的 bench 命令对文件系统进行性能测试。
 ---
 
 ### 基础测试

--- a/docs/zh_cn/benchmark/metadata_engines_benchmark.md
+++ b/docs/zh_cn/benchmark/metadata_engines_benchmark.md
@@ -2,6 +2,7 @@
 title: 元数据引擎性能测试
 sidebar_position: 6
 slug: /metadata_engines_benchmark
+description: 本文采用亚马逊云的真实环境，介绍如何对 JuiceFS 的各种元数据引擎性能进行测试和评估。
 ---
 
 首先展示结论：

--- a/docs/zh_cn/benchmark/operations_profiling.md
+++ b/docs/zh_cn/benchmark/operations_profiling.md
@@ -2,6 +2,7 @@
 title: 性能诊断
 sidebar_position: 3
 slug: /operations_profiling
+description: JuiceFS 的 profile 命令主要用作汇总过去某个时间的所有日志并定期显示统计信息，包括实时模式和回放模式。
 ---
 
 ## 介绍

--- a/docs/zh_cn/deployment/production_deployment_recommendations.md
+++ b/docs/zh_cn/deployment/production_deployment_recommendations.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /production_deployment_recommendations
+description: 本文面向即将把 JuiceFS 部署到生产环境的用户参考，提供一系列环境配置建议。
 ---
 
 # 生产环境部署建议

--- a/docs/zh_cn/development/contributing_guide.md
+++ b/docs/zh_cn/development/contributing_guide.md
@@ -1,6 +1,7 @@
 ---
 title: 贡献指南
 sidebar_position: 1
+description: JuiceFS 是开源软件，代码由全球开发者共同贡献和维护，您可以参考本文了解参与开发的流程和注意事项。
 ---
 
 ## 基本准则

--- a/docs/zh_cn/development/data_structures.md
+++ b/docs/zh_cn/development/data_structures.md
@@ -2,6 +2,7 @@
 title: 内部实现
 sidebar_position: 3
 slug: /internals
+description: 本文介绍 JuiceFS 的主要实现细节，用来为开发者了解和贡献开源代码作参考。其中内容对应的 JuiceFS 代码版本为 v1.0.0，元数据版本为 V1。
 ---
 
 ## 1. 简介

--- a/docs/zh_cn/development/data_structures.md
+++ b/docs/zh_cn/development/data_structures.md
@@ -2,7 +2,7 @@
 title: 内部实现
 sidebar_position: 3
 slug: /internals
-description: 本文介绍 JuiceFS 的主要实现细节，用来为开发者了解和贡献开源代码作参考。其中内容对应的 JuiceFS 代码版本为 v1.0.0，元数据版本为 V1。
+description: 本文介绍 JuiceFS 的主要实现细节，用来为开发者了解和贡献开源代码作参考。
 ---
 
 ## 1. 简介

--- a/docs/zh_cn/getting-started/for_distributed.md
+++ b/docs/zh_cn/getting-started/for_distributed.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: 快速上手（分布式模式）
 sidebar_position: 3
+description: 本文将指导你使用基于云的对象存储和数据库，构建一个具有分布式和共享访问能力的 JuiceFS 文件系统。
 ---
 
 # 分布式模式快速上手指南

--- a/docs/zh_cn/getting-started/installation.md
+++ b/docs/zh_cn/getting-started/installation.md
@@ -3,6 +3,7 @@ title: 安装
 sidebar_position: 1
 slug: /installation
 pagination_prev: introduction/comparison/juicefs_vs_s3ql
+description: 本文介绍 JuiceFS 在 Linux、macOS 和 Windows 上的安装方法，包括一键安装、编译安装和容器化安装。
 ---
 
 JuiceFS 有良好的跨平台能力，支持在几乎所有主流架构的各类操作系统上运行，包括且不限于 Linux、macOS、Windows 等。

--- a/docs/zh_cn/guide/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/guide/how_to_set_up_metadata_engine.md
@@ -2,6 +2,7 @@
 title: 如何设置元数据引擎
 sidebar_position: 1
 slug: /databases_for_metadata
+description: JuiceFS 支持 Redis、TiKV、PostgreSQL、MySQL 等多种数据库作为元数据引擎，本文分别介绍相应的设置和使用方法。
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/zh_cn/guide/how_to_set_up_object_storage.md
+++ b/docs/zh_cn/guide/how_to_set_up_object_storage.md
@@ -2,6 +2,7 @@
 title: 如何设置对象存储
 sidebar_position: 2
 slug: /how_to_setup_object_storage
+description: JuiceFS 以对象存储作为数据存储，本文介绍 JuiceFS 支持的对象存储以及相应的配置和使用方法。
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/zh_cn/introduction/architecture.md
+++ b/docs/zh_cn/introduction/architecture.md
@@ -2,6 +2,7 @@
 title: 技术架构
 sidebar_position: 2
 slug: /architecture
+decription: 本文介绍 JuiceFS 的技术架构以及由此带来的技术优势，同时介绍 JuiceFS 的文件存储原理。
 ---
 
 JuiceFS 文件系统由三个部分组成：

--- a/docs/zh_cn/introduction/comparison/juicefs_vs_cephfs.md
+++ b/docs/zh_cn/introduction/comparison/juicefs_vs_cephfs.md
@@ -1,5 +1,6 @@
 ---
 slug: /comparison/juicefs_vs_cephfs
+description: Ceph 是一套提供对象存储、块存储和文件存储的统一系统，本文从架构和特性两个维度来对比 JuiceFS 与 Ceph 的异同。
 ---
 
 # JuiceFS 对比 CephFS

--- a/docs/zh_cn/introduction/io_processing.md
+++ b/docs/zh_cn/introduction/io_processing.md
@@ -2,6 +2,7 @@
 title: 读写请求处理流程
 sidebar_position: 3
 slug: /internals/io_processing
+description: 本文分别介绍 JuiceFS 的读和写的流程，更进一步的介绍 JuiceFS 读写分块技术在操作系统上的实现过程。
 ---
 
 ## 写入流程

--- a/docs/zh_cn/reference/command_reference.md
+++ b/docs/zh_cn/reference/command_reference.md
@@ -2,6 +2,7 @@
 title: 命令参考
 sidebar_position: 1
 slug: /command_reference
+description: 本文提供 JuiceFS 包含的所有命令及选项的说明、用法和示例。
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
Search engine tools reported that the page descriptions of some documents were too short or too long, and this PR was targeted for correction.