### PR TITLE
meta/badger: fix the issue that scanKeysRange ignores begin/end

### DIFF
--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -102,8 +102,11 @@ func (tx *badgerTxn) scanKeysRange(begin, end []byte, limit int, filter func(k [
 	})
 	defer it.Close()
 	var ret [][]byte
-	for it.Rewind(); it.Valid(); it.Next() {
+	for it.Seek(begin); it.Valid(); it.Next() {
 		key := it.Item().KeyCopy(nil)
+		if bytes.Compare(key, end) >= 0 {
+			break
+		}
 		if filter == nil || filter(key) {
 			ret = append(ret, key)
 			if limit > 0 {

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -110,6 +110,12 @@ func testTKV(t *testing.T, c tkvClient) {
 	if len(keys) != 2 || string(keys[0]) != "k" || string(keys[1]) != "v" {
 		t.Fatalf("keys: %+v", keys)
 	}
+	txn(func(kt kvTxn) {
+		keys = kt.scanKeysRange([]byte("k"), []byte("l"), -1, nil)
+	})
+	if len(keys) != 2 || string(keys[0]) != "k" || string(keys[1]) != "k2" {
+		t.Fatalf("keys: %+v", keys)
+	}
 	txn(func(kt kvTxn) { keys = kt.scanKeys(nil) })
 	if len(keys) != 3 || string(keys[0]) != "k" || string(keys[1]) != "k2" || string(keys[2]) != "v" {
 		t.Fatalf("keys: %+v", keys)


### PR DESCRIPTION
This method is used in `doCleanupDelayedSlices` to find delSliceKeys, with the filter `len(k) == 1+8+8`. So it is possible to get these keys that are actually undesired:
```
  C...               counter
  AiiiiiiiiD...      dentry
  AiiiiiiiiX...      extented attribute
  Diiiiiiiillllllll  delete inodes
```
Moreover, the length of value has to be a multiple of 12 to be processed, while the lengths for counter, dentry, delete inodes are fixed as 8, 9 and 8. Thus, the expected cleanup happens only when there is an xattr with key of length 7 and value of length that is a multiple of 12.