### PR TITLE
sync with juicefs without mount point

### DIFF
--- a/cmd/mdtest.go
+++ b/cmd/mdtest.go
@@ -35,7 +35,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var ctx = meta.Background
+var ctx = meta.NewContext(1, uint32(os.Getuid()), []uint32{uint32(os.Getgid())})
 
 func createDir(jfs *fs.FileSystem, root string, d int, width int) error {
 	if err := jfs.Mkdir(ctx, root, 0755); err != 0 {
@@ -110,7 +110,6 @@ func runTest(jfs *fs.FileSystem, rootDir string, np, width, depth, files, bytes 
 	bar := progress.AddCountBar("create file", int64(total))
 	logger.Infof("Create %d files in %d dirs", total, dirs)
 
-	ctx = meta.NewContext(1, uint32(os.Getuid()), []uint32{uint32(os.Getgid())})
 	start := time.Now()
 	if err := jfs.Mkdir(ctx, rootDir, 0755); err != 0 {
 		logger.Errorf("mkdir %s: %s", rootDir, err)

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -408,7 +408,7 @@ func (bm *benchMarkObj) run(api apiInfo) []string {
 			line[0] = api.title
 			return line
 		}
-		if api.name == "chown" && strings.HasPrefix(bm.blob.String(), "file://") && os.Getuid() != 0 {
+		if api.name == "chown" && (strings.HasPrefix(bm.blob.String(), "file://") || strings.HasPrefix(bm.blob.String(), "jfs://")) && os.Getuid() != 0 {
 			logger.Warnf("chown test should be run by root")
 			return []string{api.title, skipped, skipped}
 		}
@@ -945,7 +945,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 	})
 
 	funFSCase("change owner/group", func() error {
-		if strings.HasPrefix(blob.String(), "file://") && os.Getuid() != 0 {
+		if (strings.HasPrefix(blob.String(), "file://") || strings.HasPrefix(blob.String(), "jfs://")) && os.Getuid() != 0 {
 			return errors.New("root required")
 		}
 		if err := fi.Chown(key, "nobody", "nogroup"); err != nil {

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -50,6 +50,8 @@ Run basic benchmarks on the target object storage to test if it works as expecte
 Examples:
 # Run benchmarks on S3
 $ ACCESS_KEY=myAccessKey SECRET_KEY=mySecretKey juicefs objbench --storage s3  https://mybucket.s3.us-east-2.amazonaws.com -p 6
+# Run benchmakks on JuiceFS
+$ juicefs objbench --storage jfs redis://localhost/1
 
 Details: https://juicefs.com/docs/community/performance_evaluation_guide#juicefs-objbench`,
 		Flags: []cli.Flag{

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -41,6 +41,9 @@ import (
 	"github.com/juicedata/juicefs/pkg/vfs"
 )
 
+var skipDir syscall.Errno = 100000
+var dirSuffix = "/"
+
 func toError(eno syscall.Errno) error {
 	if eno == 0 {
 		return nil
@@ -241,9 +244,6 @@ func (j *juiceFS) walkRoot(root string, walkFn WalkFunc) syscall.Errno {
 	return err
 }
 
-var skipDir syscall.Errno = 100000
-var dirSuffix = "/"
-
 type mEntry struct {
 	fi        *fs.FileStat
 	name      string
@@ -292,7 +292,7 @@ type WalkFunc func(path string, info *fs.FileStat, isSymlink bool, err syscall.E
 func (d *juiceFS) ListAll(prefix, marker string) (<-chan object.Object, error) {
 	listed := make(chan object.Object, 10240)
 	var walkRoot string
-	if strings.HasSuffix(prefix, dirSuffix) {
+	if strings.HasSuffix(prefix, dirSuffix) || prefix == "" {
 		walkRoot = prefix
 	} else {
 		// If the root is not ends with `/`, we'll list the directory root resides.

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -118,7 +118,7 @@ func (j *juiceFS) Put(key string, in io.Reader) error {
 		eno := j.jfs.MkdirAll(ctx, p, 0755)
 		return toError(eno)
 	}
-	tmp := p + ".tmp" + strconv.Itoa(rand.Int())
+	tmp := filepath.Join(filepath.Dir(p), "."+filepath.Base(p)+".tmp"+strconv.Itoa(rand.Int()))
 	f, eno := j.jfs.Create(ctx, tmp, 0755)
 	if eno == syscall.ENOENT {
 		_ = j.jfs.MkdirAll(ctx, filepath.Dir(tmp), 0755)

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -116,10 +116,7 @@ func (j *juiceFS) Put(key string, in io.Reader) error {
 	p := j.path(key)
 	if strings.HasSuffix(p, "/") {
 		eno := j.jfs.MkdirAll(ctx, p, 0755)
-		if eno == syscall.EEXIST || eno == 0 {
-			return nil
-		}
-		return eno
+		return toError(eno)
 	}
 	tmp := p + ".tmp" + strconv.Itoa(rand.Int())
 	f, eno := j.jfs.Create(ctx, tmp, 0755)
@@ -433,7 +430,6 @@ func newJFS(endpoint, accessKey, secretKey, token string) (object.ObjectStorage,
 		Format:          format,
 		Version:         version.Version(),
 		Chunk:           chunkConf,
-		AccessLog:       "/tmp/jfs.log",
 		AttrTimeout:     time.Second,
 		DirEntryTimeout: time.Second,
 	}

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -101,7 +101,7 @@ func (j *juiceFS) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if off > 0 {
-		f.Seek(ctx, off, io.SeekStart)
+		_, _ = f.Seek(ctx, off, io.SeekStart)
 	}
 	if limit <= 0 {
 		limit = 1 << 62

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -397,9 +397,13 @@ func getDefaultChunkConf(format *meta.Format) *chunk.Config {
 }
 
 func newJFS(endpoint, accessKey, secretKey, token string) (object.ObjectStorage, error) {
-	metaUrl, err := url.PathUnescape(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("enescape meta url: %s", err)
+	metaUrl := os.Getenv(endpoint)
+	var err error
+	if metaUrl == "" {
+		metaUrl, err = url.PathUnescape(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("unescape meta url: %s", err)
+		}
 	}
 	metaConf := &meta.Config{
 		Retries:   10,

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -1,0 +1,450 @@
+/*
+ * JuiceFS, Copyright 2023 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/chunk"
+	"github.com/juicedata/juicefs/pkg/fs"
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juicedata/juicefs/pkg/utils"
+	"github.com/juicedata/juicefs/pkg/version"
+	"github.com/juicedata/juicefs/pkg/vfs"
+)
+
+func toError(eno syscall.Errno) error {
+	if eno == 0 {
+		return nil
+	}
+	return eno
+}
+
+type juiceFS struct {
+	object.DefaultObjectStorage
+	name string
+	jfs  *fs.FileSystem
+}
+
+func (j *juiceFS) String() string {
+	return fmt.Sprintf("jfs://%s/", j.name)
+}
+
+func (j *juiceFS) Create() error {
+	return nil
+}
+
+func (j *juiceFS) path(key string) string {
+	return "/" + key
+}
+
+type jFile struct {
+	f     *fs.File
+	limit int64
+}
+
+func (f *jFile) Read(buf []byte) (int, error) {
+	if len(buf) == 0 {
+		return 0, nil
+	}
+	if f.limit <= 0 {
+		return 0, io.EOF
+	}
+	if len(buf) > int(f.limit) {
+		buf = buf[:f.limit]
+	}
+	n, err := f.f.Read(ctx, buf)
+	f.limit -= int64(n)
+	return n, err
+}
+
+func (f *jFile) Write(buf []byte) (int, error) {
+	n, eno := f.f.Write(ctx, buf)
+	return n, toError(eno)
+}
+
+func (f *jFile) Close() error {
+	return toError(f.f.Close(ctx))
+}
+
+func (j *juiceFS) Get(key string, off, limit int64) (io.ReadCloser, error) {
+	f, err := j.jfs.Open(ctx, j.path(key), 0)
+	if err != 0 {
+		return nil, err
+	}
+	if off > 0 {
+		f.Seek(ctx, off, io.SeekStart)
+	}
+	if limit <= 0 {
+		limit = 1 << 62
+	}
+	return &jFile{f, limit}, nil
+}
+
+func (j *juiceFS) Put(key string, in io.Reader) error {
+	p := j.path(key)
+	if strings.HasSuffix(p, "/") {
+		eno := j.jfs.MkdirAll(ctx, p, 0755)
+		if eno == syscall.EEXIST || eno == 0 {
+			return nil
+		}
+		return eno
+	}
+	tmp := p + ".tmp" + strconv.Itoa(rand.Int())
+	f, eno := j.jfs.Create(ctx, tmp, 0755)
+	if eno == syscall.ENOENT {
+		_ = j.jfs.MkdirAll(ctx, filepath.Dir(tmp), 0755)
+		f, eno = j.jfs.Create(ctx, tmp, 0755)
+	}
+	if eno != 0 {
+		return eno
+	}
+	_, err := io.CopyBuffer(&jFile{f, 0}, in, make([]byte, 128<<10))
+	if err != nil {
+		_ = j.jfs.Delete(ctx, tmp)
+		return err
+	}
+	eno = f.Close(ctx)
+	if eno != 0 {
+		_ = j.jfs.Delete(ctx, tmp)
+		return eno
+	}
+	eno = j.jfs.Rename(ctx, tmp, p, 0)
+	if eno != 0 {
+		_ = j.jfs.Delete(ctx, tmp)
+		return eno
+	}
+	return nil
+}
+
+func (j *juiceFS) Delete(key string) error {
+	p := strings.TrimSuffix(j.path(key), dirSuffix)
+	eno := j.jfs.Delete(ctx, p)
+	if eno == syscall.ENOENT {
+
+		eno = 0
+	}
+	return toError(eno)
+}
+
+type jObj struct {
+	key string
+	fi  *fs.FileStat
+}
+
+func (o *jObj) Key() string { return o.key }
+func (o *jObj) Size() int64 {
+	if o.fi.IsDir() {
+		return 0
+	}
+	return o.fi.Size()
+}
+func (o *jObj) Mtime() time.Time  { return o.fi.ModTime() }
+func (o *jObj) IsDir() bool       { return o.fi.IsDir() }
+func (o *jObj) IsSymlink() bool   { return o.fi.IsSymlink() }
+func (o *jObj) Owner() string     { return utils.UserName(o.fi.Uid()) }
+func (o *jObj) Group() string     { return utils.GroupName(o.fi.Gid()) }
+func (o *jObj) Mode() os.FileMode { return o.fi.Mode() }
+
+func (j *juiceFS) Head(key string) (object.Object, error) {
+	fi, eno := j.jfs.Stat(ctx, j.path(key))
+	if eno == syscall.ENOENT {
+		return nil, os.ErrNotExist
+	}
+	if eno != 0 {
+		return nil, eno
+	}
+	return &jObj{key, fi}, nil
+}
+
+func (j *juiceFS) List(prefix, marker, delimiter string, limit int64) ([]object.Object, error) {
+	return nil, errors.New("not supported")
+}
+
+// walk recursively descends path, calling w.
+func (j *juiceFS) walk(path string, info *fs.FileStat, isSymlink bool, walkFn WalkFunc) syscall.Errno {
+	err := walkFn(path, info, isSymlink, 0)
+	if err != 0 {
+		if info.IsDir() && err == skipDir {
+			return 0
+		}
+		return err
+	}
+
+	if !info.IsDir() {
+		return 0
+	}
+
+	entries, err := j.readDirSorted(path)
+	if err != 0 {
+		return walkFn(path, info, isSymlink, err)
+	}
+
+	for _, e := range entries {
+		p := path + e.name
+		err = j.walk(p, e.fi, e.isSymlink, walkFn)
+		if err != 0 && err != skipDir && err != syscall.ENOENT {
+			return err
+		}
+	}
+	return 0
+}
+
+func (j *juiceFS) walkRoot(root string, walkFn WalkFunc) syscall.Errno {
+	var err syscall.Errno
+	var lstat, info *fs.FileStat
+	lstat, err = j.jfs.Lstat(ctx, root)
+	if err != 0 {
+		err = walkFn(root, nil, false, err)
+	} else {
+		isSymlink := lstat.IsSymlink()
+		info, err = j.jfs.Stat(ctx, root)
+		if err != 0 {
+			// root is a broken link
+			err = walkFn(root, lstat, isSymlink, 0)
+		} else {
+			err = j.walk(root, info, isSymlink, walkFn)
+		}
+	}
+
+	if err == skipDir {
+		return 0
+	}
+	return err
+}
+
+var skipDir syscall.Errno = 100000
+var dirSuffix = "/"
+
+type mEntry struct {
+	fi        *fs.FileStat
+	name      string
+	isSymlink bool
+}
+
+// readDirSorted reads the directory named by dirname and returns
+// a sorted list of directory entries.
+func (j *juiceFS) readDirSorted(dirname string) ([]*mEntry, syscall.Errno) {
+	f, err := j.jfs.Open(ctx, dirname, 0)
+	if err != 0 {
+		return nil, err
+	}
+	defer f.Close(ctx)
+	entries, err := f.ReaddirPlus(ctx, 0)
+	if err != 0 {
+		return nil, err
+	}
+	mEntries := make([]*mEntry, len(entries))
+	for i, e := range entries {
+		fi := fs.AttrToFileInfo(e.Inode, e.Attr)
+		if fi.IsDir() {
+			mEntries[i] = &mEntry{fi, string(e.Name) + dirSuffix, false}
+		} else if fi.IsSymlink() {
+			// follow symlink
+			fi2, err := j.jfs.Stat(ctx, filepath.Join(dirname, string(e.Name)))
+			if err != 0 {
+				mEntries[i] = &mEntry{fi, string(e.Name), true}
+				continue
+			}
+			name := string(e.Name)
+			if fi2.IsDir() {
+				name += dirSuffix
+			}
+			mEntries[i] = &mEntry{fi2, name, true}
+		} else {
+			mEntries[i] = &mEntry{fi, string(e.Name), false}
+		}
+	}
+	sort.Slice(mEntries, func(i, j int) bool { return mEntries[i].name < mEntries[j].name })
+	return mEntries, err
+}
+
+type WalkFunc func(path string, info *fs.FileStat, isSymlink bool, err syscall.Errno) syscall.Errno
+
+func (d *juiceFS) ListAll(prefix, marker string) (<-chan object.Object, error) {
+	listed := make(chan object.Object, 10240)
+	var walkRoot string
+	if strings.HasSuffix(prefix, dirSuffix) {
+		walkRoot = prefix
+	} else {
+		// If the root is not ends with `/`, we'll list the directory root resides.
+		walkRoot = path.Dir(prefix) + "/"
+	}
+	go func() {
+		_ = d.walkRoot("/"+walkRoot, func(path string, info *fs.FileStat, isSymlink bool, err syscall.Errno) syscall.Errno {
+			if len(path) > 0 {
+				path = path[1:]
+			}
+			if err != 0 {
+				if err == syscall.ENOENT {
+					logger.Warnf("skip not exist file or directory: %s", path)
+					return 0
+				}
+				listed <- nil
+				logger.Errorf("list %s: %s", path, err)
+				return 0
+			}
+
+			if !strings.HasPrefix(path, prefix) {
+				if info.IsDir() && path != walkRoot {
+					return skipDir
+				}
+				return 0
+			}
+
+			key := path
+			if !strings.HasPrefix(key, prefix) || (marker != "" && key <= marker) {
+				if info.IsDir() && !strings.HasPrefix(prefix, key) && !strings.HasPrefix(marker, key) {
+					return skipDir
+				}
+				return 0
+			}
+			f := &jObj{key, info}
+			listed <- f
+			return 0
+		})
+		close(listed)
+	}()
+	return listed, nil
+}
+
+func (j *juiceFS) Chtimes(key string, mtime time.Time) error {
+	f, err := j.jfs.Open(ctx, j.path(key), 0)
+	if err != 0 {
+		return err
+	}
+	defer f.Close(ctx)
+	return toError(f.Utime(ctx, -1, mtime.UnixNano()/1e6))
+}
+
+func (j *juiceFS) Chmod(key string, mode os.FileMode) error {
+	f, err := j.jfs.Open(ctx, j.path(key), 0)
+	if err != 0 {
+		return err
+	}
+	defer f.Close(ctx)
+	return toError(f.Chmod(ctx, uint16(mode.Perm())))
+}
+
+func (j *juiceFS) Chown(key string, owner, group string) error {
+	uid := utils.LookupUser(owner)
+	gid := utils.LookupGroup(group)
+	f, err := j.jfs.Open(ctx, j.path(key), 0)
+	if err != 0 {
+		return err
+	}
+	defer f.Close(ctx)
+	return toError(f.Chown(ctx, uint32(uid), uint32(gid)))
+}
+
+func (d *juiceFS) Symlink(oldName, newName string) error {
+	p := d.path(newName)
+	err := d.jfs.Symlink(ctx, oldName, p)
+	if err == syscall.ENOENT {
+		_ = d.jfs.MkdirAll(ctx, filepath.Dir(p), 0755)
+		err = d.jfs.Symlink(ctx, oldName, p)
+	}
+	return toError(err)
+}
+
+func (j *juiceFS) Readlink(name string) (string, error) {
+	target, err := j.jfs.Readlink(ctx, j.path(name))
+	return string(target), toError(err)
+}
+
+func getDefaultChunkConf(format *meta.Format) *chunk.Config {
+	chunkConf := &chunk.Config{
+		BlockSize:  format.BlockSize * 1024,
+		Compress:   format.Compression,
+		HashPrefix: format.HashPrefix,
+		GetTimeout: time.Minute,
+		PutTimeout: time.Minute,
+		MaxUpload:  50,
+		MaxDeletes: 10,
+		MaxRetries: 10,
+		BufferSize: 300 << 20,
+	}
+	chunkConf.SelfCheck(format.UUID)
+	return chunkConf
+}
+
+func newJFS(endpoint, accessKey, secretKey, token string) (object.ObjectStorage, error) {
+	metaUrl, err := url.PathUnescape(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("enescape meta url: %s", err)
+	}
+	metaConf := &meta.Config{
+		Retries:   10,
+		Strict:    true,
+		NoBGJob:   true,
+		Heartbeat: time.Second * 10,
+	}
+	metaCli := meta.NewClient(metaUrl, metaConf)
+	format, err := metaCli.Load(true)
+	if err != nil {
+		return nil, fmt.Errorf("load setting: %s", err)
+	}
+	blob, err := NewReloadableStorage(format, metaCli, nil)
+	if err != nil {
+		return nil, fmt.Errorf("object storage: %s", err)
+	}
+	chunkConf := getDefaultChunkConf(format)
+	store := chunk.NewCachedStore(blob, *chunkConf, nil)
+	registerMetaMsg(metaCli, store, chunkConf)
+	err = metaCli.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("new session: %s", err)
+	}
+
+	vfsConf := &vfs.Config{
+		Meta:            metaConf,
+		Format:          format,
+		Version:         version.Version(),
+		Chunk:           chunkConf,
+		AccessLog:       "/tmp/jfs.log",
+		AttrTimeout:     time.Second,
+		DirEntryTimeout: time.Second,
+	}
+
+	vfsConf.Format.RemoveSecret()
+	d, _ := json.MarshalIndent(vfsConf, "  ", "")
+	logger.Debugf("Config: %s", string(d))
+
+	jfs, err := fs.NewFileSystem(vfsConf, metaCli, store)
+	if err != nil {
+		return nil, fmt.Errorf("Initialize: %s", err)
+	}
+	return &juiceFS{object.DefaultObjectStorage{}, format.Name, jfs}, nil
+}
+
+func init() {
+	object.Register("jfs", newJFS)
+}

--- a/cmd/object_test.go
+++ b/cmd/object_test.go
@@ -1,3 +1,18 @@
+/*
+ * JuiceFS, Copyright 2020 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cmd
 
 import (
@@ -33,6 +48,7 @@ func testKeysEqual(objs []object.Object, expectedKeys []string) error {
 	return nil
 }
 
+// copied from pkg/object/filesystem_test.go
 func testFileSystem(t *testing.T, s object.ObjectStorage) {
 	keys := []string{
 		"x/",

--- a/cmd/object_test.go
+++ b/cmd/object_test.go
@@ -171,6 +171,6 @@ func TestJFS(t *testing.T) {
 	}
 
 	jstore := &juiceFS{object.DefaultObjectStorage{}, "test", jfs}
-	blob := object.WithPrefix(jstore, "unittest/")
-	testFileSystem(t, blob)
+	testFileSystem(t, jstore)
+	testFileSystem(t, object.WithPrefix(jstore, "unittest/"))
 }

--- a/cmd/object_test.go
+++ b/cmd/object_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/chunk"
+	"github.com/juicedata/juicefs/pkg/fs"
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juicedata/juicefs/pkg/vfs"
+)
+
+func testKeysEqual(objs []object.Object, expectedKeys []string) error {
+	gottenKeys := make([]string, len(objs))
+	for idx, obj := range objs {
+		gottenKeys[idx] = obj.Key()
+	}
+	if len(gottenKeys) != len(expectedKeys) {
+		return fmt.Errorf("Expected {%s}, got {%s}", strings.Join(expectedKeys, ", "),
+			strings.Join(gottenKeys, ", "))
+	}
+
+	for idx, key := range gottenKeys {
+		if key != expectedKeys[idx] {
+			return fmt.Errorf("Expected {%s}, got {%s}", strings.Join(expectedKeys, ", "),
+				strings.Join(gottenKeys, ", "))
+		}
+	}
+	return nil
+}
+
+func testFileSystem(t *testing.T, s object.ObjectStorage) {
+	keys := []string{
+		"x/",
+		"x/x.txt",
+		"xy.txt",
+		"xyz/",
+		"xyz/xyz.txt",
+	}
+	// initialize directory tree
+	for _, key := range keys {
+		if err := s.Put(key, bytes.NewReader([]byte{})); err != nil {
+			t.Fatalf("PUT object `%s` failed: %q", key, err)
+		}
+	}
+	if o, err := s.Head("x/"); err != nil {
+		t.Fatalf("Head x/: %s", err)
+	} else if f, ok := o.(object.File); !ok {
+		t.Fatalf("Head should return File")
+	} else if !f.IsDir() {
+		t.Fatalf("x/ should be a dir")
+	}
+	// cleanup
+	defer func() {
+		// delete reversely, directory only can be deleted when it's empty
+		objs, err := listAll(s, "", "", 100)
+		if err != nil {
+			t.Fatalf("listall failed: %s", err)
+		}
+		gottenKeys := make([]string, len(objs))
+		for idx, obj := range objs {
+			gottenKeys[idx] = obj.Key()
+		}
+		idx := len(gottenKeys) - 1
+		for ; idx >= 0; idx-- {
+			if err := s.Delete(gottenKeys[idx]); err != nil {
+				t.Fatalf("DELETE object `%s` failed: %q", gottenKeys[idx], err)
+			}
+		}
+	}()
+	objs, err := listAll(s, "x/", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys := []string{"x/", "x/x.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	objs, err = listAll(s, "x", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys = []string{"x/", "x/x.txt", "xy.txt", "xyz/", "xyz/xyz.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	objs, err = listAll(s, "xy", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys = []string{"xy.txt", "xyz/", "xyz/xyz.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	if ss, ok := s.(object.SupportSymlink); ok {
+		// a< a- < a/ < a0    <    b< b- < b/ < b0
+		_ = s.Put("a-", bytes.NewReader([]byte{}))
+		_ = s.Put("a0", bytes.NewReader([]byte{}))
+		_ = s.Put("b-", bytes.NewReader([]byte{}))
+		_ = s.Put("b0", bytes.NewReader([]byte{}))
+		_ = s.Put("xyz/ol1/p.txt", bytes.NewReader([]byte{}))
+		if err = ss.Symlink("./xyz/ol1/", "a"); err != nil {
+			t.Fatalf("symlink a %s", err)
+		}
+		if target, err := ss.Readlink("a"); err != nil || target != "./xyz/ol1/" {
+			t.Fatalf("readlink a %s %s", target, err)
+		}
+		if err = ss.Symlink("./xyz/notExist/", "b"); err != nil {
+			t.Fatalf("symlink b %s", err)
+		}
+		objs, err = listAll(s, "", "", 100)
+		if err != nil {
+			t.Fatalf("listall failed: %s", err)
+		}
+		expectedKeys = []string{"", "a-", "a/", "a/p.txt", "a0", "b", "b-", "b0", "x/", "x/x.txt", "xy.txt", "xyz/", "xyz/ol1/", "xyz/ol1/p.txt", "xyz/xyz.txt"}
+		if err = testKeysEqual(objs, expectedKeys); err != nil {
+			t.Fatalf("testKeysEqual fail: %s", err)
+		}
+	}
+}
+
+func TestJFS(t *testing.T) {
+	m := meta.NewClient("memkv://", &meta.Config{})
+	format := &meta.Format{
+		Name:      "test",
+		BlockSize: 4096,
+		Capacity:  1 << 30,
+	}
+	_ = m.Init(format, true)
+	var conf = vfs.Config{
+		Meta: &meta.Config{},
+		Chunk: &chunk.Config{
+			BlockSize:  format.BlockSize << 10,
+			MaxUpload:  1,
+			MaxDeletes: 1,
+			BufferSize: 100 << 20,
+		},
+		DirEntryTimeout: time.Millisecond * 100,
+		EntryTimeout:    time.Millisecond * 100,
+		AttrTimeout:     time.Millisecond * 100,
+		AccessLog:       "/tmp/juicefs.access.log",
+	}
+	objStore, _ := object.CreateStorage("mem", "", "", "", "")
+	store := chunk.NewCachedStore(objStore, *conf.Chunk, nil)
+	jfs, err := fs.NewFileSystem(&conf, m, store)
+	if err != nil {
+		t.Fatalf("initialize  failed: %s", err)
+	}
+
+	jstore := &juiceFS{object.DefaultObjectStorage{}, "test", jfs}
+	blob := object.WithPrefix(jstore, "unittest/")
+	testFileSystem(t, blob)
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -264,7 +264,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 
 	if name == "file" {
 		endpoint = u.Path
-	} else if name == "hdfs" {
+	} else if name == "hdfs" || name == "jfs" {
 	} else if !conf.NoHTTPS && supportHTTPS(name, endpoint) {
 		endpoint = "https://" + endpoint
 	} else {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -59,8 +59,7 @@ Examples:
 $ juicefs sync oss://mybucket.oss-cn-shanghai.aliyuncs.com s3://mybucket.s3.us-east-2.amazonaws.com
 
 # Sync objects from S3 to JuiceFS
-$ juicefs mount -d redis://localhost /mnt/jfs
-$ juicefs sync s3://mybucket.s3.us-east-2.amazonaws.com/ /mnt/jfs/
+$ myfs=redis://localhost juicefs sync s3://mybucket.s3.us-east-2.amazonaws.com/ jfs://myfs/ -p 50
 
 # SRC: a1/b1,a2/b2,aaa/b1   DST: empty   sync result: aaa/b1
 $ juicefs sync --exclude='a?/b*' s3://mybucket.s3.us-east-2.amazonaws.com/ /mnt/jfs/

--- a/docs/en/guide/sync.md
+++ b/docs/en/guide/sync.md
@@ -89,6 +89,12 @@ sudo juicefs mount -d redis://10.10.0.8:6379/1 /mnt/jfs
 juicefs sync s3://ABCDEFG:HIJKLMN@aaa.s3.us-west-1.amazonaws.com/movies/ /mnt/jfs/movies/
 ```
 
+For JuiceFS 1.1+, we can sycn with JuiceFS without mounting it:
+
+```shell
+myfs=redis://10.10.0.8:6379/1 juicefs sync s3://ABCDEFG:HIJKLMN@aaa.s3.us-west-1.amazonaws.com/movies/ jfs://myfs/movies/
+```
+
 The following command synchronizes `images` directory from [JuiceFS File System](#required-storages) to [Object Storage A](#required-storages).
 
 ```shell

--- a/docs/zh_cn/guide/sync.md
+++ b/docs/zh_cn/guide/sync.md
@@ -89,6 +89,12 @@ sudo juicefs mount -d redis://10.10.0.8:6379/1 /mnt/jfs
 juicefs sync s3://ABCDEFG:HIJKLMN@aaa.s3.us-west-1.amazonaws.com/movies/ /mnt/jfs/movies/
 ```
 
+如果使用的是 JuiceFS 1.1+ 版本，无需挂载就可以直接往 JuiceFS 同步数据：
+
+```shell
+myfs=redis://10.10.0.8:6379/1 juicefs sync s3://ABCDEFG:HIJKLMN@aaa.s3.us-west-1.amazonaws.com/movies/ jfs://myfs/movies/
+```
+
 将 [JuiceFS 文件系统](#required-storages) 的 `images` 目录同步到 [对象存储 A](#required-storages)：
 
 ```shell

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -546,9 +546,11 @@ type Config struct {
 
 func (c *Config) SelfCheck(uuid string) {
 	if c.CacheSize == 0 {
-		logger.Warnf("cache-size is 0, writeback and prefetch will be disabled")
-		c.Writeback = false
-		c.Prefetch = 0
+		if c.Writeback || c.Prefetch > 0 {
+			logger.Warnf("cache-size is 0, writeback and prefetch will be disabled")
+			c.Writeback = false
+			c.Prefetch = 0
+		}
 		c.CacheDir = "memory"
 	}
 	if !c.Writeback && c.UploadDelay > 0 {
@@ -569,10 +571,10 @@ func (c *Config) SelfCheck(uuid string) {
 			ds[i] = filepath.Join(ds[i], uuid)
 		}
 		c.CacheDir = strings.Join(ds, string(os.PathListSeparator))
-	}
-	if cs := []string{CsNone, CsFull, CsShrink, CsExtend}; !utils.StringContains(cs, c.CacheChecksum) {
-		logger.Warnf("verify-cache-checksum should be one of %v", cs)
-		c.CacheChecksum = CsFull
+		if cs := []string{CsNone, CsFull, CsShrink, CsExtend}; !utils.StringContains(cs, c.CacheChecksum) {
+			logger.Warnf("verify-cache-checksum should be one of %v", cs)
+			c.CacheChecksum = CsFull
+		}
 	}
 }
 

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -442,6 +442,20 @@ func (fs *FileSystem) Mkdir(ctx meta.Context, p string, mode uint16) (err syscal
 	return
 }
 
+func (fs *FileSystem) MkdirAll(ctx meta.Context, p string, mode uint16) (err syscall.Errno) {
+	err = fs.Mkdir(ctx, p, mode)
+	if err == syscall.ENOENT {
+		_ = fs.MkdirAll(ctx, parentDir(p), mode)
+		if err == 0 {
+			err = fs.Mkdir(ctx, p, mode)
+		}
+	}
+	if err == syscall.EEXIST {
+		err = 0
+	}
+	return err
+}
+
 func (fs *FileSystem) Delete(ctx meta.Context, p string) (err syscall.Errno) {
 	defer trace.StartRegion(context.TODO(), "fs.Delete").End()
 	l := vfs.NewLogContext(ctx)

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -446,9 +446,7 @@ func (fs *FileSystem) MkdirAll(ctx meta.Context, p string, mode uint16) (err sys
 	err = fs.Mkdir(ctx, p, mode)
 	if err == syscall.ENOENT {
 		_ = fs.MkdirAll(ctx, parentDir(p), mode)
-		if err == 0 {
-			err = fs.Mkdir(ctx, p, mode)
-		}
+		err = fs.Mkdir(ctx, p, mode)
 	}
 	if err == syscall.EEXIST {
 		err = 0

--- a/pkg/object/file.go
+++ b/pkg/object/file.go
@@ -31,6 +31,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/juicedata/juicefs/pkg/utils"
 )
 
 const (
@@ -401,8 +403,8 @@ func (d *filestore) Chmod(path string, mode os.FileMode) error {
 
 func (d *filestore) Chown(path string, owner, group string) error {
 	p := d.path(path)
-	uid := lookupUser(owner)
-	gid := lookupGroup(group)
+	uid := utils.LookupUser(owner)
+	gid := utils.LookupGroup(group)
 	return os.Chown(p, uid, gid)
 }
 

--- a/pkg/object/file_unix.go
+++ b/pkg/object/file_unix.go
@@ -21,99 +21,21 @@ package object
 
 import (
 	"os"
-	"os/user"
-	"strconv"
-	"sync"
 	"syscall"
 
+	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/pkg/sftp"
 )
 
-var uids = make(map[int]string)
-var gids = make(map[int]string)
-var users = make(map[string]int)
-var groups = make(map[string]int)
-var mutex sync.Mutex
-
-func userName(uid int) string {
-	name, ok := uids[uid]
-	if !ok {
-		if u, err := user.LookupId(strconv.Itoa(uid)); err == nil {
-			name = u.Username
-		} else {
-			logger.Warnf("lookup uid %d: %s", uid, err)
-			name = strconv.Itoa(uid)
-		}
-		uids[uid] = name
-	}
-	return name
-}
-
-func groupName(gid int) string {
-	name, ok := gids[gid]
-	if !ok {
-		if g, err := user.LookupGroupId(strconv.Itoa(gid)); err == nil {
-			name = g.Name
-		} else {
-			logger.Warnf("lookup gid %d: %s", gid, err)
-			name = strconv.Itoa(gid)
-		}
-		gids[gid] = name
-	}
-	return name
-}
-
 func getOwnerGroup(info os.FileInfo) (string, string) {
-	mutex.Lock()
-	defer mutex.Unlock()
 	var owner, group string
 	switch st := info.Sys().(type) {
 	case *syscall.Stat_t:
-		owner = userName(int(st.Uid))
-		group = groupName(int(st.Gid))
+		owner = utils.UserName(int(st.Uid))
+		group = utils.GroupName(int(st.Gid))
 	case *sftp.FileStat:
-		owner = userName(int(st.UID))
-		group = groupName(int(st.GID))
+		owner = utils.UserName(int(st.UID))
+		group = utils.GroupName(int(st.GID))
 	}
 	return owner, group
-}
-
-func lookupUser(name string) int {
-	mutex.Lock()
-	defer mutex.Unlock()
-	if u, ok := users[name]; ok {
-		return u
-	}
-	var uid = -1
-	if u, err := user.Lookup(name); err == nil {
-		uid, _ = strconv.Atoi(u.Uid)
-	} else {
-		if g, e := strconv.Atoi(name); e == nil {
-			uid = g
-		} else {
-			logger.Warnf("lookup user %s: %s", name, err)
-		}
-	}
-	users[name] = uid
-	return uid
-}
-
-func lookupGroup(name string) int {
-	mutex.Lock()
-	defer mutex.Unlock()
-	if u, ok := groups[name]; ok {
-		return u
-	}
-	var gid = -1
-	if u, err := user.LookupGroup(name); err == nil {
-		gid, _ = strconv.Atoi(u.Gid)
-	} else {
-		if g, e := strconv.Atoi(name); e == nil {
-			gid = g
-		} else {
-			logger.Warnf("lookup group %s: %s", name, err)
-		}
-	}
-	groups[name] = gid
-	return gid
 }

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
@@ -276,8 +277,8 @@ func (f *sftpStore) Chown(key string, owner, group string) error {
 		return err
 	}
 	defer f.putSftpConnection(&c, err)
-	uid := lookupUser(owner)
-	gid := lookupGroup(group)
+	uid := utils.LookupUser(owner)
+	gid := utils.LookupGroup(group)
 	return c.sftpClient.Chown(f.path(key), uid, gid)
 }
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -222,7 +221,6 @@ func copyPerms(dst object.ObjectStorage, obj object.Object) {
 	fi := obj.(object.File)
 	if err := dst.(object.FileSystem).Chmod(key, fi.Mode()); err != nil {
 		logger.Warnf("Chmod %s to %o: %s", key, fi.Mode(), err)
-		debug.PrintStack()
 	}
 	if err := dst.(object.FileSystem).Chown(key, fi.Owner(), fi.Group()); err != nil {
 		logger.Warnf("Chown %s to (%s,%s): %s", key, fi.Owner(), fi.Group(), err)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -220,7 +221,8 @@ func copyPerms(dst object.ObjectStorage, obj object.Object) {
 	key := obj.Key()
 	fi := obj.(object.File)
 	if err := dst.(object.FileSystem).Chmod(key, fi.Mode()); err != nil {
-		logger.Warnf("Chmod %s to %d: %s", key, fi.Mode(), err)
+		logger.Warnf("Chmod %s to %o: %s", key, fi.Mode(), err)
+		debug.PrintStack()
 	}
 	if err := dst.(object.FileSystem).Chown(key, fi.Owner(), fi.Group()); err != nil {
 		logger.Warnf("Chown %s to (%s,%s): %s", key, fi.Owner(), fi.Group(), err)


### PR DESCRIPTION
This PR allow us sync with JuiceFS without mount point:

```
juicefs sync   a/path/   jfs://meta-url/path/
```

Since meta-url is used as `host`, so it should be escaped twice, for example, sqlite3://a.db should be

```
juicefs sync   a/path/   jfs://sqlite3%253A%252F%252Fa.db/path/
```

To simplify this, we could use environment variable to pass meta-url, for example
```
myfs=sqlite3://a.db juicefs sync  a/path/   jfs://myfs/path/
```





