### PR TITLE
objbench: change the nogroup to nobody

### DIFF
--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -550,7 +550,7 @@ func (bm *benchMarkObj) list(key string, startKey int) error {
 }
 
 func (bm *benchMarkObj) chown(key string, startKey int) error {
-	return bm.blob.(object.FileSystem).Chown(key, "nobody", "nogroup")
+	return bm.blob.(object.FileSystem).Chown(key, "nobody", "nobody")
 }
 
 func (bm *benchMarkObj) chmod(key string, startKey int) error {
@@ -946,7 +946,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 		if strings.HasPrefix(blob.String(), "file://") && os.Getuid() != 0 {
 			return errors.New("root required")
 		}
-		if err := fi.Chown(key, "nobody", "nogroup"); err != nil {
+		if err := fi.Chown(key, "nobody", "nobody"); err != nil {
 			return fmt.Errorf("failed to chown object %s", err)
 		}
 		if objInfo, err := blob.Head(key); err != nil {
@@ -955,8 +955,8 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 			if info.Owner() != "nobody" {
 				return fmt.Errorf("expect owner nobody but got %s", info.Owner())
 			}
-			if info.Group() != "nogroup" {
-				return fmt.Errorf("expect group nogroup but got %s", info.Group())
+			if info.Group() != "nobody" {
+				return fmt.Errorf("expect group nobody but got %s", info.Group())
 			}
 		}
 		return nil


### PR DESCRIPTION
Linux does not have a `nogroup` user group
<img width="2558" alt="image" src="https://user-images.githubusercontent.com/31313340/211488213-b5b7c1ed-5a22-4bcb-84bc-7b0b1eafe809.png">
https://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/usernames.html
```
# mac
$ id nobody
uid=4294967294(nobody) gid=4294967294(nobody) groups=4294967294(nobody),12(everyone),61(localaccounts),100(_lpoperator),701(com.apple.sharepoint.group.1)

# linux
$ id nobody
uid=99(nobody) gid=99(nobody) groups=99(nobody)
```
1.0.3 mac
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/31313340/211485570-65b2a0c7-8769-4465-ba0c-6131df36af4e.png">

1.0.3 linux
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/31313340/211485384-a04515cd-4683-4fb6-8ef0-b8bba9f5906f.png">


now mac
<img width="977" alt="image" src="https://user-images.githubusercontent.com/31313340/211485760-510d4996-964d-43d2-bb3b-644745482cf7.png">

now linux 
<img width="980" alt="image" src="https://user-images.githubusercontent.com/31313340/211485843-38cb3304-06b6-4c15-8d39-522e3c8d2a9f.png">

