### PR TITLE
fix reading large response from .control

### DIFF
--- a/pkg/vfs/handle.go
+++ b/pkg/vfs/handle.go
@@ -54,6 +54,13 @@ type handle struct {
 	bctx    meta.Context
 }
 
+func (h *handle) Write(buf []byte) (int, error) {
+	h.Lock()
+	defer h.Unlock()
+	h.data = append(h.data, buf...)
+	return len(buf), nil
+}
+
 func (h *handle) addOp(ctx Context) {
 	h.Lock()
 	defer h.Unlock()


### PR DESCRIPTION
When a response has more than 2MB, the first 1MB will be dropped before reading.