### PR TITLE
vfs: change conf.Format from a pointer to a struct

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -246,7 +246,7 @@ func expandPathForEmbedded(addr string) string {
 func getVfsConf(c *cli.Context, metaConf *meta.Config, format *meta.Format, chunkConf *chunk.Config) *vfs.Config {
 	cfg := &vfs.Config{
 		Meta:       metaConf,
-		Format:     format,
+		Format:     *format,
 		Version:    version.Version(),
 		Chunk:      chunkConf,
 		BackupMeta: duration(c.String("backup-meta")),
@@ -273,17 +273,9 @@ func configEqual(a, b *vfs.Config) bool {
 	}
 
 	ac, bc := *a, *b
-	ac.Meta, ac.Chunk, ac.Format, ac.Port, ac.AttrTimeout, ac.DirEntryTimeout, ac.EntryTimeout = nil, nil, nil, nil, 0, 0, 0
-	bc.Meta, bc.Chunk, bc.Format, bc.Port, bc.AttrTimeout, bc.DirEntryTimeout, bc.EntryTimeout = nil, nil, nil, nil, 0, 0, 0
+	ac.Meta, ac.Chunk, ac.Port, ac.Format.SecretKey, ac.AttrTimeout, ac.DirEntryTimeout, ac.EntryTimeout = nil, nil, nil, "", 0, 0, 0
+	bc.Meta, bc.Chunk, bc.Port, bc.Format.SecretKey, bc.AttrTimeout, bc.DirEntryTimeout, bc.EntryTimeout = nil, nil, nil, "", 0, 0, 0
 	eq := ac == bc
-
-	if a.Format == nil || b.Format == nil {
-		eq = eq && a.Format == b.Format
-	} else {
-		af, bf := *a.Format, *b.Format
-		af.SecretKey, bf.SecretKey = "", ""
-		eq = eq && af == bf
-	}
 
 	if a.Meta == nil || b.Meta == nil {
 		eq = eq && a.Meta == b.Meta

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -210,16 +210,7 @@ func Test_configEqual(t *testing.T) {
 			a: &vfs.Config{}, b: &vfs.Config{}, equal: true,
 		},
 		{
-			a: &vfs.Config{Format: &meta.Format{}}, b: &vfs.Config{}, equal: false,
-		},
-		{
-			a: &vfs.Config{}, b: &vfs.Config{Format: &meta.Format{}}, equal: false,
-		},
-		{
-			a: &vfs.Config{Format: &meta.Format{}}, b: &vfs.Config{Format: &meta.Format{}}, equal: true,
-		},
-		{
-			a: &vfs.Config{Format: &meta.Format{SecretKey: "1"}}, b: &vfs.Config{Format: &meta.Format{SecretKey: "2"}}, equal: true,
+			a: &vfs.Config{Format: meta.Format{SecretKey: "1"}}, b: &vfs.Config{Format: meta.Format{SecretKey: "2"}}, equal: true,
 		},
 		{
 			a: &vfs.Config{Port: &vfs.Port{}}, b: &vfs.Config{}, equal: true,

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -437,7 +437,7 @@ func newJFS(endpoint, accessKey, secretKey, token string) (object.ObjectStorage,
 
 	vfsConf := &vfs.Config{
 		Meta:            metaConf,
-		Format:          format,
+		Format:          *format,
 		Version:         version.Version(),
 		Chunk:           chunkConf,
 		AttrTimeout:     time.Second,

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -99,7 +99,7 @@ func mount(url, mp string) {
 
 	conf := &vfs.Config{
 		Meta:   metaConf,
-		Format: format,
+		Format: *format,
 		Chunk:  &chunkConf,
 	}
 

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -218,12 +218,8 @@ func (m *baseMeta) timeit(start time.Time) {
 	m.opDist.Observe(time.Since(start).Seconds())
 }
 
-func (m *baseMeta) GetBase() *baseMeta {
+func (m *baseMeta) getBase() *baseMeta {
 	return m
-}
-
-func (m *baseMeta) GetFormat() Format {
-	return *m.fmt
 }
 
 func (m *baseMeta) checkRoot(inode Ino) Ino {
@@ -1248,6 +1244,10 @@ func (m *baseMeta) Chroot(ctx Context, subdir string) syscall.Errno {
 		subdir = ps[1]
 	}
 	return 0
+}
+
+func (m *baseMeta) GetFormat() Format {
+	return *m.fmt
 }
 
 func (m *baseMeta) CompactAll(ctx Context, threads int, bar *utils.Bar) syscall.Errno {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -218,8 +218,12 @@ func (m *baseMeta) timeit(start time.Time) {
 	m.opDist.Observe(time.Since(start).Seconds())
 }
 
-func (m *baseMeta) getBase() *baseMeta {
+func (m *baseMeta) GetBase() *baseMeta {
 	return m
+}
+
+func (m *baseMeta) GetFormat() Format {
+	return *m.fmt
 }
 
 func (m *baseMeta) checkRoot(inode Ino) Ino {

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -74,7 +74,7 @@ func testMeta(t *testing.T, m Meta) {
 	testCloseSession(t, m)
 	testConcurrentDir(t, m)
 	testAttrFlags(t, m)
-	base := m.GetBase()
+	base := m.getBase()
 	base.conf.OpenCache = time.Second
 	base.of.expire = time.Second
 	testOpenCache(t, m)
@@ -114,7 +114,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	if err != nil || len(ses) != 1 {
 		t.Fatalf("list sessions %+v: %s", ses, err)
 	}
-	base := m.GetBase()
+	base := m.getBase()
 	if base.sid != ses[0].Sid {
 		t.Fatalf("my sid %d != registered sid %d", base.sid, ses[0].Sid)
 	}
@@ -1193,7 +1193,7 @@ func testCloseSession(t *testing.T, m Meta) {
 	if st := m.Unlink(ctx, 1, "f"); st != 0 {
 		t.Fatalf("unlink f: %s", st)
 	}
-	sid := m.GetBase().sid
+	sid := m.getBase().sid
 	s, err := m.GetSession(sid, true)
 	if err != nil {
 		t.Fatalf("get session: %s", err)
@@ -1318,7 +1318,7 @@ func testTrash(t *testing.T, m Meta) {
 	if st := m.Rename(ctx2, TrashInode+1, "d", 1, "f", 0, &inode, attr); st != syscall.EPERM {
 		t.Fatalf("rename d -> f: %s", st)
 	}
-	m.GetBase().doCleanupTrash(true)
+	m.getBase().doCleanupTrash(true)
 	if st := m.GetAttr(ctx2, TrashInode+1, attr); st != syscall.ENOENT {
 		t.Fatalf("getattr: %s", st)
 	}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -74,7 +74,7 @@ func testMeta(t *testing.T, m Meta) {
 	testCloseSession(t, m)
 	testConcurrentDir(t, m)
 	testAttrFlags(t, m)
-	base := m.getBase()
+	base := m.GetBase()
 	base.conf.OpenCache = time.Second
 	base.of.expire = time.Second
 	testOpenCache(t, m)
@@ -114,7 +114,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	if err != nil || len(ses) != 1 {
 		t.Fatalf("list sessions %+v: %s", ses, err)
 	}
-	base := m.getBase()
+	base := m.GetBase()
 	if base.sid != ses[0].Sid {
 		t.Fatalf("my sid %d != registered sid %d", base.sid, ses[0].Sid)
 	}
@@ -1193,7 +1193,7 @@ func testCloseSession(t *testing.T, m Meta) {
 	if st := m.Unlink(ctx, 1, "f"); st != 0 {
 		t.Fatalf("unlink f: %s", st)
 	}
-	sid := m.getBase().sid
+	sid := m.GetBase().sid
 	s, err := m.GetSession(sid, true)
 	if err != nil {
 		t.Fatalf("get session: %s", err)
@@ -1318,7 +1318,7 @@ func testTrash(t *testing.T, m Meta) {
 	if st := m.Rename(ctx2, TrashInode+1, "d", 1, "f", 0, &inode, attr); st != syscall.EPERM {
 		t.Fatalf("rename d -> f: %s", st)
 	}
-	m.getBase().doCleanupTrash(true)
+	m.GetBase().doCleanupTrash(true)
 	if st := m.GetAttr(ctx2, TrashInode+1, attr); st != syscall.ENOENT {
 		t.Fatalf("getattr: %s", st)
 	}

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -363,6 +363,8 @@ type Meta interface {
 	Check(ctx Context, fpath string, repair bool, recursive bool) syscall.Errno
 	// Change root to a directory specified by subdir
 	Chroot(ctx Context, subdir string) syscall.Errno
+	// Get a copy of the current format
+	GetFormat() Format
 
 	// OnMsg add a callback for the given message type.
 	OnMsg(mtype uint32, cb MsgCallback)
@@ -373,8 +375,8 @@ type Meta interface {
 	DumpMeta(w io.Writer, root Ino, keepSecret bool) error
 	LoadMeta(r io.Reader) error
 
-	// GetBase return the base engine.
-	GetBase() *baseMeta
+	// getBase return the base engine.
+	getBase() *baseMeta
 	InitMetrics(registerer prometheus.Registerer)
 }
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -373,8 +373,8 @@ type Meta interface {
 	DumpMeta(w io.Writer, root Ino, keepSecret bool) error
 	LoadMeta(r io.Reader) error
 
-	// getBase return the base engine.
-	getBase() *baseMeta
+	// GetBase return the base engine.
+	GetBase() *baseMeta
 	InitMetrics(registerer prometheus.Registerer)
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -406,7 +406,7 @@ func (v *VFS) Open(ctx Context, ino Ino, flags uint32) (entry *meta.Entry, fh ui
 		case statsInode:
 			h.data = collectMetrics(v.registry)
 		case configInode:
-			v.Conf.Format = v.Meta.GetBase().GetFormat()
+			v.Conf.Format = v.Meta.GetFormat()
 			v.Conf.Format.RemoveSecret()
 			h.data, _ = json.MarshalIndent(v.Conf, "", " ")
 			entry.Attr.Length = uint64(len(h.data))

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -49,7 +49,7 @@ type Port struct {
 
 type Config struct {
 	Meta            *meta.Config
-	Format          *meta.Format
+	Format          meta.Format
 	Chunk           *chunk.Config
 	Port            *Port
 	Version         string
@@ -406,6 +406,7 @@ func (v *VFS) Open(ctx Context, ino Ino, flags uint32) (entry *meta.Entry, fh ui
 		case statsInode:
 			h.data = collectMetrics(v.registry)
 		case configInode:
+			v.Conf.Format = v.Meta.GetBase().GetFormat()
 			v.Conf.Format.RemoveSecret()
 			h.data, _ = json.MarshalIndent(v.Conf, "", " ")
 			entry.Attr.Length = uint64(len(h.data))

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -58,7 +58,7 @@ func createTestVFS() (*VFS, object.ObjectStorage) {
 	}
 	conf := &Config{
 		Meta:    metaConf,
-		Format:  format,
+		Format:  *format,
 		Version: "Juicefs",
 		Chunk: &chunk.Config{
 			BlockSize:  format.BlockSize * 1024,

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -485,7 +485,7 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 
 		conf := &vfs.Config{
 			Meta:            metaConf,
-			Format:          format,
+			Format:          *format,
 			Chunk:           &chunkConf,
 			AttrTimeout:     time.Millisecond * time.Duration(jConf.AttrTimeout*1000),
 			EntryTimeout:    time.Millisecond * time.Duration(jConf.EntryTimeout*1000),


### PR DESCRIPTION
close #3175 

This PR also fix the issue that secret keys in baseMeta.fmt are removed for a short time [here](https://github.com/juicedata/juicefs/blob/v1.0.3/pkg/vfs/vfs.go#L942).

`meta.Load` can't be used for `.config` file to load the current format, because this method will update the one cached in baseMeta, which fails the detection of format change in `baseMeta.refresh`.