### PR TITLE
meta/redis: ignore check maxMemoryPolicy when meta engine is keydb

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -71,6 +71,11 @@ jobs:
           sudo service mysql start
           sudo mysql -uroot -proot -e "use mysql;alter user 'root'@'localhost' identified with mysql_native_password by '';"
           sudo service postgresql start
+          echo "deb https://download.keydb.dev/open-source-dist $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/keydb.list
+          sudo wget -O /etc/apt/trusted.gpg.d/keydb.gpg https://download.keydb.dev/open-source-dist/keyring.gpg
+          sudo apt update
+          sudo apt install keydb
+          keydb-server --storage-provider  flash /tmp/ --port 6378 --bind 127.0.0.1 --daemonize yes
           sudo chmod 777 /etc/postgresql/*/main/pg_hba.conf
           sudo sed  -i "s?local.*all.*postgres.*peer?local   all             postgres                                trust?" /etc/postgresql/*/main/pg_hba.conf
           sudo sed  -i "s?host.*all.*all.*32.*scram-sha-256?host    all             all             127.0.0.1/32            trust?" /etc/postgresql/*/main/pg_hba.conf

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -76,6 +76,7 @@ jobs:
           sudo apt update
           sudo apt install keydb
           keydb-server --storage-provider  flash /tmp/ --port 6378 --bind 127.0.0.1 --daemonize yes
+          keydb-server --port 6377 --bind 127.0.0.1 --daemonize yes
           sudo chmod 777 /etc/postgresql/*/main/pg_hba.conf
           sudo sed  -i "s?local.*all.*postgres.*peer?local   all             postgres                                trust?" /etc/postgresql/*/main/pg_hba.conf
           sudo sed  -i "s?host.*all.*all.*32.*scram-sha-256?host    all             all             127.0.0.1/32            trust?" /etc/postgresql/*/main/pg_hba.conf

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -46,41 +46,44 @@ func TestRedisClient(t *testing.T) {
 }
 
 func TestKeyDB(t *testing.T) {
-	m, err := newRedisMeta("redis", "127.0.0.1:6378/10", &Config{})
-	if err != nil || m.Name() != "redis" {
-		t.Fatalf("create meta: %s", err)
-	}
-	if r, ok := m.(*redisMeta); ok {
-		rawInfo, err := r.rdb.Info(Background).Result()
-		if err != nil {
-			t.Fatalf("parse info: %s", err)
+	// 127.0.0.1:6378 enable flash, 127.0.0.1:6377 disable flash
+	for _, addr := range []string{"127.0.0.1:6378/10", "127.0.0.1:6377/10"} {
+		m, err := newRedisMeta("redis", addr, &Config{})
+		if err != nil || m.Name() != "redis" {
+			t.Fatalf("create meta: %s", err)
 		}
-		var storageProvider, maxMemoryPolicy string
-		for _, l := range strings.Split(strings.TrimSpace(rawInfo), "\n") {
-			l = strings.TrimSpace(l)
-			if l == "" || strings.HasPrefix(l, "#") {
-				continue
+		if r, ok := m.(*redisMeta); ok {
+			rawInfo, err := r.rdb.Info(Background).Result()
+			if err != nil {
+				t.Fatalf("parse info: %s", err)
 			}
-			kvPair := strings.SplitN(l, ":", 2)
-			if len(kvPair) < 2 {
-				continue
+			var storageProvider, maxMemoryPolicy string
+			for _, l := range strings.Split(strings.TrimSpace(rawInfo), "\n") {
+				l = strings.TrimSpace(l)
+				if l == "" || strings.HasPrefix(l, "#") {
+					continue
+				}
+				kvPair := strings.SplitN(l, ":", 2)
+				if len(kvPair) < 2 {
+					continue
+				}
+				key, val := kvPair[0], kvPair[1]
+				switch key {
+				case "maxmemory_policy":
+					maxMemoryPolicy = val
+				case "storage_provider":
+					storageProvider = val
+				}
 			}
-			key, val := kvPair[0], kvPair[1]
-			switch key {
-			case "maxmemory_policy":
-				maxMemoryPolicy = val
-			case "storage_provider":
-				storageProvider = val
+			if storageProvider == "none" && maxMemoryPolicy != "noeviction" {
+				t.Fatalf("maxmemory_policy should be noeviction")
 			}
+			if storageProvider == "flash" && maxMemoryPolicy == "noeviction" {
+				t.Fatalf("maxmemory_policy should not be noeviction")
+			}
+		} else {
+			t.Fatalf("should be redisMeta")
 		}
-		if storageProvider == "none" && maxMemoryPolicy != "noeviction" {
-			t.Fatalf("maxmemory_policy should be noeviction")
-		}
-		if storageProvider == "flash" && maxMemoryPolicy == "noeviction" {
-			t.Fatalf("maxmemory_policy should not be noeviction")
-		}
-	} else {
-		t.Fatalf("should be redisMeta")
 	}
 }
 

--- a/pkg/meta/info.go
+++ b/pkg/meta/info.go
@@ -62,17 +62,13 @@ type redisInfo struct {
 	aofEnabled      bool
 	maxMemoryPolicy string
 	redisVersion    string
-	isKeyDB         bool
-	storageProvider string
+	storageProvider string // redis is "", keyDB is "none" or "flash"
 }
 
 func checkRedisInfo(rawInfo string) (info redisInfo, err error) {
 	lines := strings.Split(strings.TrimSpace(rawInfo), "\n")
 	for _, l := range lines {
 		l = strings.TrimSpace(l)
-		if l == "# KeyDB" {
-			info.isKeyDB = true
-		}
 		if l == "" || strings.HasPrefix(l, "#") {
 			continue
 		}
@@ -100,7 +96,10 @@ func checkRedisInfo(rawInfo string) (info redisInfo, err error) {
 				}
 			}
 		case "storage_provider":
-			info.storageProvider = val
+			// if storage_provider is none reset it to ""
+			if val == "flash" {
+				info.storageProvider = val
+			}
 		}
 	}
 	return

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3090,7 +3090,8 @@ func (m *redisMeta) checkServerConfig() {
 	if err != nil {
 		logger.Warnf("parse info: %s", err)
 	}
-	if rInfo.maxMemoryPolicy != "noeviction" {
+	if !(rInfo.isKeyDB && rInfo.storageProvider == "flash") && rInfo.maxMemoryPolicy != "noeviction" {
+		logger.Warnf("maxmemory_policy is %q,  we will try to reconfigure it to 'noeviction'.", rInfo.maxMemoryPolicy)
 		if _, err := m.rdb.ConfigSet(Background, "maxmemory-policy", "noeviction").Result(); err != nil {
 			logger.Errorf("try to reconfigure maxmemory-policy to 'noeviction' failed: %s", err)
 		} else if result, err := m.rdb.ConfigGet(Background, "maxmemory-policy").Result(); err != nil {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3090,7 +3090,7 @@ func (m *redisMeta) checkServerConfig() {
 	if err != nil {
 		logger.Warnf("parse info: %s", err)
 	}
-	if !(rInfo.isKeyDB && rInfo.storageProvider == "flash") && rInfo.maxMemoryPolicy != "noeviction" {
+	if rInfo.storageProvider == "" && rInfo.maxMemoryPolicy != "noeviction" {
 		logger.Warnf("maxmemory_policy is %q,  we will try to reconfigure it to 'noeviction'.", rInfo.maxMemoryPolicy)
 		if _, err := m.rdb.ConfigSet(Background, "maxmemory-policy", "noeviction").Result(); err != nil {
 			logger.Errorf("try to reconfigure maxmemory-policy to 'noeviction' failed: %s", err)


### PR DESCRIPTION
When the meta engine is keydb and storage provider is flash, do not adjust the maxMemoryPolicy.
```
# keydb info
redis-cli -h xxxxxxx  -p 6379
47.99.52.222:6379> info
# Server
redis_version:6.3.2
redis_git_sha1:d1dff8c2
redis_git_dirty:0
redis_build_id:ff5573d014b83759
redis_mode:standalone
os:Linux 4.18.0-348.7.1.el8_5.x86_64 x86_64
arch_bits:64
multiplexing_api:epoll
atomicvar_api:atomic-builtin
gcc_version:8.5.0
process_id:10515
process_supervised:no
run_id:cb07e0f23b039299373ff0264436b1847f473eaa
tcp_port:6379
server_time_usec:1675063191723253
uptime_in_seconds:203
uptime_in_days:0
hz:10
configured_hz:10
lru_clock:14118807
executable:/root/keydb-server
config_file:/root/keydb.conf

# Clients
connected_clients:1
cluster_connections:0
maxclients:10000
client_recent_max_input_buffer:16
client_recent_max_output_buffer:0
blocked_clients:0
tracking_clients:0
clients_in_timeout_table:0
current_client_thread:0
thread_0_clients:1
thread_1_clients:0

# Memory
used_memory:3512168
used_memory_human:3.35M
used_memory_rss:24985600
used_memory_rss_human:23.83M
used_memory_peak:3572488
used_memory_peak_human:3.41M
used_memory_peak_perc:98.31%
used_memory_overhead:3643080
used_memory_startup:3447240
used_memory_dataset:18446744073709420704
used_memory_dataset_perc:28411077666537472.00%
allocator_allocated:4683272
allocator_active:5758976
allocator_resident:10866688
total_system_memory:7995740160
total_system_memory_human:7.45G
used_memory_lua:37888
used_memory_lua_human:37.00K
used_memory_scripts:0
used_memory_scripts_human:0B
number_of_cached_scripts:0
maxmemory:3634427345
maxmemory_human:3.38G
maxmemory_policy:allkeys-lru
allocator_frag_ratio:1.23
allocator_frag_bytes:1075704
allocator_rss_ratio:1.89
allocator_rss_bytes:5107712
rss_overhead_ratio:2.30
rss_overhead_bytes:14118912
mem_fragmentation_ratio:7.20
mem_fragmentation_bytes:21516192
mem_not_counted_for_evict:1048576
mem_replication_backlog:0
mem_clients_slaves:0
mem_clients_normal:20496
mem_aof_buffer:0
mem_allocator:jemalloc-5.2.1
active_defrag_running:0
lazyfree_pending_objects:0
lazyfreed_objects:0
storage_provider:flash
flash_memory:714046

# Persistence
loading:0
current_cow_size:0
current_cow_size_age:0
current_fork_perc:0.00
current_save_keys_processed:0
current_save_keys_total:0
rdb_changes_since_last_save:0
rdb_bgsave_in_progress:0
rdb_last_save_time:1675062988
rdb_last_bgsave_status:ok
rdb_last_bgsave_time_sec:-1
rdb_current_bgsave_time_sec:-1
rdb_last_cow_size:0
aof_enabled:0
aof_rewrite_in_progress:0
aof_rewrite_scheduled:0
aof_last_rewrite_time_sec:-1
aof_current_rewrite_time_sec:-1
aof_last_bgrewrite_status:ok
aof_last_write_status:ok
aof_last_cow_size:0
module_fork_in_progress:0
module_fork_last_cow_size:0

# Stats
total_connections_received:2
total_commands_processed:3
instantaneous_ops_per_sec:0
total_net_input_bytes:62
total_net_output_bytes:47406
instantaneous_input_kbps:0.00
instantaneous_output_kbps:0.00
rejected_connections:0
sync_full:0
sync_partial_ok:0
sync_partial_err:0
expired_keys:0
expired_stale_perc:0.00
expired_time_cap_reached_count:0
expire_cycle_cpu_milliseconds:0
evicted_keys:0
keyspace_hits:0
keyspace_misses:0
pubsub_channels:0
pubsub_patterns:0
latest_fork_usec:0
total_forks:0
migrate_cached_sockets:0
slave_expires_tracked_keys:0
active_defrag_hits:0
active_defrag_misses:0
active_defrag_key_hits:0
active_defrag_key_misses:0
tracking_total_keys:0
tracking_total_items:0
tracking_total_prefixes:0
unexpected_error_replies:0
total_error_replies:0
dump_payload_sanitizations:0
total_reads_processed:5
total_writes_processed:3
instantaneous_lock_contention:1
avg_lock_contention:0.015625
storage_provider_read_hits:0
storage_provider_read_misses:0

# Replication
role:master
connected_slaves:0
master_failover_state:no-failover
master_replid:51bc9363729990de3fe223799703cdc7d001370b
master_replid2:0000000000000000000000000000000000000000
master_repl_offset:0
second_repl_offset:-1
repl_backlog_active:0
repl_backlog_size:1048576
repl_backlog_first_byte_offset:0
repl_backlog_histlen:0

# CPU
used_cpu_sys:0.136346
used_cpu_user:0.385855
used_cpu_sys_children:0.000000
used_cpu_user_children:0.000000
server_threads:2
long_lock_waits:0
used_cpu_sys_main_thread:0.052706
used_cpu_user_main_thread:0.250579

# Modules

# Errorstats

# Cluster
cluster_enabled:0

# Keyspace
db10:keys=4281,expires=0,avg_ttl=0,cached_keys=0

# KeyDB
mvcc_depth:0
```

close #3195