### PR TITLE
improve docs on allow_other

### DIFF
--- a/docs/en/reference/fuse_mount_options.md
+++ b/docs/en/reference/fuse_mount_options.md
@@ -31,9 +31,7 @@ The kernel performs standard Unix permission checks based on mode bits, UID/GID,
 
 ## allow_other
 
-By default, only the user who mounted the file system can access the files. The `allow_other` option allows other users (including the root user) to access the files as well.
-
-By default, this option is only available to the root user, but can be unrestricted by modifying `/etc/fuse.conf` and turning on the `user_allow_other` configuration option.
+By default FUSE only allows access to the user mounting the file system. `allow_other` option overrides this behavior to allow access for other users. When mounting JuiceFS using root, `allow_other` is automatically assumed (search for `AllowOther` in [`fuse.go`](https://github.com/juicedata/juicefs/blob/main/pkg/fuse/fuse.go)). When mounting by non-root users, you'll need to first modify `/etc/fuse.conf` and enable `user_allow_other`, and then add `allow_other` to the mount command.
 
 ## writeback_cache
 

--- a/docs/zh_cn/reference/fuse_mount_options.md
+++ b/docs/zh_cn/reference/fuse_mount_options.md
@@ -31,9 +31,7 @@ JuiceFS 在挂载时会自动启用该选项，无需显式指定。该选项将
 
 ## allow_other
 
-FUSE 默认只有挂载文件系统的用户可以访问挂载点中的文件，`allow_other` 选项可以让其他用户（包括 root 用户）也可以访问挂载点上的文件。
-
-默认情况下，这个选项只允许 root 用户使用，但是可以通过修改 `/etc/fuse.conf`，在该配置文件中开启 `user_allow_other` 配置选项解除限制。
+FUSE 默认只有挂载文件系统的用户可以访问挂载点中的文件，`allow_other` 选项可以让其他用户也可以访问挂载点上的文件。当 root 用户挂载时，该选项会自动启用（在 [`fuse.go`](https://github.com/juicedata/juicefs/blob/main/pkg/fuse/fuse.go) 搜索 `AllowOther` 字样），无需显式指定。而如果是普通用户挂载，则需要修改 `/etc/fuse.conf`，在该配置文件中开启 `user_allow_other` 配置选项，才能在普通用户挂载时启用 `allow_other`。
 
 ## writeback_cache
 


### PR DESCRIPTION
this pr puts code references directly in docs, creating a precedent