### PR TITLE
optionally turn off 'S3Disable100Continue' via url query parameter

### DIFF
--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -450,7 +450,7 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 		HTTPClient: httpClient,
 	}
 
-	disable100Continue := strings.EqualFold(uri.Query().Get("disable100Continue"), "true")
+	disable100Continue := strings.EqualFold(uri.Query().Get("disable-100-continue"), "true")
 	if disable100Continue {
 		awsConfig.S3Disable100Continue = aws.Bool(true)
 	}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -444,11 +444,12 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 	}
 
 	ssl := strings.ToLower(uri.Scheme) == "https"
+	disable100Continue := strings.EqualFold(uri.Query().Get("disable100Continue"), "true")
 	awsConfig := &aws.Config{
 		Region:               aws.String(region),
 		DisableSSL:           aws.Bool(!ssl),
 		HTTPClient:           httpClient,
-		S3Disable100Continue: aws.Bool(true),
+		S3Disable100Continue: aws.Bool(disable100Continue),
 	}
 	if accessKey == "anonymous" {
 		awsConfig.Credentials = credentials.AnonymousCredentials

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -445,9 +445,10 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 
 	ssl := strings.ToLower(uri.Scheme) == "https"
 	awsConfig := &aws.Config{
-		Region:     aws.String(region),
-		DisableSSL: aws.Bool(!ssl),
-		HTTPClient: httpClient,
+		Region:               aws.String(region),
+		DisableSSL:           aws.Bool(!ssl),
+		HTTPClient:           httpClient,
+		S3Disable100Continue: aws.Bool(true),
 	}
 	if accessKey == "anonymous" {
 		awsConfig.Credentials = credentials.AnonymousCredentials

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -444,13 +444,17 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 	}
 
 	ssl := strings.ToLower(uri.Scheme) == "https"
-	disable100Continue := strings.EqualFold(uri.Query().Get("disable100Continue"), "true")
 	awsConfig := &aws.Config{
-		Region:               aws.String(region),
-		DisableSSL:           aws.Bool(!ssl),
-		HTTPClient:           httpClient,
-		S3Disable100Continue: aws.Bool(disable100Continue),
+		Region:     aws.String(region),
+		DisableSSL: aws.Bool(!ssl),
+		HTTPClient: httpClient,
 	}
+
+	disable100Continue := strings.EqualFold(uri.Query().Get("disable100Continue"), "true")
+	if disable100Continue {
+		awsConfig.S3Disable100Continue = aws.Bool(true)
+	}
+
 	if accessKey == "anonymous" {
 		awsConfig.Credentials = credentials.AnonymousCredentials
 	} else if accessKey != "" {


### PR DESCRIPTION
问题：
aws-sdk-go 客户端上传文件到 s3 时，如果文件大于 2m 会自动加上请求头 Expect: '100-Continue'，但http规范 Expect 的值是 '100-continue' （大小写不一样）

如果请求发生重试，aws-sdk-go 会讲 Expect header 请求头用作签名，由于上面大小写问题，如果对象存储在验签时将 '100-continue' 作为 expect 的值，那么会导致签名校验失败

考虑上面原因 以及  juicefs 实际上传 s3 的都是分块文件比较下，所以这里将 expect 请求头禁用