### PR TITLE
Use go oldstable in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: 'oldstable'
         cache: true
 
     - name: Change go version for root user

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 'oldstable'
           cache: true
 
       - name: Build 

--- a/.github/workflows/fio_benchmark.yml
+++ b/.github/workflows/fio_benchmark.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 'oldstable'
           cache: true
             
       - name: Build linux target

--- a/.github/workflows/mutate-test.yml
+++ b/.github/workflows/mutate-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 'oldstable'
 
       - name: install go-mutesting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 'oldstable'
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 'oldstable'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: 'oldstable'
         cache: true
       id: go
       

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 'oldstable'
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -21,7 +21,6 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -154,7 +153,7 @@ func mount_flags() []cli.Flag {
 
 func disableUpdatedb() {
 	path := "/etc/updatedb.conf"
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -172,7 +171,7 @@ func disableUpdatedb() {
 		nd = append(nd, fstype...)
 		nd = append(nd, ' ')
 		nd = append(nd, data[p2:]...)
-		err = ioutil.WriteFile(path, nd, 0644)
+		err = os.WriteFile(path, nd, 0644)
 		if err != nil {
 			logger.Warnf("update %s: %s", path, err)
 		} else {

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -624,7 +623,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 		if err != nil {
 			return "", err
 		}
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strconv"
@@ -346,7 +346,7 @@ func readStats(path string) map[string]float64 {
 		return nil
 	}
 	defer f.Close()
-	d, err := ioutil.ReadAll(f)
+	d, err := io.ReadAll(f)
 	if err != nil {
 		logger.Warnf("read %s: %s", path, err)
 		return nil

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestSync(t *testing.T) {
 	}
 
 	for _, instance := range testInstances {
-		c, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", localDir, instance.path))
+		c, err := os.ReadFile(fmt.Sprintf("%s/%s", localDir, instance.path))
 		if err != nil || string(c) != instance.content {
 			t.Fatalf("sync failed: %v", err)
 		}

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -197,7 +196,7 @@ func StatFS(t *testing.T, mp string) {
 
 func Xattrs(t *testing.T, mp string) {
 	path := filepath.Join(mp, "myfile")
-	ioutil.WriteFile(path, []byte(""), 0644)
+	os.WriteFile(path, []byte(""), 0644)
 
 	const prefix = "user."
 	var value = []byte("test-attr-value")
@@ -224,7 +223,7 @@ func Xattrs(t *testing.T, mp string) {
 
 func Flock(t *testing.T, mp string) {
 	path := filepath.Join(mp, "go-lock.lock")
-	ioutil.WriteFile(path, []byte(""), 0644)
+	os.WriteFile(path, []byte(""), 0644)
 
 	fileLock := flock.New(path)
 	locked, err := fileLock.TryLock()

--- a/pkg/meta/load_dump_test.go
+++ b/pkg/meta/load_dump_test.go
@@ -18,7 +18,7 @@ package meta
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -71,7 +71,7 @@ func TestEscape(t *testing.T) {
 
 func Utf8ToGbk(s []byte) ([]byte, error) {
 	reader := transform.NewReader(bytes.NewReader(s), simplifiedchinese.GBK.NewEncoder())
-	d, e := ioutil.ReadAll(reader)
+	d, e := io.ReadAll(reader)
 	if e != nil {
 		return nil, e
 	}
@@ -80,7 +80,7 @@ func Utf8ToGbk(s []byte) ([]byte, error) {
 
 func GbkToUtf8(s []byte) ([]byte, error) {
 	reader := transform.NewReader(bytes.NewReader(s), simplifiedchinese.GBK.NewDecoder())
-	d, e := ioutil.ReadAll(reader)
+	d, e := io.ReadAll(reader)
 	if e != nil {
 		return nil, e
 	}

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 
@@ -36,7 +36,7 @@ const settingPath = "/tmp/juicefs.memkv.setting.json"
 
 func newMockClient(addr string) (tkvClient, error) {
 	client := &memKV{items: btree.New(2), temp: &kvItem{}}
-	if d, err := ioutil.ReadFile(settingPath); err == nil {
+	if d, err := os.ReadFile(settingPath); err == nil {
 		var buffer map[string][]byte
 		if err = json.Unmarshal(d, &buffer); err == nil {
 			for k, v := range buffer {
@@ -224,7 +224,7 @@ func (c *memKV) txn(f func(*kvTxn) error) error {
 	}
 	if _, ok := tx.buffer["setting"]; ok {
 		d, _ := json.Marshal(tx.buffer)
-		if err := ioutil.WriteFile(settingPath, d, 0644); err != nil {
+		if err := os.WriteFile(settingPath, d, 0644); err != nil {
 			return err
 		}
 	}

--- a/pkg/object/encrypt.go
+++ b/pkg/object/encrypt.go
@@ -28,7 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/youmark/pkcs8"
@@ -107,7 +107,7 @@ func ParseRsaPrivateKeyFromPem(enc []byte, passphrase []byte) (*rsa.PrivateKey, 
 }
 
 func ParseRsaPrivateKeyFromPath(path, passphrase string) (*rsa.PrivateKey, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (e *encrypted) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		return nil, err
 	}
 	defer r.Close()
-	ciphertext, err := ioutil.ReadAll(r)
+	ciphertext, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -251,11 +251,11 @@ func (e *encrypted) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		limit = l - off
 	}
 	data := plain[off : off+limit]
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (e *encrypted) Put(key string, in io.Reader) error {
-	plain, err := ioutil.ReadAll(in)
+	plain, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/encrypt_test.go
+++ b/pkg/object/encrypt_test.go
@@ -22,7 +22,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -153,7 +154,7 @@ func genrsa(path string, password string) error {
 			return err
 		}
 	}
-	if err := ioutil.WriteFile(path, pem.EncodeToMemory(block), 0755); err != nil {
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0755); err != nil {
 		return err
 	}
 	return nil
@@ -213,13 +214,13 @@ func TestEncryptedStore(t *testing.T) {
 		t.Errorf("Get a: %s", err)
 		t.Fail()
 	}
-	d, _ := ioutil.ReadAll(r)
+	d, _ := io.ReadAll(r)
 	if string(d) != "el" {
 		t.Fail()
 	}
 
 	r, _ = es.Get("a", 0, -1)
-	d, _ = ioutil.ReadAll(r)
+	d, _ = io.ReadAll(r)
 	if string(d) != "hello" {
 		t.Fail()
 	}

--- a/pkg/object/etcd.go
+++ b/pkg/object/etcd.go
@@ -25,7 +25,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -61,14 +60,14 @@ func (c *etcdClient) Get(key string, off, limit int64) (io.ReadCloser, error) {
 			if limit > 0 && limit < int64(len(data)) {
 				data = data[:limit]
 			}
-			return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+			return io.NopCloser(bytes.NewBuffer(data)), nil
 		}
 	}
 	return nil, os.ErrNotExist
 }
 
 func (c *etcdClient) Put(key string, in io.Reader) error {
-	d, err := ioutil.ReadAll(in)
+	d, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/file.go
+++ b/pkg/object/file.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -117,7 +116,7 @@ func (d *filestore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	}
 	if finfo.IsDir() {
 		_ = f.Close()
-		return ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil
+		return io.NopCloser(bytes.NewBuffer([]byte{})), nil
 	}
 
 	if off > 0 {
@@ -132,7 +131,7 @@ func (d *filestore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		if n, err := f.Read(buf); err != nil {
 			return nil, err
 		} else {
-			return ioutil.NopCloser(bytes.NewBuffer(buf[:n])), nil
+			return io.NopCloser(bytes.NewBuffer(buf[:n])), nil
 		}
 	}
 	return f, nil

--- a/pkg/object/hdfs.go
+++ b/pkg/object/hdfs.go
@@ -23,15 +23,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/user"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	"github.com/colinmarc/hdfs/v2"
 	"github.com/colinmarc/hdfs/v2/hadoopconf"
@@ -42,8 +41,8 @@ var supergroup = "supergroup"
 
 type hdfsclient struct {
 	DefaultObjectStorage
-	addr string
-	c    *hdfs.Client
+	addr           string
+	c              *hdfs.Client
 	dfsReplication int
 }
 
@@ -107,7 +106,7 @@ func (h *hdfsclient) Get(key string, off, limit int64) (io.ReadCloser, error) {
 
 	finfo := f.Stat()
 	if finfo.IsDir() {
-		return ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil
+		return io.NopCloser(bytes.NewBuffer([]byte{})), nil
 	}
 
 	if off > 0 {

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -79,7 +78,7 @@ func (s *ibmcos) Put(key string, in io.Reader) error {
 	if b, ok := in.(io.ReadSeeker); ok {
 		body = b
 	} else {
-		data, err := ioutil.ReadAll(in)
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return err
 		}

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -102,7 +101,7 @@ func (s *ks3) Put(key string, in io.Reader) error {
 	if b, ok := in.(io.ReadSeeker); ok {
 		body = b
 	} else {
-		data, err := ioutil.ReadAll(in)
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return err
 		}

--- a/pkg/object/mem.go
+++ b/pkg/object/mem.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -92,7 +91,7 @@ func (m *memStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if limit > 0 && limit < int64(len(data)) {
 		data = data[:limit]
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (m *memStore) Put(key string, in io.Reader) error {
@@ -106,7 +105,7 @@ func (m *memStore) Put(key string, in io.Reader) error {
 	if ok {
 		logger.Debugf("overwrite %s", key)
 	}
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/nos.go
+++ b/pkg/object/nos.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -98,7 +97,7 @@ func (s *nos) Put(key string, in io.Reader) error {
 	case io.ReadSeeker:
 		body = in.(io.ReadSeeker)
 	default:
-		data, err := ioutil.ReadAll(in)
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return err
 		}

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"reflect"
@@ -42,7 +42,7 @@ func get(s ObjectStorage, k string, off, limit int64) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
 	}
@@ -246,7 +246,7 @@ func testStorage(t *testing.T, s ObjectStorage) {
 		}
 	}
 
-	f, _ := ioutil.TempFile("", "test")
+	f, _ := os.CreateTemp("", "test")
 	f.Write([]byte("this is a file"))
 	f.Seek(0, 0)
 	os.Remove(f.Name())
@@ -307,7 +307,7 @@ func testStorage(t *testing.T, s ObjectStorage) {
 		}
 		if in, err := s.Get(k, 0, -1); err != nil {
 			t.Fatalf("large not exists")
-		} else if d, err := ioutil.ReadAll(in); err != nil {
+		} else if d, err := io.ReadAll(in); err != nil {
 			t.Fatalf("fail to read large file")
 		} else if len(d) != partSize+part2Size {
 			t.Fatalf("size of large file: %d != %d", len(d), partSize+part2Size)

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -118,7 +117,7 @@ func (s *obsClient) Put(key string, in io.Reader) error {
 		sum = h.Sum(nil)
 		body = b
 	} else {
-		data, err := ioutil.ReadAll(in)
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return err
 		}

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -229,7 +228,7 @@ func fetch(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func fetchStsToken() (*stsCred, error) {

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -111,7 +110,7 @@ func findLen(in io.Reader) (io.Reader, int64, error) {
 			return nil, 0, err
 		}
 	default:
-		d, err := ioutil.ReadAll(in)
+		d, err := io.ReadAll(in)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/pkg/object/redis.go
+++ b/pkg/object/redis.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -65,11 +64,11 @@ func (r *redisStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if limit > 0 && limit < int64(len(data)) {
 		data = data[:limit]
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (r *redisStore) Put(key string, in io.Reader) error {
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -90,7 +89,7 @@ func GetHttpClient() *http.Client {
 
 func cleanup(response *http.Response) {
 	if response != nil && response.Body != nil {
-		_, _ = ioutil.ReadAll(response.Body)
+		_, _ = io.ReadAll(response.Body)
 		_ = response.Body.Close()
 	}
 }
@@ -150,7 +149,7 @@ func (s *RestfulStorage) request(method, key string, body io.Reader, headers map
 }
 
 func parseError(resp *http.Response) error {
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("request failed: %s", err)
 	}
@@ -220,7 +219,7 @@ func (s *RestfulStorage) Copy(dst, src string) error {
 		return err
 	}
 	defer in.Close()
-	d, err := ioutil.ReadAll(in)
+	d, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -128,7 +127,7 @@ func (s *s3client) Put(key string, in io.Reader) error {
 	if b, ok := in.(io.ReadSeeker); ok {
 		body = b
 	} else {
-		data, err := ioutil.ReadAll(in)
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return err
 		}

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -194,7 +193,7 @@ func (f *sftpStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if finfo.IsDir() {
-		return ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil
+		return io.NopCloser(bytes.NewBuffer([]byte{})), nil
 	}
 
 	if off > 0 {
@@ -208,7 +207,7 @@ func (f *sftpStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		if n, err := ff.Read(buf); n == 0 && err != nil {
 			return nil, err
 		} else {
-			return ioutil.NopCloser(bytes.NewBuffer(buf[:n])), nil
+			return io.NopCloser(bytes.NewBuffer(buf[:n])), nil
 		}
 	}
 	return ff, err
@@ -476,7 +475,7 @@ func newSftp(endpoint, username, pass, token string) (ObjectStorage, error) {
 
 	var signers []ssh.Signer
 	if privateKeyPath := os.Getenv("SSH_PRIVATE_KEY_PATH"); privateKeyPath != "" {
-		key, err := ioutil.ReadFile(privateKeyPath)
+		key, err := os.ReadFile(privateKeyPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read private key, error: %v", err)
 		}
@@ -489,9 +488,9 @@ func newSftp(endpoint, username, pass, token string) (ObjectStorage, error) {
 		home := filepath.Join(os.Getenv("HOME"), ".ssh")
 		var algo = []string{"rsa", "dsa", "ecdsa", "ecdsa_sk", "ed25519", "xmss"}
 		for _, a := range algo {
-			key, err := ioutil.ReadFile(filepath.Join(home, "id_"+a))
+			key, err := os.ReadFile(filepath.Join(home, "id_"+a))
 			if err != nil {
-				key, err = ioutil.ReadFile(filepath.Join(home, "id_"+a+"-cert"))
+				key, err = os.ReadFile(filepath.Join(home, "id_"+a+"-cert"))
 			}
 			if err == nil {
 				signer, err := ssh.ParsePrivateKey(key)

--- a/pkg/object/sql.go
+++ b/pkg/object/sql.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -79,11 +78,11 @@ func (s *sqlStore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if limit > 0 && limit < int64(len(data)) {
 		data = data[:limit]
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (s *sqlStore) Put(key string, in io.Reader) error {
-	d, err := ioutil.ReadAll(in)
+	d, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/tikv.go
+++ b/pkg/object/tikv.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -61,11 +60,11 @@ func (t *tikv) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if limit > 0 && limit < int64(len(data)) {
 		data = data[:limit]
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (t *tikv) Put(key string, in io.Reader) error {
-	d, err := ioutil.ReadAll(in)
+	d, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/ufile.go
+++ b/pkg/object/ufile.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -121,7 +120,7 @@ func (u *ufile) parseResp(resp *http.Response, out interface{}) error {
 	defer resp.Body.Close()
 	var data []byte
 	if resp.ContentLength <= 0 || resp.ContentLength > (1<<31) {
-		d, err := ioutil.ReadAll(resp.Body)
+		d, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -149,7 +148,7 @@ func copyObj(store ObjectStorage, dst, src string) error {
 		return err
 	}
 	defer in.Close()
-	d, err := ioutil.ReadAll(in)
+	d, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/upyun.go
+++ b/pkg/object/upyun.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -75,7 +74,7 @@ func (u *up) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if limit > 0 && limit < int64(len(data)) {
 		data = data[:limit]
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (u *up) Put(key string, in io.Reader) error {

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -70,7 +70,7 @@ func httpRequest(url string, body []byte) (ans []byte, err error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func sendStats(addr string) {
@@ -169,7 +169,7 @@ func startManager(tasks <-chan object.Object) (string, error) {
 			http.Error(w, "POST required", http.StatusBadRequest)
 			return
 		}
-		d, err := ioutil.ReadAll(req.Body)
+		d, err := io.ReadAll(req.Body)
 		if err != nil {
 			logger.Errorf("read: %s", err)
 			return

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -337,7 +336,7 @@ func doCopySingle(src, dst object.ObjectStorage, key string, size int64) error {
 		} else {
 			var f *os.File
 			// download the object into disk
-			if f, err = ioutil.TempFile("", "rep"); err != nil {
+			if f, err = os.CreateTemp("", "rep"); err != nil {
 				logger.Warnf("create temp file: %s", err)
 				goto SINGLE
 			}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -18,7 +18,7 @@ package sync
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"reflect"
@@ -341,7 +341,7 @@ func TestSyncLink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get content failed: %s", err)
 	}
-	if c, err := ioutil.ReadAll(content); err != nil || string(c) != "test" {
+	if c, err := io.ReadAll(content); err != nil || string(c) != "test" {
 		t.Fatalf("read content failed: err %s content %s", err, string(c))
 	}
 
@@ -353,7 +353,7 @@ func TestSyncLink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("content failed: %s", err)
 	}
-	if c, err := ioutil.ReadAll(content); err != nil || string(c) != "test" {
+	if c, err := io.ReadAll(content); err != nil || string(c) != "test" {
 		t.Fatalf("read content failed: err %s content %s", err, string(c))
 	}
 
@@ -391,7 +391,7 @@ func TestSyncLinkWithOutFollow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get content error: %s", err)
 	}
-	if c, err := ioutil.ReadAll(content); err != nil || string(c) != "test" {
+	if c, err := io.ReadAll(content); err != nil || string(c) != "test" {
 		t.Fatalf("read content error: %s", err)
 	}
 

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"time"
@@ -60,7 +60,7 @@ func sendUsage(u usage) error {
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("got %s", resp.Status)
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	return err
 }
 

--- a/pkg/usage/usage_test.go
+++ b/pkg/usage/usage_test.go
@@ -19,7 +19,7 @@ package usage
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -47,7 +47,7 @@ func TestUsageReport(t *testing.T) {
 	var u usage
 	done := make(chan bool)
 	mux.HandleFunc("/report-usage", func(rw http.ResponseWriter, r *http.Request) {
-		d, _ := ioutil.ReadAll(r.Body)
+		d, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(d, &u)
 		_, _ = rw.Write([]byte("OK"))
 		done <- true

--- a/pkg/utils/logger_test.go
+++ b/pkg/utils/logger_test.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func TestLogger(t *testing.T) {
 	logger.Warnf("warn level")
 	logger.Error("error level")
 
-	d, _ := ioutil.ReadFile(f.Name())
+	d, _ := os.ReadFile(f.Name())
 	s := string(d)
 	if strings.Contains(s, "info level") || strings.Contains(s, "debug level") {
 		t.Fatalf("info/debug should not be logged: %s", s)

--- a/pkg/utils/memusage.go
+++ b/pkg/utils/memusage.go
@@ -21,13 +21,13 @@ package utils
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"syscall"
 )
 
 func MemoryUsage() (virt, rss uint64) {
-	stat, err := ioutil.ReadFile("/proc/self/stat")
+	stat, err := os.ReadFile("/proc/self/stat")
 	if err == nil {
 		stats := bytes.Split(stat, []byte(" "))
 		if len(stats) >= 24 {


### PR DESCRIPTION
fix #3226 

1. change go version in CI workflows to [oldstable](https://github.com/actions/setup-go#using-stableoldstable-aliases)
2. fix lint error about deprecation of `io/ioutil`
2.1 https://github.com/golang/go/issues/40025
2.2 https://github.com/golang/go/issues/42026

