### PR TITLE
object: set encoding type when list object

### DIFF
--- a/pkg/object/cos.go
+++ b/pkg/object/cos.go
@@ -122,14 +122,17 @@ func (c *COS) Delete(key string) error {
 
 func (c *COS) List(prefix, marker, delimiter string, limit int64) ([]Object, error) {
 	param := cos.BucketGetOptions{
-		Prefix:    prefix,
-		Marker:    marker,
-		MaxKeys:   int(limit),
-		Delimiter: delimiter,
+		Prefix:       prefix,
+		Marker:       marker,
+		MaxKeys:      int(limit),
+		Delimiter:    delimiter,
+		EncodingType: "url",
 	}
 	resp, _, err := c.c.Bucket.Get(ctx, &param)
 	for err == nil && len(resp.Contents) == 0 && resp.IsTruncated {
-		param.Marker = resp.NextMarker
+		if param.Marker, err = cos.DecodeURIComponent(resp.NextMarker); err != nil {
+			return nil, err
+		}
 		resp, _, err = c.c.Bucket.Get(ctx, &param)
 	}
 	if err != nil {
@@ -140,11 +143,19 @@ func (c *COS) List(prefix, marker, delimiter string, limit int64) ([]Object, err
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
 		t, _ := time.Parse(time.RFC3339, o.LastModified)
-		objs[i] = &obj{o.Key, int64(o.Size), t, strings.HasSuffix(o.Key, "/")}
+		key, err := cos.DecodeURIComponent(o.Key)
+		if err != nil {
+			return nil, err
+		}
+		objs[i] = &obj{key, int64(o.Size), t, strings.HasSuffix(key, "/")}
 	}
 	if delimiter != "" {
 		for _, p := range resp.CommonPrefixes {
-			objs = append(objs, &obj{p, 0, time.Unix(0, 0), true})
+			key, err := cos.DecodeURIComponent(p)
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, &obj{key, 0, time.Unix(0, 0), true})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -137,11 +137,12 @@ func (s *ibmcos) Delete(key string) error {
 
 func (s *ibmcos) List(prefix, marker, delimiter string, limit int64) ([]Object, error) {
 	param := s3.ListObjectsInput{
-		Bucket:    &s.bucket,
-		Prefix:    &prefix,
-		Marker:    &marker,
-		MaxKeys:   &limit,
-		Delimiter: &delimiter,
+		Bucket:       &s.bucket,
+		Prefix:       &prefix,
+		Marker:       &marker,
+		MaxKeys:      &limit,
+		Delimiter:    &delimiter,
+		EncodingType: aws.String("url"),
 	}
 	resp, err := s.s3.ListObjects(&param)
 	if err != nil {
@@ -151,11 +152,19 @@ func (s *ibmcos) List(prefix, marker, delimiter string, limit int64) ([]Object, 
 	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		objs[i] = &obj{*o.Key, *o.Size, *o.LastModified, strings.HasSuffix(*o.Key, "/")}
+		oKey, err := url.QueryUnescape(*o.Key)
+		if err != nil {
+			return nil, err
+		}
+		objs[i] = &obj{oKey, *o.Size, *o.LastModified, strings.HasSuffix(oKey, "/")}
 	}
 	if delimiter != "" {
 		for _, p := range resp.CommonPrefixes {
-			objs = append(objs, &obj{*p.Prefix, 0, time.Unix(0, 0), true})
+			prefix, err := url.QueryUnescape(*p.Prefix)
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/IBM/ibm-cos-sdk-go/aws"
 	"github.com/IBM/ibm-cos-sdk-go/aws/awserr"
 	"github.com/IBM/ibm-cos-sdk-go/aws/credentials/ibmiam"
@@ -154,7 +156,7 @@ func (s *ibmcos) List(prefix, marker, delimiter string, limit int64) ([]Object, 
 		o := resp.Contents[i]
 		oKey, err := url.QueryUnescape(*o.Key)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithMessagef(err, "failed to decode key %s", *o.Key)
 		}
 		objs[i] = &obj{oKey, *o.Size, *o.LastModified, strings.HasSuffix(oKey, "/")}
 	}
@@ -162,7 +164,7 @@ func (s *ibmcos) List(prefix, marker, delimiter string, limit int64) ([]Object, 
 		for _, p := range resp.CommonPrefixes {
 			prefix, err := url.QueryUnescape(*p.Prefix)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithMessagef(err, "failed to decode commonPrefixes %s", *p.Prefix)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true})
 		}

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/ks3sdklib/aws-sdk-go/aws"
@@ -159,7 +161,7 @@ func (s *ks3) List(prefix, marker, delimiter string, limit int64) ([]Object, err
 		o := resp.Contents[i]
 		oKey, err := url.QueryUnescape(*o.Key)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithMessagef(err, "failed to decode key %s", *o.Key)
 		}
 		objs[i] = &obj{oKey, *o.Size, *o.LastModified, strings.HasSuffix(oKey, "/")}
 	}
@@ -167,7 +169,7 @@ func (s *ks3) List(prefix, marker, delimiter string, limit int64) ([]Object, err
 		for _, p := range resp.CommonPrefixes {
 			prefix, err := url.QueryUnescape(*p.Prefix)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithMessagef(err, "failed to decode commonPrefixes %s", *p.Prefix)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true})
 		}

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -81,6 +81,17 @@ func testStorage(t *testing.T, s ObjectStorage) {
 			t.Fatalf("delete failed: %s", err)
 		}
 	}()
+
+	key := "测试编码文件" + string('\u001F')
+	if err := s.Put(key, bytes.NewReader(nil)); err != nil {
+		t.Logf("PUT testEncodeFile failed: %s", err.Error())
+	} else {
+		if resp, err := s.List("", "测试编码文件", "", 1); err != nil || (len(resp) == 1 && resp[0].Key() != key) {
+			t.Logf("List testEncodeFile Failed %s", err)
+		}
+	}
+	_ = s.Delete(key)
+
 	k := "large"
 	defer s.Delete(k)
 

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -82,7 +82,7 @@ func testStorage(t *testing.T, s ObjectStorage) {
 		}
 	}()
 
-	key := "测试编码文件" + string('\u001F')
+	key := "测试编码文件" + `{"name":"zhijian"}` + string('\u001F')
 	if err := s.Put(key, bytes.NewReader(nil)); err != nil {
 		t.Logf("PUT testEncodeFile failed: %s", err.Error())
 	} else {

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/huaweicloud/huaweicloud-sdk-go-obs/obs"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"golang.org/x/net/http/httpproxy"
@@ -177,7 +179,7 @@ func (s *obsClient) List(prefix, marker, delimiter string, limit int64) ([]Objec
 		o := resp.Contents[i]
 		key, err := obs.UrlDecode(o.Key)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithMessagef(err, "failed to decode key %s", o.Key)
 		}
 		objs[i] = &obj{key, o.Size, o.LastModified, strings.HasSuffix(key, "/")}
 	}
@@ -185,7 +187,7 @@ func (s *obsClient) List(prefix, marker, delimiter string, limit int64) ([]Objec
 		for _, p := range resp.CommonPrefixes {
 			prefix, err := obs.UrlDecode(p)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithMessagef(err, "failed to decode commonPrefixes %s", p)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true})
 		}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -171,11 +171,12 @@ func (s *s3client) Delete(key string) error {
 
 func (s *s3client) List(prefix, marker, delimiter string, limit int64) ([]Object, error) {
 	param := s3.ListObjectsInput{
-		Bucket:    &s.bucket,
-		Prefix:    &prefix,
-		Marker:    &marker,
-		MaxKeys:   &limit,
-		Delimiter: &delimiter,
+		Bucket:       &s.bucket,
+		Prefix:       &prefix,
+		Marker:       &marker,
+		MaxKeys:      &limit,
+		Delimiter:    &delimiter,
+		EncodingType: aws.String("url"),
 	}
 	resp, err := s.s3.ListObjects(&param)
 	if err != nil {
@@ -185,19 +186,27 @@ func (s *s3client) List(prefix, marker, delimiter string, limit int64) ([]Object
 	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		if !strings.HasPrefix(*o.Key, prefix) || *o.Key < marker {
-			return nil, fmt.Errorf("found invalid key %s from List, prefix: %s, marker: %s", *o.Key, prefix, marker)
+		oKey, err := url.QueryUnescape(*o.Key)
+		if err != nil {
+			return nil, err
+		}
+		if !strings.HasPrefix(oKey, prefix) || oKey < marker {
+			return nil, fmt.Errorf("found invalid key %s from List, prefix: %s, marker: %s", oKey, prefix, marker)
 		}
 		objs[i] = &obj{
-			*o.Key,
+			oKey,
 			*o.Size,
 			*o.LastModified,
-			strings.HasSuffix(*o.Key, "/"),
+			strings.HasSuffix(oKey, "/"),
 		}
 	}
 	if delimiter != "" {
 		for _, p := range resp.CommonPrefixes {
-			objs = append(objs, &obj{*p.Prefix, 0, time.Unix(0, 0), true})
+			prefix, err := url.QueryUnescape(*p.Prefix)
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -31,6 +31,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -188,7 +190,7 @@ func (s *s3client) List(prefix, marker, delimiter string, limit int64) ([]Object
 		o := resp.Contents[i]
 		oKey, err := url.QueryUnescape(*o.Key)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithMessagef(err, "failed to decode key %s", *o.Key)
 		}
 		if !strings.HasPrefix(oKey, prefix) || oKey < marker {
 			return nil, fmt.Errorf("found invalid key %s from List, prefix: %s, marker: %s", oKey, prefix, marker)
@@ -204,7 +206,7 @@ func (s *s3client) List(prefix, marker, delimiter string, limit int64) ([]Object
 		for _, p := range resp.CommonPrefixes {
 			prefix, err := url.QueryUnescape(*p.Prefix)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithMessagef(err, "failed to decode commonPrefixes %s", *p.Prefix)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true})
 		}


### PR DESCRIPTION
| Object Storage | Protocol | Encode type config | Notes                                               |
| -------------- | -------- | ------------------ | --------------------------------------------------- |
| Azure          | XML      | NO                 | PUT failed:`The request URL is invalid`             |
| NOS            | XML      | NO                 |                                                     |
| COS            | XML      | YES                |                                                     |
| OBS            | XML      | YES                |                                                     |
| OSS            | XML      | YES                | listobject api  adds `EncodingType=url`  by default |
| S3             | XML      | YES                |                                                     |
| TOS            | JSON     | YES                | Since it is a JSON protocol, it is ok not to process it                                           |
| Ufile          | JSON     | NO                 |                                                     |
| Qiniu          | JSON     | NO                 |                                                     |
| B2             | JSON     | NO                 |                                                     |
| BOS            | JSON     | NO                 |                                                     |
| GS             | JSON     | NO                 |                                                     |
| Qingstor       | JSON     | NO                 |                                                     |
| Swift          | JSON     | NO                 |                                                     |
| SCS            | JSON     | NO                 |                                                     |


These special object stores are not handled：`webdav tikv sql sftp redis restful mem file etcd ceph hdfs `

close #3216
