### PR TITLE
fix open cache: use configurable limitation

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -198,7 +198,8 @@ func clientFlags() []cli.Flag {
 		},
 		&cli.Uint64Flag{
 			Name:  "open-cache-limit",
-			Usage: "max number of open files to cache (soft limit)",
+			Value: 10000,
+			Usage: "max number of open files to cache (soft limit, 0 means unlimited)",
 		},
 		&cli.StringFlag{
 			Name:  "subdir",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -198,7 +198,6 @@ func clientFlags() []cli.Flag {
 		},
 		&cli.Uint64Flag{
 			Name:  "open-cache-limit",
-			Value: 10000,
 			Usage: "max number of open files to cache (soft limit)",
 		},
 		&cli.StringFlag{

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -158,7 +158,7 @@ func newBaseMeta(addr string, conf *Config) *baseMeta {
 		addr:         utils.RemovePassword(addr),
 		conf:         conf,
 		root:         RootInode,
-		of:           newOpenFiles(conf.OpenCache, conf.OpenCacheLimit, 12*time.Hour),
+		of:           newOpenFiles(conf.OpenCache, conf.OpenCacheLimit),
 		removedFiles: make(map[Ino]bool),
 		compacting:   make(map[uint64]bool),
 		maxDeleting:  make(chan struct{}, 100),

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -48,7 +48,7 @@ func (o *openfiles) cleanup() {
 		}
 		for ino, of := range o.files {
 			cnt++
-			if cnt > 1e3 {
+			if cnt > 1e3 || todel > 0 && deleted >= todel {
 				break
 			}
 			if of.refs <= 0 {
@@ -57,7 +57,7 @@ func (o *openfiles) cleanup() {
 					deleted++
 					continue
 				}
-				if todel == 0 || deleted >= todel {
+				if todel == 0 {
 					continue
 				}
 				if candidateIno == 0 {

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -27,9 +27,6 @@ type openfiles struct {
 }
 
 func newOpenFiles(expire time.Duration, limit uint64, timeout time.Duration) *openfiles {
-	if limit == 0 {
-		limit = 1e4
-	}
 	if timeout == 0 {
 		timeout = 12 * time.Hour
 	}
@@ -53,7 +50,7 @@ func (o *openfiles) cleanup() {
 		o.Lock()
 		for ino, of := range o.files {
 			cnt++
-			if cnt > 1e3 {
+			if len(o.files) <= int(o.limit) || cnt > 1e3 {
 				break
 			}
 			if of.refs <= 0 {

--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -20,21 +20,16 @@ type openFile struct {
 
 type openfiles struct {
 	sync.Mutex
-	expire  time.Duration
-	limit   uint64
-	timeout time.Duration
-	files   map[Ino]*openFile
+	expire time.Duration
+	limit  uint64
+	files  map[Ino]*openFile
 }
 
-func newOpenFiles(expire time.Duration, limit uint64, timeout time.Duration) *openfiles {
-	if timeout == 0 {
-		timeout = 12 * time.Hour
-	}
+func newOpenFiles(expire time.Duration, limit uint64) *openfiles {
 	of := &openfiles{
-		expire:  expire,
-		limit:   limit,
-		timeout: timeout,
-		files:   make(map[Ino]*openFile),
+		expire: expire,
+		limit:  limit,
+		files:  make(map[Ino]*openFile),
 	}
 	go of.cleanup()
 	return of
@@ -57,7 +52,7 @@ func (o *openfiles) cleanup() {
 				break
 			}
 			if of.refs <= 0 {
-				if time.Since(of.lastCheck) > o.timeout {
+				if time.Since(of.lastCheck) > time.Hour*12 {
 					delete(o.files, ino)
 					deleted++
 					continue


### PR DESCRIPTION
In #3241 we introduce `open-cache-limit` flags but not use it, this PR will fix this mistake.

Moreover, this PR reduce the default limitation to zero, which means all unused files will eventually be cleaned, while used files are not affected.