### PR TITLE
meta/tikv: add background GC worker for TiKV

### DIFF
--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -202,7 +202,7 @@ func (c *badgerClient) close() error {
 	return c.client.Close()
 }
 
-func (c *badgerClient) gc(time.Time) {}
+func (c *badgerClient) gc() {}
 
 func newBadgerClient(addr string) (tkvClient, error) {
 	opt := badger.DefaultOptions(addr)

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -202,7 +202,7 @@ func (c *badgerClient) close() error {
 	return c.client.Close()
 }
 
-func (c *badgerClient) bgJob(any) {}
+func (c *badgerClient) gc(time.Time) {}
 
 func newBadgerClient(addr string) (tkvClient, error) {
 	opt := badger.DefaultOptions(addr)

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -202,6 +202,8 @@ func (c *badgerClient) close() error {
 	return c.client.Close()
 }
 
+func (c *badgerClient) bgJob(any) {}
+
 func newBadgerClient(addr string) (tkvClient, error) {
 	opt := badger.DefaultOptions(addr)
 	opt.Logger = utils.GetLogger("badger")

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -286,6 +286,8 @@ func (c *etcdClient) close() error {
 	return c.client.Close()
 }
 
+func (c *etcdClient) bgJob(any) {}
+
 func buildTlsConfig(u *url.URL) (*tls.Config, error) {
 	var tsinfo transport.TLSInfo
 	q := u.Query()

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -286,7 +286,7 @@ func (c *etcdClient) close() error {
 	return c.client.Close()
 }
 
-func (c *etcdClient) bgJob(any) {}
+func (c *etcdClient) gc(time.Time) {}
 
 func buildTlsConfig(u *url.URL) (*tls.Config, error) {
 	var tsinfo transport.TLSInfo

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -286,7 +286,7 @@ func (c *etcdClient) close() error {
 	return c.client.Close()
 }
 
-func (c *etcdClient) gc(time.Time) {}
+func (c *etcdClient) gc() {}
 
 func buildTlsConfig(u *url.URL) (*tls.Config, error) {
 	var tsinfo transport.TLSInfo

--- a/pkg/meta/tkv_fdb.go
+++ b/pkg/meta/tkv_fdb.go
@@ -22,6 +22,7 @@ package meta
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 )
@@ -121,7 +122,7 @@ func (c *fdbClient) shouldRetry(err error) bool {
 	return false
 }
 
-func (c *fdbClient) bgJob(any) {}
+func (c *fdbClient) gc(time.Time) {}
 
 func (tx *fdbTxn) get(key []byte) []byte {
 	return tx.Get(fdb.Key(key)).MustGet()

--- a/pkg/meta/tkv_fdb.go
+++ b/pkg/meta/tkv_fdb.go
@@ -22,7 +22,6 @@ package meta
 import (
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 )

--- a/pkg/meta/tkv_fdb.go
+++ b/pkg/meta/tkv_fdb.go
@@ -121,6 +121,8 @@ func (c *fdbClient) shouldRetry(err error) bool {
 	return false
 }
 
+func (c *fdbClient) bgJob(any) {}
+
 func (tx *fdbTxn) get(key []byte) []byte {
 	return tx.Get(fdb.Key(key)).MustGet()
 }

--- a/pkg/meta/tkv_fdb.go
+++ b/pkg/meta/tkv_fdb.go
@@ -122,7 +122,7 @@ func (c *fdbClient) shouldRetry(err error) bool {
 	return false
 }
 
-func (c *fdbClient) gc(time.Time) {}
+func (c *fdbClient) gc() {}
 
 func (tx *fdbTxn) get(key []byte) []byte {
 	return tx.Get(fdb.Key(key)).MustGet()

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/btree"
 )
@@ -271,4 +272,4 @@ func (c *memKV) close() error {
 	return nil
 }
 
-func (c *memKV) bgJob(any) {}
+func (c *memKV) gc(time.Time) {}

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/google/btree"
 )
@@ -272,4 +271,4 @@ func (c *memKV) close() error {
 	return nil
 }
 
-func (c *memKV) gc(time.Time) {}
+func (c *memKV) gc() {}

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -270,3 +270,5 @@ func (c *memKV) reset(prefix []byte) error {
 func (c *memKV) close() error {
 	return nil
 }
+
+func (c *memKV) bgJob(any) {}

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -81,6 +81,7 @@ func newTikvClient(addr string) (tkvClient, error) {
 		}
 		interval = dur
 	}
+	logger.Infof("TiKV gc interval is set to %s", interval)
 
 	client, err := txnkv.NewClient(strings.Split(tUrl.Host, ","))
 	if err != nil {

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -228,8 +228,8 @@ func (c *tikvClient) close() error {
 	return c.client.Close()
 }
 
-func (c *tikvClient) bgJob(arg any) {
-	safePoint, err := c.client.GC(Background, oracle.GoTimeToTS(time.Now().Add(-arg.(time.Duration))))
+func (c *tikvClient) gc(edge time.Time) {
+	safePoint, err := c.client.GC(Background, oracle.GoTimeToTS(edge))
 	if err == nil {
 		logger.Debugf("TiKV GC returns new safe point: %d (%s)", safePoint, oracle.GetTimeFromTS(safePoint))
 	} else {


### PR DESCRIPTION
The GC cleans up old entries before 3 hours by default, and can be configured with the query string "gc-interval".
It should be disabled by setting "gc-interval=0" if there's already TiDB daemon or any other service that can trigger the GC deployed.

Refs: https://github.com/tikv/client-go/blob/master/examples/gcworker/gcworker.go

TODO: not fully tested.