### PR TITLE
object/gs: remove unnecessary region check

### DIFF
--- a/docs/en/guide/how_to_set_up_object_storage.md
+++ b/docs/en/guide/how_to_set_up_object_storage.md
@@ -246,7 +246,7 @@ Once you have configured the environment variables for passing key information, 
 ```bash
 juicefs format \
     --storage gs \
-    --bucket <bucket> \
+    --bucket <bucket>[.region] \
     ... \
     myjfs
 ```

--- a/docs/zh_cn/guide/how_to_set_up_object_storage.md
+++ b/docs/zh_cn/guide/how_to_set_up_object_storage.md
@@ -246,7 +246,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="$HOME/service-account-file.json"
 ```bash
 juicefs format \
     --storage gs \
-    --bucket <bucket> \
+    --bucket <bucket>[.region] \
     ... \
     myjfs
 ```

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -73,9 +73,6 @@ func (g *gs) Create() error {
 		if err == nil && len(zone) > 2 {
 			g.region = zone[:len(zone)-2]
 		}
-		if g.region == "" {
-			return errors.New("Could not guess region to create bucket")
-		}
 	}
 
 	err := g.client.Bucket(g.bucket).Create(ctx, projectID, &storage.BucketAttrs{


### PR DESCRIPTION
The bucket defaut region is US. 
ref: [LINK](https://pkg.go.dev/cloud.google.com/go/storage@v1.21.0#section-readme:~:text=//%20Location%20is%20the%20location%20of%20the%20bucket.%20It%20defaults%20to%20%22US%22.%0A%09Location%20string)

set a region manually
https://github.com/juicedata/juicefs/blob/5a35d18017e70afba7d476eaef46dcb59c08f152/pkg/object/gs.go#L177-L182