### PR TITLE
CI: adjust the timeout for unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ release:
 		juicedata/golang-cross:latest release --rm-dist
 
 test:
-	go test -v -cover -count=1 -timeout=8m ./pkg/... -coverprofile=cov1.out
+	go test -v -cover -count=1 -timeout=12m ./pkg/... -coverprofile=cov1.out
 	sudo JFS_GC_SKIPPEDTIME=1 MINIO_ACCESS_KEY=testUser MINIO_SECRET_KEY=testUserPassword go test -v -count=1 -cover -timeout=8m ./cmd/... -coverprofile=cov2.out -coverpkg=./pkg/...,./cmd/...
 
 test.fdb:
-	go test -v -cover -count=1 -timeout=8m ./pkg/meta/ -tags fdb -run=TestFdb -coverprofile=cov3.out
+	go test -v -cover -count=1 -timeout=4m ./pkg/meta/ -tags fdb -run=TestFdb -coverprofile=cov3.out


### PR DESCRIPTION
Recent action shows that the time used for these tests are:
- test for all pkgs: 8 mins
- test for all cmds: 5 mins
- test for fdb: 40s