### PR TITLE
optimize fast summary

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2241,7 +2241,7 @@ func (m *redisMeta) doGetParents(ctx Context, inode Ino) map[Ino]int {
 }
 
 func (m *redisMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, error) {
-	field := strconv.FormatUint(uint64(ino), 16)
+	field := strconv.FormatUint(uint64(ino), 10)
 	space, inodes, err := m.calcDirStat(ctx, ino)
 	if err != nil {
 		return nil, err

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2241,7 +2241,7 @@ func (m *redisMeta) doGetParents(ctx Context, inode Ino) map[Ino]int {
 }
 
 func (m *redisMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, error) {
-	field := strconv.FormatUint(uint64(ino), 10)
+	field := ino.String()
 	space, inodes, err := m.calcDirStat(ctx, ino)
 	if err != nil {
 		return nil, err
@@ -2261,7 +2261,7 @@ func (m *redisMeta) doUpdateDirStat(ctx Context, batch map[Ino]dirStat) error {
 	statList := make([]Ino, 0, len(batch))
 	pipeline := m.rdb.Pipeline()
 	for ino := range batch {
-		pipeline.HExists(ctx, spaceKey, strconv.FormatUint(uint64(ino), 10))
+		pipeline.HExists(ctx, spaceKey, ino.String())
 		statList = append(statList, ino)
 	}
 	rets, err := pipeline.Exec(ctx)
@@ -2284,7 +2284,7 @@ func (m *redisMeta) doUpdateDirStat(ctx Context, batch map[Ino]dirStat) error {
 	for _, group := range m.groupBatch(batch, 1000) {
 		_, err := m.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 			for _, ino := range group {
-				field := strconv.FormatUint(uint64(ino), 10)
+				field := ino.String()
 				if nonexist[ino] {
 					continue
 				}
@@ -2308,7 +2308,7 @@ func (m *redisMeta) doUpdateDirStat(ctx Context, batch map[Ino]dirStat) error {
 func (m *redisMeta) doGetDirStat(ctx Context, ino Ino, trySync bool) (*dirStat, error) {
 	spaceKey := m.dirUsedSpaceKey()
 	inodesKey := m.dirUsedInodesKey()
-	field := strconv.FormatUint(uint64(ino), 10)
+	field := ino.String()
 	usedSpace, errSpace := m.rdb.HGet(ctx, spaceKey, field).Int64()
 	if errSpace != nil && errSpace != redis.Nil {
 		return nil, errSpace


### PR DESCRIPTION
- fix a bug in `doSyncDirStat` of redis engine
- use `inodes` in dir stat of leaf dirs instead read them