### PR TITLE
meta/tkv: add an option to skip updating of nlink to reduce conflict

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -110,6 +110,10 @@ func clientFlags() []cli.Flag {
 			Usage: "number of threads to delete objects",
 		},
 		&cli.IntFlag{
+			Name:  "skip-dir-nlink",
+			Usage: "number of retries after which the update of directory nlink will be skipped (used for tkv only, 0 means never)",
+		},
+		&cli.IntFlag{
 			Name:  "buffer-size",
 			Value: 300,
 			Usage: "total read/write buffering in MB",

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -350,6 +350,7 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 	conf := meta.DefaultConf()
 	conf.Retries = c.Int("io-retries")
 	conf.MaxDeletes = c.Int("max-deletes")
+	conf.SkipDirNlink = c.Int("skip-dir-nlink")
 	conf.ReadOnly = readOnly
 	conf.NoBGJob = c.Bool("no-bgjob")
 	conf.OpenCache = time.Duration(c.Float64("open-cache") * 1e9)

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Strict         bool // update ctime
 	Retries        int
 	MaxDeletes     int
+	SkipDirNlink   int
 	CaseInsensi    bool
 	ReadOnly       bool
 	NoBGJob        bool // disable background jobs like clean-up, backup, etc.

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1131,7 +1131,7 @@ func (m *kvMeta) doMknod(ctx Context, parent Ino, name string, _type uint8, mode
 		if parent != TrashInode {
 			if _type == TypeDirectory {
 				pattr.Nlink++
-				if tx.retry < 10 {
+				if m.conf.SkipDirNlink <= 0 || tx.retry < m.conf.SkipDirNlink {
 					updateParent = true
 				} else {
 					logger.Warnf("Skip updating nlink of directory %d to reduce conflict", parent)

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -249,6 +249,7 @@ type javaConf struct {
 	DownloadLimit     int     `json:"downloadLimit"`
 	MaxUploads        int     `json:"maxUploads"`
 	MaxDeletes        int     `json:"maxDeletes"`
+	SkipDirNlink      int     `json:"skipDirNlink"`
 	IORetries         int     `json:"ioRetries"`
 	GetTimeout        int     `json:"getTimeout"`
 	PutTimeout        int     `json:"putTimeout"`
@@ -384,6 +385,7 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 		metaConf := meta.DefaultConf()
 		metaConf.Retries = jConf.IORetries
 		metaConf.MaxDeletes = jConf.MaxDeletes
+		metaConf.SkipDirNlink = jConf.SkipDirNlink
 		metaConf.ReadOnly = jConf.ReadOnly
 		metaConf.NoBGJob = jConf.NoBGJob
 		metaConf.OpenCache = time.Duration(jConf.OpenCache * 1e9)

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -325,6 +325,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     obj.put("autoCreate", Boolean.valueOf(getConf(conf, "auto-create-cache-dir", "true")));
     obj.put("maxUploads", Integer.valueOf(getConf(conf, "max-uploads", "20")));
     obj.put("maxDeletes", Integer.valueOf(getConf(conf, "max-deletes", "10")));
+    obj.put("skipDirNlink", Integer.valueOf(getConf(conf, "skip-dir-nlink", "0")));
     obj.put("uploadLimit", Integer.valueOf(getConf(conf, "upload-limit", "0")));
     obj.put("downloadLimit", Integer.valueOf(getConf(conf, "download-limit", "0")));
     obj.put("ioRetries", Integer.valueOf(getConf(conf, "io-retries", "10")));


### PR DESCRIPTION
This makes #3285 configurable.