### PR TITLE
add progress bar for recursive info

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -87,7 +87,7 @@ func info(ctx *cli.Context) error {
 	if ctx.Bool("raw") {
 		raw = 1
 	}
-	progress := utils.NewProgress(false)
+	progress := utils.NewProgress(recursive == 0) // only show progress for recursive info
 	for i := 0; i < ctx.Args().Len(); i++ {
 		path := ctx.Args().Get(i)
 		dspin := progress.AddDoubleSpinner(path)

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -709,7 +709,7 @@ func TestInternalFile(t *testing.T) {
 	readControl := func(resp []byte, off *uint64) (int, syscall.Errno) {
 		for {
 			if n, errno := v.Read(ctx, fe.Inode, resp, *off, fh); n == 0 {
-				time.Sleep(time.Millisecond * 300)
+				time.Sleep(time.Millisecond * 200)
 			} else if n%17 == 0 {
 				*off += uint64(n)
 				continue

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -772,14 +772,23 @@ func TestInternalFile(t *testing.T) {
 	}
 	off += uint64(len(buf))
 	buf = make([]byte, 1024*10)
+	if n, e = readControl(buf, &off); e != 0 {
+		t.Fatalf("read progress bar: %s %d", e, n)
+	} else if buf[0] != 0 {
+		t.Fatalf("info v2 st: %s", syscall.Errno(buf[0]))
+	} else {
+		off += uint64(n)
+	}
+
 	var infoResp InfoResponse
 	if n, e = readControl(buf, &off); e != 0 {
-		t.Fatalf("read result: %s %d", e, n)
+		t.Fatalf("read response: %s %d", e, n)
 	} else if infoResp.Decode(bytes.NewBuffer(buf[:n])) != nil {
 		t.Fatalf("info v2 result: %s", string(buf[:n]))
 	} else {
 		off += uint64(n)
 	}
+
 	// fill
 	buf = make([]byte, 4+4+8+1+1+2+1)
 	w = utils.FromBuffer(buf)


### PR DESCRIPTION
```bash
~/s/juicefs (info-process-bar)> ./juicefs info -r ~/mnt/jfs/
/home/hexi/mnt/jfs/: 490959                       163175.9/s   
/home/hexi/mnt/jfs/: 5.9 GiB (6347726848 Bytes)   2.0 GiB/s    
/home/hexi/mnt/jfs/:
  inode: 1
  files: 490959
   dirs: 47203
 length: 4.35 GiB (4671020626 Bytes)
   size: 5.91 GiB (6347726848 Bytes)
   path: /

```