### PR TITLE
fix s3fs folder

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -584,17 +584,20 @@ func (n *jfsObjects) GetObjectInfo(ctx context.Context, bucket, object string, o
 		etag, _ = n.fs.GetXattr(mctx, n.path(bucket, object), s3Etag)
 	}
 	size := fi.Size()
+	var contentType string
 	if fi.IsDir() {
 		size = 0
+		contentType = "application/octet-stream"
 	}
 	return minio.ObjectInfo{
-		Bucket:  bucket,
-		Name:    object,
-		ModTime: fi.ModTime(),
-		Size:    size,
-		IsDir:   fi.IsDir(),
-		AccTime: fi.ModTime(),
-		ETag:    string(etag),
+		Bucket:      bucket,
+		Name:        object,
+		ModTime:     fi.ModTime(),
+		Size:        size,
+		IsDir:       fi.IsDir(),
+		AccTime:     fi.ModTime(),
+		ETag:        string(etag),
+		ContentType: contentType,
 	}, nil
 }
 


### PR DESCRIPTION
when s3fs identify whether the object is a folder, s3fs need to check a header "Content-Type: application/octet-stream" returned by HEAD Object rest api of juicefs s3 gateway