### PR TITLE
Add delimiter for mem storage

### DIFF
--- a/pkg/object/mem.go
+++ b/pkg/object/mem.go
@@ -140,7 +140,7 @@ func (m *memStore) List(prefix, marker, delimiter string, limit int64) ([]Object
 			if delimiter != "" {
 				remainString := strings.TrimPrefix(k, prefix)
 				pos := strings.Index(remainString, delimiter)
-				if pos != -1 && pos != len(remainString) {
+				if pos != -1 && pos != (len(remainString) - 1) {
 					commonPrefix := remainString[0:pos + 1]
 					if _, ok := commonPrefixsMap[commonPrefix]; ok {
 						continue

--- a/pkg/object/mem.go
+++ b/pkg/object/mem.go
@@ -139,9 +139,8 @@ func (m *memStore) List(prefix, marker, delimiter string, limit int64) ([]Object
 			o := m.objects[k]
 			if delimiter != "" {
 				remainString := strings.TrimPrefix(k, prefix)
-				pos := strings.Index(remainString, delimiter)
-				if pos != -1 && pos != (len(remainString) - 1) {
-					commonPrefix := remainString[0:pos + 1]
+				if pos := strings.Index(remainString, delimiter);pos != -1 {
+					commonPrefix := remainString[0 : pos + 1]
 					if _, ok := commonPrefixsMap[commonPrefix]; ok {
 						continue
 					}
@@ -152,9 +151,9 @@ func (m *memStore) List(prefix, marker, delimiter string, limit int64) ([]Object
 							time.Unix(0, 0),
 							strings.HasSuffix(commonPrefix, "/"),
 						},
-						"",
-						"",
-						0,
+						o.owner,
+						o.group,
+						o.mode,
 						false,
 					}
 					objs = append(objs, f)

--- a/pkg/object/mem.go
+++ b/pkg/object/mem.go
@@ -129,16 +129,40 @@ func (m *memStore) Delete(key string) error {
 }
 
 func (m *memStore) List(prefix, marker, delimiter string, limit int64) ([]Object, error) {
-	if delimiter != "" {
-		return nil, notSupportedDelimiter
-	}
 	m.Lock()
 	defer m.Unlock()
 
 	objs := make([]Object, 0)
+	commonPrefixsMap := make(map[string]bool, 0)
 	for k := range m.objects {
 		if strings.HasPrefix(k, prefix) && k > marker {
 			o := m.objects[k]
+			if delimiter != "" {
+				remainString := strings.TrimPrefix(k, prefix)
+				pos := strings.Index(remainString, delimiter)
+				if pos != -1 && pos != len(remainString) {
+					commonPrefix := remainString[0:pos + 1]
+					if _, ok := commonPrefixsMap[commonPrefix]; ok {
+						continue
+					}
+					f := &file{
+						obj{
+							prefix + commonPrefix,
+							0,
+							time.Unix(0, 0),
+							strings.HasSuffix(commonPrefix, "/"),
+						},
+						"",
+						"",
+						0,
+						false,
+					}
+					objs = append(objs, f)
+					commonPrefixsMap[commonPrefix] = true
+					continue
+				}
+			}
+
 			f := &file{
 				obj{
 					k,

--- a/pkg/object/mem.go
+++ b/pkg/object/mem.go
@@ -139,8 +139,8 @@ func (m *memStore) List(prefix, marker, delimiter string, limit int64) ([]Object
 			o := m.objects[k]
 			if delimiter != "" {
 				remainString := strings.TrimPrefix(k, prefix)
-				if pos := strings.Index(remainString, delimiter);pos != -1 {
-					commonPrefix := remainString[0 : pos + 1]
+				if pos := strings.Index(remainString, delimiter); pos != -1 {
+					commonPrefix := remainString[0 : pos+1]
 					if _, ok := commonPrefixsMap[commonPrefix]; ok {
 						continue
 					}

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -754,7 +754,7 @@ func TestEncrypted(t *testing.T) {
 	testStorage(t, es)
 }
 
-func TestMarsharl(t *testing.T) {
+func TestMarsharl(t *testing.T) { //skip mutate
 	if os.Getenv("HDFS_ADDR") == "" {
 		t.SkipNow()
 	}

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -754,7 +754,7 @@ func TestEncrypted(t *testing.T) {
 	testStorage(t, es)
 }
 
-func TestMarsharl(t *testing.T) { //skip mutate
+func TestMarsharl(t *testing.T) {
 	if os.Getenv("HDFS_ADDR") == "" {
 		t.SkipNow()
 	}

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -225,6 +225,14 @@ func testStorage(t *testing.T, s ObjectStorage) {
 	if err := s.Put("a1", bytes.NewReader(br)); err != nil {
 		t.Fatalf("PUT failed: %s", err.Error())
 	}
+	defer s.Delete("a/b/c/d/e/f")
+	if err := s.Put("a/b/c/d/e/f", bytes.NewReader(br)); err != nil {
+		t.Fatalf("PUT failed: %s", err.Error())
+	}
+
+	if err := s.Put("a1", bytes.NewReader(br)); err != nil {
+		t.Fatalf("PUT failed: %s", err.Error())
+	}
 	if obs, err := s.List("", "", "/", 10); err != nil {
 		if !(errors.Is(err, notSupportedDelimiter) || errors.Is(err, notSupported)) {
 			t.Fatalf("list with delimiter: %s", err)
@@ -236,6 +244,24 @@ func testStorage(t *testing.T, s ObjectStorage) {
 			t.Fatalf("list with delimiter should return five results but got %d", len(obs))
 		}
 		keys := []string{"a/", "a1", "b/", "c/", "test"}
+		for i, o := range obs {
+			if o.Key() != keys[i] {
+				t.Fatalf("should get key %s but got %s", keys[i], o.Key())
+			}
+		}
+	}
+	
+	if obs, err := s.List("a/", "", "/", 10); err != nil {
+		if !(errors.Is(err, notSupportedDelimiter) || errors.Is(err, notSupported)) {
+			t.Fatalf("list with delimiter: %s", err)
+		} else {
+			t.Logf("list api error: %s", err)
+		}
+	} else {
+		if len(obs) != 3 {
+			t.Fatalf("list with delimiter should return three results but got %d", len(obs))
+		}
+		keys := []string{"a/a", "a/a1", "a/b/"}
 		for i, o := range obs {
 			if o.Key() != keys[i] {
 				t.Fatalf("should get key %s but got %s", keys[i], o.Key())

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -250,7 +250,7 @@ func testStorage(t *testing.T, s ObjectStorage) {
 			}
 		}
 	}
-	
+
 	if obs, err := s.List("a/", "", "/", 10); err != nil {
 		if !(errors.Is(err, notSupportedDelimiter) || errors.Is(err, notSupported)) {
 			t.Fatalf("list with delimiter: %s", err)


### PR DESCRIPTION
mem storage does not currently support delimiter, so some test codes cannot rely entirely on mem storage to mock
This PR adds delimiter support to mem storage