### PR TITLE
load and dump flags field

### DIFF
--- a/pkg/meta/dump.go
+++ b/pkg/meta/dump.go
@@ -55,6 +55,7 @@ type DumpedSustained struct {
 
 type DumpedAttr struct {
 	Inode     Ino    `json:"inode"`
+	Flags     uint8  `json:"flags,omitempty"`
 	Type      string `json:"type"`
 	Mode      uint16 `json:"mode"`
 	Uid       uint32 `json:"uid"`
@@ -265,6 +266,7 @@ func (dm *DumpedMeta) writeJsonWithOutTree(w io.Writer) (*bufio.Writer, error) {
 
 func dumpAttr(a *Attr, d *DumpedAttr) {
 	d.Type = typeToString(a.Typ)
+	d.Flags = a.Flags
 	d.Mode = a.Mode
 	d.Uid = a.Uid
 	d.Gid = a.Gid
@@ -285,7 +287,7 @@ func dumpAttr(a *Attr, d *DumpedAttr) {
 
 func loadAttr(d *DumpedAttr) *Attr {
 	return &Attr{
-		// Flags:     0,
+		Flags:     d.Flags,
 		Typ:       typeFromString(d.Type),
 		Mode:      d.Mode,
 		Uid:       d.Uid,

--- a/pkg/meta/load_dump_test.go
+++ b/pkg/meta/load_dump_test.go
@@ -149,6 +149,11 @@ func testLoad(t *testing.T, uri, fname string) Meta {
 	if attr.Nlink != 1 || attr.Length != 24 {
 		t.Fatalf("nlink: %d, length: %d", attr.Nlink, attr.Length)
 	}
+
+	if attr.Flags != 128 {
+		t.Fatalf("expect the flags euqal 128, but actual is: %d", attr.Flags)
+	}
+
 	var slices []Slice
 	if st := m.Read(ctx, 2, 0, &slices); st != 0 {
 		t.Fatalf("read chunk: %s", st)

--- a/pkg/meta/metadata.sample
+++ b/pkg/meta/metadata.sample
@@ -66,7 +66,7 @@
         }
       },
       "f1": {
-        "attr": {"inode":2,"type":"regular","mode":420,"uid":501,"gid":20,"atime":1623746580,"mtime":1623746661,"ctime":1623746661,"atimensec":219686000,"mtimensec":219686000,"ctimensec":219686000,"nlink":1,"length":24},
+        "attr": {"inode":2,"flags":128,"type":"regular","mode":420,"uid":501,"gid":20,"atime":1623746580,"mtime":1623746661,"ctime":1623746661,"atimensec":219686000,"mtimensec":219686000,"ctimensec":219686000,"nlink":1,"length":24},
         "xattrs": [{"name":"k","value":"v"}],
         "chunks": [{"index":0,"slices":[{"id":1,"size":6,"len":6},{"id":2,"size":12,"len":12},{"id":4,"size":24,"len":24}]}]
       },

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -3477,6 +3477,7 @@ func (m *dbMeta) loadEntry(e *DumpedEntry, chs []chan interface{}) {
 	attr := e.Attr
 	n := &node{
 		Inode:  inode,
+		Flags:  attr.Flags,
 		Type:   typeFromString(attr.Type),
 		Mode:   attr.Mode,
 		Uid:    attr.Uid,


### PR DESCRIPTION
At present, when meta dumps, there is no flags field, and this PR is used to dump the flags field.