### PR TITLE
adjust the log level of granting FUSE

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -436,7 +436,7 @@ func Serve(v *vfs.VFS, options string, xattrs, ioctl bool) error {
 	}
 	err := grantAccess()
 	if err != nil {
-		logger.Warnf("grant access to /dev/fuse: %s", err)
+		logger.Debugf("grant access to /dev/fuse: %s", err)
 	}
 	ensureFuseDev()
 


### PR DESCRIPTION
In some environment, like cgroup2, or container without host cgroup fs, the warning of granting failure is annoying. As this case is easily reproducible and cannot be resolved by users, we should modify the log level to `debug`.