### PR TITLE
Refactor metrics and  make the cacheManager more generic

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -71,7 +71,7 @@ type cacheStore struct {
 	scanInterval time.Duration
 	pending      chan pendingFile
 	pages        map[string]*Page
-	m            *cacheManager
+	m            *CacheManagerMetrics
 
 	used     int64
 	keys     map[cacheKey]cacheItem
@@ -81,7 +81,7 @@ type cacheStore struct {
 	uploader func(key, path string, force bool) bool
 }
 
-func newCacheStore(m *cacheManager, dir string, cacheSize int64, pendingPages int, config *Config, uploader func(key, path string, force bool) bool) *cacheStore {
+func newCacheStore(m *CacheManagerMetrics, dir string, cacheSize int64, pendingPages int, config *Config, uploader func(key, path string, force bool) bool) *cacheStore {
 	if config.CacheMode == 0 {
 		config.CacheMode = 0600 // only owner can read/write cache
 	}
@@ -155,6 +155,18 @@ func (cache *cacheStore) refreshCacheKeys() {
 			cache.scanCached()
 		}
 	}
+}
+func (cache *cacheStore) removeStage(key string) error {
+	stagingPath := cache.stagePath(key)
+	fi, err := os.Stat(stagingPath)
+	if err == nil {
+		size := fi.Size()
+		if err = os.Remove(stagingPath); err == nil {
+			cache.m.stageBlocks.Sub(1)
+			cache.m.stageBlockBytes.Sub(float64(size))
+		}
+	}
+	return err
 }
 
 func (cache *cacheStore) cache(key string, p *Page, force bool) {
@@ -305,14 +317,7 @@ func (cache *cacheStore) remove(key string) {
 	cache.Unlock()
 	if path != "" {
 		_ = os.Remove(path)
-		stagingPath := cache.stagePath(key)
-		if fi, err := os.Stat(stagingPath); err == nil {
-			size := fi.Size()
-			if err = os.Remove(stagingPath); err == nil {
-				cache.m.stageBlocks.Sub(1)
-				cache.m.stageBlockBytes.Sub(float64(size))
-			}
-		}
+		_ = cache.removeStage(key)
 	}
 }
 
@@ -635,16 +640,8 @@ func (cache *cacheStore) scanStaging() {
 }
 
 type cacheManager struct {
-	stores []*cacheStore
-
-	cacheDrops      prometheus.Counter
-	cacheWrites     prometheus.Counter
-	cacheEvicts     prometheus.Counter
-	cacheWriteBytes prometheus.Counter
-	cacheWriteHist  prometheus.Histogram
-	stageBlocks     prometheus.Gauge
-	stageBlockBytes prometheus.Gauge
-	stageBlockDelay prometheus.Counter
+	stores  []*cacheStore
+	metrics *CacheManagerMetrics
 }
 
 func keyHash(s string) uint32 {
@@ -698,14 +695,16 @@ type CacheManager interface {
 	load(key string) (ReadCloser, error)
 	uploaded(key string, size int)
 	stage(key string, data []byte, keepCache bool) (string, error)
+	removeStage(key string) error
 	stagePath(key string) string
 	stats() (int64, int64)
 	usedMemory() int64
 }
 
 func newCacheManager(config *Config, reg prometheus.Registerer, uploader func(key, path string, force bool) bool) CacheManager {
+	metrics := newCacheManagerMetrics(reg)
 	if config.CacheDir == "memory" || config.CacheSize == 0 {
-		return newMemStore(config, reg)
+		return newMemStore(config, metrics)
 	}
 	var dirs []string
 	for _, d := range utils.SplitDir(config.CacheDir) {
@@ -722,65 +721,26 @@ func newCacheManager(config *Config, reg prometheus.Registerer, uploader func(ke
 	}
 	if len(dirs) == 0 {
 		logger.Warnf("No cache dir existed")
-		return newMemStore(config, reg)
+		return newMemStore(config, metrics)
 	}
 	sort.Strings(dirs)
 	dirCacheSize := config.CacheSize << 20
 	dirCacheSize /= int64(len(dirs))
 	m := &cacheManager{
-		stores: make([]*cacheStore, len(dirs)),
-
-		cacheDrops: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_drops",
-			Help: "dropped block",
-		}),
-		cacheWrites: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_writes",
-			Help: "written cached block",
-		}),
-		cacheEvicts: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_evicts",
-			Help: "evicted cache blocks",
-		}),
-		cacheWriteBytes: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_write_bytes",
-			Help: "write bytes of cached block",
-		}),
-		cacheWriteHist: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "blockcache_write_hist_seconds",
-			Help:    "write cached block latency distribution",
-			Buckets: prometheus.ExponentialBuckets(0.00001, 2, 20),
-		}),
-		stageBlocks: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "staging_blocks",
-			Help: "Number of blocks in the staging path.",
-		}),
-		stageBlockBytes: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "staging_block_bytes",
-			Help: "Total bytes of blocks in the staging path.",
-		}),
-		stageBlockDelay: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "staging_block_delay_seconds",
-			Help: "Total seconds of delay for staging blocks",
-		}),
-	}
-	if reg != nil {
-		reg.MustRegister(m.cacheWrites)
-		reg.MustRegister(m.cacheWriteBytes)
-		reg.MustRegister(m.cacheDrops)
-		reg.MustRegister(m.cacheEvicts)
-		reg.MustRegister(m.cacheWriteHist)
-		reg.MustRegister(m.stageBlocks)
-		reg.MustRegister(m.stageBlockBytes)
-		reg.MustRegister(m.stageBlockDelay)
+		stores:  make([]*cacheStore, len(dirs)),
+		metrics: metrics,
 	}
 
 	// 20% of buffer could be used for pending pages
 	pendingPages := config.BufferSize * 2 / 10 / config.BlockSize / len(dirs)
 	for i, d := range dirs {
-		m.stores[i] = newCacheStore(m, strings.TrimSpace(d)+string(filepath.Separator), dirCacheSize, pendingPages, config, uploader)
+		m.stores[i] = newCacheStore(metrics, strings.TrimSpace(d)+string(filepath.Separator), dirCacheSize, pendingPages, config, uploader)
 	}
 	return m
+}
+
+func (m *cacheManager) removeStage(key string) error {
+	return m.getStore(key).removeStage(key)
 }
 
 func (m *cacheManager) getStore(key string) *cacheStore {

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -34,10 +34,10 @@ type memcache struct {
 	used     int64
 	pages    map[string]memItem
 
-	metrics *CacheManagerMetrics
+	metrics *cacheManagerMetrics
 }
 
-func newMemStore(config *Config, metrics *CacheManagerMetrics) *memcache {
+func newMemStore(config *Config, metrics *cacheManagerMetrics) *memcache {
 	c := &memcache{
 		capacity: config.CacheSize << 20,
 		pages:    make(map[string]memItem),

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -21,8 +21,6 @@ import (
 	"runtime"
 	"sync"
 	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type memItem struct {
@@ -36,33 +34,14 @@ type memcache struct {
 	used     int64
 	pages    map[string]memItem
 
-	cacheWrites     prometheus.Counter
-	cacheEvicts     prometheus.Counter
-	cacheWriteBytes prometheus.Counter
+	metrics *CacheManagerMetrics
 }
 
-func newMemStore(config *Config, reg prometheus.Registerer) *memcache {
+func newMemStore(config *Config, metrics *CacheManagerMetrics) *memcache {
 	c := &memcache{
 		capacity: config.CacheSize << 20,
 		pages:    make(map[string]memItem),
-
-		cacheWrites: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_writes",
-			Help: "written cached block",
-		}),
-		cacheEvicts: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_evicts",
-			Help: "evicted cache blocks",
-		}),
-		cacheWriteBytes: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "blockcache_write_bytes",
-			Help: "write bytes of cached block",
-		}),
-	}
-	if reg != nil {
-		reg.MustRegister(c.cacheWrites)
-		reg.MustRegister(c.cacheWriteBytes)
-		reg.MustRegister(c.cacheEvicts)
+		metrics:  metrics,
 	}
 	runtime.SetFinalizer(c, func(c *memcache) {
 		for _, p := range c.pages {
@@ -71,6 +50,10 @@ func newMemStore(config *Config, reg prometheus.Registerer) *memcache {
 		c.pages = nil
 	})
 	return c
+}
+
+func (c *memcache) removeStage(key string) error {
+	return nil
 }
 
 func (c *memcache) usedMemory() int64 {
@@ -95,8 +78,8 @@ func (c *memcache) cache(key string, p *Page, force bool) {
 		return
 	}
 	size := int64(cap(p.Data))
-	c.cacheWrites.Add(1)
-	c.cacheWriteBytes.Add(float64(size))
+	c.metrics.cacheWrites.Add(1)
+	c.metrics.cacheWriteBytes.Add(float64(size))
 	p.Acquire()
 	c.pages[key] = memItem{time.Now(), p}
 	c.used += size
@@ -146,7 +129,7 @@ func (c *memcache) cleanup() {
 		cnt++
 		if cnt > 1 {
 			logger.Debugf("remove %s from cache, age: %d", lastKey, now.Sub(lastValue.atime))
-			c.cacheEvicts.Add(1)
+			c.metrics.cacheEvicts.Add(1)
 			c.delete(lastKey, lastValue.page)
 			cnt = 0
 			if c.used < c.capacity {

--- a/pkg/chunk/metrics.go
+++ b/pkg/chunk/metrics.go
@@ -19,7 +19,7 @@ package chunk
 import "github.com/prometheus/client_golang/prometheus"
 
 // CacheManager Metrics
-type CacheManagerMetrics struct {
+type cacheManagerMetrics struct {
 	cacheDrops      prometheus.Counter
 	cacheWrites     prometheus.Counter
 	cacheEvicts     prometheus.Counter
@@ -29,14 +29,14 @@ type CacheManagerMetrics struct {
 	stageBlockBytes prometheus.Gauge
 }
 
-func newCacheManagerMetrics(reg prometheus.Registerer) *CacheManagerMetrics {
-	metrics := &CacheManagerMetrics{}
+func newCacheManagerMetrics(reg prometheus.Registerer) *cacheManagerMetrics {
+	metrics := &cacheManagerMetrics{}
 	metrics.initMetrics()
 	metrics.registerMetrics(reg)
 	return metrics
 }
 
-func (c *CacheManagerMetrics) registerMetrics(reg prometheus.Registerer) {
+func (c *cacheManagerMetrics) registerMetrics(reg prometheus.Registerer) {
 	if reg != nil {
 		reg.MustRegister(c.cacheDrops)
 		reg.MustRegister(c.cacheWrites)
@@ -48,7 +48,7 @@ func (c *CacheManagerMetrics) registerMetrics(reg prometheus.Registerer) {
 	}
 }
 
-func (c *CacheManagerMetrics) initMetrics() {
+func (c *cacheManagerMetrics) initMetrics() {
 	c.cacheDrops = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "blockcache_drops",
 		Help: "dropped block",

--- a/pkg/chunk/metrics.go
+++ b/pkg/chunk/metrics.go
@@ -1,0 +1,81 @@
+/*
+ * JuiceFS, Copyright 2020 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chunk
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// CacheManager Metrics
+type CacheManagerMetrics struct {
+	cacheDrops      prometheus.Counter
+	cacheWrites     prometheus.Counter
+	cacheEvicts     prometheus.Counter
+	cacheWriteBytes prometheus.Counter
+	cacheWriteHist  prometheus.Histogram
+	stageBlocks     prometheus.Gauge
+	stageBlockBytes prometheus.Gauge
+}
+
+func newCacheManagerMetrics(reg prometheus.Registerer) *CacheManagerMetrics {
+	metrics := &CacheManagerMetrics{}
+	metrics.initMetrics()
+	metrics.registerMetrics(reg)
+	return metrics
+}
+
+func (c *CacheManagerMetrics) registerMetrics(reg prometheus.Registerer) {
+	if reg != nil {
+		reg.MustRegister(c.cacheDrops)
+		reg.MustRegister(c.cacheWrites)
+		reg.MustRegister(c.cacheEvicts)
+		reg.MustRegister(c.cacheWriteHist)
+		reg.MustRegister(c.cacheWriteBytes)
+		reg.MustRegister(c.stageBlocks)
+		reg.MustRegister(c.stageBlockBytes)
+	}
+}
+
+func (c *CacheManagerMetrics) initMetrics() {
+	c.cacheDrops = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "blockcache_drops",
+		Help: "dropped block",
+	})
+	c.cacheWrites = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "blockcache_writes",
+		Help: "written cached block",
+	})
+	c.cacheEvicts = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "blockcache_evicts",
+		Help: "evicted cache blocks",
+	})
+	c.cacheWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "blockcache_write_bytes",
+		Help: "write bytes of cached block",
+	})
+	c.cacheWriteHist = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "blockcache_write_hist_seconds",
+		Help:    "write cached block latency distribution",
+		Buckets: prometheus.ExponentialBuckets(0.00001, 2, 20),
+	})
+	c.stageBlocks = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "staging_blocks",
+		Help: "Number of blocks in the staging path.",
+	})
+	c.stageBlockBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "staging_block_bytes",
+		Help: "Total bytes of blocks in the staging path.",
+	})
+}

--- a/pkg/chunk/utils_linux.go
+++ b/pkg/chunk/utils_linux.go
@@ -17,9 +17,13 @@
 package chunk
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func getAtime(fi os.FileInfo) time.Time {
@@ -27,4 +31,44 @@ func getAtime(fi os.FileInfo) time.Time {
 		return time.Unix(sst.Atim.Unix())
 	}
 	return fi.ModTime()
+}
+
+// Copy from https://github.com/prometheus/client_golang/blob/v1.14.0/prometheus/testutil/testutil.go
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
 }

--- a/pkg/chunk/utils_linux.go
+++ b/pkg/chunk/utils_linux.go
@@ -17,13 +17,9 @@
 package chunk
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 )
 
 func getAtime(fi os.FileInfo) time.Time {
@@ -31,44 +27,4 @@ func getAtime(fi os.FileInfo) time.Time {
 		return time.Unix(sst.Atim.Unix())
 	}
 	return fi.ModTime()
-}
-
-// Copy from https://github.com/prometheus/client_golang/blob/v1.14.0/prometheus/testutil/testutil.go
-func ToFloat64(c prometheus.Collector) float64 {
-	var (
-		m      prometheus.Metric
-		mCount int
-		mChan  = make(chan prometheus.Metric)
-		done   = make(chan struct{})
-	)
-
-	go func() {
-		for m = range mChan {
-			mCount++
-		}
-		close(done)
-	}()
-
-	c.Collect(mChan)
-	close(mChan)
-	<-done
-
-	if mCount != 1 {
-		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
-	}
-
-	pb := &dto.Metric{}
-	if err := m.Write(pb); err != nil {
-		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
-	}
-	if pb.Gauge != nil {
-		return pb.Gauge.GetValue()
-	}
-	if pb.Counter != nil {
-		return pb.Counter.GetValue()
-	}
-	if pb.Untyped != nil {
-		return pb.Untyped.GetValue()
-	}
-	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
 }


### PR DESCRIPTION
1. enable self-contained metrics tracking for cacheManager, without relying on cachedStore for tracking
2. separating metrics from the cacheManager allows other object to use them.
3. remove the metrics "stageBlockDelay" from the cacheManager and place it in the cachedStore.