### PR TITLE
enhance disable updatedb to prevent concurrent modification

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -21,6 +21,7 @@ package cmd
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -153,7 +154,21 @@ func mount_flags() []cli.Flag {
 
 func disableUpdatedb() {
 	path := "/etc/updatedb.conf"
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	// obtain exclusive and not block flock
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return
+	}
+	defer func() {
+		// release flock
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	}()
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return
 	}
@@ -181,7 +196,7 @@ func disableUpdatedb() {
 }
 
 func mount_main(v *vfs.VFS, c *cli.Context) {
-	if os.Getuid() == 0 && os.Getpid() != 1 {
+	if os.Getuid() == 0 {
 		disableUpdatedb()
 	}
 


### PR DESCRIPTION
1. juicefs csi driver has already add host /etc/updatedb.conf to mount pod, so we should also disable updatedb in k8s node,so i dropped os.Getpid() != 1
https://github.com/juicedata/juicefs-csi-driver/commit/77dad895a5100b4835982f86dd69d9d4fe026a8f

2. add flock to prevent multiple juicefs clients writing  updatedb.conf at the same time