### PR TITLE
statfs support bind mount quota

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -234,7 +234,7 @@ func config(ctx *cli.Context) error {
 		}
 		if quota {
 			var totalSpace, availSpace, iused, iavail uint64
-			_ = m.StatFS(meta.Background, &totalSpace, &availSpace, &iused, &iavail, false)
+			_ = m.StatFS(meta.Background, meta.RootInode, &totalSpace, &availSpace, &iused, &iavail)
 			usedSpace := totalSpace - availSpace
 			if format.Capacity > 0 && usedSpace >= format.Capacity ||
 				format.Inodes > 0 && iused >= format.Inodes {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -143,7 +143,7 @@ func destroy(ctx *cli.Context) error {
 			logger.Fatalf("%d sessions are active, please disconnect them first:\n%s", num, printSessions(ss))
 		}
 		var totalSpace, availSpace, iused, iavail uint64
-		_ = m.StatFS(meta.Background, &totalSpace, &availSpace, &iused, &iavail, false)
+		_ = m.StatFS(meta.Background, meta.RootInode, &totalSpace, &availSpace, &iused, &iavail)
 
 		fmt.Printf(" volume name: %s\n", format.Name)
 		fmt.Printf(" volume UUID: %s\n", format.UUID)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -113,7 +113,7 @@ func status(ctx *cli.Context) error {
 
 	stat := &statistic{}
 	var totalSpace uint64
-	if err = m.StatFS(meta.Background, &totalSpace, &stat.AvailableSpace, &stat.UsedInodes, &stat.AvailableInodes, false); err != syscall.Errno(0) {
+	if err = m.StatFS(meta.Background, meta.RootInode, &totalSpace, &stat.AvailableSpace, &stat.UsedInodes, &stat.AvailableInodes); err != syscall.Errno(0) {
 		logger.Fatalf("stat fs: %s", err)
 	}
 	stat.UsedSpace = totalSpace - stat.AvailableSpace

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -342,7 +342,7 @@ func (fs *FileSystem) StatFS(ctx meta.Context) (totalspace uint64, availspace ui
 	l := vfs.NewLogContext(ctx)
 	defer func() { fs.log(l, "StatFS (): (%d,%d)", totalspace, availspace) }()
 	var iused, iavail uint64
-	_ = fs.m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, false)
+	_ = fs.m.StatFS(ctx, meta.RootInode, &totalspace, &availspace, &iused, &iavail)
 	return
 }
 

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -515,7 +515,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	}
 
 	var totalspace, availspace, iused, iavail uint64
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, false); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<50 || iavail != 10<<20 {
@@ -526,12 +526,12 @@ func testMetaClient(t *testing.T, m Meta) {
 	if err = m.Init(format, false); err != nil {
 		t.Fatalf("set quota failed: %s", err)
 	}
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, false); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<20 || iavail != 97 {
 		time.Sleep(time.Millisecond * 100)
-		_ = m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, false)
+		_ = m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail)
 		if totalspace != 1<<20 || iavail != 97 {
 			t.Fatalf("total space %d, iavail %d", totalspace, iavail)
 		}
@@ -544,7 +544,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	if st := m.Chroot(ctx, "subdir"); st != 0 {
 		t.Fatalf("chroot: %s", st)
 	}
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, true); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<20 || iavail != 96 {
@@ -559,7 +559,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	}); err != nil {
 		t.Fatalf("set quota: %s", err)
 	}
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, true); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<20-4*uint64(align4K(0)) || iavail != 96 {
@@ -574,7 +574,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	}); err != nil {
 		t.Fatalf("set quota: %s", err)
 	}
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, true); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<10 || iavail != 96 {
@@ -589,7 +589,7 @@ func testMetaClient(t *testing.T, m Meta) {
 	}); err != nil {
 		t.Fatalf("set quota: %s", err)
 	}
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, true); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<20-4*uint64(align4K(0)) || iavail != 10 {
@@ -605,14 +605,14 @@ func testMetaClient(t *testing.T, m Meta) {
 		t.Fatalf("set quota: %s", err)
 	}
 
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, true); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<10 || iavail != 10 {
 		t.Fatalf("total space %d, iavail %d", totalspace, iavail)
 	}
 
-	if st := m.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, false); st != 0 {
+	if st := m.StatFS(ctx, RootInode, &totalspace, &availspace, &iused, &iavail); st != 0 {
 		t.Fatalf("statfs: %s", st)
 	}
 	if totalspace != 1<<20 || iavail != 96 {
@@ -2156,7 +2156,7 @@ func testClone(t *testing.T, m Meta) {
 	attr.Mtime = 1
 	m.SetAttr(Background, 1, SetAttrMtime, 0, &attr)
 	var totalspace, availspace, iused, iavail, space, iused2 uint64
-	m.StatFS(Background, &totalspace, &availspace, &iused, &iavail, false)
+	m.StatFS(Background, RootInode, &totalspace, &availspace, &iused, &iavail)
 	space = totalspace - availspace
 	iused2 = iused
 
@@ -2199,7 +2199,7 @@ func testClone(t *testing.T, m Meta) {
 	if rootAttr.Mtime == 1 {
 		t.Fatalf("mtime of rootDir is not updated")
 	}
-	m.StatFS(Background, &totalspace, &availspace, &iused, &iavail, false)
+	m.StatFS(Background, RootInode, &totalspace, &availspace, &iused, &iavail)
 	if totalspace-availspace-space != 32768 {
 		t.Fatalf("added space: %d", totalspace-availspace-space)
 	}

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -332,7 +332,7 @@ type Meta interface {
 	CleanupDetachedNodesBefore(ctx Context, edge time.Time, increProgress func())
 
 	// StatFS returns summary statistics of a volume.
-	StatFS(ctx Context, totalspace, availspace, iused, iavail *uint64, subdir bool) syscall.Errno
+	StatFS(ctx Context, ino Ino, totalspace, availspace, iused, iavail *uint64) syscall.Errno
 	// Access checks the access permission on given inode.
 	Access(ctx Context, inode Ino, modemask uint8, attr *Attr) syscall.Errno
 	// Lookup returns the inode and attributes for the given entry in a directory.

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -80,7 +80,7 @@ func ReportUsage(m meta.Meta, version string) {
 	var start = time.Now()
 	for {
 		var totalSpace, availSpace, iused, iavail uint64
-		_ = m.StatFS(ctx, &totalSpace, &availSpace, &iused, &iavail, false)
+		_ = m.StatFS(ctx, meta.RootInode, &totalSpace, &availSpace, &iused, &iavail)
 		u.Uptime = int64(time.Since(start).Seconds())
 		u.UsedSpace = int64(totalSpace - availSpace)
 		u.UsedInodes = int64(iused)

--- a/pkg/vfs/backup.go
+++ b/pkg/vfs/backup.go
@@ -52,7 +52,7 @@ func Backup(m meta.Meta, blob object.ObjectStorage, interval time.Duration) {
 		if now := time.Now(); now.Sub(last) >= interval {
 			if interval <= time.Hour {
 				var iused, dummy uint64
-				_ = m.StatFS(ctx, &dummy, &dummy, &iused, &dummy, false)
+				_ = m.StatFS(ctx, meta.RootInode, &dummy, &dummy, &iused, &dummy)
 				if iused > 1e6 {
 					logger.Warnf("backup metadata skipped because of too many inodes: %d %s; "+
 						"you may increase `--backup-meta` to enable it again", iused, interval)

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -43,7 +43,7 @@ type Statfs struct {
 
 func (v *VFS) StatFS(ctx Context, ino Ino) (st *Statfs, err syscall.Errno) {
 	var totalspace, availspace, iused, iavail uint64
-	_ = v.Meta.StatFS(ctx, &totalspace, &availspace, &iused, &iavail, true)
+	_ = v.Meta.StatFS(ctx, ino, &totalspace, &availspace, &iused, &iavail)
 	st = new(Statfs)
 	st.Total = totalspace
 	st.Avail = availspace


### PR DESCRIPTION
`statfs` now both support subdir quota and bind mount quota. The `df` command now works for bind volume in container.

```bash
hexi@ArchLinux ~> docker run --rm -v ~/mnt/jfs/lani/:/lani -it ubuntu bash
root@d05faa3213d9:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         295G  192G   88G  69% /
tmpfs            64M     0   64M   0% /dev
shm              64M     0   64M   0% /dev/shm
JuiceFS:myjfs    10G  2.8G  7.3G  28% /lani
/dev/nvme0n1p2  295G  192G   88G  69% /etc/hosts
tmpfs            16G     0   16G   0% /proc/asound
tmpfs            16G     0   16G   0% /proc/acpi
tmpfs            16G     0   16G   0% /proc/scsi
tmpfs            16G     0   16G   0% /sys/firmware
root@d05faa3213d9:/#
exit
```