### PR TITLE
CI / ltptest：replace sed default delimiter

### DIFF
--- a/.github/workflows/bash/rm_list.sh
+++ b/.github/workflows/bash/rm_list.sh
@@ -5,6 +5,6 @@ LIST=`cat $1`
 
 
 for LINE in $LIST; do
-      sudo sed -i "s/^$LINE.*//g" $2
+      sudo sed -i "s!^$LINE.*!!g" $2
 done
 


### PR DESCRIPTION
https://github.com/juicedata/juicefs/actions/runs/4652380547/jobs/8237811380#:~:text=sed%3A%20%2De%20expression%20%231%2C%20char,93%3A%20unknown%20option%20to%20%60s%27
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/31313340/230858834-cb364ed1-572f-47ae-90dd-940176ef7212.png">
