### PR TITLE
cmd/mount: add `single-mode` option to skips the heartbeat and metadata synchronization

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -195,6 +195,10 @@ func clientFlags() []cli.Flag {
 			Name:  "no-bgjob",
 			Usage: "disable background jobs (clean-up, backup, etc.)",
 		},
+		&cli.BoolFlag{
+			Name:  "single-mode",
+			Usage: "enable single node mode, which skips the heartbeat and metadata synchronization",
+		},
 		&cli.Float64Flag{
 			Name:  "open-cache",
 			Value: 0.0,

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -353,6 +353,7 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 	conf.SkipDirNlink = c.Int("skip-dir-nlink")
 	conf.ReadOnly = readOnly
 	conf.NoBGJob = c.Bool("no-bgjob")
+	conf.SingleMode = c.Bool("single-mode")
 	conf.OpenCache = time.Duration(c.Float64("open-cache") * 1e9)
 	conf.OpenCacheLimit = c.Uint64("open-cache-limit")
 	conf.Heartbeat = duration(c.String("heartbeat"))

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	CaseInsensi    bool
 	ReadOnly       bool
 	NoBGJob        bool // disable background jobs like clean-up, backup, etc.
+	SingleMode     bool // single node mode
 	OpenCache      time.Duration
 	OpenCacheLimit uint64 // max number of files to cache (soft limit)
 	Heartbeat      time.Duration


### PR DESCRIPTION
close #3329 

We need the heartbeat as a ticker to reload new configurations (conf, quota, etc.). So instead of setting heartbeat to 0, we may add a new single node mode, which skips the management of sessions and synchronization of background tasks.