### PR TITLE
chore: replace star history chart with a stable source

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,4 +225,4 @@ For more FAQs, please see the [full list](https://juicefs.com/docs/community/faq
 
 ## Stargazers over time
 
-[![Stargazers over time](https://starchart.cc/juicedata/juicefs.svg)](https://starchart.cc/juicedata/juicefs)
+[![Star History Chart](https://api.star-history.com/svg?repos=juicedata/juicefs&type=Date)](https://star-history.com/#juicedata/juicefs&Date)


### PR DESCRIPTION
The current provider is unstable:

<img width="859" alt="image" src="https://user-images.githubusercontent.com/18818196/231348171-8bae3e3d-6879-44e2-8e97-15211a286a49.png">

Also, star-history has an elegant style:

<img width="888" alt="image" src="https://user-images.githubusercontent.com/18818196/231348258-6ee4d177-655a-4950-ae89-a67df54f0bfe.png">
