### PR TITLE
quota: fix wrong iused in output table

### DIFF
--- a/cmd/quota.go
+++ b/cmd/quota.go
@@ -149,7 +149,7 @@ func quota(c *cli.Context) error {
 		} else {
 			size = "unlimited"
 		}
-		iused := humanize.Comma(q.MaxInodes)
+		iused := humanize.Comma(q.UsedInodes)
 		var itotal, iusedR string
 		if q.MaxInodes > 0 {
 			itotal = humanize.Comma(q.MaxInodes)


### PR DESCRIPTION
Before:
```
+-------+---------+---------+------+--------+-------+---------+
|  Path |   Size  |   Used  | Use% | Inodes | IUsed |  IUse%  |
+-------+---------+---------+------+--------+-------+---------+
| /lani | 1.0 GiB | 2.8 GiB | 279% |    100 |   100 | 260024% |
+-------+---------+---------+------+--------+-------+---------+
```

Now:
```
+-------+---------+---------+------+--------+---------+---------+
|  Path |   Size  |   Used  | Use% | Inodes |  IUsed  |  IUse%  |
+-------+---------+---------+------+--------+---------+---------+
| /lani | 1.0 GiB | 2.8 GiB | 279% |    100 | 260,024 | 260024% |
+-------+---------+---------+------+--------+---------+---------+
```