### PR TITLE
object/gs: remove storage class settings

### DIFF
--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -76,9 +76,8 @@ func (g *gs) Create() error {
 	}
 
 	err := g.client.Bucket(g.bucket).Create(ctx, projectID, &storage.BucketAttrs{
-		Name:         g.bucket,
-		StorageClass: "regional",
-		Location:     g.region,
+		Name:     g.bucket,
+		Location: g.region,
 	})
 	if err != nil && strings.Contains(err.Error(), "You already own this bucket") {
 		return nil


### PR DESCRIPTION
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/31313340/234767247-7c242517-df85-4191-918a-edbf4d0583ef.png">

The `regional` is an illegal value, which seems to be a bug