### PR TITLE
object: add dummy object store

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -439,7 +439,7 @@ func format(c *cli.Context) error {
 		logger.Fatalf("object storage: %s", err)
 	}
 	logger.Infof("Data use %s", blob)
-	if os.Getenv("JFS_NO_CHECK_OBJECT_STORAGE") == "" {
+	if os.Getenv("JFS_NO_CHECK_OBJECT_STORAGE") == "" && format.Storage != "dummy" {
 		if err := test(blob); err != nil {
 			logger.Fatalf("Storage %s is not configured correctly: %s", blob, err)
 		}

--- a/docs/en/guide/how_to_set_up_object_storage.md
+++ b/docs/en/guide/how_to_set_up_object_storage.md
@@ -184,6 +184,7 @@ If you wish to use a storage system that is not listed, feel free to submit a re
 | [PostgreSQL](#postgresql)                                   | `postgres` |
 | [Local disk](#local-disk)                                   | `file`     |
 | [SFTP/SSH](#sftp)                                           | `sftp`     |
+| [Dummy](#dummy)                                             | `dummy`     |
 
 ## Amazon S3
 
@@ -1147,3 +1148,13 @@ juicefs format  \
 - `--bucket` is used to set the server address and storage path in the format `<IP/Domain>:[port]:<Path>`. Note that the address should not contain a protocol header, the directory name should end with `/`, and the port number is optionally defaulted to `22`, e.g. `192.168.1.11:22:myjfs/`.
 - `--access-key` set the username of the remote server
 - `--secret-key` set the password of the remote server
+
+## Dummy {#dummy}
+
+A Dummy object storage implementation, it does nothing, that means it discards all uploaded data, and download always returns error. It's useful for developers to debug/develop non-object storage related functions like local disk cache.
+
+```shell
+juicefs format \
+    --storage dummy \
+    redis://localhost:6379/1 myjfs
+```

--- a/docs/zh_cn/guide/how_to_set_up_object_storage.md
+++ b/docs/zh_cn/guide/how_to_set_up_object_storage.md
@@ -184,6 +184,7 @@ juicefs format \
 | [PostgreSQL](#postgresql)                   | `postgres` |
 | [本地磁盘](#本地磁盘)                       | `file`     |
 | [SFTP/SSH](#sftp)                           | `sftp`     |
+| [Dummy](#dummy)                             | `dummy`     |
 
 ## Amazon S3
 
@@ -1143,3 +1144,13 @@ juicefs format  \
 - `--bucket` 用来设置服务器的地址及存储路径，格式为 `<IP/Domain>:[port]:<Path>`。注意，地址中不要包含协议头，目录名应该以 `/` 结尾，端口号为可选项默认为 `22`，例如 `192.168.1.11:22:myjfs/`。
 - `--access-key` 用来设置远程服务器的用户名
 - `--secret-key` 用来设置远程服务器的密码
+
+## Dummy {#dummy}
+
+一个 Dummy object storage 后端实现，什么都不做，上传的数据会被丢掉，下载会直接返回错误。仅用作开发测试使用，比如 debug 和后端 object storage 无关的功能时，比如本地缓存等。
+
+```shell
+juicefs format \
+    --storage dummy \
+    redis://localhost:6379/1 myjfs
+```

--- a/pkg/object/dummy.go
+++ b/pkg/object/dummy.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Alibaba Cloud, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"io"
+)
+
+type dummystore struct {
+	DefaultObjectStorage
+}
+
+func (d *dummystore) String() string {
+	return "dummy"
+}
+
+func (d *dummystore) Get(_key string, _off, _limit int64) (io.ReadCloser, error) {
+	return nil, notSupported
+}
+
+func (d *dummystore) Put(_key string, _in io.Reader) error {
+	return nil
+}
+
+func (d *dummystore) Delete(_key string) error {
+	return nil
+}
+
+func (d *dummystore) CompleteUpload(_key string, _uploadID string, _parts []*Part) error {
+	return nil
+}
+
+func newDummyStore(root, accesskey, secretkey, token string) (ObjectStorage, error) {
+	return &dummystore{}, nil
+}
+
+func init() {
+	Register("dummy", newDummyStore)
+}


### PR DESCRIPTION
Introduce a dummy object store as juicefs backend, which might be useful for developers to write/debug non-object storage related code such as disk cache.