### PR TITLE
fix update mtime before close

### DIFF
--- a/cmd/mdtest.go
+++ b/cmd/mdtest.go
@@ -70,7 +70,7 @@ func createFile(jfs *fs.FileSystem, bar *utils.Bar, np int, root string, d int, 
 				if bytes < (indx+1)*meta.ChunkSize {
 					size = bytes - indx*meta.ChunkSize
 				}
-				if st := m.Write(ctx, f.Inode(), uint32(indx), 0, meta.Slice{Id: id, Size: uint32(size), Len: uint32(size)}); st != 0 {
+				if st := m.Write(ctx, f.Inode(), uint32(indx), 0, meta.Slice{Id: id, Size: uint32(size), Len: uint32(size)}, time.Now()); st != 0 {
 					return fmt.Errorf("writeend %s: %s", fn, st)
 				}
 			}

--- a/pkg/meta/benchmarks_test.go
+++ b/pkg/meta/benchmarks_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/sirupsen/logrus"
@@ -536,7 +537,7 @@ func benchWrite(b *testing.B, m Meta) {
 		if err := m.NewSlice(ctx, &sliceId); err != 0 {
 			b.Fatalf("newchunk: %s", err)
 		}
-		if err := m.Write(ctx, inode, 0, offset, Slice{Id: sliceId, Size: step, Len: step}); err != 0 {
+		if err := m.Write(ctx, inode, 0, offset, Slice{Id: sliceId, Size: step, Len: step}, time.Now()); err != 0 {
 			b.Fatalf("write: %s", err)
 		}
 		offset += step
@@ -562,7 +563,7 @@ func benchRead(b *testing.B, m Meta, n int) {
 		if err := m.NewSlice(ctx, &sliceId); err != 0 {
 			b.Fatalf("newchunk: %s", err)
 		}
-		if err := m.Write(ctx, inode, 0, uint32(j)*step, Slice{Id: sliceId, Size: step, Len: step}); err != 0 {
+		if err := m.Write(ctx, inode, 0, uint32(j)*step, Slice{Id: sliceId, Size: step, Len: step}, time.Now()); err != 0 {
 			b.Fatalf("write: %s", err)
 		}
 	}

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -382,7 +382,7 @@ type Meta interface {
 	// NewSlice returns an id for new slice.
 	NewSlice(ctx Context, id *uint64) syscall.Errno
 	// Write put a slice of data on top of the given chunk.
-	Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno
+	Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice, mtime time.Time) syscall.Errno
 	// InvalidateChunkCache invalidate chunk cache
 	InvalidateChunkCache(ctx Context, inode Ino, indx uint32) syscall.Errno
 	// CopyFileRange copies part of a file to another one.

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2128,7 +2128,7 @@ func (m *redisMeta) Read(ctx Context, inode Ino, indx uint32, slices *[]Slice) s
 	return 0
 }
 
-func (m *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
+func (m *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice, mtime time.Time) syscall.Errno {
 	defer m.timeit("Write", time.Now())
 	f := m.of.find(inode)
 	if f != nil {
@@ -2159,11 +2159,10 @@ func (m *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice
 		if err := m.checkQuota(ctx, newSpace, 0, m.getParents(ctx, tx, inode, attr.Parent)...); err != 0 {
 			return err
 		}
-		now := time.Now()
-		attr.Mtime = now.Unix()
-		attr.Mtimensec = uint32(now.Nanosecond())
-		attr.Ctime = now.Unix()
-		attr.Ctimensec = uint32(now.Nanosecond())
+		attr.Mtime = mtime.Unix()
+		attr.Mtimensec = uint32(mtime.Nanosecond())
+		attr.Ctime = mtime.Unix()
+		attr.Ctimensec = uint32(mtime.Nanosecond())
 
 		var rpush *redis.IntCmd
 		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2159,10 +2159,11 @@ func (m *redisMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice
 		if err := m.checkQuota(ctx, newSpace, 0, m.getParents(ctx, tx, inode, attr.Parent)...); err != 0 {
 			return err
 		}
+		now := time.Now()
 		attr.Mtime = mtime.Unix()
 		attr.Mtimensec = uint32(mtime.Nanosecond())
-		attr.Ctime = mtime.Unix()
-		attr.Ctimensec = uint32(mtime.Nanosecond())
+		attr.Ctime = now.Unix()
+		attr.Ctimensec = uint32(now.Nanosecond())
 
 		var rpush *redis.IntCmd
 		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2114,9 +2114,8 @@ func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		if err := m.checkQuota(ctx, newSpace, 0, m.getParents(s, inode, nodeAttr.Parent)...); err != 0 {
 			return err
 		}
-		now := mtime.UnixNano() / 1e3
-		nodeAttr.Mtime = now
-		nodeAttr.Ctime = now
+		nodeAttr.Mtime = mtime.UnixNano() / 1e3
+		nodeAttr.Ctime = time.Now().UnixNano() / 1e3
 
 		var ck = chunk{Inode: inode, Indx: indx}
 		ok, err = s.ForUpdate().MustCols("indx").Get(&ck)

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2081,7 +2081,7 @@ func (m *dbMeta) Read(ctx Context, inode Ino, indx uint32, slices *[]Slice) sysc
 	return 0
 }
 
-func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice) syscall.Errno {
+func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Slice, mtime time.Time) syscall.Errno {
 	defer m.timeit("Write", time.Now())
 	f := m.of.find(inode)
 	if f != nil {
@@ -2114,7 +2114,7 @@ func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		if err := m.checkQuota(ctx, newSpace, 0, m.getParents(s, inode, nodeAttr.Parent)...); err != 0 {
 			return err
 		}
-		now := time.Now().UnixNano() / 1e3
+		now := mtime.UnixNano() / 1e3
 		nodeAttr.Mtime = now
 		nodeAttr.Ctime = now
 

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1862,10 +1862,11 @@ func (m *kvMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		if err := m.checkQuota(ctx, newSpace, 0, m.getParents(tx, inode, attr.Parent)...); err != 0 {
 			return err
 		}
+		now := time.Now()
 		attr.Mtime = mtime.Unix()
 		attr.Mtimensec = uint32(mtime.Nanosecond())
-		attr.Ctime = mtime.Unix()
-		attr.Ctimensec = uint32(mtime.Nanosecond())
+		attr.Ctime = now.Unix()
+		attr.Ctimensec = uint32(now.Nanosecond())
 		val := tx.append(m.chunkKey(inode, indx), marshalSlice(off, slice.Id, slice.Size, slice.Off, slice.Len))
 		tx.set(m.inodeKey(inode), m.marshal(&attr))
 		needCompact = (len(val)/sliceBytes)%100 == 99

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -178,6 +179,10 @@ func (v *VFS) SetAttr(ctx Context, ino Ino, set int, opened uint8, mode, uid, gi
 	if set&meta.SetAttrMtime != 0 {
 		attr.Mtime = mtime
 		attr.Mtimensec = mtimensec
+		v.writer.UpdateMtime(ino, time.Unix(mtime, int64(mtimensec)))
+	}
+	if set&meta.SetAttrMtimeNow != 0 {
+		v.writer.UpdateMtime(ino, time.Now())
 	}
 	err = v.Meta.SetAttr(ctx, ino, uint16(set), 0, attr)
 	if err == 0 {


### PR DESCRIPTION
Currently, it updates mtime as it updates the chunks in meta engine after data persisted. Actually, the mtime should be the time when data was written from kernel or application, not the time when data is persisted. 

Especially, a setattr could be called to update mtime before data is persisted, then the `mtime` could be lost (overwritten by data persistency).

close #3204