### PR TITLE
fix vfs.Truncate: throw error from meta.Truncate

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -464,7 +464,7 @@ func (v *VFS) Truncate(ctx Context, ino Ino, size int64, opened uint8, attr *Att
 		v.reader.Truncate(ino, uint64(size))
 		v.invalidateLength(ino)
 	}
-	return 0
+	return err
 }
 
 func (v *VFS) ReleaseHandler(ino Ino, fh uint64) {


### PR DESCRIPTION
Currently, the `vfs.Truncate` ignores error thrown by `meta.Truncate`