### PR TITLE
mount: speedup cache scan using WalkDir

### DIFF
--- a/cmd/umount.go
+++ b/cmd/umount.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -175,12 +176,12 @@ func waitWritebackComplete(stagingDir string) error {
 
 func fileSizeInDir(dir string) (uint64, error) {
 	var size uint64
-	err := filepath.Walk(dir, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += uint64(info.Size())
+	err := filepath.WalkDir(dir, func(name string, d fs.DirEntry, err error) error {
+		if d != nil && !d.IsDir() {
+			fi, _ := d.Info()
+			if fi != nil {
+				size += uint64(fi.Size())
+			}
 		}
 		return nil
 	})

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -22,6 +22,7 @@ import (
 	"hash/crc32"
 	"hash/fnv"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -569,7 +570,11 @@ func (cache *cacheStore) scanCached() {
 
 	cachePrefix := filepath.Join(cache.dir, cacheDir)
 	logger.Debugf("Scan %s to find cached blocks", cachePrefix)
-	_ = filepath.Walk(cachePrefix, func(path string, fi os.FileInfo, err error) error {
+	_ = filepath.WalkDir(cachePrefix, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		fi, _ := d.Info()
 		if fi != nil {
 			if fi.IsDir() || strings.HasSuffix(path, ".tmp") {
 				if fi.ModTime().Before(oneMinAgo) {
@@ -612,7 +617,11 @@ func (cache *cacheStore) scanStaging() {
 	var count int
 	stagingPrefix := filepath.Join(cache.dir, stagingDir)
 	logger.Debugf("Scan %s to find staging blocks", stagingPrefix)
-	_ = filepath.Walk(stagingPrefix, func(path string, fi os.FileInfo, err error) error {
+	_ = filepath.WalkDir(stagingPrefix, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // ignore it
+		}
+		fi, _ := d.Info()
 		if fi != nil {
 			if fi.IsDir() || strings.HasSuffix(path, ".tmp") {
 				if fi.ModTime().Before(oneMinAgo) {


### PR DESCRIPTION
WalkDir uses readdirplus() to fetch all the attributes of files in batch, which is faster than calling stat for each files.