### PR TITLE
CI: debug testdownload

### DIFF
--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestDownload(t *testing.T) {
+	os.Setenv("JFS_PAGE_STACK", "1")
 	key := "testDownload"
 	a, _ := object.CreateStorage("file", "/tmp/download/", "", "", "")
 	t.Cleanup(func() {

--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -156,7 +156,7 @@ func TestDownload(t *testing.T) {
 		}},
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 100; i++ {
 		for _, c := range tcases {
 			content := make([]byte, c.config.fsize)
 			rand.Read(content)

--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestDownload(t *testing.T) {
-	os.Setenv("JFS_PAGE_STACK", "1")
 	key := "testDownload"
 	a, _ := object.CreateStorage("file", "/tmp/download/", "", "", "")
 	t.Cleanup(func() {
@@ -166,7 +165,7 @@ func TestDownload(t *testing.T) {
 		}},
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 50; i++ {
 		for _, c := range tcases {
 			content := make([]byte, c.config.fsize)
 			rand.Read(content)

--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -45,6 +45,7 @@ func TestDownload(t *testing.T) {
 
 	tcases := []tcase{
 		{config: config{fsize: 1110, concurrent: 4, blockSize: 300}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res, err := io.ReadAll(pr)
 			if err != nil {
 				t.Fatal(err)
@@ -55,6 +56,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 97340326, concurrent: 4, blockSize: 5 << 20}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res, err := io.ReadAll(pr)
 			if err != nil {
 				t.Fatal(err)
@@ -65,6 +67,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 1110, concurrent: 5, blockSize: 300}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res, err := io.ReadAll(pr)
 			if err != nil {
 				t.Fatal(err)
@@ -75,6 +78,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 1, concurrent: 5, blockSize: 10}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res := make([]byte, 1)
 			n, err := pr.Read(res)
 			if err != nil || n != 1 || res[0] != content[0] {
@@ -87,6 +91,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 2, concurrent: 5, blockSize: 10}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res := make([]byte, 1)
 			n, err := pr.Read(res)
 			if err != nil || n != 1 || res[0] != content[0] {
@@ -103,6 +108,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 2, concurrent: 1, blockSize: 10}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res := make([]byte, 1)
 			n, err := pr.Read(res)
 
@@ -120,6 +126,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 1000, concurrent: 3, blockSize: 5}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res := make([]byte, 20)
 			n, err := io.ReadFull(pr, res)
 
@@ -139,6 +146,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 0, concurrent: 5, blockSize: 10}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res := make([]byte, 1)
 			n, err := pr.Read(res)
 			if err != io.EOF || n != 0 {
@@ -147,6 +155,7 @@ func TestDownload(t *testing.T) {
 		}},
 
 		{config: config{fsize: 100, concurrent: 5, blockSize: 10}, tfunc: func(t *testing.T, pr *parallelDownloader, content []byte) {
+			defer pr.Close()
 			res := make([]byte, 1)
 			pr.key = "notExist"
 			n, err := pr.Read(res)

--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -149,16 +149,19 @@ func TestDownload(t *testing.T) {
 			res := make([]byte, 1)
 			pr.key = "notExist"
 			n, err := pr.Read(res)
+			logger.Infof("test download not exist file:n: %d, err: %v", n, err)
 			if !os.IsNotExist(err) || n != 0 {
 				t.Fatalf("err should be ErrNotExist or n should equal 0")
 			}
 		}},
 	}
 
-	for _, c := range tcases {
-		content := make([]byte, c.config.fsize)
-		rand.Read(content)
-		_ = a.Put(key, bytes.NewReader(content))
-		c.tfunc(t, newParallelDownloader(a, key, c.config.fsize, c.blockSize, make(chan int, c.concurrent)), content)
+	for i := 0; i < 20; i++ {
+		for _, c := range tcases {
+			content := make([]byte, c.config.fsize)
+			rand.Read(content)
+			_ = a.Put(key, bytes.NewReader(content))
+			c.tfunc(t, newParallelDownloader(a, key, c.config.fsize, c.blockSize, make(chan int, c.concurrent)), content)
+		}
 	}
 }


### PR DESCRIPTION
just for test
```
=== RUN   TestDownload
2023/05/18 06:43:24.908254 juicefs[15502] <INFO>: test download not exist file:n: 0, err: open /tmp/download/notExist: no such file or directory [download_test.go:152]
2023/05/18 06:43:35.619795 juicefs[15502] <INFO>: test download not exist file:n: 0, err: open /tmp/download/notExist: no such file or directory [download_test.go:152]
2023/05/18 06:43:46.194644 juicefs[15502] <INFO>: test download not exist file:n: 0, err: open /tmp/download/notExist: no such file or directory [download_test.go:152]
2023/05/18 06:43:56.830453 juicefs[15502] <INFO>: test download not exist file:n: 0, err: open /tmp/download/notExist: no such file or directory [download_test.go:152]
2023/05/18 06:43:57.205575 juicefs[15502] <ERROR>: refcount of page 0xc00043f900 (8 bytes) is not zero: 1, created by:  [page.go:58]
2023/05/18 06:44:07.442657 juicefs[15502] <INFO>: test download not exist file:n: 0, err: open /tmp/download/notExist: no such file or directory [download_test.go:152]
2023/05/18 06:44:07.901253 juicefs[15502] <ERROR>: refcount of page 0xc00043f080 (8 bytes) is not zero: 1, created by:  [page.go:58]
2023/05/18 06:44:18.019797 juicefs[15502] <INFO>: test download not exist file:n: 0, err: open /tmp/download/notExist: no such file or directory [download_test.go:152]
2023/05/18 06:44:23.624011 juicefs[15502] <INFO>: test download not exist file:n: 1, err: <nil> [download_test.go:152]
    download_test.go:154: err should be ErrNotExist or n should equal 0
```


`2023/05/18 06:43:57.205575 juicefs[15502] <ERROR>: refcount of page 0xc00043f900 (8 bytes) is not zero: 1, created by:  [page.go:58]`