### PR TITLE
cmd/clone: fix prefix check

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -95,7 +96,7 @@ func clone(ctx *cli.Context) error {
 	if srcMp != dstMp {
 		return fmt.Errorf("the clone DST path should be at the same mount point as the SRC path")
 	}
-	if strings.HasPrefix(dstAbsPath, srcAbsPath) {
+	if strings.HasPrefix(dstAbsPath, path.Clean(srcAbsPath)+"/") {
 		return fmt.Errorf("the clone DST path should not be under the SRC path")
 	}
 


### PR DESCRIPTION
supprot `juicefs clone /tmp/jfs/a /tmp/jfs/a1`
close #3663
