### PR TITLE
fix sustained inodes test

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -1361,8 +1361,7 @@ func testCloseSession(t *testing.T, m Meta) {
 	if err != nil {
 		t.Fatalf("get session: %s", err)
 	} else {
-		// if len(s.Flocks) != 1 || len(s.Plocks) != 1 || len(s.Sustained) != 1 {
-		if len(s.Flocks) != 1 || len(s.Plocks) != 1 {
+		if len(s.Flocks) != 1 || len(s.Plocks) != 1 || len(s.Sustained) != 1 {
 			t.Fatalf("incorrect session: flock %d plock %d sustained %d", len(s.Flocks), len(s.Plocks), len(s.Sustained))
 		}
 	}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -1356,6 +1356,7 @@ func testCloseSession(t *testing.T, m Meta) {
 	if st := m.Unlink(ctx, 1, "f"); st != 0 {
 		t.Fatalf("unlink f: %s", st)
 	}
+	time.Sleep(10 * time.Millisecond)
 	sid := m.getBase().sid
 	s, err := m.GetSession(sid, true)
 	if err != nil {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for i in {1..100}
+do
+   echo "test $i: "
+   go clean -testcache && go test -run '^TestSQLiteClient$' github.com/juicedata/juicefs/pkg/meta
+done

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-for i in {1..100}
-do
-   echo "test $i: "
-   go clean -testcache && go test -run '^TestSQLiteClient$' github.com/juicedata/juicefs/pkg/meta
-done


### PR DESCRIPTION
close #3264

We disabled the checking of sustained inodes in close session tests, because it was flaky before.