### PR TITLE
sdk/java: limit generated uid/gid to int32 for sql engines

### DIFF
--- a/sdk/java/libjfs/guid.go
+++ b/sdk/java/libjfs/guid.go
@@ -33,6 +33,7 @@ type mapping struct {
 	sync.Mutex
 	salt      string
 	local     bool
+	mask      uint32
 	usernames map[string]uint32
 	userIDs   map[uint32]string
 	groups    map[string]uint32
@@ -55,7 +56,11 @@ func (m *mapping) genGuid(name string) uint32 {
 	digest := md5.Sum([]byte(m.salt + name + m.salt))
 	a := binary.LittleEndian.Uint64(digest[0:8])
 	b := binary.LittleEndian.Uint64(digest[8:16])
-	return uint32(a ^ b)
+	id := uint32(a ^ b)
+	if m.mask > 0 {
+		id &= m.mask
+	}
+	return id
 }
 
 func (m *mapping) lookupUser(name string) uint32 {

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -326,6 +326,10 @@ func getOrCreate(name, user, group, superuser, supergroup string, f func() *fs.F
 		if jfs == nil {
 			return 0
 		}
+		switch jfs.Meta().Name() {
+		case "mysql", "postgres", "sqlite3":
+			m.mask = 0x7FFFFFFF // limit generated uid to int32
+		}
 		logger.Infof("JuiceFileSystem created for user:%s group:%s", user, group)
 	}
 	w := &wrapper{jfs, nil, m, user, superuser, supergroup}


### PR DESCRIPTION
closes #3679 