### PR TITLE
fix TestFdbClient: replace DefaultConf with testConfig

### DIFF
--- a/pkg/meta/tkv_fdb_test.go
+++ b/pkg/meta/tkv_fdb_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestFdbClient(t *testing.T) { //skip mutate
-	m, err := newKVMeta("fdb", "/etc/foundationdb/fdb.cluster?prefix=test2", DefaultConf())
+	m, err := newKVMeta("fdb", "/etc/foundationdb/fdb.cluster?prefix=test2", testConfig())
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
 	}


### PR DESCRIPTION
in #3678, most of engine test use `testConfig()` instead of `DefaultConf` expect for `TestFdbClient`