### PR TITLE
cmd/sync: fix duplicated path in HDFS

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -332,7 +332,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 		}
 	}
 	switch name {
-	case "file":
+	case "file", "hdfs":
 	case "minio":
 		if strings.Count(u.Path, "/") > 1 {
 			// skip bucket name

--- a/pkg/object/hdfs.go
+++ b/pkg/object/hdfs.go
@@ -377,6 +377,7 @@ func parseHDFSAddr(addr string, conf hadoopconf.HadoopConf) (rpcAddresses []stri
 		}
 	}
 	if len(nns) > 0 {
+		sort.Strings(nns)
 		rpcAddresses = nns
 	} else {
 		rpcAddresses = strings.Split(authority, ",")


### PR DESCRIPTION
The path of HDFS uri is already used, we should not add a prefix over it.

The bug is introduced by #3528