### PR TITLE
cmd: add `log-level` option to customize the log level

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -43,8 +43,9 @@ func globalFlags() []cli.Flag {
 			Usage: "enable trace log",
 		},
 		&cli.StringFlag{
-			Name:  "log-level",
-			Usage: "set log level (trace, debug, info, warn, error, fatal, panic)",
+			Name:   "log-level",
+			Usage:  "set log level (trace, debug, info, warn, error, fatal, panic)",
+			Hidden: true,
 		},
 		&cli.BoolFlag{
 			Name:  "no-agent",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -42,6 +42,10 @@ func globalFlags() []cli.Flag {
 			Name:  "trace",
 			Usage: "enable trace log",
 		},
+		&cli.StringFlag{
+			Name:  "log-level",
+			Usage: "set log level (trace, debug, info, warn, error, fatal, panic)",
+		},
 		&cli.BoolFlag{
 			Name:  "no-agent",
 			Usage: "disable pprof (:6060) agent",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -249,14 +249,31 @@ func setup(c *cli.Context, n int) {
 		os.Exit(1)
 	}
 
-	if c.Bool("trace") {
+	switch c.String("log-level") {
+	case "trace":
 		utils.SetLogLevel(logrus.TraceLevel)
-	} else if c.Bool("verbose") {
+	case "debug":
 		utils.SetLogLevel(logrus.DebugLevel)
-	} else if c.Bool("quiet") {
-		utils.SetLogLevel(logrus.WarnLevel)
-	} else {
+	case "info":
 		utils.SetLogLevel(logrus.InfoLevel)
+	case "warn":
+		utils.SetLogLevel(logrus.WarnLevel)
+	case "error":
+		utils.SetLogLevel(logrus.ErrorLevel)
+	case "fatal":
+		utils.SetLogLevel(logrus.FatalLevel)
+	case "panic":
+		utils.SetLogLevel(logrus.PanicLevel)
+	default:
+		if c.Bool("trace") {
+			utils.SetLogLevel(logrus.TraceLevel)
+		} else if c.Bool("verbose") {
+			utils.SetLogLevel(logrus.DebugLevel)
+		} else if c.Bool("quiet") {
+			utils.SetLogLevel(logrus.WarnLevel)
+		} else {
+			utils.SetLogLevel(logrus.InfoLevel)
+		}
 	}
 	if c.Bool("no-color") {
 		utils.DisableLogColor()


### PR DESCRIPTION
Sometimes (in tests) we want to set log level to `error` or even higher.