### PR TITLE
meta/sql: fix update dir stats by fault

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2439,6 +2439,9 @@ func (m *redisMeta) doGetParents(ctx Context, inode Ino) map[Ino]int {
 }
 
 func (m *redisMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno) {
+	if m.conf.ReadOnly {
+		return nil, syscall.EROFS
+	}
 	field := ino.String()
 	stat, st := m.calcDirStat(ctx, ino)
 	if st != 0 {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2485,7 +2485,7 @@ func (m *dbMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno) {
 		record := &dirStats{ino, stat.length, stat.space, stat.inodes}
 		_, err = s.Insert(record)
 		if err != nil && isDuplicateEntryErr(err) {
-			_, err = s.Where("inode = ?", ino).Cols("data_length", "used_space", "used_inodes").Update(record)
+			_, err = s.Cols("data_length", "used_space", "used_inodes").Update(record, &dirStats{Inode: ino})
 		}
 		return err
 	})


### PR DESCRIPTION
close #3725

we introduce a bug in #3715, which causes all dir stats will be updated by single record.