### PR TITLE
load/sql: update max fields count to reduce max batch size

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -43,7 +43,7 @@ import (
 	"xorm.io/xorm/names"
 )
 
-const MaxFieldsCountOfTable = 13 // node table
+const MaxFieldsCountOfTable = 16 // node table
 
 type setting struct {
 	Name  string `xorm:"pk"`


### PR DESCRIPTION
in #3654 we introduce three new fields for the `node` table, so the numbers of placeholders may exceed the limitation of SQL engine like https://github.com/juicedata/juicefs/actions/runs/5049460379/jobs/9058941017 