### PR TITLE
sdk: skip permission check for root

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -701,7 +701,7 @@ func (fs *FileSystem) resolve(ctx meta.Context, p string, followLastSymlink bool
 			parent = inode
 			break
 		}
-		if i > 0 {
+		if parent > 1 {
 			if (name == "." || name == "..") && attr.Typ != meta.TypeDirectory {
 				return nil, syscall.ENOTDIR
 			}


### PR DESCRIPTION
When the path starts with `/`, it will check permission for root.

We assume root is accessible for everyone. 