### PR TITLE
sync: wait() may miss signal then cause deadlock

### DIFF
--- a/pkg/utils/cond.go
+++ b/pkg/utils/cond.go
@@ -43,14 +43,6 @@ func (c *Cond) Broadcast() {
 	c.signal = make(chan struct{})
 }
 
-// Wait until Signal() or Broadcast() is called.
-func (c *Cond) Wait() {
-	ch := c.signal
-	c.L.Unlock()
-	<-ch
-	c.L.Lock()
-}
-
 var timerPool = sync.Pool{
 	New: func() interface{} {
 		return time.NewTimer(time.Second)

--- a/pkg/utils/cond_test.go
+++ b/pkg/utils/cond_test.go
@@ -32,7 +32,8 @@ func TestCond(t *testing.T) {
 	go func() {
 		m.Lock()
 		wg.Done()
-		l.Wait()
+		for l.WaitWithTimeout(time.Second) {
+		}
 		l.Signal()
 		m.Unlock()
 		done <- true
@@ -40,7 +41,8 @@ func TestCond(t *testing.T) {
 	wg.Wait()
 	m.Lock()
 	l.Signal()
-	l.Wait()
+	for l.WaitWithTimeout(time.Second) {
+	}
 	m.Unlock()
 	select {
 	case <-done:


### PR DESCRIPTION
There is a chance that Wait() may miss the signal from Signal(), then deadlock, we should always use WaitWithTimeout().

```
G1                        G2

read is false
Unlock
                            Lock
                            ready = true
                            select ch {
                            default:
                            }
<- ch (deadlock)
```
