### PR TITLE
Update sql.go, Add index to column refs in sliceRef

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -97,7 +97,7 @@ type chunk struct {
 type sliceRef struct {
 	Id   uint64 `xorm:"pk chunkid"`
 	Size uint32 `xorm:"notnull"`
-	Refs int    `xorm:"notnull"`
+	Refs int    `xorm:"index notnull"`
 }
 
 func (c *sliceRef) TableName() string {


### PR DESCRIPTION
Add index to column refs in sliceRef table because the doCleanupSlices function query statement executes too slowly when there are too many rows in the table.