### PR TITLE
#3849 kvtxn interface should allow returning errors

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -2377,7 +2377,7 @@ func testClone(t *testing.T, m Meta) {
 		removedItem = append(removedItem, m.detachedKey(cloneDstIno))
 		m.txn(func(tx *kvTxn) error {
 			for _, key := range removedItem {
-				if buf := tx.get(key.([]byte)); buf != nil {
+				if buf, _ := tx.get(key.([]byte)); buf != nil {
 					t.Fatalf("has keys not removed: %v", removedItem)
 				}
 			}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -4043,7 +4043,7 @@ func (m *redisMeta) LoadMeta(r io.Reader) (err error) {
 			return err
 		}
 		if dbsize > 0 {
-			return fmt.Errorf("Database redis://%s is not empty", m.addr)
+			return fmt.Errorf("database redis://%s is not empty", m.addr)
 		}
 	}
 

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -121,7 +121,10 @@ func (tx *badgerTxn) append(key []byte, value []byte) ([]byte, error) {
 		return nil, err
 	}
 	list := append(old, value...)
-	tx.set(key, list)
+	err = tx.set(key, list)
+	if err != nil {
+		return nil, err
+	}
 	return list, nil
 }
 

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -163,7 +163,10 @@ func (tx *etcdTxn) append(key []byte, value []byte) ([]byte, error) {
 		return nil, err
 	}
 	new := append(old, value...)
-	tx.set(key, new)
+	err = tx.set(key, new)
+	if err != nil {
+		return nil, err
+	}
 	return new, nil
 }
 

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -143,7 +143,10 @@ func (tx *memTxn) append(key []byte, value []byte) ([]byte, error) {
 		return nil, err
 	}
 	new := append(old, value...)
-	tx.set(key, new)
+	err = tx.set(key, new)
+	if err != nil {
+		return nil, err
+	}
 	return new, nil
 }
 

--- a/pkg/meta/tkv_prefix.go
+++ b/pkg/meta/tkv_prefix.go
@@ -46,18 +46,18 @@ func (tx *prefixTxn) gets(keys ...[]byte) ([][]byte, error) {
 	return tx.kvTxn.gets(realKeys...)
 }
 
-func (tx *prefixTxn) scan(begin, end []byte, keysOnly bool, handler func(k, v []byte) bool) {
-	tx.kvTxn.scan(tx.realKey(begin), tx.realKey(end), keysOnly, func(k, v []byte) bool {
+func (tx *prefixTxn) scan(begin, end []byte, keysOnly bool, handler func(k, v []byte) bool) error {
+	return tx.kvTxn.scan(tx.realKey(begin), tx.realKey(end), keysOnly, func(k, v []byte) bool {
 		return handler(tx.origKey(k), v)
 	})
 }
 
-func (tx *prefixTxn) exist(prefix []byte) bool {
+func (tx *prefixTxn) exist(prefix []byte) (bool, error) {
 	return tx.kvTxn.exist(tx.realKey(prefix))
 }
 
-func (tx *prefixTxn) set(key, value []byte) {
-	tx.kvTxn.set(tx.realKey(key), value)
+func (tx *prefixTxn) set(key, value []byte) error {
+	return tx.kvTxn.set(tx.realKey(key), value)
 }
 
 func (tx *prefixTxn) append(key []byte, value []byte) ([]byte, error) {
@@ -68,8 +68,8 @@ func (tx *prefixTxn) incrBy(key []byte, value int64) (int64, error) {
 	return tx.kvTxn.incrBy(tx.realKey(key), value)
 }
 
-func (tx *prefixTxn) delete(key []byte) {
-	tx.kvTxn.delete(tx.realKey(key))
+func (tx *prefixTxn) delete(key []byte) error {
+	return tx.kvTxn.delete(tx.realKey(key))
 }
 
 type prefixClient struct {

--- a/pkg/meta/tkv_prefix.go
+++ b/pkg/meta/tkv_prefix.go
@@ -34,11 +34,11 @@ func (tx *prefixTxn) origKey(key []byte) []byte {
 	return key[len(tx.prefix):]
 }
 
-func (tx *prefixTxn) get(key []byte) []byte {
+func (tx *prefixTxn) get(key []byte) ([]byte, error) {
 	return tx.kvTxn.get(tx.realKey(key))
 }
 
-func (tx *prefixTxn) gets(keys ...[]byte) [][]byte {
+func (tx *prefixTxn) gets(keys ...[]byte) ([][]byte, error) {
 	realKeys := make([][]byte, len(keys))
 	for i, key := range keys {
 		realKeys[i] = tx.realKey(key)
@@ -60,11 +60,11 @@ func (tx *prefixTxn) set(key, value []byte) {
 	tx.kvTxn.set(tx.realKey(key), value)
 }
 
-func (tx *prefixTxn) append(key []byte, value []byte) []byte {
+func (tx *prefixTxn) append(key []byte, value []byte) ([]byte, error) {
 	return tx.kvTxn.append(tx.realKey(key), value)
 }
 
-func (tx *prefixTxn) incrBy(key []byte, value int64) int64 {
+func (tx *prefixTxn) incrBy(key []byte, value int64) (int64, error) {
 	return tx.kvTxn.incrBy(tx.realKey(key), value)
 }
 

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -89,7 +89,7 @@ func testTKV(t *testing.T, c tkvClient) {
 		kt.append(k, v)
 	})
 	var r []byte
-	txn(func(kt *kvTxn) { r = kt.get(k) })
+	txn(func(kt *kvTxn) { r, err = kt.get(k) })
 	if !bytes.Equal(r, []byte("valuevalue")) {
 		t.Fatalf("expect 'valuevalue', but got %v", string(r))
 	}
@@ -98,7 +98,7 @@ func testTKV(t *testing.T, c tkvClient) {
 		kt.set([]byte("v"), k)
 	})
 	var ks [][]byte
-	txn(func(kt *kvTxn) { ks = kt.gets([]byte("k1"), []byte("k2")) })
+	txn(func(kt *kvTxn) { ks, err = kt.gets([]byte("k1"), []byte("k2")) })
 	if ks[0] != nil || string(ks[1]) != "value" {
 		t.Fatalf("gets k1,k2: %+v != %+v", ks, [][]byte{nil, []byte("value")})
 	}
@@ -176,7 +176,7 @@ func testTKV(t *testing.T, c tkvClient) {
 			kt.delete(key)
 		}
 	})
-	txn(func(kt *kvTxn) { r = kt.get(k) })
+	txn(func(kt *kvTxn) { r, err = kt.get(k) })
 	if r != nil {
 		t.Fatalf("expect nil, but got %v", string(r))
 	}
@@ -197,23 +197,23 @@ func testTKV(t *testing.T, c tkvClient) {
 
 	// counters
 	var count int64
-	c.txn(func(tx *kvTxn) error {
-		count = tx.incrBy([]byte("counter"), -1)
-		return nil
+	c.txn(func(tx *kvTxn) (xerr error) {
+		count, xerr = tx.incrBy([]byte("counter"), -1)
+		return xerr
 	}, 0)
 	if count != -1 {
 		t.Fatalf("counter should be -1, but got %d", count)
 	}
-	c.txn(func(tx *kvTxn) error {
-		count = tx.incrBy([]byte("counter"), 0)
-		return nil
+	c.txn(func(tx *kvTxn) (xerr error) {
+		count, xerr = tx.incrBy([]byte("counter"), 0)
+		return xerr
 	}, 0)
 	if count != -1 {
 		t.Fatalf("counter should be -1, but got %d", count)
 	}
-	c.txn(func(tx *kvTxn) error {
-		count = tx.incrBy([]byte("counter"), 2)
-		return nil
+	c.txn(func(tx *kvTxn) (xerr error) {
+		count, xerr = tx.incrBy([]byte("counter"), 2)
+		return xerr
 	}, 0)
 	if count != 1 {
 		t.Fatalf("counter should be 1, but got %d", count)
@@ -226,7 +226,7 @@ func testTKV(t *testing.T, c tkvClient) {
 	})
 	var v2 []byte
 	txn(func(kt *kvTxn) {
-		v2 = kt.get(k)
+		v2, err = kt.get(k)
 	})
 	if !bytes.Equal(v2, v) {
 		t.Fatalf("expect %v but got %v", v, v2)

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -77,7 +77,7 @@ func testTKV(t *testing.T, c tkvClient) {
 		t.Fatalf("reset: %s", err)
 	}
 	var hasKey bool
-	txn(func(kt *kvTxn) { hasKey = kt.exist(nil) })
+	txn(func(kt *kvTxn) { hasKey, _ = kt.exist(nil) })
 	if hasKey {
 		t.Fatalf("has key after reset")
 	}
@@ -167,7 +167,7 @@ func testTKV(t *testing.T, c tkvClient) {
 	}
 
 	// exists
-	txn(func(kt *kvTxn) { hasKey = kt.exist([]byte("k")) })
+	txn(func(kt *kvTxn) { hasKey, _ = kt.exist([]byte("k")) })
 	if !hasKey {
 		t.Fatalf("has key k*")
 	}
@@ -190,7 +190,7 @@ func testTKV(t *testing.T, c tkvClient) {
 	if len(keys) != 0 {
 		t.Fatalf("no keys: %+v", keys)
 	}
-	txn(func(kt *kvTxn) { hasKey = kt.exist(nil) })
+	txn(func(kt *kvTxn) { hasKey, _ = kt.exist(nil) })
 	if hasKey {
 		t.Fatalf("has not keys")
 	}

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -151,7 +151,10 @@ func (tx *tikvTxn) append(key []byte, value []byte) ([]byte, error) {
 		return nil, err
 	}
 	new := append(old, value...)
-	tx.set(key, new)
+	err = tx.set(key, new)
+	if err != nil {
+		return nil, err
+	}
 	return new, nil
 }
 

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -118,32 +118,31 @@ func (tx *tikvTxn) gets(keys ...[]byte) ([][]byte, error) {
 	return values, nil
 }
 
-func (tx *tikvTxn) scan(begin, end []byte, keysOnly bool, handler func(k, v []byte) bool) {
+func (tx *tikvTxn) scan(begin, end []byte, keysOnly bool, handler func(k, v []byte) bool) error {
 	it, err := tx.Iter(begin, end)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer it.Close()
 	for it.Valid() && handler(it.Key(), it.Value()) {
 		if err = it.Next(); err != nil {
-			panic(err)
+			return err
 		}
 	}
+	return nil
 }
 
-func (tx *tikvTxn) exist(prefix []byte) bool {
+func (tx *tikvTxn) exist(prefix []byte) (bool, error) {
 	it, err := tx.Iter(prefix, nextKey(prefix))
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 	defer it.Close()
-	return it.Valid()
+	return it.Valid(), nil
 }
 
-func (tx *tikvTxn) set(key, value []byte) {
-	if err := tx.Set(key, value); err != nil {
-		panic(err)
-	}
+func (tx *tikvTxn) set(key, value []byte) error {
+	return tx.Set(key, value)
 }
 
 func (tx *tikvTxn) append(key []byte, value []byte) ([]byte, error) {
@@ -169,10 +168,8 @@ func (tx *tikvTxn) incrBy(key []byte, value int64) (int64, error) {
 	return new, nil
 }
 
-func (tx *tikvTxn) delete(key []byte) {
-	if err := tx.Delete(key); err != nil {
-		panic(err)
-	}
+func (tx *tikvTxn) delete(key []byte) error {
+	return tx.Delete(key)
 }
 
 type tikvClient struct {


### PR DESCRIPTION
This patch adds support for error handling into the kvtxn interface and its implementations.