### PR TITLE
metrics: fix the bug of `juicefs_object_request_data_bytes` name 

### DIFF
--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -171,6 +171,7 @@ func collectMetrics(registry *prometheus.Registry) []byte {
 			continue
 		}
 		for _, m := range mf.Metric {
+			var name = *mf.Name
 			for _, l := range m.Label {
 				if *l.Name != "mp" && *l.Name != "vol_name" {
 					name += "_" + *l.Value


### PR DESCRIPTION
Fix the error of the name change for the 'juicefs_object_request_data_bytes' metric.
ref #3501

