### PR TITLE
object/ceph: fix ceph range get and get no-exist

### DIFF
--- a/pkg/object/ceph.go
+++ b/pkg/object/ceph.go
@@ -98,6 +98,9 @@ type cephReader struct {
 }
 
 func (r *cephReader) Read(buf []byte) (n int, err error) {
+	if r.limit == 0 {
+		return 0, io.EOF
+	}
 	if r.limit > 0 && int64(len(buf)) > r.limit {
 		buf = buf[:r.limit]
 	}
@@ -121,6 +124,9 @@ func (r *cephReader) Close() error {
 }
 
 func (c *ceph) Get(key string, off, limit int64) (io.ReadCloser, error) {
+	if _, err := c.Head(key); err != nil {
+		return nil, err
+	}
 	ctx, err := c.newContext()
 	if err != nil {
 		return nil, err
@@ -135,6 +141,7 @@ var cephPool = sync.Pool{
 }
 
 func (c *ceph) Put(key string, in io.Reader) error {
+	// ceph default osd_max_object_size = 128M
 	return c.do(func(ctx *rados.IOContext) error {
 		if b, ok := in.(*bytes.Reader); ok {
 			v := reflect.ValueOf(b)
@@ -142,7 +149,10 @@ func (c *ceph) Put(key string, in io.Reader) error {
 			if len(data) == 0 {
 				return errors.New("ceph: can't put empty file")
 			}
-			return ctx.WriteFull(key, data)
+			// If the data exceeds 90M, ceph will report an error: 'rados: ret=-90, Message too long'
+			if len(data) < 85<<20 {
+				return ctx.WriteFull(key, data)
+			}
 		}
 		buf := cephPool.Get().([]byte)
 		defer cephPool.Put(buf)


### PR DESCRIPTION
close #3836 
<img width="1701" alt="image" src="https://github.com/juicedata/juicefs/assets/31313340/8a989b6c-ffe2-421e-b411-2fd742124806">


```
      // use ctx.WriteFull(key, data)

        for i := 85; i < 95; i++ {
		body := make([]byte, i<<20)
		rand.Read(body)
		err = s.Put("test", bytes.NewReader(body))
		if err != nil {
			t.Errorf("PUT %dM failed: %s", i, err.Error())
		} else {
			t.Logf("PUT %dM success", i)
		}
	}
```
<img width="1452" alt="image" src="https://github.com/juicedata/juicefs/assets/31313340/d8b8285b-1796-4907-8bea-fffc24bc4ffa">
