### PR TITLE
dont try set maxmemory_policy if setting does not exist

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3548,7 +3548,7 @@ func (m *redisMeta) checkServerConfig() {
 	if err != nil {
 		logger.Warnf("parse info: %s", err)
 	}
-	if rInfo.storageProvider == "" && rInfo.maxMemoryPolicy != "noeviction" {
+	if rInfo.storageProvider == "" && rInfo.maxMemoryPolicy != "" && rInfo.maxMemoryPolicy != "noeviction" {
 		logger.Warnf("maxmemory_policy is %q,  we will try to reconfigure it to 'noeviction'.", rInfo.maxMemoryPolicy)
 		if _, err := m.rdb.ConfigSet(Background, "maxmemory-policy", "noeviction").Result(); err != nil {
 			logger.Errorf("try to reconfigure maxmemory-policy to 'noeviction' failed: %s", err)


### PR DESCRIPTION
Apache KVRocks supports the needed Redis commands (see https://kvrocks.apache.org/docs/supported-commands) to be a backend for JuiceFS, however because it uses RocksDB, there is no max_memory policy, but JuiceFS will try and set this, resulting in an non-critical error at startup.