### PR TITLE
CI: run load test only for juicedata/juicefs repo

### DIFF
--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -42,6 +42,7 @@ jobs:
       meta_matrix: ${{ steps.set-matrix.outputs.meta_matrix }}
 
   load:
+    if: github.repository == 'juicedata/juicefs'
     needs: [build-matrix]
     strategy:
       fail-fast: false


### PR DESCRIPTION
because we use secret when save benchmark, the pr from other repos will fail on empty secrets.