### PR TITLE
cmd/sync: allows customization of the IP address and port that the management node listens on

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -213,17 +213,17 @@ func syncStorageFlags() []cli.Flag {
 func clusterFlags() []cli.Flag {
 	return addCategories("CLUSTER", []cli.Flag{
 		&cli.StringFlag{
-			Name:  "manager",
-			Usage: "manager address",
+			Name:   "manager",
+			Usage:  "the manager address used only by the worker node",
+			Hidden: true,
 		},
 		&cli.StringSliceFlag{
 			Name:  "worker",
 			Usage: "hosts (separated by comma) to launch worker",
 		},
-		&cli.BoolFlag{
-			Name:   "is-worker",
-			Usage:  "start as a worker",
-			Hidden: true,
+		&cli.StringFlag{
+			Name:  "manager-address",
+			Usage: "manager address",
 		},
 	})
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -222,8 +222,8 @@ func clusterFlags() []cli.Flag {
 			Usage: "hosts (separated by comma) to launch worker",
 		},
 		&cli.StringFlag{
-			Name:  "manager-address",
-			Usage: "manager address",
+			Name:  "manager-addr",
+			Usage: "the IP address to communicate with workers",
 		},
 	})
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -220,6 +220,11 @@ func clusterFlags() []cli.Flag {
 			Name:  "worker",
 			Usage: "hosts (separated by comma) to launch worker",
 		},
+		&cli.BoolFlag{
+			Name:   "is-worker",
+			Usage:  "start as a worker",
+			Hidden: true,
+		},
 	})
 }
 

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -172,8 +172,8 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 		_, _ = w.Write([]byte("OK"))
 	})
 	var addr string
-	if config.Manager != "" && !config.IsWorker {
-		addr = config.Manager
+	if config.ManagerAddr != "" {
+		addr = config.ManagerAddr
 	} else {
 		ips, err := utils.FindLocalIPs()
 		if err != nil {
@@ -267,9 +267,9 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 			args = append(args, rpath)
 			if strings.HasSuffix(path, "juicefs") {
 				args = append(args, os.Args[1:]...)
-				args = append(args, "--is-worker", "--manager", address)
+				args = append(args, "--manager", address)
 			} else {
-				args = append(args, "--is-worker", "--manager", address)
+				args = append(args, "--manager", address)
 				args = append(args, os.Args[1:]...)
 			}
 			if !config.Verbose && !config.Quiet {

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -189,7 +189,10 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 		if ip == "" {
 			return "", fmt.Errorf("no local ip found")
 		}
-		addr = ip + ":"
+	}
+
+	if !strings.Contains(addr, ":") {
+		addr += ":"
 	}
 
 	l, err := net.Listen("tcp", addr)

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -40,13 +40,13 @@ func (o *obj) StorageClass() string { return "" }
 func TestCluster(t *testing.T) {
 	// manager
 	todo := make(chan object.Object, 100)
-	addr, err := startManager(todo)
+	var conf Config
+	addr, err := startManager(&conf, todo)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// sendStats(addr)
 	// worker
-	var conf Config
 	conf.Manager = addr
 	mytodo := make(chan object.Object, 100)
 	go fetchJobs(mytodo, &conf)

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	Limit          int64
 	Manager        string
 	Workers        []string
-	IsWorker       bool
+	ManagerAddr    string
 	ListThreads    int
 	ListDepth      int
 	BWLimit        int
@@ -150,7 +150,7 @@ func NewConfigFromCli(c *cli.Context) *Config {
 		Links:          c.Bool("links"),
 		Limit:          c.Int64("limit"),
 		Workers:        c.StringSlice("worker"),
-		IsWorker:       c.Bool("is-worker"),
+		ManagerAddr:    c.String("manager-address"),
 		Manager:        c.String("manager"),
 		BWLimit:        c.Int("bwlimit"),
 		NoHTTPS:        c.Bool("no-https"),

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Limit          int64
 	Manager        string
 	Workers        []string
+	IsWorker       bool
 	ListThreads    int
 	ListDepth      int
 	BWLimit        int
@@ -149,6 +150,7 @@ func NewConfigFromCli(c *cli.Context) *Config {
 		Links:          c.Bool("links"),
 		Limit:          c.Int64("limit"),
 		Workers:        c.StringSlice("worker"),
+		IsWorker:       c.Bool("is-worker"),
 		Manager:        c.String("manager"),
 		BWLimit:        c.Int("bwlimit"),
 		NoHTTPS:        c.Bool("no-https"),

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -150,7 +150,7 @@ func NewConfigFromCli(c *cli.Context) *Config {
 		Links:          c.Bool("links"),
 		Limit:          c.Int64("limit"),
 		Workers:        c.StringSlice("worker"),
-		ManagerAddr:    c.String("manager-address"),
+		ManagerAddr:    c.String("manager-addr"),
 		Manager:        c.String("manager"),
 		BWLimit:        c.Int("bwlimit"),
 		NoHTTPS:        c.Bool("no-https"),


### PR DESCRIPTION
The `sync` subcommand allows customization of the IP address and port that the management node listens on.