### PR TITLE
cmd/sync: add `/` to end when path is `.`

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -275,7 +275,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.Replace(absPath, "\\", "/", -1)
 			}
-			if strings.HasSuffix(uri, "/") {
+			if strings.HasSuffix(uri, "/") || uri == "." {
 				absPath += "/"
 			}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -275,7 +275,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.Replace(absPath, "\\", "/", -1)
 			}
-			if strings.HasSuffix(uri, "/") || strings.HasSuffix(uri, "/.") || strings.HasSuffix(uri, "/..") {
+			if strings.HasSuffix(uri, "/") || uri == "." || uri == ".." || strings.HasSuffix(uri, "/.") || strings.HasSuffix(uri, "/..") {
 				absPath += "/"
 			}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -272,10 +272,14 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			if err != nil {
 				logger.Fatalf("invalid path: %s", err.Error())
 			}
+			fileInfo, err := os.Stat(absPath)
+			if err != nil {
+				logger.Fatalf("invalid path: %s", err.Error())
+			}
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.Replace(absPath, "\\", "/", -1)
 			}
-			if strings.HasSuffix(uri, "/") || uri == "." {
+			if fileInfo.IsDir() {
 				absPath += "/"
 			}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -275,7 +275,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.Replace(absPath, "\\", "/", -1)
 			}
-			if strings.HasSuffix(uri, "/") || strings.HasSuffix(uri, ".") {
+			if strings.HasSuffix(uri, "/") || strings.HasSuffix(uri, "/.") || strings.HasSuffix(uri, "/..") {
 				absPath += "/"
 			}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -272,14 +272,10 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			if err != nil {
 				logger.Fatalf("invalid path: %s", err.Error())
 			}
-			fileInfo, err := os.Stat(absPath)
-			if err != nil {
-				logger.Fatalf("invalid path: %s", err.Error())
-			}
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.Replace(absPath, "\\", "/", -1)
 			}
-			if fileInfo.IsDir() {
+			if strings.HasSuffix(uri, "/") || uri == "." {
 				absPath += "/"
 			}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -275,7 +275,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.Replace(absPath, "\\", "/", -1)
 			}
-			if strings.HasSuffix(uri, "/") || uri == "." {
+			if strings.HasSuffix(uri, "/") || strings.HasSuffix(uri, ".") {
 				absPath += "/"
 			}
 


### PR DESCRIPTION
close #3976 