### PR TITLE
Update how_to_set_up_metadata_engine.md

### DIFF
--- a/docs/zh_cn/guide/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/guide/how_to_set_up_metadata_engine.md
@@ -482,7 +482,7 @@ juicefs format \
 ### 挂载文件系统
 
 ```shell
-juicefs mount -d "tikv://192.168.1.6:2379,192.168.1.7:2379,192.168.1.8:2379/jfs" /mnt/jfs
+juicefs mount -d "tikv://192.168.1.6:2379,192.168.1.7:2379,192.168.1.8:2379/jfs?ca=/path/to/ca.pem&cert=/path/to/tikv-server.pem&key=/path/to/tikv-server-key.pem&verify-cn=CN1,CN2" /mnt/jfs
 ```
 
 ## etcd


### PR DESCRIPTION
When using tikv as the metadata engine, the key path also needs to be configured when mounting