### PR TITLE
meta: add mount time in session info

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -465,6 +465,7 @@ func (m *baseMeta) newSessionInfo() []byte {
 		HostName:   host,
 		IPAddrs:    addrs,
 		MountPoint: m.conf.MountPoint,
+		MountTime:  time.Now(),
 		ProcessID:  os.Getpid(),
 	})
 	if err != nil {

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -251,6 +251,7 @@ type SessionInfo struct {
 	HostName   string
 	IPAddrs    []string `json:",omitempty"`
 	MountPoint string
+	MountTime  time.Time
 	ProcessID  int
 }
 


### PR DESCRIPTION
Mount time might be useful when debugging issues.