### PR TITLE
upgrade godeltaprof to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20221129023506-621ec37aac7a // indirect
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/pyroscope-io/godeltaprof v0.1.0 // indirect
+	github.com/pyroscope-io/godeltaprof v0.1.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -889,6 +889,8 @@ github.com/pyroscope-io/client v0.7.0 h1:LWuuqPQ1oa6x7BnmUOuo/aGwdX85QGhWZUBYWWW
 github.com/pyroscope-io/client v0.7.0/go.mod h1:4h21iOU4pUOq0prKyDlvYRL+SCKsBc5wKiEtV+rJGqU=
 github.com/pyroscope-io/godeltaprof v0.1.0 h1:UBqtjt0yZi4jTxqZmLAs34XG6ycS3vUTlhEUSq4NHLE=
 github.com/pyroscope-io/godeltaprof v0.1.0/go.mod h1:psMITXp90+8pFenXkKIpNhrfmI9saQnPbba27VIaiQE=
+github.com/pyroscope-io/godeltaprof v0.1.2 h1:MdlEmYELd5w+lvIzmZvXGNMVzW2Qc9jDMuJaPOR75g4=
+github.com/pyroscope-io/godeltaprof v0.1.2/go.mod h1:psMITXp90+8pFenXkKIpNhrfmI9saQnPbba27VIaiQE=
 github.com/qingstor/qingstor-sdk-go/v4 v4.4.0 h1:tbItWtGB1TDfYzqK8dtm6tV+xWU5iYMwL37C6AL5dDs=
 github.com/qingstor/qingstor-sdk-go/v4 v4.4.0/go.mod h1:mDVFtA7+bXQ5xoELTWkoFy1Ad13wtp8jtlnl/RU+zzM=
 github.com/qiniu/dyn v1.3.0/go.mod h1:E8oERcm8TtwJiZvkQPbcAh0RL8jO1G0VXJMW3FAWdkk=


### PR DESCRIPTION
godeltaprof v0.1.0 building fails on golang 1.21:

```bash
(main)> make
go version
go version go1.21.0 linux/amd64
go build -ldflags="-s -w -X github.com/juicedata/juicefs/pkg/version.revision=d3bbc0ca -X github.com/juicedata/juicefs/pkg/version.revisionDate=2023-08-11"  -o juicefs .
# github.com/pyroscope-io/godeltaprof/internal/pprof
../../go/pkg/mod/github.com/pyroscope-io/godeltaprof@v0.1.0/internal/pprof/delta_mutex.go:25:20: undefined: runtime_cyclesPerSecond
../../go/pkg/mod/github.com/pyroscope-io/godeltaprof@v0.1.0/internal/pprof/proto.go:400:8: undefined: runtime_expandFinalInlineFrame
make: *** [Makefile:24: juicefs] Error 1
```

They fix it in v0.1.2