### PR TITLE
Makefile: use commit time for revision date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO111MODULE=on
 all: juicefs
 
 REVISION := $(shell git rev-parse --short HEAD 2>/dev/null)
-REVISIONDATE := $(shell git log -1 --pretty=format:'%ad' --date short 2>/dev/null)
+REVISIONDATE := $(shell git log -1 --pretty=format:'%cd' --date short 2>/dev/null)
 PKG := github.com/juicedata/juicefs/pkg/version
 LDFLAGS = -s -w
 ifneq ($(strip $(REVISION)),) # Use git clone

--- a/sdk/java/libjfs/Makefile
+++ b/sdk/java/libjfs/Makefile
@@ -2,7 +2,7 @@ export GO111MODULE=on
 LDFLAGS = -s -w
 
 REVISION := $(shell git rev-parse --short HEAD 2>/dev/null)
-REVISIONDATE := $(shell git log -1 --pretty=format:'%ad' --date short 2>/dev/null)
+REVISIONDATE := $(shell git log -1 --pretty=format:'%cd' --date short 2>/dev/null)
 PKG := github.com/juicedata/juicefs/pkg/version
 LDFLAGS = -s -w
 LDFLAGS += -X $(PKG).revision=$(REVISION) \


### PR DESCRIPTION
Author time might be an old timestamp, commit time is always monotonically increasing and useful to identify a revision.