### PR TITLE
use crypto/rand.Read, and remove math/rand.Seed

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 'oldstable'
 
       - uses: actions/checkout@v3
       - name: golangci-lint

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -17,8 +17,8 @@
 package cmd
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -121,7 +121,9 @@ func (bc *benchCase) writeFiles(index int) {
 			logger.Fatalf("Failed to open file %s: %s", fname, err)
 		}
 		buf := make([]byte, bc.bsize)
-		_, _ = rand.Read(buf)
+		if _, err = rand.Read(buf); err != nil {
+			logger.Fatalf("Generate random content: %s", err)
+		}
 		for j := 0; j < bc.bcount; j++ {
 			if _, err = fp.Write(buf); err != nil {
 				logger.Fatalf("Failed to write file %s: %s", fname, err)

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -113,6 +113,12 @@ type benchmark struct {
 	tmpdir     string
 }
 
+func randRead(buf []byte) {
+	if _, err := rand.Read(buf); err != nil {
+		logger.Fatalf("Generate random content: %s", err)
+	}
+}
+
 func (bc *benchCase) writeFiles(index int) {
 	for i := 0; i < bc.fcount; i++ {
 		fname := fmt.Sprintf("%s/%s.%d.%d", bc.bm.tmpdir, bc.name, index, i)
@@ -121,9 +127,7 @@ func (bc *benchCase) writeFiles(index int) {
 			logger.Fatalf("Failed to open file %s: %s", fname, err)
 		}
 		buf := make([]byte, bc.bsize)
-		if _, err = rand.Read(buf); err != nil {
-			logger.Fatalf("Generate random content: %s", err)
-		}
+		randRead(buf)
 		for j := 0; j < bc.bcount; j++ {
 			if _, err = fp.Write(buf); err != nil {
 				logger.Fatalf("Failed to write file %s: %s", fname, err)

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	crand "crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -323,12 +322,11 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 func test(store object.ObjectStorage) error {
 	key := "testing/" + randSeq(10)
 	data := make([]byte, 100)
+	randRead(data)
+	nRetry := 3
 	var err error
-	for i := 0; i < 3; i++ {
-		_, err = crand.Read(data)
-		if err == nil {
-			err = doTesting(store, key, data)
-		}
+	for i := 0; i < nRetry; i++ {
+		err = doTesting(store, key, data)
 		if err == nil {
 			break
 		}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -274,8 +275,9 @@ var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345
 
 func randSeq(n int) string {
 	b := make([]rune, n)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[r.Intn(len(letters))]
 	}
 	return string(b)
 }
@@ -319,14 +321,14 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 }
 
 func test(store object.ObjectStorage) error {
-	rand.Seed(time.Now().UnixNano())
 	key := "testing/" + randSeq(10)
 	data := make([]byte, 100)
-	_, _ = rand.Read(data)
-	nRetry := 3
 	var err error
-	for i := 0; i < nRetry; i++ {
-		err = doTesting(store, key, data)
+	for i := 0; i < 3; i++ {
+		_, err = crand.Read(data)
+		if err == nil {
+			err = doTesting(store, key, data)
+		}
 		if err == nil {
 			break
 		}

--- a/cmd/mdtest.go
+++ b/cmd/mdtest.go
@@ -126,7 +126,6 @@ func runTest(jfs *fs.FileSystem, rootDir string, np, width, depth, files, bytes 
 	t1 := time.Since(start)
 	logger.Infof("Created %d dirs in %s (%d dirs/s)", dirs, t1, int(float64(dirs)/t1.Seconds()))
 
-	rand.Seed(time.Now().Unix())
 	var g sync.WaitGroup
 	for i := 0; i < np; i++ {
 		g.Add(1)

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -343,8 +342,8 @@ func objbench(ctx *cli.Context) error {
 		seed:        make([]byte, bSize),
 		smallSeed:   make([]byte, smallBSize),
 	}
-	rand.Read(bm.seed)
-	rand.Read(bm.smallSeed)
+	randRead(bm.seed)
+	randRead(bm.smallSeed)
 
 	for _, api := range apis {
 		pResult = append(pResult, bm.run(api))
@@ -909,7 +908,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 		fsize := 256 << 20
 		buffL := 4 << 20
 		buff := make([]byte, buffL)
-		rand.Read(buff)
+		randRead(buff)
 		count := int(math.Floor(float64(fsize) / float64(buffL)))
 		content := make([]byte, fsize)
 		for i := 0; i < count; i++ {
@@ -951,7 +950,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 			}
 			total := 3
 			seed := make([]byte, upload.MinPartSize)
-			rand.Read(seed)
+			randRead(seed)
 			parts := make([]*object.Part, total)
 			content := make([][]byte, total)
 			for i := 0; i < total; i++ {

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -18,11 +18,11 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"os"
 	"os/user"
 	"path/filepath"

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -17,8 +17,8 @@
 package chunk
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -443,7 +443,7 @@ func testStorage(t *testing.T, s ObjectStorage) {
 	if upload, err := s.CreateMultipartUpload(k); err == nil {
 		total := 3
 		seed := make([]byte, upload.MinPartSize)
-		rand.Read(seed)
+		_, _ = rand.Read(seed)
 		parts := make([]*Part, total)
 		content := make([][]byte, total)
 		for i := 0; i < total; i++ {

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -38,7 +38,6 @@ var resolver = dnscache.New(time.Minute)
 var httpClient *http.Client
 
 func init() {
-	rand.Seed(time.Now().Unix())
 	httpClient = &http.Client{
 		Transport: &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
@@ -61,7 +60,7 @@ func init() {
 				}
 				var conn net.Conn
 				n := len(ips)
-				first := rand.Intn(n)
+				first := rand.New(rand.NewSource(time.Now().Unix())).Intn(n)
 				dialer := &net.Dialer{Timeout: time.Second * 10}
 				for i := 0; i < n; i++ {
 					ip := ips[(first+i)%n]

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -60,7 +60,7 @@ func init() {
 				}
 				var conn net.Conn
 				n := len(ips)
-				first := rand.New(rand.NewSource(time.Now().Unix())).Intn(n)
+				first := rand.Intn(n)
 				dialer := &net.Dialer{Timeout: time.Second * 10}
 				for i := 0; i < n; i++ {
 					ip := ips[(first+i)%n]

--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -166,7 +166,7 @@ func TestDownload(t *testing.T) {
 
 	for _, c := range tcases {
 		content := make([]byte, c.config.fsize)
-		rand.Read(content)
+		_, _ = rand.Read(content)
 		_ = a.Put(key, bytes.NewReader(content))
 		c.tfunc(t, newParallelDownloader(a, key, c.config.fsize, c.blockSize, make(chan int, c.concurrent)), content)
 	}

--- a/pkg/sync/download_test.go
+++ b/pkg/sync/download_test.go
@@ -18,8 +18,8 @@ package sync
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io"
-	"math/rand"
 	"os"
 	"testing"
 


### PR DESCRIPTION
Lint error for Go 1.20:
```
Error: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access.  (staticcheck)
Error: SA1019: rand.Read has been deprecated since Go 1.20 because it shouldn't be used: For almost all use cases, crypto/rand.Read is more appropriate.  (staticcheck)
```