### PR TITLE
Time duration can identify the number of days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ cmd/cmd
 .hypothesis
 __pycache__
 /node_modules
+/vendor


### PR DESCRIPTION
In some scenarios, the time parameter supports days, which is better. For example, data is rarely modified and the backup interval is expected to be one week. Although 168h can also be used, 7d is more intuitive, such as --backup-meta 7d.