### PR TITLE
object/file: use Readdir to lookup FileInfo faster

### DIFF
--- a/pkg/object/gluster.go
+++ b/pkg/object/gluster.go
@@ -221,11 +221,7 @@ func (d *gluster) List(prefix, marker, delimiter string, limit int64, followLink
 		if !strings.HasPrefix(key, prefix) || (marker != "" && key <= marker) {
 			continue
 		}
-		info, err := e.Info()
-		if err != nil {
-			logger.Warnf("stat %s: %s", p, err)
-			continue
-		}
+		info := e.Info()
 		f := d.toFile(key, info, e.isSymlink)
 		objs = append(objs, f)
 		if len(objs) == int(limit) {


### PR DESCRIPTION
Change back to use Readdir() instead of ReadDir(), because List() needs FileInfo, Readdir() issue lstat() during the loop (cache hit), but ReadDir() will not, so we will issue lstat() after that, (cache miss).  When list a huge directory, Readdir() can be much faster than ReadDir() + many lstats(). 