### PR TITLE
object/gluster: allow customizing log path

### DIFF
--- a/pkg/object/gluster.go
+++ b/pkg/object/gluster.go
@@ -297,6 +297,7 @@ func newGluster(endpoint, ak, sk, token string) (ObjectStorage, error) {
 			level = gfapi.LogTrace
 		}
 	}
+	logPath := os.Getenv("JFS_GLUSTER_LOG_PATH")
 	hosts := strings.Split(uri.Host, ",")
 	pid := os.Getpid()
 	ostore := gluster{
@@ -310,7 +311,11 @@ func newGluster(endpoint, ak, sk, token string) (ObjectStorage, error) {
 		if err != nil {
 			return nil, fmt.Errorf("init %s: %s", name, err)
 		}
-		err = v.SetLogging(fmt.Sprintf("/var/log/glusterfs/%s-%s-%d-%d.log", hosts[0], name, pid, i), level)
+		if logPath == "" {
+			err = v.SetLogging(fmt.Sprintf("/var/log/glusterfs/%s-%s-%d-%d.log", hosts[0], name, pid, i), level)
+		} else {
+			err = v.SetLogging(logPath, level)
+		}
 		if err != nil {
 			logger.Warnf("Set gluster logging for vol %s: %s", name, err)
 		}


### PR DESCRIPTION
Try using `JFS_GLUSTER_LOG_PATH=/dev/stdout` or `JFS_GLUSTER_LOG_PATH=/dev/stderr` to redirect the log within k8s.