### PR TITLE
sdk/java: Fix print result inaccurate when TestDFSIO by local

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/bench/TestDFSIO.java
+++ b/sdk/java/src/main/java/io/juicefs/bench/TestDFSIO.java
@@ -311,9 +311,9 @@ public class TestDFSIO extends Main.Command {
             "      Number of threads: " + threadsPerMap,
             "Number files per thread: " + filesPerThread,
             "            Total files: " + threadsPerMap * filesPerThread,
-            " Total MBytes processed: " + df.format(TestDFSIO.toMB(sizeProcessed.get())),
-            "Total Throughput MB/sec: " + df.format(TestDFSIO.toMB(sizeProcessed.get()) / TestDFSIO.msToSecs(end - start)),
-            "     Test exec time sec: " + df.format(TestDFSIO.msToSecs(end - start)),
+            " Total MBytes processed: " + df.format(toMB(sizeProcessed.get())),
+            "Total Throughput MB/sec: " + df.format(toMB(sizeProcessed.get()) / msToSecs(end - start)),
+            "     Test exec time sec: " + df.format(msToSecs(end - start)),
             ""};
 
     for (String resultLine : resultLines) {

--- a/sdk/java/src/main/java/io/juicefs/bench/TestDFSIO.java
+++ b/sdk/java/src/main/java/io/juicefs/bench/TestDFSIO.java
@@ -312,7 +312,7 @@ public class TestDFSIO extends Main.Command {
             "Number files per thread: " + filesPerThread,
             "            Total files: " + threadsPerMap * filesPerThread,
             " Total MBytes processed: " + df.format(TestDFSIO.toMB(sizeProcessed.get())),
-            "Total Throughput mb/sec: " + df.format(TestDFSIO.toMB(sizeProcessed.get()) / TestDFSIO.msToSecs(end - start)),
+            "Total Throughput MB/sec: " + df.format(TestDFSIO.toMB(sizeProcessed.get()) / TestDFSIO.msToSecs(end - start)),
             "     Test exec time sec: " + df.format(TestDFSIO.msToSecs(end - start)),
             ""};
 


### PR DESCRIPTION
When testing I/O throughput by local. I found the result pring should be MB/sec.