### PR TITLE
utils/logger: support append user specified ID in log

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -47,6 +47,10 @@ func globalFlags() []cli.Flag {
 			Usage:  "set log level (trace, debug, info, warn, error, fatal, panic)",
 			Hidden: true,
 		},
+		&cli.StringFlag{
+			Name:  "log-id",
+			Usage: "append the given log id in log, use \"random\" to use random uuid",
+		},
 		&cli.BoolFlag{
 			Name:  "no-agent",
 			Usage: "disable pprof (:6060) agent",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 
 	"github.com/erikdubbelboer/gspt"
+	"github.com/google/uuid"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juicedata/juicefs/pkg/version"
 	"github.com/pyroscope-io/client/pyroscope"
@@ -197,6 +198,9 @@ func reorderOptions(app *cli.App, args []string) []string {
 			newArgs = append(newArgs, option)
 			if hasValue {
 				i++
+				if i >= len(args) {
+					logger.Fatalf("option %s requires value", option)
+				}
 				newArgs = append(newArgs, args[i])
 			}
 		} else {
@@ -281,6 +285,14 @@ func setup(c *cli.Context, n int) {
 	// set the correct value when it runs inside container
 	if undo, err := maxprocs.Set(maxprocs.Logger(logger.Debugf)); err != nil {
 		undo()
+	}
+
+	logID := c.String("log-id")
+	if logID != "" {
+		if logID == "random" {
+			logID = uuid.New().String()
+		}
+		utils.SetLogID("[" + logID + "] ")
 	}
 
 	if !c.Bool("no-agent") {

--- a/docs/en/reference/command_reference.md
+++ b/docs/en/reference/command_reference.md
@@ -56,6 +56,7 @@ GLOBAL OPTIONS:
    --verbose, --debug, -v  enable debug log (default: false)
    --quiet, -q             show warning and errors only (default: false)
    --trace                 enable trace log (default: false)
+   --log-id value          append the given log id in log, use "random" to use random uuid
    --no-agent              disable pprof (:6060) agent (default: false)
    --pyroscope value       pyroscope address
    --no-color              disable colors (default: false)

--- a/docs/zh_cn/reference/command_reference.md
+++ b/docs/zh_cn/reference/command_reference.md
@@ -56,6 +56,7 @@ GLOBAL OPTIONS:
    --verbose, --debug, -v  enable debug log (default: false)
    --quiet, -q             show warning and errors only (default: false)
    --trace                 enable trace log (default: false)
+   --log-id value          append the given log id in log, use "random" to use random uuid
    --no-agent              disable pprof (:6060) agent (default: false)
    --pyroscope value       pyroscope address
    --no-color              disable colors (default: false)

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -34,6 +34,7 @@ type logHandle struct {
 	logrus.Logger
 
 	name     string
+	logid    string
 	lvl      *logrus.Level
 	colorful bool
 }
@@ -60,7 +61,8 @@ func (l *logHandle) Format(e *logrus.Entry) ([]byte, error) {
 	}
 	const timeFormat = "2006/01/02 15:04:05.000000"
 	timestamp := e.Time.Format(timeFormat)
-	str := fmt.Sprintf("%v %s[%d] <%v>: %v [%s:%d]",
+	str := fmt.Sprintf("%s%v %s[%d] <%v>: %v [%s:%d]",
+		l.logid,
 		timestamp,
 		l.name,
 		os.Getpid(),
@@ -141,5 +143,13 @@ func SetOutput(w io.Writer) {
 	defer mu.Unlock()
 	for _, logger := range loggers {
 		logger.SetOutput(w)
+	}
+}
+
+func SetLogID(id string) {
+	mu.Lock()
+	defer mu.Unlock()
+	for _, logger := range loggers {
+		logger.logid = id
 	}
 }

--- a/pkg/utils/logger_test.go
+++ b/pkg/utils/logger_test.go
@@ -34,6 +34,7 @@ func TestLogger(t *testing.T) {
 	SetOutFile("") // invalid
 	SetOutFile(f.Name())
 	InitLoggers(true)
+	SetLogID("testid")
 
 	SetLogLevel(logrus.TraceLevel)
 	SetLogLevel(logrus.DebugLevel)
@@ -53,5 +54,7 @@ func TestLogger(t *testing.T) {
 		t.Fatalf("info/debug should not be logged: %s", s)
 	} else if !strings.Contains(s, "warn level") || !strings.Contains(s, "error level") {
 		t.Fatalf("warn/error should be logged: %s", s)
+	} else if !strings.Contains(s, "testid") {
+		t.Fatalf("logid \"testid\" should be logged: %s", s)
 	}
 }


### PR DESCRIPTION
So that we could filter logs from the same juicefs instance. And use "--log-id random" to generate random uuid as log id.