### PR TITLE
CI: don't save benchmark when mysql password is empty.

### DIFF
--- a/.github/scripts/db.py
+++ b/.github/scripts/db.py
@@ -29,6 +29,9 @@ import argparse
 def add_perf_record(name, result, product_version,  meta, storage, extra):
     result = float(result)
     passowrd = os.environ['MYSQL_PASSWORD']
+    if not passowrd:
+        print('<WARNING>: MYSQL_PASSWORD is empty')
+        return 
     github_ref_name = os.environ.get('GITHUB_REF_NAME')
     print(f'github_ref_name is: {github_ref_name}')
     github_run_id = os.environ.get('GITHUB_RUN_ID')


### PR DESCRIPTION
when PR from external repos, the secret MYSQL_PASSWORD will not set, in this case , we do not save the data to db.