### PR TITLE
cmd/gateway: disable compression

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -70,7 +70,7 @@ type jfsObjects struct {
 }
 
 func (n *jfsObjects) IsCompressionSupported() bool {
-	return n.conf.Chunk.Compress != "" && n.conf.Chunk.Compress != "none"
+	return false
 }
 
 func (n *jfsObjects) IsEncryptionSupported() bool {


### PR DESCRIPTION
Since the gateway is not set to enable compression, returning true or false will ultimately not compress. This is the expected behavior, but returning false direct here would be clearer.