### PR TITLE
cmd/mount: `mount.juicefs` support `-d`

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: MountJuiceFSTest
         run: |
-          sudo /tmp/mount.juicefs redis://127.0.0.1:6379/1 /tmp/mount-jfs
+          sudo /tmp/mount.juicefs redis://127.0.0.1:6379/1 /tmp/mount-jfs -o d
           [ `stat --format "%i" /tmp/mount-jfs` -eq 1 ]
 
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,7 +109,7 @@ func handleSysMountArgs(args []string) []string {
 		"entrycacheto":    "entry-cache",
 		"direntrycacheto": "dir-entry-cache",
 	}
-	newArgs := []string{"juicefs", "mount", "-d"}
+	newArgs := []string{"juicefs", "mount"}
 	if len(args) < 3 {
 		return nil
 	}
@@ -118,7 +118,7 @@ func handleSysMountArgs(args []string) []string {
 	fuseOptions := make([]string, 0, 20)
 	cmdFlagsLookup := make(map[string]bool, 20)
 	for _, f := range append(cmdMount().Flags, globalFlags()...) {
-		if names := f.Names(); len(names) > 0 && len(names[0]) > 1 {
+		if names := f.Names(); len(names) > 0 && len(names[0]) >= 1 {
 			_, cmdFlagsLookup[names[0]] = f.(*cli.BoolFlag)
 		}
 	}


### PR DESCRIPTION
`mount.juicefs` supports both foreground and background running without the `JFS_FOREGROUND` variables