### PR TITLE
cmd/sync: add p8s metrics for sync command

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -103,17 +103,14 @@ func installHandler(mp string) {
 	}()
 }
 
-func exposeMetrics(c *cli.Context, m meta.Meta, registerer prometheus.Registerer, registry *prometheus.Registry) string {
+func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *prometheus.Registry) string {
 	var ip, port string
 	//default set
 	ip, port, err := net.SplitHostPort(c.String("metrics"))
 	if err != nil {
 		logger.Fatalf("metrics format error: %v", err)
 	}
-
-	m.InitMetrics(registerer)
-	vfs.InitMetrics(registerer)
-	go metric.UpdateMetrics(m, registerer)
+	go metric.UpdateMetrics(registerer)
 	http.Handle("/metrics", promhttp.HandlerFor(
 		registry,
 		promhttp.HandlerOpts{
@@ -424,10 +421,14 @@ func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 }
 
 func initBackgroundTasks(c *cli.Context, vfsConf *vfs.Config, metaConf *meta.Config, m meta.Meta, blob object.ObjectStorage, registerer prometheus.Registerer, registry *prometheus.Registry) {
-	metricsAddr := exposeMetrics(c, m, registerer, registry)
+	metricsAddr := exposeMetrics(c, registerer, registry)
+	m.InitMetrics(registerer)
+	vfs.InitMetrics(registerer)
 	vfsConf.Port.PrometheusAgent = metricsAddr
 	if c.IsSet("consul") {
-		metric.RegisterToConsul(c.String("consul"), metricsAddr, vfsConf.Meta.MountPoint)
+		metadata := make(map[string]string)
+		metadata["mountPoint"] = vfsConf.Meta.MountPoint
+		metric.RegisterToConsul(c.String("consul"), metricsAddr, metadata)
 		vfsConf.Port.ConsulAddr = c.String("consul")
 	}
 	if !metaConf.ReadOnly && !metaConf.NoBGJob && vfsConf.BackupMeta > 0 {

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -73,8 +73,9 @@ func Test_exposeMetrics(t *testing.T) {
 			defer isSetPatches.Reset()
 			ResetHttp()
 			registerer, registry := wrapRegister("test", "test")
-			metricsAddr := exposeMetrics(appCtx, client, registerer, registry)
-
+			metricsAddr := exposeMetrics(appCtx, registerer, registry)
+			client.InitMetrics(registerer)
+			vfs.InitMetrics(registerer)
 			u := url.URL{Scheme: "http", Host: metricsAddr, Path: "/metrics"}
 			resp, err := http.Get(u.String())
 			So(err, ShouldBeNil)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -445,7 +445,7 @@ func doSync(c *cli.Context) error {
 		dstPath = utils.RemovePassword(dstPath)
 		registry := prometheus.NewRegistry()
 		config.Registerer = prometheus.WrapRegistererWithPrefix("juicefs_sync_",
-			prometheus.WrapRegistererWith(prometheus.Labels{"cmd": "sync", "src": srcPath, "dst": dstPath, "pid": strconv.Itoa(os.Getpid())}, registry))
+			prometheus.WrapRegistererWith(prometheus.Labels{"cmd": "sync", "pid": strconv.Itoa(os.Getpid())}, registry))
 		config.Registerer.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 		config.Registerer.MustRegister(collectors.NewGoCollector())
 		metricsAddr := exposeMetrics(c, config.Registerer, registry)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,10 +25,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
+	"github.com/juicedata/juicefs/pkg/metric"
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/sync"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -78,14 +82,18 @@ Supported storage systems: https://juicefs.com/docs/community/how_to_setup_objec
 			syncActionFlags(),
 			syncStorageFlags(),
 			clusterFlags(),
-			[]cli.Flag{
-				&cli.IntFlag{
-					Name:   "http-port",
-					Value:  6070,
-					Hidden: true,
-					Usage:  "HTTP `PORT` to listen to",
+			addCategories("METRICS", []cli.Flag{
+				&cli.StringFlag{
+					Name:  "metrics",
+					Value: "127.0.0.1:9567",
+					Usage: "address to export metrics",
 				},
-			},
+				&cli.StringFlag{
+					Name:  "consul",
+					Value: "127.0.0.1:8500",
+					Usage: "consul address to register",
+				},
+			}),
 		),
 	}
 }
@@ -421,6 +429,22 @@ func doSync(c *cli.Context) error {
 	if config.StorageClass != "" {
 		if os, ok := dst.(object.SupportStorageClass); ok {
 			os.SetStorageClass(config.StorageClass)
+		}
+	}
+
+	if config.Manager == "" && !config.Dry {
+		registry := prometheus.NewRegistry()
+		config.Registerer = prometheus.WrapRegistererWithPrefix("juicefs_sync_",
+			prometheus.WrapRegistererWith(prometheus.Labels{"cmd": "sync", "src": srcURL, "dst": dstURL, "pid": strconv.Itoa(os.Getpid())}, registry))
+		config.Registerer.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+		config.Registerer.MustRegister(collectors.NewGoCollector())
+		metricsAddr := exposeMetrics(c, config.Registerer, registry)
+		if c.IsSet("consul") {
+			metadata := make(map[string]string)
+			metadata["src"] = srcURL
+			metadata["dst"] = dstURL
+			metadata["pid"] = strconv.Itoa(os.Getpid())
+			metric.RegisterToConsul(c.String("consul"), metricsAddr, metadata)
 		}
 	}
 	return sync.Sync(src, dst, config)

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ replace github.com/hanwen/go-fuse/v2 v2.1.1-0.20210611132105-24a1dfe6b4f8 => git
 
 replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 
-replace github.com/vbauerster/mpb/v7 v7.0.3 => github.com/juicedata/mpb/v7 v7.0.4-0.20231024023106-afed12866ddf
+replace github.com/vbauerster/mpb/v7 v7.0.3 => github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b
 
 replace google.golang.org/grpc v1.43.0 => google.golang.org/grpc v1.29.0
 

--- a/go.mod
+++ b/go.mod
@@ -82,11 +82,6 @@ require (
 )
 
 require (
-	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-)
-
-require (
 	cloud.google.com/go v0.102.1 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
 	git.apache.org/thrift.git v0.13.0 // indirect
@@ -205,6 +200,7 @@ require (
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/pyroscope-io/godeltaprof v0.1.2 // indirect
+	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
@@ -231,6 +227,7 @@ require (
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a // indirect
 	github.com/willf/bitset v1.1.11 // indirect
 	github.com/willf/bloom v2.0.3+incompatible // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.9 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.9 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -254,7 +251,7 @@ replace github.com/hanwen/go-fuse/v2 v2.1.1-0.20210611132105-24a1dfe6b4f8 => git
 
 replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 
-replace github.com/vbauerster/mpb/v7 v7.0.3 => github.com/juicedata/mpb/v7 v7.0.4-0.20220719014258-68df1356cfba
+replace github.com/vbauerster/mpb/v7 v7.0.3 => github.com/juicedata/mpb/v7 v7.0.4-0.20231024023106-afed12866ddf
 
 replace google.golang.org/grpc v1.43.0 => google.golang.org/grpc v1.29.0
 

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c0
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible/go.mod h1:Ukwa8ffRQLV6QRwpqGioPjn2Wnf7TBDA4DbennDOqHE=
 github.com/juicedata/minio v0.0.0-20221113011458-8866d5c9df8c h1:w+4eiZLSLd6aQcy+7wn++hI1caDAm+rNOG7Me5qO7Sw=
 github.com/juicedata/minio v0.0.0-20221113011458-8866d5c9df8c/go.mod h1:8oMBmyEWA8aYwMwO7eUNOjvVNOhDeqDlio2RSv6T/4Q=
-github.com/juicedata/mpb/v7 v7.0.4-0.20220719014258-68df1356cfba h1:YSCPvyONPDp/ivKgRanFpNEHh3N5/0UsKmwbbKQIuGE=
-github.com/juicedata/mpb/v7 v7.0.4-0.20220719014258-68df1356cfba/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
+github.com/juicedata/mpb/v7 v7.0.4-0.20231024023106-afed12866ddf h1:sEZpQelfYee5tvLkUuzaOCNhH3bhcBleSPhzY9Ah+S0=
+github.com/juicedata/mpb/v7 v7.0.4-0.20231024023106-afed12866ddf/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
 github.com/juju/ratelimit v1.0.2/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c0
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible/go.mod h1:Ukwa8ffRQLV6QRwpqGioPjn2Wnf7TBDA4DbennDOqHE=
 github.com/juicedata/minio v0.0.0-20221113011458-8866d5c9df8c h1:w+4eiZLSLd6aQcy+7wn++hI1caDAm+rNOG7Me5qO7Sw=
 github.com/juicedata/minio v0.0.0-20221113011458-8866d5c9df8c/go.mod h1:8oMBmyEWA8aYwMwO7eUNOjvVNOhDeqDlio2RSv6T/4Q=
-github.com/juicedata/mpb/v7 v7.0.4-0.20231024023106-afed12866ddf h1:sEZpQelfYee5tvLkUuzaOCNhH3bhcBleSPhzY9Ah+S0=
-github.com/juicedata/mpb/v7 v7.0.4-0.20231024023106-afed12866ddf/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
+github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b h1:0/6suPNZnrOlRlBaU/Bnitu8HiKkkLSzQhHbwQ9AysM=
+github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
 github.com/juju/ratelimit v1.0.2/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/pkg/metric/metrics.go
+++ b/pkg/metric/metrics.go
@@ -25,8 +25,6 @@ import (
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
-
-	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -57,7 +55,7 @@ var (
 	})
 )
 
-func UpdateMetrics(m meta.Meta, registerer prometheus.Registerer) {
+func UpdateMetrics(registerer prometheus.Registerer) {
 	if registerer == nil {
 		return
 	}
@@ -66,7 +64,7 @@ func UpdateMetrics(m meta.Meta, registerer prometheus.Registerer) {
 	registerer.MustRegister(uptime)
 }
 
-func RegisterToConsul(consulAddr, metricsAddr, mountPoint string) {
+func RegisterToConsul(consulAddr, metricsAddr string, metadata map[string]string) {
 	if metricsAddr == "" {
 		logger.Errorf("Metrics server start err,so can't register to consul")
 		return
@@ -101,14 +99,21 @@ func RegisterToConsul(consulAddr, metricsAddr, mountPoint string) {
 		return
 	}
 
-	localMeta := make(map[string]string)
 	hostname, err := os.Hostname()
 	if err != nil {
 		logger.Errorf("Get hostname failed:%s", err)
 		return
 	}
-	localMeta["hostName"] = hostname
-	localMeta["mountPoint"] = mountPoint
+	metadata["hostName"] = hostname
+	var id, name string
+	if mp, ok := metadata["mountPoint"]; ok {
+		id = fmt.Sprintf("%s:%s", localIp, mp)
+		name = "juicefs"
+	} else {
+		// for sync metrics, id format: 127.0.0.1:src->dst;pid=6666
+		id = fmt.Sprintf("%s:%s->%s;pid=%s", localIp, metadata["src"], metadata["dst"], metadata["pid"])
+		name = "juicefs-sync"
+	}
 
 	check := &consulapi.AgentServiceCheck{
 		HTTP:                           fmt.Sprintf("http://%s:%d/metrics", localIp, port),
@@ -118,11 +123,11 @@ func RegisterToConsul(consulAddr, metricsAddr, mountPoint string) {
 	}
 
 	registration := consulapi.AgentServiceRegistration{
-		ID:      fmt.Sprintf("%s:%s", localIp, mountPoint),
-		Name:    "juicefs",
+		ID:      id,
+		Name:    name,
 		Port:    port,
 		Address: localIp,
-		Meta:    localMeta,
+		Meta:    metadata,
 		Check:   check,
 	}
 	if err = client.Agent().ServiceRegister(&registration); err != nil {

--- a/pkg/metric/metrics.go
+++ b/pkg/metric/metrics.go
@@ -110,8 +110,10 @@ func RegisterToConsul(consulAddr, metricsAddr string, metadata map[string]string
 		id = fmt.Sprintf("%s:%s", localIp, mp)
 		name = "juicefs"
 	} else {
-		// for sync metrics, id format: 127.0.0.1:src->dst;pid=6666
-		id = fmt.Sprintf("%s:%s->%s;pid=%s", localIp, metadata["src"], metadata["dst"], metadata["pid"])
+		// for sync metrics, id format: 127.0.0.1;src->dst;pid=6666
+		id = fmt.Sprintf("%s;%s->%s;pid=%s", localIp, metadata["src"], metadata["dst"], metadata["pid"])
+		delete(metadata, "src")
+		delete(metadata, "dst")
 		name = "juicefs-sync"
 	}
 

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -57,6 +58,7 @@ type Config struct {
 
 	rules          []rule
 	concurrentList chan int
+	Registerer     prometheus.Registerer
 }
 
 func envList() []string {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1116,11 +1116,13 @@ func initSyncMetrics(config *Config) {
 		config.Registerer.MustRegister(
 			prometheus.NewCounterFunc(prometheus.CounterOpts{
 				Name: "scanned",
+				Help: "Scanned objects",
 			}, func() float64 {
 				return float64(handled.Total())
 			}),
 			prometheus.NewCounterFunc(prometheus.CounterOpts{
 				Name: "handled",
+				Help: "Handled objects",
 			}, func() float64 {
 				return float64(handled.Current())
 			}),

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juju/ratelimit"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // The max number of key per listing request
@@ -1032,6 +1033,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 		}
 	}()
 
+	initSyncMetrics(config)
 	for i := 0; i < config.Threads; i++ {
 		wg.Add(1)
 		go func() {
@@ -1107,4 +1109,76 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 		}
 	}
 	return nil
+}
+
+func initSyncMetrics(config *Config) {
+	if config.Manager == "" && !config.Dry {
+		config.Registerer.MustRegister(
+			prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "scanned",
+			}, func() float64 {
+				return float64(handled.Total())
+			}),
+			prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "handled",
+			}, func() float64 {
+				return float64(handled.Current())
+			}),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Name: "pending",
+				Help: "Pending objects",
+			}, func() float64 {
+				return float64(pending.Current())
+			}),
+			prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "copied",
+				Help: "Copied objects",
+			}, func() float64 {
+				return float64(copied.Current())
+			}),
+			prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "copied_bytes",
+				Help: "Copied bytes",
+			}, func() float64 {
+				return float64(copiedBytes.Current())
+			}),
+			prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "skipped",
+				Help: "Skipped objects",
+			}, func() float64 {
+				return float64(skipped.Current())
+			}),
+		)
+		if failed != nil {
+			config.Registerer.MustRegister(prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "failed",
+				Help: "Failed objects",
+			}, func() float64 {
+				return float64(failed.Current())
+			}))
+		}
+		if deleted != nil {
+			config.Registerer.MustRegister(prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Name: "deleted",
+				Help: "Deleted objects",
+			}, func() float64 {
+				return float64(deleted.Current())
+			}))
+		}
+		if checked != nil && checkedBytes != nil {
+			config.Registerer.MustRegister(
+				prometheus.NewCounterFunc(prometheus.CounterOpts{
+					Name: "checked",
+					Help: "Checked objects",
+				}, func() float64 {
+					return float64(checked.Current())
+				}),
+				prometheus.NewCounterFunc(prometheus.CounterOpts{
+					Name: "checked_bytes",
+					Help: "Checked bytes",
+				}, func() float64 {
+					return float64(checkedBytes.Current())
+				}))
+		}
+	}
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1112,7 +1112,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 }
 
 func initSyncMetrics(config *Config) {
-	if config.Manager == "" && !config.Dry {
+	if config.Registerer != nil {
 		config.Registerer.MustRegister(
 			prometheus.NewCounterFunc(prometheus.CounterOpts{
 				Name: "scanned",

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -471,7 +471,7 @@ func jfs_init(cname, jsonConf, user, group, superuser, supergroup *C.char) uintp
 			}
 			m.InitMetrics(registerer)
 			vfs.InitMetrics(registerer)
-			go metric.UpdateMetrics(m, registerer)
+			go metric.UpdateMetrics(registerer)
 		}
 
 		blob, err := cmd.NewReloadableStorage(format, m, func(f *meta.Format) {


### PR DESCRIPTION
depend on https://github.com/juicedata/mpb/pull/2
close #4109

p8s http://127.0.0.1:9567/metrics
```
# HELP juicefs_sync_checked Checked objects
# TYPE juicefs_sync_checked counter
juicefs_sync_checked{cmd="sync",pid="18939"} 1008
# HELP juicefs_sync_checked_bytes Checked bytes
# TYPE juicefs_sync_checked_bytes counter
juicefs_sync_checked_bytes{cmd="sync",pid="18939"} 3.262846983e+09
# HELP juicefs_sync_copied Copied objects
# TYPE juicefs_sync_copied counter
juicefs_sync_copied{cmd="sync",pid="18939"} 0
# HELP juicefs_sync_copied_bytes Copied bytes
# TYPE juicefs_sync_copied_bytes counter
juicefs_sync_copied_bytes{cmd="sync",pid="18939"} 0
# HELP juicefs_sync_cpu_usage Accumulated CPU usage in seconds.
# TYPE juicefs_sync_cpu_usage gauge
juicefs_sync_cpu_usage{cmd="sync",pid="18939"} 10.618006000000001
# HELP juicefs_sync_failed Failed objects
# TYPE juicefs_sync_failed counter
juicefs_sync_failed{cmd="sync",pid="18939"} 0
# HELP juicefs_sync_go_build_info Build information about the main Go module.
# TYPE juicefs_sync_go_build_info gauge
juicefs_sync_go_build_info{checksum="",cmd="sync",path="github.com/juicedata/juicefs",pid="18939",version="(devel)"} 1
# HELP juicefs_sync_go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE juicefs_sync_go_gc_duration_seconds summary
juicefs_sync_go_gc_duration_seconds{cmd="sync",pid="18939",quantile="0"} 7.6753e-05
juicefs_sync_go_gc_duration_seconds{cmd="sync",pid="18939",quantile="0.25"} 7.9967e-05
juicefs_sync_go_gc_duration_seconds{cmd="sync",pid="18939",quantile="0.5"} 0.000196007
juicefs_sync_go_gc_duration_seconds{cmd="sync",pid="18939",quantile="0.75"} 0.000198748
juicefs_sync_go_gc_duration_seconds{cmd="sync",pid="18939",quantile="1"} 0.000198748
juicefs_sync_go_gc_duration_seconds_sum{cmd="sync",pid="18939"} 0.000551475
juicefs_sync_go_gc_duration_seconds_count{cmd="sync",pid="18939"} 4
# HELP juicefs_sync_go_goroutines Number of goroutines that currently exist.
# TYPE juicefs_sync_go_goroutines gauge
juicefs_sync_go_goroutines{cmd="sync",pid="18939"} 471
# HELP juicefs_sync_go_info Information about the Go environment.
# TYPE juicefs_sync_go_info gauge
juicefs_sync_go_info{cmd="sync",pid="18939",version="go1.20.4"} 1
# HELP juicefs_sync_go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE juicefs_sync_go_memstats_alloc_bytes gauge
juicefs_sync_go_memstats_alloc_bytes{cmd="sync",pid="18939"} 3.3811224e+07
# HELP juicefs_sync_go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE juicefs_sync_go_memstats_alloc_bytes_total counter
juicefs_sync_go_memstats_alloc_bytes_total{cmd="sync",pid="18939"} 4.4856216e+07
# HELP juicefs_sync_go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE juicefs_sync_go_memstats_buck_hash_sys_bytes gauge
juicefs_sync_go_memstats_buck_hash_sys_bytes{cmd="sync",pid="18939"} 1.45887e+06
# HELP juicefs_sync_go_memstats_frees_total Total number of frees.
# TYPE juicefs_sync_go_memstats_frees_total counter
juicefs_sync_go_memstats_frees_total{cmd="sync",pid="18939"} 96504
# HELP juicefs_sync_go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE juicefs_sync_go_memstats_gc_sys_bytes gauge
juicefs_sync_go_memstats_gc_sys_bytes{cmd="sync",pid="18939"} 8.838168e+06
# HELP juicefs_sync_go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE juicefs_sync_go_memstats_heap_alloc_bytes gauge
juicefs_sync_go_memstats_heap_alloc_bytes{cmd="sync",pid="18939"} 3.3811224e+07
# HELP juicefs_sync_go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE juicefs_sync_go_memstats_heap_idle_bytes gauge
juicefs_sync_go_memstats_heap_idle_bytes{cmd="sync",pid="18939"} 7.102464e+06
# HELP juicefs_sync_go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE juicefs_sync_go_memstats_heap_inuse_bytes gauge
juicefs_sync_go_memstats_heap_inuse_bytes{cmd="sync",pid="18939"} 4.03456e+07
# HELP juicefs_sync_go_memstats_heap_objects Number of allocated objects.
# TYPE juicefs_sync_go_memstats_heap_objects gauge
juicefs_sync_go_memstats_heap_objects{cmd="sync",pid="18939"} 152836
# HELP juicefs_sync_go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE juicefs_sync_go_memstats_heap_released_bytes gauge
juicefs_sync_go_memstats_heap_released_bytes{cmd="sync",pid="18939"} 6.955008e+06
# HELP juicefs_sync_go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE juicefs_sync_go_memstats_heap_sys_bytes gauge
juicefs_sync_go_memstats_heap_sys_bytes{cmd="sync",pid="18939"} 4.7448064e+07
# HELP juicefs_sync_go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE juicefs_sync_go_memstats_last_gc_time_seconds gauge
juicefs_sync_go_memstats_last_gc_time_seconds{cmd="sync",pid="18939"} 1.698203361252099e+09
# HELP juicefs_sync_go_memstats_lookups_total Total number of pointer lookups.
# TYPE juicefs_sync_go_memstats_lookups_total counter
juicefs_sync_go_memstats_lookups_total{cmd="sync",pid="18939"} 0
# HELP juicefs_sync_go_memstats_mallocs_total Total number of mallocs.
# TYPE juicefs_sync_go_memstats_mallocs_total counter
juicefs_sync_go_memstats_mallocs_total{cmd="sync",pid="18939"} 249340
# HELP juicefs_sync_go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE juicefs_sync_go_memstats_mcache_inuse_bytes gauge
juicefs_sync_go_memstats_mcache_inuse_bytes{cmd="sync",pid="18939"} 19200
# HELP juicefs_sync_go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE juicefs_sync_go_memstats_mcache_sys_bytes gauge
juicefs_sync_go_memstats_mcache_sys_bytes{cmd="sync",pid="18939"} 31200
# HELP juicefs_sync_go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE juicefs_sync_go_memstats_mspan_inuse_bytes gauge
juicefs_sync_go_memstats_mspan_inuse_bytes{cmd="sync",pid="18939"} 484480
# HELP juicefs_sync_go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE juicefs_sync_go_memstats_mspan_sys_bytes gauge
juicefs_sync_go_memstats_mspan_sys_bytes{cmd="sync",pid="18939"} 489600
# HELP juicefs_sync_go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE juicefs_sync_go_memstats_next_gc_bytes gauge
juicefs_sync_go_memstats_next_gc_bytes{cmd="sync",pid="18939"} 5.4950072e+07
# HELP juicefs_sync_go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE juicefs_sync_go_memstats_other_sys_bytes gauge
juicefs_sync_go_memstats_other_sys_bytes{cmd="sync",pid="18939"} 3.466202e+06
# HELP juicefs_sync_go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE juicefs_sync_go_memstats_stack_inuse_bytes gauge
juicefs_sync_go_memstats_stack_inuse_bytes{cmd="sync",pid="18939"} 7.077888e+06
# HELP juicefs_sync_go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE juicefs_sync_go_memstats_stack_sys_bytes gauge
juicefs_sync_go_memstats_stack_sys_bytes{cmd="sync",pid="18939"} 7.077888e+06
# HELP juicefs_sync_go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE juicefs_sync_go_memstats_sys_bytes gauge
juicefs_sync_go_memstats_sys_bytes{cmd="sync",pid="18939"} 6.8809992e+07
# HELP juicefs_sync_go_threads Number of OS threads created.
# TYPE juicefs_sync_go_threads gauge
juicefs_sync_go_threads{cmd="sync",pid="18939"} 32
# HELP juicefs_sync_handled Handled objects
# TYPE juicefs_sync_handled counter
juicefs_sync_handled{cmd="sync",pid="18939"} 1008
# HELP juicefs_sync_memory Used memory in bytes.
# TYPE juicefs_sync_memory gauge
juicefs_sync_memory{cmd="sync",pid="18939"} 7.2474624e+07
# HELP juicefs_sync_pending Pending objects
# TYPE juicefs_sync_pending gauge
juicefs_sync_pending{cmd="sync",pid="18939"} 6324
# HELP juicefs_sync_scanned Scanned objects
# TYPE juicefs_sync_scanned counter
juicefs_sync_scanned{cmd="sync",pid="18939"} 7342
# HELP juicefs_sync_skipped Skipped objects
# TYPE juicefs_sync_skipped counter
juicefs_sync_skipped{cmd="sync",pid="18939"} 1008
# HELP juicefs_sync_uptime Total running time in seconds.
# TYPE juicefs_sync_uptime gauge
juicefs_sync_uptime{cmd="sync",pid="18939"} 6.133265119
```
consul
<img width="2083" alt="image" src="https://github.com/juicedata/juicefs/assets/31313340/6c4548b4-ee20-409f-9030-958b8c3bbd0e">
<img width="1395" alt="image" src="https://github.com/juicedata/juicefs/assets/31313340/d2ccc225-9d3a-43f6-be33-75d2a0b61c44">
