### PR TITLE
Return remove dir error of table dirStats to trigger retry.

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1585,6 +1585,7 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, skip
 		}
 		if _, err := s.Delete(&dirStats{Inode: e.Inode}); err != nil {
 			logger.Warnf("remove dir usage of ino(%d): %s", e.Inode, err)
+			return err
 		}
 		if _, err = s.Delete(&dirQuota{Inode: e.Inode}); err != nil {
 			return err


### PR DESCRIPTION
The current issue is that when there's an error in deleting dirstats, the rmdir operation still proceeds (the transaction is successfully committed). However, the next time a mkdir operation with the same name is attempted, it will check dirstats. If it already exists, an error is reported, making it impossible to make a directory with the same name. 

There are two options to fix this issue: 
1) Return the rmdir error. This will trigger a retry to execute rmdir later.
2) Ignore existing dirstats during mkdir.

For option2, I think it requires the logic to check if the dirStats table is the only one not removed by the previous transaction, if so, overwrite the old one during mkdir, if not, report EEXIST error. This requires far more changes than option1, so option1 is preferred here.