### PR TITLE
cmd/objbench: fix the objbench command run on Windows

### DIFF
--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -167,17 +168,18 @@ func objbench(ctx *cli.Context) error {
 		pass = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, GREEN, pass, RESET_SEQ)
 		failed = fmt.Sprintf("%s%dm%s%s", COLOR_SEQ, RED, failed, RESET_SEQ)
 	}
-	nobody, err := user.Lookup("nobody")
-	if err != nil {
-		logger.Fatalf("lookup nobody user failed: %v", err)
-	} else {
-		group, err := user.LookupGroupId(nobody.Gid)
+	if runtime.GOOS != "windows" {
+		nobody, err := user.Lookup("nobody")
 		if err != nil {
-			logger.Fatalf("lookup nobody's group failed: %v", err)
+			logger.Fatalf("lookup nobody user failed: %v", err)
+		} else {
+			group, err := user.LookupGroupId(nobody.Gid)
+			if err != nil {
+				logger.Fatalf("lookup nobody's group failed: %v", err)
+			}
+			groupName = group.Name
 		}
-		groupName = group.Name
 	}
-
 	if ctx.Bool("skip-functional-tests") {
 		if err := blob.Create(); err != nil {
 			return fmt.Errorf("can't create bucket: %s", err)
@@ -650,6 +652,7 @@ func functionalTesting(blob object.ObjectStorage, result *[][]string, colorful b
 		if err != nil {
 			return "", err
 		}
+		defer r.Close()
 		data, err := io.ReadAll(r)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
1. The user system for Windows is different from linux
> 2023/11/08 23:23:57.612797 juicefs[3440] &lt;FATAL&gt;: lookup nobody user failed: No mapping between account names and security IDs was done. [objbench.go:172]

2. Cannot perform rename and delete operations on files that are not closed under window
> golang.org/x/sys/windows.ERROR_SHARING_VIOLATION (32)

3. Chmod does not work in Windows,  may be use https://pkg.go.dev/golang.org/x/sys/windows or https://github.com/hectane/go-acl



```
PS C:\Users\15810\GolandProjects\juicefs> .\juicefs.exe objbench C:\Users\15810\Desktop\tmp\d1\
Start Functional Testing ...
+----------+---------------------+--------------------------------------------------+
| CATEGORY |         TEST        |                      RESULT                      |
+----------+---------------------+--------------------------------------------------+
|    basic |     create a bucket |                                             pass |
|    basic |       put an object |                                             pass |
|    basic |       get an object |                                             pass |
|    basic |       get non-exist |                                             pass |
|    basic |  get partial object |                                             pass |
|    basic |      head an object |                                             pass |
|    basic |    delete an object |                                             pass |
|    basic |    delete non-exist |                                             pass |
|    basic |        list objects |                                             pass |
|    basic |         special key | put encode file failed: open C:\Users\15810\D... |
|     sync |    put a big object |                                             pass |
|     sync | put an empty object |                                             pass |
|     sync |    multipart upload |                                      not support |
|     sync |  change owner/group |                                    root required |
|     sync |   change permission |                      expect mode 777 but got 666 |
|     sync |        change mtime |                                             pass |
+----------+---------------------+--------------------------------------------------+

Start Performance Testing ...
2023/11/08 23:43:30.360865 juicefs[24360] <WARNING>: chown test should be run by root [objbench.go:437]
 put small objects: 100/100 [==============================================================]  3115.8/s  used: 32.0946ms                                                                                                                                                                                             
 get small objects: 100/100 [==============================================================]  1521.0/s  used: 65.7461ms                                                                                                                                                                                             
    upload objects: 256/256 [==============================================================]  1181.2/s  used: 216.7329ms                                                                                                                                                                                            
  download objects: 256/256 [==============================================================]  661.2/s   used: 387.182ms                                                                                                                                                                                             
      list objects: 100/100 [==============================================================]  12081.5/s used: 8.2771ms                                                                                                                                                                                              
      head objects: 100/100 [==============================================================]  48586.1/s used: 2.0582ms                                                                                                                                                                                              
      update mtime: 100/100 [==============================================================]  19413.0/s used: 5.1512ms                                                                                                                                                                                              
change permissions: 100/100 [==============================================================]  12877.5/s used: 7.7655ms                                                                                                                                                                                              
    delete objects: 100/100 [==============================================================]  17592.0/s used: 6.1979ms                                                                                                                                                                                              
Benchmark finished! block-size: 4096 KiB, big-object-size: 1024 MiB, small-object-size: 128 KiB, small-objects: 100, NumThreads: 4
+--------------------+----------------------+----------------+
|        ITEM        |         VALUE        |      COST      |
+--------------------+----------------------+----------------+
|     upload objects |        4746.61 MiB/s | 3.37 ms/object |
|   download objects |        2655.05 MiB/s | 6.03 ms/object |
|  put small objects |     3115.8 objects/s | 1.28 ms/object |
|  get small objects |     1521.0 objects/s | 2.63 ms/object |
|       list objects | 1287647.60 objects/s |     0.31 ms/op |
|       head objects |   194817.8 objects/s | 0.02 ms/object |
|     delete objects |    19298.7 objects/s | 0.21 ms/object |
| change permissions |    65125.4 objects/s | 0.06 ms/object |
| change owner/group |              skipped |        skipped |
|       update mtime |    24276.0 objects/s | 0.16 ms/object |
+--------------------+----------------------+----------------+

```
close #4139
