### PR TITLE
CI: remove tmp test bucket path before test

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -44,7 +44,9 @@ func getStdout(args []string) ([]byte, error) {
 
 func TestConfig(t *testing.T) {
 	_ = resetTestMeta()
-	if err := Main([]string{"", "format", testMeta, "--bucket", "/tmp/testBucket", testVolume}); err != nil {
+	bucketPath := "/tmp/testBucket"
+	_ = os.RemoveAll(bucketPath)
+	if err := Main([]string{"", "format", testMeta, "--bucket", bucketPath, testVolume}); err != nil {
 		t.Fatalf("format: %s", err)
 	}
 

--- a/pkg/object/filesystem_test.go
+++ b/pkg/object/filesystem_test.go
@@ -44,7 +44,9 @@ func testKeysEqual(objs []Object, expectedKeys []string) error {
 }
 
 func TestDisk2(t *testing.T) {
-	s, _ := newDisk("/tmp/abc/", "", "", "")
+	diskPath := "/tmp/abc/"
+	_ = os.RemoveAll(diskPath)
+	s, _ := newDisk(diskPath, "", "", "")
 	s = WithPrefix(s, "prefix/")
 	testFileSystem(t, s)
 }


### PR DESCRIPTION
To avoid test failure from the second run, as the test bucket path is not empty, i.e.

<FATAL>: Storage file:///tmp/testBucket/test/ is not empty; please clean it up or pick another volume name