### PR TITLE
chaos-test: reduce io-delay of minio to 50ms

### DIFF
--- a/.github/scripts/chaos/workflow.yaml
+++ b/.github/scripts/chaos/workflow.yaml
@@ -65,7 +65,7 @@ spec:
           labelSelectors:
             app: minio-server
         volumePath: /data
-        delay: '1s'
+        delay: '50ms'
     # minio 内存压力
     - name: minio-memory
       templateType: StressChaos


### PR DESCRIPTION
Delaying each io operation for 1s is almost unacceptable for minio, which cause [chaos-test](https://github.com/juicedata/juicefs/actions/workflows/chaos.yml ) fails frequently.