### PR TITLE
sync: fix temporary name when create a file

### DIFF
--- a/cmd/object.go
+++ b/cmd/object.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -127,7 +126,18 @@ func (j *juiceFS) Put(key string, in io.Reader) (err error) {
 	if object.PutInplace {
 		tmp = p
 	} else {
-		tmp = path.Join(path.Dir(p), "."+path.Base(p)+".tmp"+strconv.Itoa(rand.Int()))
+		name := path.Base(p)
+		if len(name) > 200 {
+			name = name[:200]
+		}
+		tmp = path.Join(path.Dir(p), fmt.Sprintf(".%s.tmp.%d", name, rand.Int()))
+		defer func() {
+			if err != nil {
+				if e := j.jfs.Delete(ctx, tmp); e != 0 {
+					logger.Warnf("Failed to delete %s: %s", tmp, e)
+				}
+			}
+		}()
 	}
 	f, eno := j.jfs.Create(ctx, tmp, 0666, j.umask)
 	if eno == syscall.ENOENT {
@@ -142,15 +152,6 @@ func (j *juiceFS) Put(key string, in io.Reader) (err error) {
 
 	if eno != 0 {
 		return toError(eno)
-	}
-	if !object.PutInplace {
-		defer func() {
-			if err != nil {
-				if e := j.jfs.Delete(ctx, tmp); e != 0 {
-					logger.Warnf("Failed to delete %s: %s", tmp, e)
-				}
-			}
-		}()
 	}
 	buf := bufPool.Get().(*[]byte)
 	defer bufPool.Put(buf)

--- a/cmd/object_test.go
+++ b/cmd/object_test.go
@@ -141,6 +141,12 @@ func testFileSystem(t *testing.T, s object.ObjectStorage) {
 			t.Fatalf("testKeysEqual fail: %s", err)
 		}
 	}
+
+	// put a file with very long name
+	longName := strings.Repeat("a", 255)
+	if err := s.Put("dir/"+longName, bytes.NewReader([]byte{0})); err != nil {
+		t.Fatalf("PUT a file with long name `%s` failed: %q", longName, err)
+	}
 }
 
 func TestJFS(t *testing.T) {

--- a/pkg/object/filesystem_test.go
+++ b/pkg/object/filesystem_test.go
@@ -227,4 +227,10 @@ func testFileSystem(t *testing.T, s ObjectStorage) {
 			}
 		}
 	}
+
+	// put a file with very long name
+	longName := strings.Repeat("a", 255)
+	if err := s.Put("dir/"+longName, bytes.NewReader([]byte{0})); err != nil {
+		t.Fatalf("PUT a file with long name `%s` failed: %q", longName, err)
+	}
 }


### PR DESCRIPTION
This PR also fixed a but that may leak temporary file when Create() returns an error but the file is created.

close #4212 