### PR TITLE
fix windows fs truncate return syscall.EBADF

### DIFF
--- a/.github/scripts/setup-hdfs.sh
+++ b/.github/scripts/setup-hdfs.sh
@@ -19,8 +19,8 @@ set -e
 sudo apt-get update
 sudo apt-get install openjdk-8-jdk -y
 
-HADOOP_VERSION="2.10.1"
-wget -q https://dlcdn.apache.org/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz
+HADOOP_VERSION="2.10.2"
+wget -q https://dlcdn.apache.org/hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz
 mkdir ~/app
 tar -zxf hadoop-${HADOOP_VERSION}.tar.gz -C ~/app
 

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -394,7 +394,7 @@ func (j *juice) Truncate(path string, size int64, fh uint64) (e int) {
 		e = -fuse.EBADF
 		return
 	}
-	e = -int(j.vfs.Truncate(ctx, ino, size, 1, nil))
+	e = -int(j.vfs.Truncate(ctx, ino, size, 0, nil))
 	return
 }
 


### PR DESCRIPTION
1. fix windows fs truncate return syscall.EBADF
2. fix setup-hdfs.sh: upgrate hdfs verion from 2.10.1 to 2.10.2, because hadoop-2.10.1.tar.gz is not available in https://dlcdn.apache.org/hadoop/common

BTW, It’s difficult to get a PR passed through all checks. I pushed my branch without any changes for 6 times to get my PR passed through all checks.