### PR TITLE
chunk: lower FreeSpace config in TestFillCache

### DIFF
--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -217,6 +217,7 @@ func TestFillCache(t *testing.T) {
 	mem, _ := object.CreateStorage("mem", "", "", "", "")
 	conf := defaultConf
 	conf.CacheSize = 10
+	conf.FreeSpace = 0.01
 	_ = os.RemoveAll(conf.CacheDir)
 	store := NewCachedStore(mem, conf, nil)
 	if err := forgetSlice(store, 10, 1024); err != nil {


### PR DESCRIPTION
When testing in constrained env with few space in /tmp, TestFillCache() may fail due to not caching all chunks, as free space ratio is less than 10% and some chunks are evicted.

So lower FreeSpace ratio in the test to avoid its impact as much as possible.