### PR TITLE
feat: dragonfly as read-only object storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/dustin/go-humanize v1.0.1
 	github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377
-	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/goccy/go-json v0.10.2
 	github.com/gofrs/flock v0.8.1
@@ -42,6 +41,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c
 	github.com/minio/minio-go/v7 v7.0.10
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/ncw/swift/v2 v2.0.1
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,6 @@ github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a h1:v6zMvHuY9yue4+QkG/HQ/W67wvtQmWJ4SDo9aK/GIno=
-github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a/go.mod h1:I79BieaU4fxrw4LMXby6q5OS9XnoR9UIKLOzDFjUmuw=
 github.com/go-ini/ini v1.44.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -761,6 +759,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.5.0 h1:2EkzeTSqBB4V4bJwWrt5gIIrZmpJBcoIRGS2kWLgzmk=
 github.com/montanaflynn/stats v0.5.0/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mozillazg/go-httpheader v0.2.1 h1:geV7TrjbL8KXSyvghnFm+NyTux/hxwueTSrwhe88TQQ=

--- a/pkg/object/dragonfly.go
+++ b/pkg/object/dragonfly.go
@@ -20,588 +20,175 @@
 package object
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
-	"path"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/go-http-utils/headers"
+	"github.com/mohae/deepcopy"
 )
 
 const (
-	// AsyncWriteBack writes the object asynchronously to the backend.
-	AsyncWriteBack = iota
+	// BackendStorageS3 is the backend storage of s3.
+	BackendStorageS3 = "s3"
 
-	// WriteBack writes the object synchronously to the backend.
-	WriteBack
+	// BackendStorageOSS is the backend storage of oss.
+	BackendStorageOSS = "oss"
 
-	// Ephemeral only writes the object to the dfdaemon.
-	// It is only provided for creating temporary objects between peers,
-	// and users are not allowed to use this mode.
-	Ephemeral
+	// BackendStorageOBS is the backend storage of obs.
+	BackendStorageOBS = "obs"
 )
 
 const (
-	// HeaderDragonflyObjectMetaLastModifiedTime is used for last modified time of object storage.
-	HeaderDragonflyObjectMetaLastModifiedTime = "X-Dragonfly-Object-Meta-Last-Modified-Time"
-
-	// HeaderDragonflyObjectMetaStorageClass is used for storage class of object storage.
-	HeaderDragonflyObjectMetaStorageClass = "X-Dragonfly-Object-Meta-Storage-Class"
-
-	// HeaderDragonflyObjectOperation is used for object storage operation.
-	HeaderDragonflyObjectOperation = "X-Dragonfly-Object-Operation"
+	// FilterHeaderKey is the filter header key of dragonfly.
+	FilterHeaderKey = "X-Dragonfly-Filter"
 )
 
 const (
-	// Upper limit of maxGetObjectMetadatas.
-	MaxGetObjectMetadatasLimit = 1000
+	// FilterHeaderS3 is the filter of s3 url for generating task id.
+	FilterHeaderS3 = "X-Amz-Algorithm&X-Amz-Credential&X-Amz-Date&X-Amz-Expires&X-Amz-SignedHeaders&X-Amz-Signature"
 
-	// DefaultMaxReplicas is the default value of maxReplicas.
-	DefaultMaxReplicas = 0
+	// FilterHeaderOSS is the filter of oss url for generating task id.
+	FilterHeaderOSS = "Expires&Signature"
 
-	// Upper limit of maxReplicas.
-	MaxReplicasLimit = 100
+	// FilterHeaderOBS is the filter of obs url for generating task id.
+	FilterHeaderOBS = "X-Amz-Algorithm&X-Amz-Credential&X-Amz-Date&X-Obs-Date&X-Amz-Expires&X-Amz-SignedHeaders&X-Amz-Signature"
 )
 
-const (
-	// CopyOperation is the operation of copying object.
-	CopyOperation = "copy"
-)
-
-const (
-	// FilterOSS is the filter of oss url for generating task id.
-	FilterOSS = "Expires&Signature"
-
-	// FilterS3 is the filter of s3 url for generating task id.
-	FilterS3 = "X-Amz-Algorithm&X-Amz-Credential&X-Amz-Date&X-Amz-Expires&X-Amz-SignedHeaders&X-Amz-Signature"
-
-	// FilterOBS is the filter of obs url for generating task id.
-	FilterOBS = "X-Amz-Algorithm&X-Amz-Credential&X-Amz-Date&X-Obs-Date&X-Amz-Expires&X-Amz-SignedHeaders&X-Amz-Signature"
-)
-
-// ObjectMetadatas is the object metadata list.
-type ObjectMetadatas struct {
-	// CommonPrefixes are similar prefixes in object storage.
-	CommonPrefixes []string `json:"CommonPrefixes"`
-
-	// Metadatas are object metadata.
-	Metadatas []*ObjectMetadata `json:"Metadatas"`
-}
-
-// ObjectMetadata is the object metadata.
-type ObjectMetadata struct {
-	// Key is object key.
-	Key string
-
-	// ContentDisposition is Content-Disposition header.
-	ContentDisposition string
-
-	// ContentEncoding is Content-Encoding header.
-	ContentEncoding string
-
-	// ContentLanguage is Content-Language header.
-	ContentLanguage string
-
-	// ContentLanguage is Content-Length header.
-	ContentLength int64
-
-	// ContentType is Content-Type header.
-	ContentType string
-
-	// ETag is ETag header.
-	ETag string
-
-	// Digest is object digest.
-	Digest string
-
-	// LastModifiedTime is last modified time.
-	LastModifiedTime time.Time
-
-	// StorageClass is object storage class.
-	StorageClass string
-}
-
-// ObjectStorageMetadata is the object storage metadata.
-type ObjectStorageMetadata struct {
-	// Name is object storage name of type, it can be s3, oss or obs.
-	Name string
-
-	// Region is storage region.
-	Region string
-
-	// Endpoint is datacenter endpoint.
-	Endpoint string
-}
+// DefaultSignedURLExpire is the default expire time of signed url.
+var DefaultSignedURLExpire = 5 * time.Minute
 
 // dragonfly is the dragonfly object storage.
 type dragonfly struct {
-	// DefaultObjectStorage is the default object storage.
-	DefaultObjectStorage
+	// Object storage interface.
+	ObjectStorage
 
-	// Address of the object storage service.
-	endpoint string
+	// filterHeader is the filter header of dragonfly.
+	filterHeader string
 
-	// Filter is used to generate a unique Task ID by
-	// filtering unnecessary query params in the URL,
-	// it is separated by & character.
-	filter string
-
-	// Mode is the mode in which the backend is written,
-	// including WriteBack and AsyncWriteBack.
-	mode int
-
-	// MaxReplicas is the maximum number of
-	// replicas of an object cache in seed peers.
-	maxReplicas int
-
-	// ObjectStorage bucket name.
-	bucket string
-
-	// http client.
-	client *http.Client
-}
-
-// String returns the string representation of the dragonfly.
-func (d *dragonfly) String() string {
-	return fmt.Sprintf("dragonfly://%s/", d.bucket)
-}
-
-// Create creates the object if it does not exist.
-func (d *dragonfly) Create() error {
-	if _, err := d.List("", "", "", 1, false); err == nil {
-		return nil
-	}
-
-	u, err := url.Parse(d.endpoint)
-	if err != nil {
-		return err
-	}
-
-	u.Path = path.Join("buckets", d.bucket)
-	query := u.Query()
-	u.RawQuery = query.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), nil)
-	if err != nil && !isExists(err) {
-		return err
-	}
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("bad response status %s", resp.Status)
-	}
-
-	return nil
-}
-
-// Head returns the object metadata if it exists.
-func (d *dragonfly) Head(key string) (Object, error) {
-	// get get object metadata request.
-	u, err := url.Parse(d.endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	u.Path = path.Join("buckets", d.bucket, "objects", key)
-	if strings.HasSuffix(key, "/") {
-		u.Path += "/"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Head object.
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		if resp.StatusCode == http.StatusNotFound {
-			err = os.ErrNotExist
-		}
-
-		return nil, err
-	}
-
-	contentLength, err := strconv.ParseInt(resp.Header.Get(headers.ContentLength), 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	lastModifiedTime, err := time.Parse(http.TimeFormat, resp.Header.Get(HeaderDragonflyObjectMetaLastModifiedTime))
-	if err != nil {
-		return nil, err
-	}
-
-	return &obj{
-		key,
-		int64(contentLength),
-		lastModifiedTime,
-		strings.HasSuffix(key, "/"),
-		resp.Header.Get(HeaderDragonflyObjectMetaStorageClass),
-	}, nil
+	// http client with dragonfly proxy.
+	httpClient *http.Client
 }
 
 // Get returns the object if it exists.
 func (d *dragonfly) Get(key string, off, limit int64) (io.ReadCloser, error) {
-	u, err := url.Parse(d.endpoint)
+	ss, ok := d.ObjectStorage.(SupportSignedURL)
+	if !ok {
+		return nil, fmt.Errorf("not support signed url")
+	}
+
+	// Parse the signed url.
+	signedURL, err := ss.SignedURL(key, DefaultSignedURLExpire)
+	url, err := url.Parse(signedURL)
+	if err != nil {
+		return nil, err
+	}
+	url.Scheme = "http"
+
+	// Create the request.
+	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	u.Path = path.Join("buckets", d.bucket, "objects", key)
-	if strings.HasSuffix(key, "/") {
-		u.Path += "/"
+	// Add the filter header.
+	req.Header.Add(FilterHeaderKey, d.filterHeader)
+
+	// Add the range header.
+	if off > 0 || limit > 0 {
+		req.Header.Add("Range", getRange(off, limit))
 	}
 
-	query := u.Query()
-	if d.filter != "" {
-		query.Add("filter", d.filter)
-	}
+	// Add the date header.
+	now := time.Now().UTC().Format(http.TimeFormat)
+	req.Header.Add("Date", now)
 
-	u.RawQuery = query.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	resp, err := d.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set(headers.Range, getRange(off, limit))
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return nil, err
+	if resp.StatusCode != 200 && resp.StatusCode != 206 {
+		return nil, parseError(resp)
 	}
 
-	if resp.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("bad response status %s", resp.Status)
+	if err = checkGetStatus(resp.StatusCode, req.Header.Get("Range") != ""); err != nil {
+		_ = resp.Body.Close()
+		return nil, err
 	}
 
 	return resp.Body, nil
 }
 
-// Put creates or replaces the object.
-func (d *dragonfly) Put(key string, data io.Reader) error {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	// AsyncWriteBack mode is used by default.
-	if err := writer.WriteField("mode", fmt.Sprint(d.mode)); err != nil {
-		return err
-	}
-
-	if d.filter != "" {
-		if err := writer.WriteField("filter", d.filter); err != nil {
-			return err
-		}
-	}
-
-	if d.maxReplicas > 0 {
-		if err := writer.WriteField("maxReplicas", fmt.Sprint(d.maxReplicas)); err != nil {
-			return err
-		}
-	}
-
-	part, err := writer.CreateFormFile("file", path.Base(key))
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(part, data); err != nil {
-		return err
-	}
-
-	if err := writer.Close(); err != nil {
-		return err
-	}
-
-	u, err := url.Parse(d.endpoint)
-	if err != nil {
-		return err
-	}
-
-	u.Path = path.Join("buckets", d.bucket, "objects", key)
-	if strings.HasSuffix(key, "/") {
-		u.Path += "/"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), body)
-	if err != nil {
-		return err
-	}
-	req.Header.Add(headers.ContentType, writer.FormDataContentType())
-
-	// Put object.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("bad response status %s", resp.Status)
-	}
-
-	return nil
-}
-
-// Copy copies the object if it exists.
-func (d *dragonfly) Copy(dst, src string) error {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	if err := writer.WriteField("source_object_key", src); err != nil {
-		return err
-	}
-
-	if err := writer.Close(); err != nil {
-		return err
-	}
-
-	u, err := url.Parse(d.endpoint)
-	if err != nil {
-		return err
-	}
-
-	u.Path = path.Join("buckets", d.bucket, "objects", dst)
-	query := u.Query()
-	u.RawQuery = query.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), body)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add(headers.ContentType, writer.FormDataContentType())
-	req.Header.Add(HeaderDragonflyObjectOperation, fmt.Sprint(CopyOperation))
-
-	// copy object.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("bad response status %s", resp.Status)
-	}
-
-	return nil
-}
-
-// Delete deletes the object if it exists.
-func (d *dragonfly) Delete(key string) error {
-	// get delete object request.
-	u, err := url.Parse(d.endpoint)
-	if err != nil {
-		return err
-	}
-
-	u.Path = path.Join("buckets", d.bucket, "objects", key)
-	if strings.HasSuffix(key, "/") {
-		u.Path += "/"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	// Delete object.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("bad response status %s", resp.Status)
-	}
-
-	return nil
-}
-
-// List lists the objects with the given prefix.
-func (d *dragonfly) List(prefix, marker, delimiter string, limit int64, followLink bool) ([]Object, error) {
-	if limit > MaxGetObjectMetadatasLimit {
-		limit = MaxGetObjectMetadatasLimit
-	}
-
-	u, err := url.Parse(d.endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	u.Path = path.Join("buckets", d.bucket, "metadatas")
-	query := u.Query()
-	if prefix != "" {
-		query.Set("prefix", prefix)
-	}
-
-	if marker != "" {
-		query.Set("marker", marker)
-	}
-
-	if delimiter != "" {
-		query.Set("delimiter", delimiter)
-	}
-
-	if limit != 0 {
-		query.Set("limit", fmt.Sprint(limit))
-	}
-
-	u.RawQuery = query.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// List object.
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("bad response status %s", resp.Status)
-	}
-
-	var objectMetadatas ObjectMetadatas
-	if err := json.NewDecoder(resp.Body).Decode(&objectMetadatas); err != nil {
-		return nil, err
-	}
-
-	objs := make([]Object, 0, len(objectMetadatas.Metadatas))
-	for _, meta := range objectMetadatas.Metadatas {
-		objs = append(objs, &obj{
-			meta.Key,
-			meta.ContentLength,
-			meta.LastModifiedTime,
-			strings.HasSuffix(meta.Key, "/"),
-			meta.StorageClass,
-		})
-	}
-
-	if delimiter != "" {
-		for _, o := range objectMetadatas.CommonPrefixes {
-			objs = append(objs, &obj{o, 0, time.Unix(0, 0), true, ""})
-		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
-	}
-
-	return objs, err
-}
-
 // newDragonfly creates a new dragonfly object storage.
 func newDragonfly(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) {
-	if !strings.Contains(endpoint, "://") {
-		endpoint = fmt.Sprintf("http://%s", endpoint)
-	}
-
 	// Parse the endpoint.
-	uri, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	endpoint = uri.Scheme + "://" + uri.Host
-	bucket := uri.Path
-	if bucket == "" {
-		return nil, fmt.Errorf("bucket name required")
-	}
-
 	if !strings.Contains(endpoint, "://") {
-		endpoint = fmt.Sprintf("http://%s", endpoint)
+		endpoint = fmt.Sprintf("https://%s", endpoint)
 	}
 
-	mode := WriteBack
-	if value := uri.Query().Get("mode"); value != "" {
-		mode, err = strconv.Atoi(value)
-		if err != nil || (mode != WriteBack && mode != AsyncWriteBack) {
-			return nil, fmt.Errorf("unexpected dragonfly mode: %s", value)
-		}
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	endpoint = endpointURL.Scheme + "://" + endpointURL.Host
+
+	// Parse the dragonfly proxy.
+	proxy := endpointURL.Query().Get("proxy")
+	if !strings.Contains(proxy, "://") {
+		proxy = fmt.Sprintf("http://%s", proxy)
 	}
 
-	maxReplicas := DefaultMaxReplicas
-	if value := uri.Query().Get("maxReplicas"); value != "" {
-		maxReplicas, err = strconv.Atoi(value)
-		if err != nil || maxReplicas > MaxReplicasLimit || maxReplicas < 0 {
-			return nil, fmt.Errorf("unexpected dragonfly max replicas: %s", value)
-		}
-	}
-
-	metadata, err := getObjectStorageMetadata(endpoint)
+	proxyURL, err := url.Parse(proxy)
 	if err != nil {
 		return nil, err
 	}
 
-	var filter string
-	switch metadata.Name {
-	case "s3":
-		filter = FilterS3
-	case "oss":
-		filter = FilterOSS
-	case "obs":
-		filter = FilterOBS
-	default:
-		return nil, fmt.Errorf("unexpected dragonfly object storage name: %s", metadata.Name)
+	// Parse the backend storage.
+	backendStorageName := endpointURL.Query().Get("backendStorage")
+	if backendStorageName == "" {
+		return nil, fmt.Errorf("backend storage is required")
 	}
+
+	// Initialize the backend storage and filter header.
+	var (
+		backendStorage ObjectStorage
+		filterHeader   string
+	)
+	switch backendStorageName {
+	case BackendStorageS3:
+		filterHeader = FilterHeaderS3
+		backendStorage, err = newS3(endpoint, accessKey, secretKey, token)
+		if err != nil {
+			return nil, err
+		}
+	case BackendStorageOSS:
+		filterHeader = FilterHeaderOSS
+		backendStorage, err = newOSS(endpoint, accessKey, secretKey, token)
+		if err != nil {
+			return nil, err
+		}
+	case BackendStorageOBS:
+		filterHeader = FilterHeaderOBS
+		backendStorage, err = newOBS(endpoint, accessKey, secretKey, token)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("not supported backend storage: %s", backendStorage)
+	}
+
+	// Create the http client with dragonfly proxy.
+	httpClient := deepcopy.Copy(httpClient).(*http.Client)
+	httpClient.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
 
 	return &dragonfly{
-		endpoint:    endpoint,
-		filter:      filter,
-		mode:        mode,
-		maxReplicas: maxReplicas,
-		bucket:      bucket,
-		client:      httpClient,
+		ObjectStorage: backendStorage,
+		filterHeader:  filterHeader,
+		httpClient:    httpClient,
 	}, nil
-}
-
-// getObjectStorageMetadata returns the object storage metadata.
-func getObjectStorageMetadata(endpoint string) (*ObjectStorageMetadata, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, nil
-	}
-
-	u.Path = path.Join("metadata")
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get object storage Metadata.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("bad response status %s", resp.Status)
-	}
-
-	var objectStorageMetadata ObjectStorageMetadata
-	if err := json.NewDecoder(resp.Body).Decode(&objectStorageMetadata); err != nil {
-		return nil, err
-	}
-
-	return &objectStorageMetadata, nil
 }
 
 // init registers the dragonfly object storage.

--- a/pkg/object/dragonfly.go
+++ b/pkg/object/dragonfly.go
@@ -81,6 +81,10 @@ func (d *dragonfly) Get(key string, off, limit int64) (io.ReadCloser, error) {
 
 	// Parse the signed url.
 	signedURL, err := ss.SignedURL(key, DefaultSignedURLExpire)
+	if err != nil {
+		return nil, err
+	}
+
 	url, err := url.Parse(signedURL)
 	if err != nil {
 		return nil, err

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -48,6 +48,11 @@ type SupportStorageClass interface {
 	SetStorageClass(sc string)
 }
 
+type SupportSignedURL interface {
+	// SignedURL returns a signed url for the object.
+	SignedURL(key string, expire time.Duration) (string, error)
+}
+
 type File interface {
 	Object
 	Owner() string

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -335,6 +335,19 @@ func (s *obsClient) SetStorageClass(sc string) {
 	s.sc = sc
 }
 
+func (s *obsClient) SignedURL(key string, expire time.Duration) (string, error) {
+	params := &obs.CreateSignedUrlInput{}
+	params.Method = http.MethodGet
+	params.Bucket = s.bucket
+	params.Key = key
+	params.Expires = int(expire.Seconds())
+	resp, err := s.c.CreateSignedUrl(params)
+	if err != nil {
+		return "", err
+	}
+	return resp.SignedUrl, nil
+}
+
 func autoOBSEndpoint(bucketName, accessKey, secretKey, token string) (string, error) {
 	region := obsDefaultRegion
 	if r := os.Getenv("HWCLOUD_DEFAULT_REGION"); r != "" {

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -271,6 +271,10 @@ func (o *ossClient) SetStorageClass(sc string) {
 	o.sc = sc
 }
 
+func (o *ossClient) SignedURL(key string, expire time.Duration) (string, error) {
+	return o.bucket.SignURL(key, oss.HTTPGet, int64(expire/time.Second))
+}
+
 type stsCred struct {
 	AccessKeyId     string
 	AccessKeySecret string

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -356,6 +356,15 @@ func (s *s3client) SetStorageClass(sc string) {
 	s.sc = sc
 }
 
+func (s *s3client) SignedURL(key string, expire time.Duration) (string, error) {
+	input := &s3.GetObjectInput{
+		Bucket: &s.bucket,
+		Key:    &key,
+	}
+	req, _ := s.s3.GetObjectRequest(input)
+	return req.Presign(expire)
+}
+
 func autoS3Region(bucketName, accessKey, secretKey string) (string, error) {
 	awsConfig := &aws.Config{
 		HTTPClient: httpClient,


### PR DESCRIPTION
Dragonfly read requests via peer proxy and write requests via the default client of object storage. Backend storage now supports s3, oss and obs.

English document: https://github.com/juicedata/juicefs/files/13787601/Fluid.JuiceFS.Dragonfly-EN.V2.pdf
Chinese document: https://github.com/juicedata/juicefs/files/13787604/Fluid.JuiceFS.Dargonfly-ZH.V2.pdf