### PR TITLE
cmd/sync: increase memory pool for sync oversize files(part > 1G)

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -444,6 +444,10 @@ func doCopyMultiple(src, dst object.ObjectStorage, key string, size int64, uploa
 	if partSize == 0 {
 		partSize = defaultPartSize
 	}
+	limits := dst.Limits()
+	if size > int64(limits.MaxPartSize)*int64(limits.MaxPartCount) {
+		return fmt.Errorf("object size %d is too large to copy", size)
+	}
 	if size > partSize*int64(upload.MaxCount) {
 		partSize = size / int64(upload.MaxCount)
 		partSize = ((partSize-1)>>20 + 1) << 20 // align to MB

--- a/pkg/utils/alloc.go
+++ b/pkg/utils/alloc.go
@@ -62,8 +62,8 @@ func powerOf2(s int) int {
 }
 
 func init() {
-	pools = make([]*sync.Pool, 30) // 1 - 1G
-	for i := 0; i < 30; i++ {
+	pools = make([]*sync.Pool, 33) // 1 - 8G
+	for i := 0; i < 33; i++ {
 		func(bits int) {
 			pools[i] = &sync.Pool{
 				New: func() interface{} {


### PR DESCRIPTION
Scanned objects: 178828/189169 [==========================================================>---]  0.5/s ETA: 6h9m12s
Skipped objects: 137390                            0.4/s                                       ⠸
Pending objects: 10240                             0.0/s                                       ⠸
 Copied objects: 41435                             0.1/s                                       ⠸
   Copied bytes: 80.9 TiB (88996429305820 Bytes)   221.6 MiB/s                                 ⠸
 Failed objects: 3                                 0.0/s                                       ⠸
panic: runtime error: index out of range [31] with length 30

goroutine 65784726 [running]:
[github.com/juicedata/juicefs/pkg/utils.Alloc(0xc06722b4c8?)](http://github.com/juicedata/juicefs/pkg/utils.Alloc(0xc06722b4c8?))
        /go/pkg/mod/[github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/utils/alloc.go:32](http://github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/utils/alloc.go:32) +0x133
[github.com/juicedata/juicefs/pkg/chunk.NewOffPage(0xc00024aa80?)](http://github.com/juicedata/juicefs/pkg/chunk.NewOffPage(0xc00024aa80?))
        /go/pkg/mod/[github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/chunk/page.go:50](http://github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/chunk/page.go:50) +0x2e
[github.com/juicedata/juicefs/pkg/sync.doCopyMultiple.func1(0x2617)](http://github.com/juicedata/juicefs/pkg/sync.doCopyMultiple.func1(0x2617))
        /go/pkg/mod/[github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/sync/sync.go:490](http://github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/sync/sync.go:490) +0x305
created by [github.com/juicedata/juicefs/pkg/sync.doCopyMultiple](http://github.com/juicedata/juicefs/pkg/sync.doCopyMultiple)
        /go/pkg/mod/[github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/sync/sync.go:458](http://github.com/juicedata/juicefs@v1.2.0-dev.0.20231214061046-f5d631e95dca/pkg/sync/sync.go:458) +0x295