### PR TITLE
meta: fix protection check for compaction

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -1280,15 +1280,11 @@ func testCompaction(t *testing.T, m Meta, trash bool) {
 	if c, ok := m.(compactor); ok {
 		c.compactChunk(inode, 0, true)
 	}
-	var slices2 []Slice
-	if st := m.Read(ctx, inode, 0, &slices2); st != 0 {
+	if st := m.Read(ctx, inode, 0, &slices); st != 0 {
 		t.Fatalf("read 0: %s", st)
 	}
-	if len(slices) == 2 && len(slices2) == 2 {
-		slices2[1].Id = slices[1].Id
-	}
-	if !reflect.DeepEqual(slices, slices2) {
-		t.Fatalf("slices not equal:\n%+v\n%+v", slices, slices2)
+	if len(slices) != 1 || slices[0].Len != 3<<20 {
+		t.Fatalf("inode %d should be compacted, but have %d slices, size %d", inode, len(slices), slices[0].Len)
 	}
 }
 

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2923,17 +2923,17 @@ func (m *redisMeta) compactChunk(inode Ino, indx uint32, force bool) {
 		return
 	}
 	skipped := skipSome(ss)
-	var last *slice
+	var first, last *slice
 	if skipped > 0 {
-		last = ss[skipped-1]
+		first, last = ss[0], ss[skipped-1]
 	}
 	ss = ss[skipped:]
 	pos, size, slices := compactChunk(ss)
 	if len(ss) < 2 || size == 0 {
 		return
 	}
-	if last != nil && last.pos+last.len > pos {
-		panic(fmt.Sprintf("invalid compaction: last skipped slice %+v, pos %d", last, pos))
+	if first != nil && last != nil && pos+size > first.pos && last.pos+last.len > pos {
+		panic(fmt.Sprintf("invalid compaction: skipped slices [%+v, %+v], pos %d, size %d", *first, *last, pos, size))
 	}
 
 	var id uint64

--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -157,11 +157,12 @@ func buildSlice(ss []*slice) []Slice {
 func compactChunk(ss []*slice) (uint32, uint32, []Slice) {
 	var chunk = buildSlice(ss)
 	var pos uint32
+	for len(chunk) > 1 && chunk[0].Id == 0 {
+		pos += chunk[0].Len
+		chunk = chunk[1:]
+	}
 	if len(chunk) == 1 && chunk[0].Id == 0 {
 		chunk[0].Len = 1
-	} else if len(chunk) > 1 && chunk[0].Id == 0 {
-		pos = chunk[0].Len
-		chunk = chunk[1:]
 	}
 	var size uint32
 	for _, c := range chunk {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2783,17 +2783,17 @@ func (m *dbMeta) compactChunk(inode Ino, indx uint32, force bool) {
 		return
 	}
 	skipped := skipSome(ss)
-	var last *slice
+	var first, last *slice
 	if skipped > 0 {
-		last = ss[skipped-1]
+		first, last = ss[0], ss[skipped-1]
 	}
 	ss = ss[skipped:]
 	pos, size, slices := compactChunk(ss)
 	if len(ss) < 2 || size == 0 {
 		return
 	}
-	if last != nil && last.pos+last.len > pos {
-		panic(fmt.Sprintf("invalid compaction: last skipped slice %+v, pos %d", last, pos))
+	if first != nil && last != nil && pos+size > first.pos && last.pos+last.len > pos {
+		panic(fmt.Sprintf("invalid compaction: skipped slices [%+v, %+v], pos %d, size %d", *first, *last, pos, size))
 	}
 
 	var id uint64

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2410,17 +2410,17 @@ func (m *kvMeta) compactChunk(inode Ino, indx uint32, force bool) {
 		return
 	}
 	skipped := skipSome(ss)
-	var last *slice
+	var first, last *slice
 	if skipped > 0 {
-		last = ss[skipped-1]
+		first, last = ss[0], ss[skipped-1]
 	}
 	ss = ss[skipped:]
 	pos, size, slices := compactChunk(ss)
 	if len(ss) < 2 || size == 0 {
 		return
 	}
-	if last != nil && last.pos+last.len > pos {
-		panic(fmt.Sprintf("invalid compaction: last skipped slice %+v, pos %d", last, pos))
+	if first != nil && last != nil && pos+size > first.pos && last.pos+last.len > pos {
+		panic(fmt.Sprintf("invalid compaction: skipped slices [%+v, %+v], pos %d, size %d", *first, *last, pos, size))
 	}
 
 	var id uint64


### PR DESCRIPTION
close #4347 

Handle cases like:
```
          |___1___|
|___|
   |___|             ==>
      |___|
|____0____|              |____0____|___1___|

// the slice with ID = 1 will be skipped
```
