### PR TITLE
Fix: bug in cache

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -1024,11 +1024,11 @@ func (store *cachedStore) FillCache(id uint64, length uint32) error {
 			continue
 		}
 		p := NewOffPage(size)
-		defer p.Release()
 		if e := store.load(k, p, true, true); e != nil {
 			logger.Warnf("Failed to load key: %s %s", k, e)
 			err = e
 		}
+		p.Release()
 	}
 	return err
 }

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -355,7 +355,12 @@ func (cache *cacheStore) getPathFromKey(k cacheKey) string {
 
 func (cache *cacheStore) remove(key string) {
 	cache.Lock()
-	delete(cache.pages, key)
+
+	if p, ok := cache.pages[key]; ok {
+		p.Release()
+		delete(cache.pages, key)
+	}
+
 	path := cache.cachePath(key)
 	k := cache.getCacheKey(key)
 	if it, ok := cache.keys[k]; ok {

--- a/pkg/vfs/fill.go
+++ b/pkg/vfs/fill.go
@@ -187,6 +187,7 @@ func (v *VFS) walkDir(ctx meta.Context, inode Ino, todo chan _file) {
 func (v *VFS) fillInode(ctx meta.Context, inode Ino, size uint64, bytes *uint64) error {
 	var slices []meta.Slice
 	for indx := uint64(0); indx*meta.ChunkSize < size; indx++ {
+		slices = nil
 		if st := v.Meta.Read(ctx, inode, uint32(indx), &slices); st != 0 {
 			return fmt.Errorf("Failed to get slices of inode %d index %d: %d", inode, indx, st)
 		}


### PR DESCRIPTION
1. Fix page release. Currently, it will be reclaimed by runtime.SetFinalizer.
2. Fix slices repeat cache when chunk does not exist.