### PR TITLE
fix: cleanup cache expire skip staging

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -170,6 +170,9 @@ func (cache *cacheStore) cleanupExpire() {
 			if cnt > 1e3 {
 				break
 			}
+			if v.size < 0 {
+				continue // staging
+			}
 			if v.atime < cutoff {
 				deleted++
 				delete(cache.keys, k)


### PR DESCRIPTION
disk cache cleanup expire cache items should skip staging cache items which size is <0, otherwise it will add wrong cache.used