### PR TITLE
implement deadlock detection

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -119,36 +119,36 @@ func testMeta(t *testing.T, m Meta) {
 	}
 
 	testMetaClient(t, m)
-	// testTruncateAndDelete(t, m)
-	// testTrash(t, m)
-	// testParents(t, m)
-	// testRemove(t, m)
-	// testResolve(t, m)
-	// testStickyBit(t, m)
-	// testLocks(t, m)
-	// testListLocks(t, m)
+	testTruncateAndDelete(t, m)
+	testTrash(t, m)
+	testParents(t, m)
+	testRemove(t, m)
+	testResolve(t, m)
+	testStickyBit(t, m)
+	testLocks(t, m)
+	testListLocks(t, m)
 	testDeadlockDetection(t, m)
-	// testConcurrentWrite(t, m)
-	// testCompaction(t, m, false)
-	// time.Sleep(time.Second)
-	// testCompaction(t, m, true)
-	// testCopyFileRange(t, m)
-	// testCloseSession(t, m)
-	// testConcurrentDir(t, m)
-	// testAttrFlags(t, m)
-	// testQuota(t, m)
-	// testAtime(t, m)
-	// base := m.getBase()
-	// base.conf.OpenCache = time.Second
-	// base.of.expire = time.Second
-	// testOpenCache(t, m)
-	// base.conf.CaseInsensi = true
-	// testCaseIncensi(t, m)
-	// testCheckAndRepair(t, m)
-	// testDirStat(t, m)
-	// testClone(t, m)
-	// base.conf.ReadOnly = true
-	// testReadOnly(t, m)
+	testConcurrentWrite(t, m)
+	testCompaction(t, m, false)
+	time.Sleep(time.Second)
+	testCompaction(t, m, true)
+	testCopyFileRange(t, m)
+	testCloseSession(t, m)
+	testConcurrentDir(t, m)
+	testAttrFlags(t, m)
+	testQuota(t, m)
+	testAtime(t, m)
+	base := m.getBase()
+	base.conf.OpenCache = time.Second
+	base.of.expire = time.Second
+	testOpenCache(t, m)
+	base.conf.CaseInsensi = true
+	testCaseIncensi(t, m)
+	testCheckAndRepair(t, m)
+	testDirStat(t, m)
+	testClone(t, m)
+	base.conf.ReadOnly = true
+	testReadOnly(t, m)
 }
 
 func testMetaClient(t *testing.T, m Meta) {
@@ -999,40 +999,47 @@ func testDeadlockDetection(t *testing.T, m Meta) {
 		t.Fatalf("create f: %s", st)
 	}
 
-	var g sync.WaitGroup
+	var gAll sync.WaitGroup
+	var gLock sync.WaitGroup
 	var err syscall.Errno
 	for i := 0; i < 3; i++ {
-		g.Add(1)
+		gAll.Add(1)
+		gLock.Add(1)
 		go func(i int) {
-			defer g.Done()
+			defer gAll.Done()
 			start1 := uint64(i) << 8
 			end1 := start1 + 0xFF
 			if st := m.Setlk(ctx, inode, uint64(i), true, syscall.F_WRLCK, start1, end1, uint32(i)); st != 0 {
-				panic(fmt.Errorf("set wlock"))
+				panic(fmt.Errorf("plock wlock"))
 			}
-			t.Logf("%d locks %d-%d", i, start1, end1)
-			time.Sleep(100 * time.Millisecond)
+			gLock.Done()
+			gLock.Wait()
 			start2 := uint64((i+1) % 3) << 8
 			end2 := start2 + 0xFF
-			if st := m.Setlk(ctx, inode, uint64(i), true, syscall.F_WRLCK, start2, end2, uint32(i)); st != 0 {
+			if st := m.Setlk(ctx, inode, uint64(i), true, syscall.F_RDLCK, start2, end2, uint32(i)); st != 0 {
 				err = st
-				t.Logf("%d try to locks %d-%d, got %d", i, start2, end2, st)
-			} else {
-				t.Logf("%d locks %d-%d", i, start2, end2)
 			}
-			time.Sleep(100 * time.Millisecond)
 			if st := m.Setlk(ctx, inode, uint64(i), false, syscall.F_UNLCK, start2, end2, uint32(i)); st != 0 {
-				panic(fmt.Errorf("set unlock"))
+				panic(fmt.Errorf("plock unlock"))
 			}
 			if st := m.Setlk(ctx, inode, uint64(i), false, syscall.F_UNLCK, start1, end1, uint32(i)); st != 0 {
-				panic(fmt.Errorf("set unlock"))
+				panic(fmt.Errorf("plock unlock"))
 			}
 		}(i)
 	}
-	g.Wait()
+	gAll.Wait()
 	if err != syscall.EDEADLK {
-        t.Fatalf("should be DEADLK")
+        t.Fatalf("deadlock not detected, %s", err)
     }
+	if r, ok := m.(*redisMeta); ok {
+		ms, err := r.rdb.HKeys(context.Background(), r.conflictKey()).Result()
+		if err != nil {
+			t.Fatalf("Skeys %s: %s", r.conflictKey(), err)
+		}
+		if len(ms) != 0 {
+			t.Fatalf("conflict key leaked: %d", len(ms))
+		}
+	}
 }
 
 func testResolve(t *testing.T, m Meta) {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -569,6 +569,10 @@ func (m *redisMeta) plockKey(inode Ino) string {
 	return m.prefix + "lockp" + inode.String()
 }
 
+func (m *redisMeta) conflictKey() string {
+	return m.prefix + "conflict"
+}
+
 func (m *redisMeta) setting() string {
 	return m.prefix + "setting"
 }


### PR DESCRIPTION
WIP for #774 

I'm using pjdfstest to verify, testcases used is listed below
```
$ cat runtest/syscalls-ddlk
fcntl17 fcntl17
fcntl17_64 fcntl17_64
```

Main branch:
```
$ ./runltp -d /mnt/jfs -f syscalls-ddlk
<some log>
Running tests.......
fcntl17     0  TINFO  :  Enter preparation phase
fcntl17     0  TINFO  :  Exit preparation phase
fcntl17     0  TINFO  :  Enter block 1
fcntl17     0  TINFO  :  child 1 starting
fcntl17     0  TINFO  :  child 1 pid 82931 locked
fcntl17     0  TINFO  :  child 2 starting
fcntl17     0  TINFO  :  child 2 pid 82932 locked
fcntl17     0  TINFO  :  child 3 starting
fcntl17     0  TINFO  :  child 3 pid 82933 locked
fcntl17     0  TINFO  :  child 3 resuming
fcntl17     0  TINFO  :  child 2 resuming
fcntl17     0  TINFO  :  child 1 resuming
fcntl17     0  TINFO  :  child 1 unlocked
fcntl17     1  TFAIL  :  fcntl17.c:429: Alarm expired, deadlock not detected
fcntl17     0  TWARN  :  fcntl17.c:430: You may need to kill child processes by hand
fcntl17     2  TFAIL  :  fcntl17.c:408: Unexpected death of child process
fcntl17     0  TWARN  :  tst_tmpdir.c:336: tst_rmdir: rmobj(/mnt/jfs/ltp-6SyZCZsNEH/fcndBzo6b) failed: unlink(/mnt/jfs/ltp-6SyZCZsNEH/fcndBzo6b) failed; errno=2: ENOENT
fcntl17     3  TFAIL  :  fcntl17.c:363: parent_wait() failed
fcntl17     4  TFAIL  :  fcntl17.c:605: child 2 didn't deadlock, returned: 4
fcntl17     5  TFAIL  :  fcntl17.c:295: fcntl on file failed, errno =9
fcntl17     6  TFAIL  :  fcntl17.c:295: fcntl on file failed, errno =9
fcntl17     7  TBROK  :  tst_sig.c:232: unexpected signal SIGPIPE(13) received (pid = 82930).
fcntl17     8  TBROK  :  tst_sig.c:232: Remaining cases broken
fcntl17     0  TINFO  :  Enter preparation phase
fcntl17     0  TINFO  :  Exit preparation phase
fcntl17     0  TINFO  :  Enter block 1
fcntl17     0  TINFO  :  child 1 starting
fcntl17     0  TINFO  :  child 1 pid 82946 locked
fcntl17     0  TINFO  :  child 2 starting
fcntl17     0  TINFO  :  child 2 pid 82947 locked
fcntl17     0  TINFO  :  child 3 starting
fcntl17     0  TINFO  :  child 3 pid 82948 locked
fcntl17     0  TINFO  :  child 3 resuming
fcntl17     0  TINFO  :  child 1 resuming
fcntl17     0  TINFO  :  child 2 resuming
fcntl17     0  TINFO  :  child 1 unlocked
fcntl17     1  TFAIL  :  fcntl17.c:429: Alarm expired, deadlock not detected
fcntl17     0  TWARN  :  fcntl17.c:430: You may need to kill child processes by hand
fcntl17     2  TFAIL  :  fcntl17.c:408: Unexpected death of child process
fcntl17     0  TWARN  :  tst_tmpdir.c:336: tst_rmdir: rmobj(/mnt/jfs/ltp-6SyZCZsNEH/fcnYP2Nas) failed: unlink(/mnt/jfs/ltp-6SyZCZsNEH/fcnYP2Nas) failed; errno=2: ENOENT
fcntl17     3  TFAIL  :  fcntl17.c:363: parent_wait() failed
fcntl17     4  TFAIL  :  fcntl17.c:605: child 2 didn't deadlock, returned: 4
fcntl17     5  TFAIL  :  fcntl17.c:295: fcntl on file failed, errno =9
fcntl17     6  TFAIL  :  fcntl17.c:295: fcntl on file failed, errno =9
fcntl17     7  TBROK  :  tst_sig.c:232: unexpected signal SIGPIPE(13) received (pid = 82945).
fcntl17     8  TBROK  :  tst_sig.c:232: Remaining cases broken
INFO: ltp-pan reported some tests FAIL
<some log>

$ cat /opt/ltp/results/LTP_RUN_ON-2024_03_08-10h_31m_29s.log
Test Start Time: Fri Mar  8 10:31:30 2024
-----------------------------------------
Testcase                                           Result     Exit Value
--------                                           ------     ----------
fcntl17                                            FAIL       7
fcntl17_64                                         FAIL       7

-----------------------------------------------
Total Tests: 2
Total Skipped Tests: 0
Total Failures: 2
Kernel Version: 6.1.79
Machine Architecture: x86_64
Hostname: pat
```

This branch:
```
$ ./runltp -d /mnt/jfs -f syscalls-ddlk
<some log>
Running tests.......
<<<test_start>>>
tag=fcntl17 stime=1709865314
cmdline="fcntl17"
contacts=""
analysis=exit
<<<test_output>>>
fcntl17     0  TINFO  :  Enter preparation phase
fcntl17     0  TINFO  :  Exit preparation phase
fcntl17     0  TINFO  :  Enter block 1
fcntl17     0  TINFO  :  child 1 starting
fcntl17     0  TINFO  :  child 1 pid 84263 locked
fcntl17     0  TINFO  :  child 2 starting
fcntl17     0  TINFO  :  child 2 pid 84264 locked
fcntl17     0  TINFO  :  child 3 starting
fcntl17     0  TINFO  :  child 3 pid 84265 locked
fcntl17     0  TINFO  :  child 2 resuming
fcntl17     0  TINFO  :  child 3 resuming
fcntl17     0  TINFO  :  child 1 resuming
fcntl17     0  TINFO  :  child 1 unlocked
fcntl17     0  TINFO  :  child 3 lockw err 35
fcntl17     0  TINFO  :  child 1 exiting
fcntl17     0  TINFO  :  child 3 exiting
fcntl17     0  TINFO  :  child 2 lockw err 35
fcntl17     0  TINFO  :  child 2 exiting
fcntl17     1  TPASS  :  Block 1 PASSED
fcntl17     0  TINFO  :  Exit block 1
<<<execution_status>>>
initiation_status="ok"
duration=0 termination_type=exited termination_id=0 corefile=no
cutime=0 cstime=0
<<<test_end>>>
<<<test_start>>>
tag=fcntl17_64 stime=1709865314
cmdline="fcntl17_64"
contacts=""
analysis=exit
<<<test_output>>>
incrementing stop
fcntl17     0  TINFO  :  Enter preparation phase
fcntl17     0  TINFO  :  Exit preparation phase
fcntl17     0  TINFO  :  Enter block 1
fcntl17     0  TINFO  :  child 1 starting
fcntl17     0  TINFO  :  child 1 pid 84267 locked
fcntl17     0  TINFO  :  child 2 starting
fcntl17     0  TINFO  :  child 2 pid 84268 locked
fcntl17     0  TINFO  :  child 3 starting
fcntl17     0  TINFO  :  child 3 pid 84269 locked
fcntl17     0  TINFO  :  child 2 resuming
fcntl17     0  TINFO  :  child 3 resuming
fcntl17     0  TINFO  :  child 1 resuming
fcntl17     0  TINFO  :  child 3 lockw err 35
fcntl17     0  TINFO  :  child 3 exiting
fcntl17     0  TINFO  :  child 1 unlocked
fcntl17     0  TINFO  :  child 1 exiting
fcntl17     0  TINFO  :  child 2 lockw err 35
fcntl17     0  TINFO  :  child 2 exiting
fcntl17     1  TPASS  :  Block 1 PASSED
fcntl17     0  TINFO  :  Exit block 1
<<<execution_status>>>
initiation_status="ok"
duration=0 termination_type=exited termination_id=0 corefile=no
cutime=0 cstime=0
<<<test_end>>>
<some log>

$ cat /opt/ltp/results/LTP_RUN_ON-2024_03_08-10h_35m_13s.log
Test Start Time: Fri Mar  8 10:35:14 2024
-----------------------------------------
Testcase                                           Result     Exit Value
--------                                           ------     ----------
fcntl17                                            PASS       0
fcntl17_64                                         PASS       0

-----------------------------------------------
Total Tests: 2
Total Skipped Tests: 0
Total Failures: 0
Kernel Version: 6.1.79
Machine Architecture: x86_64
Hostname: pat
```

Some advice needed about this PR:
1. I don't know if it will have much performance impact introduced by the newly added detection. So I copied the MAX ITERATION 10 from the kernel.
2. A new Redis hash set introduced here. But simple key/value  pair is also enough to use here. Which one is preferred?
3. If the data remained in meta store in any case, currently no clean up will be done.

If this implementation is good, I'll do the same on other meta store type.
