### PR TITLE
meta/sql: use upsert in Write() to avoid possible deadlock

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2434,11 +2434,11 @@ func (m *dbMeta) Write(ctx Context, inode Ino, indx uint32, off uint32, slice Sl
 		var ck = chunk{Inode: inode, Indx: indx, Slices: buf}
 		_, err = s.Insert(&ck)
 		if err != nil && isDuplicateEntryErr(err) {
-			ck.Slices = nil
-			if _, err = s.ForUpdate().MustCols("indx").Get(&ck); err != nil {
+			if err = m.appendSlice(s, inode, indx, buf); err != nil {
 				return err
 			}
-			err = m.appendSlice(s, inode, indx, buf)
+			ck.Slices = nil
+			_, err = s.MustCols("indx").Get(&ck)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
close #4494 
The current behavior with possible deadlock is not a bug (see: https://bugs.mysql.com/bug.php?id=96748). However, try insertion first seems do omit the deadlock warning.