### PR TITLE
cmd/sync: use larger io-size when writing to backends

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -318,6 +318,7 @@ func setup(c *cli.Context, n int) {
 		go debugAgentOnce.Do(func() {
 			for port := 6060; port < 6100; port++ {
 				debugAgent = fmt.Sprintf("127.0.0.1:%d", port)
+				logger.Debugf("Debug agent listening on %s", debugAgent)
 				_ = http.ListenAndServe(debugAgent, nil)
 			}
 		})

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -176,7 +176,8 @@ func CreateStorage(name, endpoint, accessKey, secretKey, token string) (ObjectSt
 
 var bufPool = sync.Pool{
 	New: func() interface{} {
-		buf := make([]byte, 32<<10)
+		// Default io.Copy uses 32KB buffer, here we choose a larger one (1MiB io-size increases throughput by ~20%)
+		buf := make([]byte, 1<<20)
 		return &buf
 	},
 }


### PR DESCRIPTION
1MiB io-size increases throughput by ~20%
<img width="757" alt="image" src="https://github.com/juicedata/juicefs/assets/2657334/ec31b06d-3405-4379-869d-0041f22a5252">
