### PR TITLE
vfs: merge fuse ops metrics in .stats

### DIFF
--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -164,7 +164,8 @@ func collectMetrics(registry *prometheus.Registry) []byte {
 	}
 	for _, mf := range mfs {
 		var name = *mf.Name
-		if name == "juicefs_meta_ops_durations_histogram_seconds" && *mf.Type == io_prometheus_client.MetricType_HISTOGRAM {
+		if (name == "juicefs_meta_ops_durations_histogram_seconds" || name == "juicefs_fuse_ops_durations_histogram_seconds") &&
+			*mf.Type == io_prometheus_client.MetricType_HISTOGRAM {
 			total, sum := mergeHistogramMetrics(mf)
 			_, _ = fmt.Fprintf(w, "%s_total %d\n", name, total)
 			_, _ = fmt.Fprintf(w, "%s_sum %s\n", name, format(sum))


### PR DESCRIPTION
A patch for #4554 .
Without it there will be multiple lines for fuse ops metrics:
```
juicefs_fuse_ops_durations_histogram_seconds_total 101
juicefs_fuse_ops_durations_histogram_seconds_sum 1.305467913
juicefs_fuse_ops_durations_histogram_seconds_total 205
juicefs_fuse_ops_durations_histogram_seconds_sum 1.6931756689999993
juicefs_fuse_ops_durations_histogram_seconds_total 211
juicefs_fuse_ops_durations_histogram_seconds_sum 0.05859979800000001
juicefs_fuse_ops_durations_histogram_seconds_total 315
juicefs_fuse_ops_durations_histogram_seconds_sum 0.09348225000000002
```