### PR TITLE
Two minor metrics updates

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -137,7 +137,7 @@ func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *p
 }
 
 func wrapRegister(c *cli.Context, mp, name string) (prometheus.Registerer, *prometheus.Registry) {
-	commonLabels := prometheus.Labels{"mp": mp, "vol_name": name}
+	commonLabels := prometheus.Labels{"mp": mp, "vol_name": name, "juicefs_version": version.Version()}
 	if h, err := os.Hostname(); err == nil {
 		commonLabels["instance"] = h
 	} else {

--- a/docs/en/grafana_template.json
+++ b/docs/en/grafana_template.json
@@ -266,11 +266,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(juicefs_uptime{vol_name=\"$name\"})",
+          "expr": "count by (juicefs_version) (juicefs_uptime{vol_name=\"$name\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Sessions",
+          "legendFormat": "Version {{juicefs_version}}",
           "refId": "A"
         }
       ],

--- a/docs/en/grafana_template_k8s.json
+++ b/docs/en/grafana_template_k8s.json
@@ -266,11 +266,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(juicefs_uptime{vol_name=\"$name\"})",
+          "expr": "count by (juicefs_version) (juicefs_uptime{vol_name=\"$name\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Sessions",
+          "legendFormat": "Version {{juicefs_version}}",
           "refId": "A"
         }
       ],

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -106,7 +106,7 @@ func (s *rSlice) ReadAt(ctx context.Context, page *Page, off int) (n int, err er
 	boff := off % s.store.conf.BlockSize
 	blockSize := s.blockSize(indx)
 	if boff+len(p) > blockSize {
-		// read beyond currend page
+		// read beyond current page
 		var got int
 		for got < len(p) {
 			// aligned to current page
@@ -884,6 +884,14 @@ func (store *cachedStore) regMetrics(reg prometheus.Registerer) {
 		func() float64 {
 			_, used := store.bcache.stats()
 			return float64(used)
+		}))
+	reg.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "object_request_uploading",
+			Help: "number of uploading requests",
+		},
+		func() float64 {
+			return float64(len(store.currentUpload))
 		}))
 }
 

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -646,7 +646,7 @@ func (m *baseMeta) CloseSession() error {
 	if m.sid > 0 {
 		err = m.en.doCleanStaleSession(m.sid)
 	}
-	logger.Infof("close session %d: %s", m.sid, err)
+	logger.Infof("close session %d: %v", m.sid, err)
 	return err
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1258,7 +1258,7 @@ func (v *VFS) cleanupModified() {
 func (v *VFS) FlushAll(path string) (err error) {
 	now := time.Now()
 	defer func() {
-		logger.Infof("flush buffered data in %s: %s", time.Since(now), err)
+		logger.Infof("flush buffered data in %s: %v", time.Since(now), err)
 	}()
 	err = v.writer.FlushAll()
 	if err != nil {


### PR DESCRIPTION
1. Export version into metrics label - useful when we are upgrading a cluster of hundreds of nodes, it provides an overview of upgrade process.

3. Export the uploading objects number - so we will know whether we are running out of `max-uploads`.