### PR TITLE
meta: fix negative values in quota before used in statfs

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -580,25 +580,20 @@ func (m *baseMeta) StatFS(ctx Context, ino Ino, totalspace, availspace, iused, i
 		if q == nil {
 			continue
 		}
+		q.sanitize()
 		if usage == nil {
 			usage = q
 		}
 		if q.MaxSpace > 0 {
-			ls := q.MaxSpace - q.UsedSpace
-			if ls < 0 {
-				ls = 0
-			}
-			if uint64(ls) < *availspace {
-				*availspace = uint64(ls)
+			ls := uint64(q.MaxSpace - q.UsedSpace)
+			if ls < *availspace {
+				*availspace = ls
 			}
 		}
 		if q.MaxInodes > 0 {
-			li := q.MaxInodes - q.UsedInodes
-			if li < 0 {
-				li = 0
-			}
-			if uint64(li) < *iavail {
-				*iavail = uint64(li)
+			li := uint64(q.MaxInodes - q.UsedInodes)
+			if li < *iavail {
+				*iavail = li
 			}
 		}
 	}

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -63,6 +63,22 @@ func (q *Quota) update(space, inodes int64) {
 	atomic.AddInt64(&q.newInodes, inodes)
 }
 
+// not thread safe
+func (q *Quota) sanitize() {
+	if q.UsedSpace < 0 {
+		q.UsedSpace = 0
+	}
+	if q.MaxSpace > 0 && q.MaxSpace < q.UsedSpace {
+		q.MaxSpace = q.UsedSpace
+	}
+	if q.UsedInodes < 0 {
+		q.UsedInodes = 0
+	}
+	if q.MaxInodes > 0 && q.MaxInodes < q.UsedInodes {
+		q.MaxInodes = q.UsedInodes
+	}
+}
+
 func (m *baseMeta) parallelSyncDirStat(ctx Context, inos map[Ino]bool) *sync.WaitGroup {
 	var wg sync.WaitGroup
 	for i := range inos {


### PR DESCRIPTION
`df` may display negative value:
```
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda2       178G   44G  127G  26% /
JuiceFS:test    1.0P -100K  1.0P   0% /mnt/jfs
```