### PR TITLE
Add `fuse_written_file_size_bytes` metric to better understand user's usage pattern

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/davies/groupcache/consistenthash"
+	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -127,7 +128,8 @@ func newCacheStore(m *cacheManagerMetrics, dir string, cacheSize int64, pendingP
 	if br < c.freeRatio || fr < c.freeRatio {
 		logger.Warnf("not enough space (%d%%) or inodes (%d%%) for caching in %s: free ratio should be >= %d%%", int(br*100), int(fr*100), c.dir, int(c.freeRatio*100))
 	}
-	logger.Infof("Disk cache (%s): capacity (%d MB), free ratio (%d%%), max pending pages (%d)", c.dir, c.capacity>>20, int(c.freeRatio*100), pendingPages)
+	logger.Infof("Disk cache (%s): capacity (%s), free ratio %d%%, used ratio - [space %s%%, inode %s%%], max pending pages %d",
+		c.dir, humanize.IBytes(uint64(c.capacity)), int(c.freeRatio*100), humanize.FtoaWithDigits(float64((1-br)*100), 1), humanize.FtoaWithDigits(float64((1-fr)*100), 1), pendingPages)
 	c.createLockFile()
 	go c.checkLockFile()
 	go c.flush()

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -494,10 +494,10 @@ func (m *baseMeta) CleanStaleSessions() {
 	for _, sid := range sids {
 		s, err := m.en.GetSession(sid, false)
 		if err != nil {
-			logger.Warnf("Get session info %d: %s", sid, err)
+			logger.Warnf("Get session info %d: %v", sid, err)
 			s = &Session{Sid: sid}
 		}
-		logger.Infof("clean up stale session %d %+v: %s", sid, s.SessionInfo, m.en.doCleanStaleSession(sid))
+		logger.Infof("clean up stale session %d %+v: %v", sid, s.SessionInfo, m.en.doCleanStaleSession(sid))
 	}
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -150,6 +150,11 @@ var (
 		Help:    "size of write distributions.",
 		Buckets: prometheus.LinearBuckets(4096, 4096, 32),
 	})
+	fileSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "fuse_written_file_size_bytes",
+		Help:    "distribution of written file size.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 41), // 1 byte to 1 TiB
+	})
 )
 
 func (v *VFS) Lookup(ctx Context, parent Ino, name string) (entry *meta.Entry, err syscall.Errno) {
@@ -1321,6 +1326,7 @@ func InitMetrics(registerer prometheus.Registerer) {
 	}
 	registerer.MustRegister(readSizeHistogram)
 	registerer.MustRegister(writtenSizeHistogram)
+	registerer.MustRegister(fileSizeHistogram)
 	registerer.MustRegister(opsDurationsHistogram)
 	registerer.MustRegister(compactSizeHistogram)
 }

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -404,7 +404,11 @@ func (f *fileWriter) Flush(ctx meta.Context) syscall.Errno {
 
 func (f *fileWriter) Close(ctx meta.Context) syscall.Errno {
 	defer f.w.free(f)
-	return f.Flush(ctx)
+	eno := f.Flush(ctx)
+	if eno == 0 {
+		fileSizeHistogram.Observe(float64(f.GetLength()))
+	}
+	return eno
 }
 
 func (f *fileWriter) GetLength() uint64 {


### PR DESCRIPTION
Together with `fuse_read_size_bytes` and `fuse_written_size_bytes` metrics, we can better understand user's IO pattern.