### PR TITLE
Expose the storage-class to the metrics of throughput and latency

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -248,6 +248,8 @@ func createStorage(format meta.Format) (object.ObjectStorage, error) {
 	if format.StorageClass != "" {
 		if os, ok := blob.(object.SupportStorageClass); ok {
 			os.SetStorageClass(format.StorageClass)
+		} else {
+			logger.Warnf("Storage class is not supported by %q, will ignore", format.Storage)
 		}
 	}
 	if format.EncryptKey != "" {
@@ -316,8 +318,8 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 	}
 	err = store.Delete(key)
 	if err != nil {
-		// it's OK to don't have delete permission
-		fmt.Printf("Failed to delete: %s", err)
+		// it's OK to don't have delete permission, but we should warn user explicitly
+		logger.Warnf("Failed to delete, err: %s", err)
 	}
 	return nil
 }

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/davies/groupcache/consistenthash"
+	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -127,7 +128,8 @@ func newCacheStore(m *cacheManagerMetrics, dir string, cacheSize int64, pendingP
 	if br < c.freeRatio || fr < c.freeRatio {
 		logger.Warnf("not enough space (%d%%) or inodes (%d%%) for caching in %s: free ratio should be >= %d%%", int(br*100), int(fr*100), c.dir, int(c.freeRatio*100))
 	}
-	logger.Infof("Disk cache (%s): capacity (%d MB), free ratio (%d%%), max pending pages (%d)", c.dir, c.capacity>>20, int(c.freeRatio*100), pendingPages)
+	logger.Infof("Disk cache (%s): capacity (%s), free ratio %d%%, used ratio - [space %s%%, inode %s%%], max pending pages %d",
+		c.dir, humanize.IBytes(uint64(c.capacity)), int(c.freeRatio*100), humanize.FtoaWithDigits(float64((1-br)*100), 1), humanize.FtoaWithDigits(float64((1-fr)*100), 1), pendingPages)
 	c.createLockFile()
 	go c.checkLockFile()
 	go c.flush()

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -494,10 +494,10 @@ func (m *baseMeta) CleanStaleSessions() {
 	for _, sid := range sids {
 		s, err := m.en.GetSession(sid, false)
 		if err != nil {
-			logger.Warnf("Get session info %d: %s", sid, err)
+			logger.Warnf("Get session info %d: %v", sid, err)
 			s = &Session{Sid: sid}
 		}
-		logger.Infof("clean up stale session %d %+v: %s", sid, s.SessionInfo, m.en.doCleanStaleSession(sid))
+		logger.Infof("clean up stale session %d %+v: %v", sid, s.SessionInfo, m.en.doCleanStaleSession(sid))
 	}
 }
 

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -84,7 +84,8 @@ func (b *wasb) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		return nil, err
 	}
 	ReqIDCache.put(key, aws.StringValue(download.RequestID))
-	return download.Body, err
+	// TODO fire another property request to get the actual storage class
+	return scReadCloser{download.Body, b.sc}, err
 }
 
 func str2Tier(tier string) *blob2.AccessTier {
@@ -178,6 +179,10 @@ func (b *wasb) List(prefix, marker, delimiter string, limit int64, followLink bo
 
 func (b *wasb) SetStorageClass(sc string) {
 	b.sc = sc
+}
+
+func (b *wasb) StorageClass() string {
+	return b.sc
 }
 
 func autoWasbEndpoint(containerName, accountName, scheme string, credential *azblob.SharedKeyCredential) (string, error) {

--- a/pkg/object/bos.go
+++ b/pkg/object/bos.go
@@ -101,7 +101,7 @@ func (q *bosclient) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.Body, nil
+	return scReadCloser{r.Body, r.StorageClass}, nil
 }
 
 func (q *bosclient) Put(key string, in io.Reader) error {

--- a/pkg/object/dragonfly.go
+++ b/pkg/object/dragonfly.go
@@ -292,6 +292,9 @@ func (d *dragonfly) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("bad response status %s", resp.Status)
 	}
 
+	if sc := resp.Header.Get(HeaderDragonflyObjectMetaStorageClass); sc != "" {
+		return scReadCloser{resp.Body, sc}, nil
+	}
 	return resp.Body, nil
 }
 

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -110,7 +110,8 @@ func (g *gs) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return reader, nil
+	// TODO fire another attr request to get the actual storage class
+	return scReadCloser{reader, g.sc}, nil
 }
 
 func (g *gs) Put(key string, data io.Reader) error {
@@ -172,6 +173,10 @@ func (g *gs) List(prefix, marker, delimiter string, limit int64, followLink bool
 
 func (g *gs) SetStorageClass(sc string) {
 	g.sc = sc
+}
+
+func (g *gs) StorageClass() string {
+	return g.sc
 }
 
 func newGS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) {

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -88,6 +88,9 @@ func (s *ibmcos) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StorageClass != nil {
+		return scReadCloser{resp.Body, *resp.StorageClass}, nil
+	}
 	return resp.Body, nil
 }
 
@@ -290,6 +293,10 @@ func (s *ibmcos) ListUploads(marker string) ([]*PendingPart, string, error) {
 
 func (s *ibmcos) SetStorageClass(sc string) {
 	s.sc = sc
+}
+
+func (s *ibmcos) StorageClass() string {
+	return s.sc
 }
 
 func newIBMCOS(endpoint, apiKey, serviceInstanceID, token string) (ObjectStorage, error) {

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -44,10 +44,6 @@ type SupportSymlink interface {
 	Readlink(name string) (string, error)
 }
 
-type SupportStorageClass interface {
-	SetStorageClass(sc string)
-}
-
 type File interface {
 	Object
 	Owner() string

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -128,7 +128,7 @@ func (s *obsClient) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		_ = resp.Body.Close()
 		return nil, err
 	}
-	return resp.Body, nil
+	return scReadCloser{resp.Body, string(resp.StorageClass)}, nil
 }
 
 func (s *obsClient) Put(key string, in io.Reader) error {
@@ -330,6 +330,10 @@ func (s *obsClient) ListUploads(marker string) ([]*PendingPart, string, error) {
 
 func (s *obsClient) SetStorageClass(sc string) {
 	s.sc = sc
+}
+
+func (s *obsClient) StorageClass() string {
+	return s.sc
 }
 
 func autoOBSEndpoint(bucketName, accessKey, secretKey, token string) (string, error) {

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -138,6 +138,10 @@ func (o *ossClient) Get(key string, off, limit int64) (resp io.ReadCloser, err e
 	}
 	ReqIDCache.put(key, respHeader.Get(oss.HTTPHeaderOssRequestID))
 	err = o.checkError(err)
+	if err == nil {
+		sc := respHeader.Get(oss.HTTPHeaderOssStorageClass)
+		resp = scReadCloser{resp, sc}
+	}
 	return
 }
 
@@ -269,6 +273,10 @@ func (o *ossClient) ListUploads(marker string) ([]*PendingPart, string, error) {
 
 func (o *ossClient) SetStorageClass(sc string) {
 	o.sc = sc
+}
+
+func (o *ossClient) StorageClass() string {
+	return o.sc
 }
 
 type stsCred struct {

--- a/pkg/object/prefix.go
+++ b/pkg/object/prefix.go
@@ -39,6 +39,13 @@ func (s *withPrefix) SetStorageClass(sc string) {
 	}
 }
 
+func (s *withPrefix) StorageClass() string {
+	if o, ok := s.os.(StorageClassGetter); ok {
+		return o.StorageClass()
+	}
+	return ""
+}
+
 func (s *withPrefix) Symlink(oldName, newName string) error {
 	if w, ok := s.os.(SupportSymlink); ok {
 		return w.Symlink(oldName, s.prefix+newName)

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -98,6 +98,9 @@ func (q *qingstor) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		_ = output.Body.Close()
 		return nil, err
 	}
+	if output.XQSStorageClass != nil {
+		return scReadCloser{output.Body, *output.XQSStorageClass}, nil
+	}
 	return output.Body, nil
 }
 
@@ -314,6 +317,10 @@ func (q *qingstor) ListUploads(marker string) ([]*PendingPart, string, error) {
 
 func (q *qingstor) SetStorageClass(sc string) {
 	q.sc = sc
+}
+
+func (q *qingstor) StorageClass() string {
+	return q.sc
 }
 
 func newQingStor(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) {

--- a/pkg/object/sharding.go
+++ b/pkg/object/sharding.go
@@ -85,6 +85,15 @@ func (s *sharded) SetStorageClass(sc string) {
 	}
 }
 
+func (s *sharded) StorageClass() string {
+	for _, o := range s.stores {
+		if os, ok := o.(StorageClassGetter); ok {
+			return os.StorageClass()
+		}
+	}
+	return ""
+}
+
 const maxResults = 10000
 
 // ListAll on all the keys that starts at marker from object storage.

--- a/pkg/object/storage_class.go
+++ b/pkg/object/storage_class.go
@@ -1,0 +1,53 @@
+/*
+ * JuiceFS, Copyright 2024 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import "io"
+
+const defaultStorageClass = "STANDARD"
+
+type SupportStorageClass interface {
+	SetStorageClass(sc string)
+}
+
+type StorageClassGetter interface {
+	StorageClass() string
+}
+
+type scReadCloser struct {
+	io.ReadCloser
+	sc string
+}
+
+func (s scReadCloser) StorageClass() string {
+	return s.sc
+}
+
+func GetStorageClassOrDefault(o interface{}) (sc string) {
+	if o, ok := o.(StorageClassGetter); ok {
+		sc = o.StorageClass()
+	}
+	if sc == "" {
+		sc = defaultStorageClass
+	}
+	return sc
+}
+
+var (
+	_ StorageClassGetter = &s3client{}
+	_ StorageClassGetter = scReadCloser{} // All `Get` return a struct, not a pointer
+)

--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -82,7 +82,7 @@ func (t *tosClient) Get(key string, off, limit int64) (io.ReadCloser, error) {
 		_ = resp.Content.Close()
 		return nil, err
 	}
-	return resp.Content, nil
+	return scReadCloser{resp.Content, string(resp.StorageClass)}, nil
 }
 
 func (t *tosClient) Put(key string, in io.Reader) error {
@@ -269,6 +269,10 @@ func (t *tosClient) Copy(dst, src string) error {
 
 func (t *tosClient) SetStorageClass(sc string) {
 	t.sc = sc
+}
+
+func (t *tosClient) StorageClass() string {
+	return t.sc
 }
 
 func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) {

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -587,7 +587,7 @@ func (f *fileReader) waitForIO(ctx meta.Context, reqs []*req, buf []byte) (int, 
 		for s.state != READY && uint64(s.currentPos) < s.block.len {
 			if s.cond.WaitWithTimeout(time.Second) {
 				if ctx.Canceled() {
-					logger.Warnf("read %d interrupted after %d", f.inode, time.Since(start))
+					logger.Warnf("read %d interrupted after %s", f.inode, time.Since(start))
 					return 0, syscall.EINTR
 				}
 			}


### PR DESCRIPTION
Some object storage supports configuring lifecycles to automatically move objects into different storage classes. This label allows us to observe the throughput and latency of different storage classes.