### PR TITLE
Clear out state files in tmp directory

### DIFF
--- a/pkg/vfs/handle.go
+++ b/pkg/vfs/handle.go
@@ -410,6 +410,5 @@ func (v *VFS) loadAllHandles(path string) error {
 		logger.Infof("load %d handles from %s", len(v.handleIno), path)
 	}
 	v.nextfh = vfsState.NextFh
-	// _ = os.Remove(path)
 	return nil
 }

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1215,6 +1215,8 @@ func NewVFS(conf *Config, m meta.Meta, store chunk.ChunkStore, registerer promet
 
 	if err := v.loadAllHandles(statePath); err != nil && !os.IsNotExist(err) {
 		logger.Errorf("load state from %s: %s", statePath, err)
+	} else if err == nil { // keep the file when error occurs for debugging purpose
+		_ = os.Remove(statePath)
 	}
 
 	go v.cleanupModified()


### PR DESCRIPTION
After mounting juicefs several times, I found many files are left in the tmp directory:
* One is the state files - here comes a patch
* One is fuse_fd files - here comes a [issue](https://github.com/juicedata/juicefs/issues/4620)