### PR TITLE
dfsio does not work if mapreduce.output.fileoutputformat.compress is …

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/bench/TestDFSIO.java
+++ b/sdk/java/src/main/java/io/juicefs/bench/TestDFSIO.java
@@ -584,6 +584,7 @@ public class TestDFSIO extends Main.Command {
           Class<? extends Mapper<Text, LongWritable, Text, Text>> mapperClass,
           Path outputDir) throws IOException {
     JobConf job = new JobConf(config, TestDFSIO.class);
+    job.setBoolean("mapreduce.output.fileoutputformat.compress", false);
 
     FileInputFormat.setInputPaths(job, getControlDir(config));
     job.setInputFormat(SequenceFileInputFormat.class);


### PR DESCRIPTION
…true

fix https://github.com/juicedata/juicefs/issues/4645.
``mapreduce.output.fileoutputformat.compress`` must be ``false``