### PR TITLE
Only prefetch on successful partial read

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -173,11 +173,12 @@ func (s *rSlice) ReadAt(ctx context.Context, page *Page, off int) (n int, err er
 		logRequest("GET", key, fmt.Sprintf("RANGE(%d,%d) ", boff, len(p)), reqID, err, used)
 		s.store.objectDataBytes.WithLabelValues("GET", sc).Add(float64(n))
 		s.store.objectReqsHistogram.WithLabelValues("GET", sc).Observe(used.Seconds())
-		s.store.fetcher.fetch(key)
 		if err == nil {
+			s.store.fetcher.fetch(key)
 			return n, nil
 		} else {
 			s.store.objectReqErrors.Add(1)
+			// fall back to full read
 		}
 	}
 

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -204,7 +204,7 @@ func (s *sliceReader) run() {
 	p := s.page.Slice(0, int(need))
 	defer p.Release()
 	var n int
-	ctx := context.TODO()
+	ctx := context.WithValue(context.TODO(), meta.CtxKey("inode"), inode) // Output inode in log for debugging
 	n = f.r.Read(ctx, p, slices, (uint32(s.block.off))%meta.ChunkSize)
 
 	f.Lock()
@@ -808,8 +808,8 @@ func (r *dataReader) readSlice(ctx context.Context, s *meta.Slice, page *chunk.P
 		n, err := reader.ReadAt(ctx, p, off+int(s.Off))
 		p.Release()
 		if n == 0 && err != nil {
-			logger.Warningf("fail to read sliceId %d (off:%d, size:%d, clen: %d): %s",
-				s.Id, off+int(s.Off), len(buf)-read, s.Size, err)
+			logger.Warningf("fail to read sliceId %d (off:%d, size:%d, clen: %d, inode: %d): %s",
+				s.Id, off+int(s.Off), len(buf)-read, s.Size, ctx.Value(meta.CtxKey("inode")), err)
 			return err
 		}
 		read += n


### PR DESCRIPTION
When s3 storage is unhealthy, we see lots of failed read requests for the same key - half of them are triggered by prefetch. Actually only a successful partial read needs a prefetch.