### PR TITLE
Donot fatal at startup, when failed to read .config file

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -115,7 +115,7 @@ func loadConfig(path string) (string, *vfs.Config, error) {
 			return d, &conf, err
 		}
 		if !os.IsNotExist(err) {
-			logger.Fatalf("read .config: %s", err)
+			return "", nil, fmt.Errorf("read %s: %w", d, err)
 		}
 	}
 	return "", nil, fmt.Errorf("%s is not inside JuiceFS", path)
@@ -150,6 +150,9 @@ func watchdog(ctx context.Context, mp string) {
 						logger.Infof("watching %s, pid %d", mp, conf.Pid)
 						pid = conf.Pid
 						agentAddr = conf.DebugAgent
+					} else {
+						logger.Warnf("load config: %s", err)
+						continue
 					}
 				}
 			}


### PR DESCRIPTION
Sometimes on startup, we see errors `fuse transport endpoint is not connected` when determining if we can gracefully shutdown the old mountpoint. This causes the current mount process exits with 1, which may results in an infinite restart.