### PR TITLE
Prepare slice id eagerly to have a stable and predictable write buffer usage

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -412,6 +412,9 @@ func (s *wSlice) upload(indx int) {
 	blen := s.blockSize(indx)
 	key := s.key(indx)
 	pages := s.pages[indx]
+	if pages == nil {
+		panic(fmt.Sprintf("block #%d is nil, concurrent upload?", indx))
+	}
 	s.pages[indx] = nil
 	s.pendings++
 

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -135,6 +135,9 @@ func (s *sliceWriter) write(ctx meta.Context, off uint32, data []uint8) syscall.
 		s.slen = off + uint32(len(data))
 	}
 	s.lastMod = time.Now()
+	if s.id == 0 {
+		go s.prepareID(ctx, false)
+	}
 	if s.slen == meta.ChunkSize {
 		s.freezed = true
 		go s.flushData()
@@ -145,8 +148,6 @@ func (s *sliceWriter) write(ctx meta.Context, off uint32, data []uint8) syscall.
 				logger.Warnf("write: chunk: %d off: %d %s", s.id, off, err)
 				return syscall.EIO
 			}
-		} else if int(off) <= f.w.blockSize {
-			go s.prepareID(ctx, false)
 		}
 	}
 	return 0


### PR DESCRIPTION
When user opens lots of files for write, we will see spikes in write buffer usage, which may cause write stall if we don't have large enough write buffer limit.

By preparing slice id eagerly, we now have a more predictable write buffer usage.

![img_v3_029s_89ea5766-56ce-4710-89c1-85747ee4f3dg](https://github.com/juicedata/juicefs/assets/2657334/378cda0a-af46-4ca4-833d-c51b4d0f184c)
