### PR TITLE
Fix panic when reading and writing s.writer concurrently

### DIFF
--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -120,9 +120,6 @@ func (s *sliceWriter) flushData() {
 		s.writer.Abort()
 		s.err = syscall.EIO
 	}
-	s.chunk.file.Lock()
-	s.writer = nil
-	s.chunk.file.Unlock()
 }
 
 // protected by s.chunk.file

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -120,7 +120,9 @@ func (s *sliceWriter) flushData() {
 		s.writer.Abort()
 		s.err = syscall.EIO
 	}
+	s.chunk.file.Lock()
 	s.writer = nil
+	s.chunk.file.Unlock()
 }
 
 // protected by s.chunk.file


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ed3c80]

goroutine 3559509 [running]:
github.com/juicedata/juicefs/pkg/chunk.(*wSlice).ID(0x10100c00f1f1c20?)
        /home/miaochangxin/workspace/juicefs/pkg/chunk/cached_store.go:472
github.com/juicedata/juicefs/pkg/vfs.(*sliceWriter).prepareID(0xc00f330680, {0x3fbda18, 0xc0110dcf00}, 0x0)
        /home/miaochangxin/workspace/juicefs/pkg/vfs/writer.go:91 +0x282
created by github.com/juicedata/juicefs/pkg/vfs.(*sliceWriter).write in goroutine 1
        /home/miaochangxin/workspace/juicefs/pkg/vfs/writer.go:139 +0x149
```