### PR TITLE
Revert "fix: file length after CopyFileRange and add checks for meta CopyFileRange"

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2263,6 +2263,16 @@ func (m *redisMeta) CopyFileRange(ctx Context, fin Ino, offIn uint64, fout Ino, 
 		if sattr.Typ != TypeFile {
 			return syscall.EINVAL
 		}
+		if offIn >= sattr.Length {
+			if copied != nil {
+				*copied = 0
+			}
+			return nil
+		}
+		size := size
+		if offIn+size > sattr.Length {
+			size = sattr.Length - offIn
+		}
 		attr = Attr{}
 		m.parseAttr([]byte(rs[1].(string)), &attr)
 		if attr.Typ != TypeFile {
@@ -2270,16 +2280,6 @@ func (m *redisMeta) CopyFileRange(ctx Context, fin Ino, offIn uint64, fout Ino, 
 		}
 		if (attr.Flags&FlagImmutable) != 0 || (attr.Flags&FlagAppend) != 0 {
 			return syscall.EPERM
-		}
-
-		if offIn >= sattr.Length || size == 0 {
-			if copied != nil {
-				*copied = 0
-			}
-			return nil
-		}
-		if offIn+size > sattr.Length {
-			size = sattr.Length - offIn
 		}
 
 		newleng := offOut + size

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2337,22 +2337,21 @@ func (m *dbMeta) CopyFileRange(ctx Context, fin Ino, offIn uint64, fout Ino, off
 		if nin.Type != TypeFile {
 			return syscall.EINVAL
 		}
-
-		if nout.Type != TypeFile {
-			return syscall.EINVAL
-		}
-		if (nout.Flags&FlagImmutable) != 0 || (nout.Flags&FlagAppend) != 0 {
-			return syscall.EPERM
-		}
-
-		if offIn >= nin.Length || size == 0 {
+		if offIn >= nin.Length {
 			if copied != nil {
 				*copied = 0
 			}
 			return nil
 		}
+		size := size
 		if offIn+size > nin.Length {
 			size = nin.Length - offIn
+		}
+		if nout.Type != TypeFile {
+			return syscall.EINVAL
+		}
+		if (nout.Flags&FlagImmutable) != 0 || (nout.Flags&FlagAppend) != 0 {
+			return syscall.EPERM
 		}
 
 		newleng := offOut + size

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -936,7 +936,7 @@ func (v *VFS) CopyFileRange(ctx Context, nodeIn Ino, fhIn, offIn uint64, nodeOut
 	}
 	var length uint64
 	err = v.Meta.CopyFileRange(ctx, nodeIn, offIn, nodeOut, offOut, size, flags, &copied, &length)
-	if err == 0 && copied > 0 {
+	if err == 0 {
 		v.writer.Truncate(nodeOut, length)
 		v.reader.Invalidate(nodeOut, offOut, size)
 		v.invalidateAttr(nodeOut)

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -308,18 +308,6 @@ func TestVFSIO(t *testing.T) {
 		t.Fatalf("copyfilerange too big file: %s %d", e, n)
 	}
 
-	beforeLen := v.writer.GetLength(fe.Inode)
-	if n, e := v.CopyFileRange(ctx, fe.Inode, fh, 0, fe.Inode, fh, 0, 0, 0); e != 0 || n != 0 {
-		t.Fatalf("copyfilerange zero length: %s %d", e, n)
-	}
-	if n, e := v.CopyFileRange(ctx, fe.Inode, fh, beforeLen+1, fe.Inode, fh, 0, 10, 0); e != 0 || n != 0 {
-		t.Fatalf("copyfilerange offset exceed src inode's length: %s %d", e, n)
-	}
-	afterLen := v.writer.GetLength(fe.Inode)
-	if beforeLen != afterLen {
-		t.Fatalf("copyfilerange length should be unchanged: %d %d", beforeLen, afterLen)
-	}
-
 	// sequntial write/read
 	for i := uint64(0); i < 1001; i++ {
 		if e := v.Write(ctx, fe.Inode, make([]byte, 128<<10), i*(128<<10), fh); e != 0 {


### PR DESCRIPTION
Reverts juicedata/juicefs#4713

After test in linux, copy_file_range under these conditions will return 0, and dst file's length will set to 0.
- len = 0 
- offset exceed src file length