### PR TITLE
Stage directory should also obey size limit

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -908,6 +908,20 @@ func (store *cachedStore) regMetrics(reg prometheus.Registerer) {
 			_, used := store.bcache.stats()
 			return float64(used)
 		}))
+	reg.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "staging_blocks",
+		Help: "Number of blocks in the staging path.",
+	}, func() float64 {
+		cnt, _ := store.bcache.stageStats()
+		return float64(cnt)
+	}))
+	reg.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "staging_block_bytes",
+		Help: "Total bytes of blocks in the staging path.",
+	}, func() float64 {
+		_, used := store.bcache.stageStats()
+		return float64(used)
+	}))
 	reg.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Name: "object_request_uploading",

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -93,23 +93,23 @@ func TestMetrics(t *testing.T) {
 		t.Fatalf("expect the cacheWriteBytes is %d", len(content))
 	}
 
-	if toFloat64(metrics.stageBlocks) != 0.0 {
-		t.Fatalf("expect the stageBlocks is %d", len(content))
+	if cnt, _ := m.stageStats(); cnt != 0.0 {
+		t.Fatalf("expect the stageBlocks is 0, got %d", cnt)
 	}
 
-	if toFloat64(metrics.stageBlockBytes) != 0.0 {
-		t.Fatalf("expect the stageBlockBytes is %d", len(content))
+	if _, usage := m.stageStats(); usage != 0.0 {
+		t.Fatalf("expect the stageBlockBytes is 0, got %d", usage)
 	}
 	key := fmt.Sprintf("chunks/0/5/5000_2_%d", len(content))
 	stagingPath, err := m.stage(key, content, false)
 	if err != nil {
 		t.Fatalf("stage failed: %s", err)
 	}
-	if toFloat64(metrics.stageBlocks) != 1.0 {
-		t.Fatalf("expect the stageBlocks is %d", len(content))
+	if cnt, _ := m.stageStats(); cnt != 1.0 {
+		t.Fatalf("expect the stageBlocks is 1, got %d", cnt)
 	}
 
-	if toFloat64(metrics.stageBlockBytes) != float64(len(content)) {
+	if _, usage := m.stageStats(); usage != int64(len(content)) {
 		t.Fatalf("expect the stageBlockBytes is %d", len(content))
 	}
 	err = m.removeStage(key)
@@ -117,12 +117,12 @@ func TestMetrics(t *testing.T) {
 		t.Fatalf("faild to remove stage")
 	}
 
-	if toFloat64(metrics.stageBlocks) != 0.0 {
-		t.Fatalf("expect the stageBlocks is %d", len(content))
+	if cnt, _ := m.stageStats(); cnt != 0.0 {
+		t.Fatalf("expect the stageBlocks is 0, got %d", cnt)
 	}
 
-	if toFloat64(metrics.stageBlockBytes) != 0.0 {
-		t.Fatalf("expect the stageBlockBytes is %d", len(content))
+	if _, usage := m.stageStats(); usage != 0.0 {
+		t.Fatalf("expect the stageBlockBytes is 0, got %d", usage)
 	}
 
 	if _, err := os.Stat(stagingPath); err != nil && !os.IsNotExist(err) {

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -70,6 +70,10 @@ func (c *memcache) stats() (int64, int64) {
 	return int64(len(c.pages)), c.used
 }
 
+func (c *memcache) stageStats() (int64, int64) {
+	return 0, 0
+}
+
 func (c *memcache) cache(key string, p *Page, force bool) {
 	if c.capacity == 0 {
 		return

--- a/pkg/chunk/metrics.go
+++ b/pkg/chunk/metrics.go
@@ -25,8 +25,6 @@ type cacheManagerMetrics struct {
 	cacheEvicts     prometheus.Counter
 	cacheWriteBytes prometheus.Counter
 	cacheWriteHist  prometheus.Histogram
-	stageBlocks     prometheus.Gauge
-	stageBlockBytes prometheus.Gauge
 }
 
 func newCacheManagerMetrics(reg prometheus.Registerer) *cacheManagerMetrics {
@@ -43,8 +41,6 @@ func (c *cacheManagerMetrics) registerMetrics(reg prometheus.Registerer) {
 		reg.MustRegister(c.cacheEvicts)
 		reg.MustRegister(c.cacheWriteHist)
 		reg.MustRegister(c.cacheWriteBytes)
-		reg.MustRegister(c.stageBlocks)
-		reg.MustRegister(c.stageBlockBytes)
 	}
 }
 
@@ -69,13 +65,5 @@ func (c *cacheManagerMetrics) initMetrics() {
 		Name:    "blockcache_write_hist_seconds",
 		Help:    "write cached block latency distribution",
 		Buckets: prometheus.ExponentialBuckets(0.00001, 2, 20),
-	})
-	c.stageBlocks = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "staging_blocks",
-		Help: "Number of blocks in the staging path.",
-	})
-	c.stageBlockBytes = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "staging_block_bytes",
-		Help: "Total bytes of blocks in the staging path.",
 	})
 }


### PR DESCRIPTION
Currently, the stage directory can use as much as 95% of the cache disk (with default freeRatio), which is unexpected as it resides in the cache-dir but does not obey the cache-size limit.

We encountered a cgroup bug that mount pod get OOM killed because it reads lots of cache files which causes a surge of page-cache usage. And cgroup just killed the pod because of page-cache...

See details here: https://github.com/kubernetes/kubernetes/issues/43916

```
kernel: Call Trace:
kernel:  dump_stack+0x6d/0x8b
kernel:  dump_header+0x4f/0x1eb
kernel:  oom_kill_process.cold+0xb/0x10
kernel:  out_of_memory+0x1cf/0x500
kernel:  mem_cgroup_out_of_memory+0xbd/0xe0
kernel:  try_charge+0x77c/0x810
kernel:  mem_cgroup_try_charge+0x71/0x190
kernel:  __add_to_page_cache_locked+0x2ff/0x3f0
kernel:  ? bio_add_page+0x6a/0x90
kernel:  ? scan_shadow_nodes+0x30/0x30
kernel:  add_to_page_cache_lru+0x4d/0xd0
kernel:  iomap_readpages_actor+0xf8/0x220
kernel:  iomap_apply+0xd5/0x160
kernel:  ? iomap_page_mkwrite_actor+0x80/0x80
kernel:  iomap_readpages+0xa3/0x190
kernel:  ? iomap_page_mkwrite_actor+0x80/0x80
kernel:  xfs_vm_readpages+0x35/0x90 [xfs]
kernel:  read_pages+0x71/0x1a0
kernel:  ? 0xffffffffa2000000
kernel:  __do_page_cache_readahead+0x12f/0x1a0
kernel:  ondemand_readahead+0x192/0x2d0
kernel:  page_cache_sync_readahead+0x78/0xc0
kernel:  generic_file_buffered_read+0x571/0xc10
kernel:  ? file_fdatawait_range+0x30/0x30
kernel:  generic_file_read_iter+0xdc/0x140
kernel:  ? down_read+0x13/0xa0
kernel:  xfs_file_buffered_aio_read+0x57/0xe0 [xfs]
kernel:  xfs_file_read_iter+0x72/0xe0 [xfs]
kernel:  new_sync_read+0x122/0x1b0
kernel:  __vfs_read+0x29/0x40
kernel:  vfs_read+0xab/0x160
kernel:  ksys_pread64+0x6d/0xa0
kernel:  __x64_sys_pread64+0x1e/0x20
kernel:  do_syscall_64+0x57/0x190
```

We have no easy workaround for this issue, so we just limit the cache directory to a small size, but the `--writeback` feature still hits the issue. As it turns out, the stage directory is not limited by the cache size...

Current implementation reuses the `CacheSize` config, do you suggest using another separate config?