### PR TITLE
Enable concurrent write to both stage files and object storage to get 5GB/s write throughput

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -128,6 +128,11 @@ func storageFlags() []cli.Flag {
 			Usage: "number of connections to upload",
 		},
 		&cli.IntFlag{
+			Name:  "max-stage-write",
+			Value: 0, // Enable this to have concurrent uploads to two backends, and get write bandwidth equals to sum of the two
+			Usage: "number of threads allowed to write staged files, other requests will be uploaded directly (this option is only effective when 'writeback' mode is enabled)",
+		},
+		&cli.IntFlag{
 			Name:  "max-deletes",
 			Value: 10,
 			Usage: "number of threads to delete objects",

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -83,7 +83,7 @@ $ juicefs mount redis://localhost /mnt/jfs --backup-meta 0`,
 
 func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *prometheus.Registry) string {
 	var ip, port string
-	//default set
+	// default set
 	ip, port, err := net.SplitHostPort(c.String("metrics"))
 	if err != nil {
 		logger.Fatalf("metrics format error: %v", err)
@@ -323,6 +323,7 @@ func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 		GetTimeout:    utils.Duration(c.String("get-timeout")),
 		PutTimeout:    utils.Duration(c.String("put-timeout")),
 		MaxUpload:     c.Int("max-uploads"),
+		MaxStageWrite: c.Int("max-stage-write"),
 		MaxRetries:    c.Int("io-retries"),
 		Writeback:     c.Bool("writeback"),
 		Prefetch:      c.Int("prefetch"),

--- a/pkg/chunk/metrics.go
+++ b/pkg/chunk/metrics.go
@@ -16,7 +16,9 @@
 
 package chunk
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // CacheManager Metrics
 type cacheManagerMetrics struct {
@@ -27,6 +29,7 @@ type cacheManagerMetrics struct {
 	cacheWriteHist  prometheus.Histogram
 	stageBlocks     prometheus.Gauge
 	stageBlockBytes prometheus.Gauge
+	stageWriteBytes prometheus.Counter
 }
 
 func newCacheManagerMetrics(reg prometheus.Registerer) *cacheManagerMetrics {
@@ -45,6 +48,13 @@ func (c *cacheManagerMetrics) registerMetrics(reg prometheus.Registerer) {
 		reg.MustRegister(c.cacheWriteBytes)
 		reg.MustRegister(c.stageBlocks)
 		reg.MustRegister(c.stageBlockBytes)
+		reg.MustRegister(c.stageWriteBytes)
+		reg.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "staging_writing_blocks",
+			Help: "Number of writing blocks in staging.",
+		}, func() float64 {
+			return float64(stagingBlocks.Load())
+		}))
 	}
 }
 
@@ -77,5 +87,9 @@ func (c *cacheManagerMetrics) initMetrics() {
 	c.stageBlockBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "staging_block_bytes",
 		Help: "Total bytes of blocks in the staging path.",
+	})
+	c.stageWriteBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "staging_write_bytes",
+		Help: "write bytes of blocks in the staging path.",
 	})
 }


### PR DESCRIPTION
Currently, the writeback mode works by writing the block to the staging files first, and then uploading them to the object storage. So the throughput of the writeback mode is limited by the speed of disk. And the max write concurrency is `buffer-size / block-size` which could be overwhelming for some disks.

By limiting concurrent writes to staged files and spill others to object backend, we can have concurrent uploads to two backends, and theoretically the write throughput equals to **sum of the two** (see following experiment).

> By setting `--max-stage-write=10`, we got a write throughput of **5GB/s**, almost double the speed of original write. And it lasts for a long time, as long as we have enough space for stage files

<img width="1358" alt="image" src="https://github.com/juicedata/juicefs/assets/2657334/c2d03846-20f5-40c3-a154-92c902554edf">
