### PR TITLE
cmd/load: reduce memory usage

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3953,16 +3953,16 @@ func (m *redisMeta) loadEntry(e *DumpedEntry, p redis.Pipeliner, tryExec func(),
 		attr.Length = 4 << 10
 		dentries := make(map[string]interface{}, batch)
 		var stat dirStat
-		for name, c := range e.Entries {
+		for _, a := range e.CompressedEntries {
 			length := uint64(0)
-			if typeFromString(c.Attr.Type) == TypeFile {
-				length = c.Attr.Length
+			if typeFromString(a.typ) == TypeFile {
+				length = a.length
 			}
 			stat.length += int64(length)
 			stat.space += align4K(length)
 			stat.inodes++
 
-			dentries[string(unescape(name))] = m.packEntry(typeFromString(c.Attr.Type), c.Attr.Inode)
+			dentries[string(unescape(a.name))] = m.packEntry(typeFromString(a.typ), a.inode)
 			if len(dentries) >= batch {
 				p.HSet(ctx, m.entryKey(inode), dentries)
 				tryExec()

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -3825,10 +3825,10 @@ func (m *dbMeta) loadEntry(e *DumpedEntry, chs []chan interface{}, aclMaxId *uin
 	} else if n.Type == TypeDirectory {
 		n.Length = 4 << 10
 		stat := &dirStats{Inode: inode}
-		for name, c := range e.Entries {
+		for _, a := range e.CompressedEntries {
 			length := uint64(0)
-			if typeFromString(c.Attr.Type) == TypeFile {
-				length = c.Attr.Length
+			if typeFromString(a.typ) == TypeFile {
+				length = a.length
 			}
 			stat.DataLength += int64(length)
 			stat.UsedSpace += align4K(length)
@@ -3836,9 +3836,9 @@ func (m *dbMeta) loadEntry(e *DumpedEntry, chs []chan interface{}, aclMaxId *uin
 
 			chs[1] <- &edge{
 				Parent: inode,
-				Name:   unescape(name),
-				Inode:  c.Attr.Inode,
-				Type:   typeFromString(c.Attr.Type),
+				Name:   unescape(a.name),
+				Inode:  a.inode,
+				Type:   typeFromString(a.typ),
 			}
 		}
 		chs[5] <- stat

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -3261,16 +3261,16 @@ func (m *kvMeta) loadEntry(e *DumpedEntry, kv chan *pair, aclMaxId *uint32) {
 	} else if attr.Typ == TypeDirectory {
 		attr.Length = 4 << 10
 		var stat dirStat
-		for name, c := range e.Entries {
+		for _, a := range e.CompressedEntries {
 			length := uint64(0)
-			if typeFromString(c.Attr.Type) == TypeFile {
-				length = c.Attr.Length
+			if typeFromString(a.typ) == TypeFile {
+				length = a.length
 			}
 			stat.length += int64(length)
 			stat.space += align4K(length)
 			stat.inodes++
 
-			kv <- &pair{m.entryKey(inode, string(unescape(name))), m.packEntry(typeFromString(c.Attr.Type), c.Attr.Inode)}
+			kv <- &pair{m.entryKey(inode, string(unescape(a.name))), m.packEntry(typeFromString(a.typ), a.inode)}
 		}
 		kv <- &pair{m.dirStatKey(inode), m.packDirStat(&stat)}
 	} else if attr.Typ == TypeSymlink {


### PR DESCRIPTION
close #4766 

test: 
- meta: 31M total entries, biggest dir has 11M files
- cost: loaded to badger with 14GiB memory 

```shell
echo $((14 * 1024 * 1024 * 1024)) > /sys/fs/cgroup/memory/limited_mem_group/memory.limit_in_bytesq
sudo cgexec -g memory:limited_mem_group ./juicefs load badger://test.badger /data/code/com/juicedata/test/dump.json.gz
```