### PR TITLE
meta: remove tail zero slice in compactChunk

### DIFF
--- a/pkg/meta/slice.go
+++ b/pkg/meta/slice.go
@@ -157,11 +157,20 @@ func buildSlice(ss []*slice) []Slice {
 func compactChunk(ss []*slice) (uint32, uint32, []Slice) {
 	var chunk = buildSlice(ss)
 	var pos uint32
-	for len(chunk) > 1 && chunk[0].Id == 0 {
-		pos += chunk[0].Len
-		chunk = chunk[1:]
+	n := len(chunk)
+	for n > 1 {
+		if chunk[0].Id == 0 {
+			pos += chunk[0].Len
+			chunk = chunk[1:]
+			n--
+		} else if chunk[n-1].Id == 0 {
+			chunk = chunk[:n-1]
+			n--
+		} else {
+			break
+		}
 	}
-	if len(chunk) == 1 && chunk[0].Id == 0 {
+	if n == 1 && chunk[0].Id == 0 {
 		chunk[0].Len = 1
 	}
 	var size uint32


### PR DESCRIPTION
```
$ dd if=/dev/zero of=/jfs/tmp bs=1M count=10
$ truncate -s 4 /jfs/tmp
$ juicefs compact /jfs/tmp

# before
$ juicefs info /jfs/tmp
 objects:
+------------+----------------------------------+---------+--------+---------+
| chunkIndex |            objectName            |   size  | offset |  length |
+------------+----------------------------------+---------+--------+---------+
|          0 | test/chunks/0/24/24578_0_4194304 | 4194304 |      0 | 4194304 |
|          0 | test/chunks/0/24/24578_1_4194304 | 4194304 |      0 | 4194304 |
|          0 | test/chunks/0/24/24578_2_2097152 | 2097152 |      0 | 2097152 |
+------------+----------------------------------+---------+--------+---------+

# with this fix
$ juicefs info /jfs/tmp
 objects:
+------------+----------------------------+------+--------+--------+
| chunkIndex |         objectName         | size | offset | length |
+------------+----------------------------+------+--------+--------+
|          0 | test/chunks/0/28/28674_0_4 |    4 |      0 |      4 |
+------------+----------------------------+------+--------+--------+
```