### PR TITLE
fix: fix the concurrency issue with trash cleanup

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -419,8 +419,11 @@ func (m *redisMeta) setIfSmall(name string, value, diff int64) (bool, error) {
 		if old > value-diff {
 			return nil
 		} else {
-			changed = true
-			return tx.Set(Background, name, value, 0).Err()
+			err = tx.Set(Background, name, value, 0).Err()
+			if err == nil {
+				changed = true
+			}
+			return err
 		}
 	}, name)
 


### PR DESCRIPTION
The modification of the changed value must depend on the result of the tx.Set() method. 
This could lead to issues with multiple cleanup tasks running.