### PR TITLE
feat: add disk cache recovery and improve disk failure detection

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -795,18 +795,6 @@ func NewCachedStore(storage object.ObjectStorage, config Config, reg prometheus.
 		}
 	})
 
-	go func() {
-		for {
-			if store.bcache.isEmpty() {
-				logger.Warn("cache store is empty, use memory cache")
-				config.CacheSize = 100 << 20
-				config.CacheDir = "memory"
-				store.bcache = newMemStore(&config, store.bcache.getMetrics())
-			}
-			time.Sleep(time.Second)
-		}
-	}()
-
 	if config.CacheSize == 0 {
 		config.Prefetch = 0 // disable prefetch if cache is disabled
 	}


### PR DESCRIPTION
#4798 
1. support disk cache recovery
1.1 remove the mechanism of disk cache degrading to memory cache
1.2 recover disk after n times successful read
2. improve disk failure detection
2.1 change default IO timeout to 60s
2.2 add IO error percentage judgment