### PR TITLE
Write should fail fast if file is already in error state

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -226,6 +226,7 @@ func (s *rSlice) Remove() error {
 	for i := 0; i <= lastIndx; i++ {
 		if e := s.delete(i); e != nil {
 			err = e
+			logger.Warnf("Failed to delete block %s: %s", s.key(i), e)
 		}
 	}
 	return err

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -301,6 +301,9 @@ func (f *fileWriter) Write(ctx meta.Context, off uint64, data []byte) syscall.Er
 			time.Sleep(time.Millisecond * 100)
 		}
 	}
+	if f.err != 0 {
+		return f.err
+	}
 
 	s := time.Now()
 	f.Lock()


### PR DESCRIPTION
Write should fail fast if file is already in error state, avoiding resource consumption caused by infinite retries from bad clients.

If this change poses a risk, we may consider it in 1.3