### PR TITLE
Update command_reference.md

### DIFF
--- a/docs/zh_cn/reference/command_reference.md
+++ b/docs/zh_cn/reference/command_reference.md
@@ -796,7 +796,7 @@ juicefs bench /mnt/jfs --big-file-size 0
 |-|-|
 |`--block-size=1`|块大小；单位为 MiB (默认：1)|
 |`--big-file-size=1024`|大文件大小；单位为 MiB (默认：1024)|
-|`--small-file-size=0.1`|小文件大小；单位为 MiB (默认：0.1)|
+|`--small-file-size=0.1`|小文件大小；单位为 KiB (默认：128)|
 |`--small-file-count=100`|小文件数量 (默认：100)|
 |`--threads=1, -p 1`|并发线程数 (默认：1)|
 


### PR DESCRIPTION
更新bench --small-file-size 参数单位和默认大小 与实际 juicefs 参数不一致问题