### PR TITLE
Manager's IP address is never set in sync cluster mode

### DIFF
--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -204,6 +204,7 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 		if ip == "" {
 			return "", fmt.Errorf("no local ip found")
 		}
+		addr = ip
 	}
 
 	if !strings.Contains(addr, ":") {


### PR DESCRIPTION
In sync cluster mode, manager's IP address is never set. So it sends the address of `[::]` to workers, which makes the cluster mode unusable.