### PR TITLE
stats cmd should be robust enough to handle metrics with multiple labels

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -360,10 +360,11 @@ func readStats(mp string) map[string]float64 {
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) == 2 {
-			stats[fields[0]], err = strconv.ParseFloat(fields[1], 64)
+			v, err := strconv.ParseFloat(fields[1], 64)
 			if err != nil {
 				logger.Warnf("parse %s: %s", fields[1], err)
 			}
+			stats[fields[0]] += v
 		}
 	}
 	return stats


### PR DESCRIPTION
When objects sink to cold storage, we will have multiple `storage_class` labels in `object_request_data_bytes` metric, which causes the stats cmd shows less object bandwidth than actual.

The stats cmd should be robust to this situation - it's counter-intuitive for a newcomer to realize that adding a new label to those metrics will cause the stats cmd to function incorrectly.