### PR TITLE
Flush staging files on close as much as possible

### DIFF
--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -43,4 +43,5 @@ type ChunkStore interface {
 	CheckCache(id uint64, length uint32) (uint64, error)
 	UsedMemory() int64
 	UpdateLimit(upload, download int64)
+	Close()
 }

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1268,6 +1268,7 @@ func (v *VFS) FlushAll(path string) (err error) {
 		return err
 	}
 	if path == "" {
+		v.Store.Close()
 		return nil
 	}
 	return v.dumpAllHandles(path)


### PR DESCRIPTION
Flush staging files as much as possible, making writeback safer to turn on.