### PR TITLE
fix a trivial typo in a warning message

### DIFF
--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -64,7 +64,7 @@ func (c *Config) SelfCheck() {
 		c.Heartbeat = time.Second
 	}
 	if c.Heartbeat > time.Minute*10 {
-		logger.Warnf("heartbeat shouldd not be greater than 10 minutes")
+		logger.Warnf("heartbeat should not be greater than 10 minutes")
 		c.Heartbeat = time.Minute * 10
 	}
 }


### PR DESCRIPTION
There was a typo in a warning string (an extra d in "heartbeat shouldd not be greater than 10 minutes")