### PR TITLE
fix: flush volume stats on session close

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -56,7 +56,7 @@ type engine interface {
 	// Set counter name to value if old <= value - diff.
 	setIfSmall(name string, value, diff int64) (bool, error)
 	updateStats(space int64, inodes int64)
-	flushStats()
+	doFlushStats()
 
 	doLoad() ([]byte, error)
 
@@ -399,7 +399,7 @@ func (m *baseMeta) NewSession(record bool) error {
 	}
 
 	m.loadQuotas()
-	go m.en.flushStats()
+	go m.flushStats()
 	go m.flushDirStat()
 	go m.flushQuotas()
 
@@ -521,6 +521,7 @@ func (m *baseMeta) CloseSession() error {
 	if m.conf.ReadOnly {
 		return nil
 	}
+	m.en.doFlushStats()
 	m.doFlushDirStat()
 	m.doFlushQuotas()
 	m.sesMu.Lock()

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -206,6 +206,13 @@ func (m *baseMeta) doFlushDirStat() {
 	}
 }
 
+func (m *baseMeta) flushStats() {
+	for {
+		time.Sleep(time.Second)
+		m.en.doFlushStats()
+	}
+}
+
 func (m *baseMeta) checkQuota(ctx Context, space, inodes int64, parents ...Ino) syscall.Errno {
 	if space <= 0 && inodes <= 0 {
 		return 0

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -697,7 +697,7 @@ func (m *redisMeta) updateStats(space int64, inodes int64) {
 }
 
 // redisMeta updates the usage in each transaction
-func (m *redisMeta) flushStats() {}
+func (m *redisMeta) doFlushStats() {}
 
 func (m *redisMeta) handleLuaResult(op string, res interface{}, err error, returnedIno *int64, returnedAttr *string) syscall.Errno {
 	if err != nil {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -518,25 +518,22 @@ func (m *kvMeta) updateStats(space int64, inodes int64) {
 	atomic.AddInt64(&m.newInodes, inodes)
 }
 
-func (m *kvMeta) flushStats() {
-	for {
-		if space := atomic.LoadInt64(&m.newSpace); space != 0 {
-			if v, err := m.incrCounter(usedSpace, space); err == nil {
-				atomic.AddInt64(&m.newSpace, -space)
-				atomic.StoreInt64(&m.usedSpace, v)
-			} else {
-				logger.Warnf("Update space stats: %s", err)
-			}
+func (m *kvMeta) doFlushStats() {
+	if space := atomic.LoadInt64(&m.newSpace); space != 0 {
+		if v, err := m.incrCounter(usedSpace, space); err == nil {
+			atomic.AddInt64(&m.newSpace, -space)
+			atomic.StoreInt64(&m.usedSpace, v)
+		} else {
+			logger.Warnf("Update space stats: %s", err)
 		}
-		if inodes := atomic.LoadInt64(&m.newInodes); inodes != 0 {
-			if v, err := m.incrCounter(totalInodes, inodes); err == nil {
-				atomic.AddInt64(&m.newInodes, -inodes)
-				atomic.StoreInt64(&m.usedInodes, v)
-			} else {
-				logger.Warnf("Update inodes stats: %s", err)
-			}
+	}
+	if inodes := atomic.LoadInt64(&m.newInodes); inodes != 0 {
+		if v, err := m.incrCounter(totalInodes, inodes); err == nil {
+			atomic.AddInt64(&m.newInodes, -inodes)
+			atomic.StoreInt64(&m.usedInodes, v)
+		} else {
+			logger.Warnf("Update inodes stats: %s", err)
 		}
-		time.Sleep(time.Second)
 	}
 }
 


### PR DESCRIPTION
We observed several volumes having much larger usage than the actual data size. It's confirmed when two of them are emptied but still have a large usage, and `juicefs summary` shows there are no files.
Here fix one possible reason: the usage is not flushed on close - thus we have different volume stats than dir stats.