### PR TITLE
backup: print a warning message that backups are not turned on

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -382,6 +382,8 @@ func initBackgroundTasks(c *cli.Context, vfsConf *vfs.Config, metaConf *meta.Con
 		registerer.MustRegister(vfs.LastBackupTimeG)
 		registerer.MustRegister(vfs.LastBackupDurationG)
 		go vfs.Backup(m, blob, vfsConf.BackupMeta, vfsConf.BackupSkipTrash)
+	} else {
+		logger.Warnf("Backup meta is disabled")
 	}
 	if !c.Bool("no-usage-report") {
 		go usage.ReportUsage(m, version.Version())

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -383,7 +383,7 @@ func initBackgroundTasks(c *cli.Context, vfsConf *vfs.Config, metaConf *meta.Con
 		registerer.MustRegister(vfs.LastBackupDurationG)
 		go vfs.Backup(m, blob, vfsConf.BackupMeta, vfsConf.BackupSkipTrash)
 	} else {
-		logger.Warnf("Backup meta is disabled")
+		logger.Warnf("Metadata backup is disabled")
 	}
 	if !c.Bool("no-usage-report") {
 		go usage.ReportUsage(m, version.Version())


### PR DESCRIPTION
No metadata backup in read-only mode is more confusing, it helps to have a hint.