### PR TITLE
gateway: skip init meta bucket when meta is read only

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -158,12 +158,16 @@ func gateway(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-
-	if _, err := jfsGateway.GetBucketInfo(context.Background(), minio.MinioMetaBucket); errors.As(err, &minio.BucketNotFound{}) {
-		if err := jfsGateway.MakeBucketWithLocation(context.Background(), minio.MinioMetaBucket, minio.BucketOptions{}); err != nil {
-			logger.Fatalf("init MinioMetaBucket error %s: %s", minio.MinioMetaBucket, err)
+	if c.IsSet("read-only") {
+		os.Setenv("JUICEFS_META_READ_ONLY", "1")
+	} else {
+		if _, err := jfsGateway.GetBucketInfo(context.Background(), minio.MinioMetaBucket); errors.As(err, &minio.BucketNotFound{}) {
+			if err := jfsGateway.MakeBucketWithLocation(context.Background(), minio.MinioMetaBucket, minio.BucketOptions{}); err != nil {
+				logger.Fatalf("init MinioMetaBucket error %s: %s", minio.MinioMetaBucket, err)
+			}
 		}
 	}
+
 	args := []string{"server", "--address", listenAddr, "--anonymous"}
 	if c.Bool("no-banner") {
 		args = append(args, "--quiet")

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	xorm.io/builder v0.3.7 // indirect
 )
 
-replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20240705094528-e68049ad7723
+replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20240709032621-f236038a4abd
 
 replace github.com/hanwen/go-fuse/v2 v2.1.1-0.20210611132105-24a1dfe6b4f8 => github.com/juicedata/go-fuse/v2 v2.1.1-0.20240425033113-7c40cb5eb3e9
 

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	xorm.io/builder v0.3.7 // indirect
 )
 
-replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20240709032621-f236038a4abd
+replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20240719032536-5d15c7c0135d
 
 replace github.com/hanwen/go-fuse/v2 v2.1.1-0.20210611132105-24a1dfe6b4f8 => github.com/juicedata/go-fuse/v2 v2.1.1-0.20240425033113-7c40cb5eb3e9
 

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	xorm.io/builder v0.3.7 // indirect
 )
 
-replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20240612084555-8a33dba0f571
+replace github.com/minio/minio v0.0.0-20210206053228-97fe57bba92c => github.com/juicedata/minio v0.0.0-20240705094528-e68049ad7723
 
 replace github.com/hanwen/go-fuse/v2 v2.1.1-0.20210611132105-24a1dfe6b4f8 => github.com/juicedata/go-fuse/v2 v2.1.1-0.20240425033113-7c40cb5eb3e9
 

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825 h1:7KrwI4HPqvNLK
 github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825/go.mod h1:Ho5G4KgrgbMKW0buAJdOmYoJcOImkzznJQaLiATrsx4=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible h1:2/ttSmYoX+QMegpNyAJR0Y6aHcVk57F7RJit5xN2T/s=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible/go.mod h1:Ukwa8ffRQLV6QRwpqGioPjn2Wnf7TBDA4DbennDOqHE=
-github.com/juicedata/minio v0.0.0-20240705094528-e68049ad7723 h1:lL/YPKoeR8eJOwcvJZdYC6CKs8m+9j9pAgDJy/D2c5w=
-github.com/juicedata/minio v0.0.0-20240705094528-e68049ad7723/go.mod h1:UOWyfa3ls1tnpJrNw2yzGqfrwM4nzsZq/qz+zd6H+/Q=
+github.com/juicedata/minio v0.0.0-20240709032621-f236038a4abd h1:GKODC/ODq+IlFGAv0gBz9BQMkqTDXS08kju611cgMgs=
+github.com/juicedata/minio v0.0.0-20240709032621-f236038a4abd/go.mod h1:UOWyfa3ls1tnpJrNw2yzGqfrwM4nzsZq/qz+zd6H+/Q=
 github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b h1:0/6suPNZnrOlRlBaU/Bnitu8HiKkkLSzQhHbwQ9AysM=
 github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825 h1:7KrwI4HPqvNLK
 github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825/go.mod h1:Ho5G4KgrgbMKW0buAJdOmYoJcOImkzznJQaLiATrsx4=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible h1:2/ttSmYoX+QMegpNyAJR0Y6aHcVk57F7RJit5xN2T/s=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible/go.mod h1:Ukwa8ffRQLV6QRwpqGioPjn2Wnf7TBDA4DbennDOqHE=
-github.com/juicedata/minio v0.0.0-20240612084555-8a33dba0f571 h1:usZ1RJ9AssiJxSVRibh2mbQ5cI9FuSbkXJTiweL3hxk=
-github.com/juicedata/minio v0.0.0-20240612084555-8a33dba0f571/go.mod h1:UOWyfa3ls1tnpJrNw2yzGqfrwM4nzsZq/qz+zd6H+/Q=
+github.com/juicedata/minio v0.0.0-20240705094528-e68049ad7723 h1:lL/YPKoeR8eJOwcvJZdYC6CKs8m+9j9pAgDJy/D2c5w=
+github.com/juicedata/minio v0.0.0-20240705094528-e68049ad7723/go.mod h1:UOWyfa3ls1tnpJrNw2yzGqfrwM4nzsZq/qz+zd6H+/Q=
 github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b h1:0/6suPNZnrOlRlBaU/Bnitu8HiKkkLSzQhHbwQ9AysM=
 github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825 h1:7KrwI4HPqvNLK
 github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825/go.mod h1:Ho5G4KgrgbMKW0buAJdOmYoJcOImkzznJQaLiATrsx4=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible h1:2/ttSmYoX+QMegpNyAJR0Y6aHcVk57F7RJit5xN2T/s=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible/go.mod h1:Ukwa8ffRQLV6QRwpqGioPjn2Wnf7TBDA4DbennDOqHE=
-github.com/juicedata/minio v0.0.0-20240709032621-f236038a4abd h1:GKODC/ODq+IlFGAv0gBz9BQMkqTDXS08kju611cgMgs=
-github.com/juicedata/minio v0.0.0-20240709032621-f236038a4abd/go.mod h1:UOWyfa3ls1tnpJrNw2yzGqfrwM4nzsZq/qz+zd6H+/Q=
+github.com/juicedata/minio v0.0.0-20240719032536-5d15c7c0135d h1:rDGD7VqSTs2gTr8HNFgnit1xrUPUWl6v+5HsgL2QrYM=
+github.com/juicedata/minio v0.0.0-20240719032536-5d15c7c0135d/go.mod h1:UOWyfa3ls1tnpJrNw2yzGqfrwM4nzsZq/qz+zd6H+/Q=
 github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b h1:0/6suPNZnrOlRlBaU/Bnitu8HiKkkLSzQhHbwQ9AysM=
 github.com/juicedata/mpb/v7 v7.0.4-0.20231024073412-2b8d31be510b/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -218,9 +218,11 @@ func (n *jfsObjects) MakeBucketWithLocation(ctx context.Context, bucket string, 
 		}
 	}
 	eno := n.fs.Mkdir(mctx, n.path(bucket), 0777, n.gConf.Umask)
-	metadata := minio.NewBucketMetadata(bucket)
-	if err := metadata.Save(ctx, n); err != nil {
-		return err
+	if eno == 0 {
+		metadata := minio.NewBucketMetadata(bucket)
+		if err := metadata.Save(ctx, n); err != nil {
+			return err
+		}
 	}
 	return jfsToObjectErr(ctx, eno, bucket)
 }


### PR DESCRIPTION
1. Resolve a compatibility issue where the 1.2 version of gateway could not create a configuration file directory in the case of meta-readonly.
2. Fixed the bug that deleting an object through a web page does not report an error when using meta read-only.

close https://github.com/juicedata/juicefs/issues/4975
close #4989
close #4988