### PR TITLE
cmd/webdav: support PROPPATCH method

### DIFF
--- a/cmd/webdav.go
+++ b/cmd/webdav.go
@@ -46,6 +46,10 @@ func cmdWebDav() *cli.Command {
 			Name:  "disallowList",
 			Usage: "disallow list a directory",
 		},
+		&cli.BoolFlag{
+			Name:  "enable-proppatch",
+			Usage: "enable proppatch method support",
+		},
 		&cli.StringFlag{
 			Name:  "log",
 			Usage: "path for WebDAV log",
@@ -83,13 +87,14 @@ func webdav(c *cli.Context) error {
 	listenAddr := c.Args().Get(1)
 	_, jfs := initForSvc(c, "webdav", metaUrl, listenAddr)
 	fs.StartHTTPServer(jfs, fs.WebdavConfig{
-		Addr:         listenAddr,
-		DisallowList: c.Bool("disallowList"),
-		EnableGzip:   c.Bool("gzip"),
-		Username:     os.Getenv("WEBDAV_USER"),
-		Password:     os.Getenv("WEBDAV_PASSWORD"),
-		CertFile:     c.String("cert-file"),
-		KeyFile:      c.String("key-file"),
+		Addr:            listenAddr,
+		DisallowList:    c.Bool("disallowList"),
+		EnableGzip:      c.Bool("gzip"),
+		Username:        os.Getenv("WEBDAV_USER"),
+		Password:        os.Getenv("WEBDAV_PASSWORD"),
+		CertFile:        c.String("cert-file"),
+		KeyFile:         c.String("key-file"),
+		EnableProppatch: c.Bool("enable-proppatch"),
 	})
 	return jfs.Meta().CloseSession()
 }

--- a/pkg/fs/http_test.go
+++ b/pkg/fs/http_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestWebdav(t *testing.T) {
 	jfs := createTestFS(t)
-	webdavFS := &webdavFS{meta.NewContext(uint32(os.Getpid()), uint32(os.Getuid()), []uint32{uint32(os.Getgid())}), jfs, uint16(utils.GetUmask())}
+	webdavFS := &webdavFS{meta.NewContext(uint32(os.Getpid()), uint32(os.Getuid()), []uint32{uint32(os.Getgid())}), jfs, uint16(utils.GetUmask()), WebdavConfig{EnableProppatch: true}}
 	ctx := context.Background()
 	_, err := webdavFS.Stat(ctx, "/")
 	if err != nil {


### PR DESCRIPTION
ref #5023
```
$ juicefs  webdav redis://127.0.0.1/1  127.0.0.1:9092 --enable-proppatch

make[1]: Entering directory '/root/repo/litmus-0.13/lib/neon'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/root/repo/litmus-0.13/lib/neon'
gcc  -o basic src/basic.o -L. -ltest -Llib/neon -lneon  -lexpat
gcc  -o copymove src/copymove.o -L. -ltest -Llib/neon -lneon  -lexpat
gcc  -o props src/props.o -L. -ltest -Llib/neon -lneon  -lexpat
gcc  -o locks src/locks.o -L. -ltest -Llib/neon -lneon  -lexpat
gcc  -o http src/http.o -L. -ltest -Llib/neon -lneon  -lexpat
-> running `basic':
 0. init.................. pass
 1. begin................. pass
 2. options............... pass
 3. put_get............... pass
 4. put_get_utf8_segment.. pass
 5. put_no_parent......... pass
 6. mkcol_over_plain...... pass
 7. delete................ pass
 8. delete_null........... pass
 9. delete_fragment....... pass
10. mkcol................. pass
11. mkcol_again........... pass
12. delete_coll........... pass
13. mkcol_no_parent....... pass
14. mkcol_with_body....... pass
15. finish................ pass
<- summary for `basic': of 16 tests run: 16 passed, 0 failed. 100.0%
-> running `copymove':
 0. init.................. pass
 1. begin................. pass
 2. copy_init............. pass
 3. copy_simple........... pass
 4. copy_overwrite........ pass
 5. copy_nodestcoll....... pass
 6. copy_cleanup.......... pass
 7. copy_coll............. pass
 8. copy_shallow.......... pass
 9. move.................. pass
10. move_coll............. pass
11. move_cleanup.......... pass
12. finish................ pass
<- summary for `copymove': of 13 tests run: 13 passed, 0 failed. 100.0%
-> running `props':
 0. init.................. pass
 1. begin................. pass
 2. propfind_invalid...... pass
 3. propfind_invalid2..... pass
 4. propfind_d0........... pass
 5. propinit.............. pass
 6. propset............... pass
 7. propget............... pass
 8. propextended.......... pass
 9. propmove.............. pass
10. propget............... pass
11. propdeletes........... pass
12. propget............... pass
13. propreplace........... pass
14. propget............... pass
15. propnullns............ pass
16. propget............... pass
17. prophighunicode....... pass
18. propget............... pass
19. propremoveset......... pass
20. propget............... pass
21. propsetremove......... pass
22. propget............... pass
23. propvalnspace......... pass
24. propwformed........... pass
25. propinit.............. pass
26. propmanyns............ pass
27. propget............... pass
28. propcleanup........... pass
29. finish................ pass
<- summary for `props': of 30 tests run: 30 passed, 0 failed. 100.0%
-> running `locks':
 0. init.................. pass
 1. begin................. pass
 2. options............... pass
 3. precond............... pass
 4. init_locks............ pass
 5. put................... pass
 6. lock_excl............. pass
 7. discover.............. pass
 8. refresh............... pass
 9. notowner_modify....... pass
10. notowner_lock......... pass
11. owner_modify.......... pass
12. notowner_modify....... pass
13. notowner_lock......... pass
14. copy.................. pass
15. cond_put.............. pass
16. fail_cond_put......... pass
17. cond_put_with_not..... pass
18. cond_put_corrupt_token WARNING: PUT failed with 412 not 423
    ...................... pass (with 1 warning)
19. complex_cond_put...... pass
20. fail_complex_cond_put. FAIL (PUT with complex bogus conditional should fail with 412: 201 Created)
21. unlock................ pass
22. fail_cond_put_unlocked pass
23. lock_shared........... FAIL (LOCK on `/litmus/lockme': 501 Not Implemented)
24. notowner_modify....... SKIPPED
25. notowner_lock......... SKIPPED
26. owner_modify.......... SKIPPED
27. double_sharedlock..... SKIPPED
28. notowner_modify....... SKIPPED
29. notowner_lock......... SKIPPED
30. unlock................ SKIPPED
31. prep_collection....... pass
32. lock_collection....... pass
33. owner_modify.......... pass
34. notowner_modify....... pass
35. refresh............... pass
36. indirect_refresh...... pass
37. unlock................ pass
38. unmapped_lock......... pass
39. unlock................ pass
40. finish................ pass
-> 7 tests were skipped.
<- summary for `locks': of 34 tests run: 32 passed, 2 failed. 94.1%
-> 1 warning was issued.
See debug.log for network/debug traces.
make: *** [Makefile:65: check] Error 1
```