### PR TITLE
doc:default bucket path doc optimize

### DIFF
--- a/docs/en/getting-started/standalone.md
+++ b/docs/en/getting-started/standalone.md
@@ -32,7 +32,7 @@ juicefs format [command options] META-URL NAME
 
 To format a file system, three types of information are required:
 
-- **[command options]**: Specifies the storage medium for the file system. By default, the **local disk** is used with the path set to `"$HOME/.juicefs/local"`, `"/var/jfs"`, or `"C:/jfs/local"`.
+- **[command options]**: Specifies the storage medium for the file system. By default, the **local disk** is used with the path set to `"$HOME/.juicefs/local"`(on darwin/macOS), `"/var/jfs"`(on Linux), or `"C:/jfs/local"`(on Windows).
 - **META-URL**: Defines the metadata engine, typically a URL or the file path of a database.
 - **NAME**: The name of the file system.
 

--- a/docs/zh_cn/getting-started/standalone.md
+++ b/docs/zh_cn/getting-started/standalone.md
@@ -31,7 +31,7 @@ juicefs format [command options] META-URL NAME
 
 可见，格式化文件系统需要提供 3 种信息：
 
-- **[command options]**：设定文件系统的存储介质，留空则**默认使用本地磁盘**作为存储介质，路径为 `"$HOME/.juicefs/local"`，`"/var/jfs"` 或 `"C:/jfs/local"`；
+- **[command options]**：设定文件系统的存储介质，留空则**默认使用本地磁盘**作为存储介质，路径为 `"$HOME/.juicefs/local"`(darwin/macOS)，`"/var/jfs"`(linux) 或 `"C:/jfs/local"`(Windows)；
 - **META-URL**：用来设置元数据存储，即数据库相关的信息，通常是数据库的 URL 或文件路径；
 - **NAME**：是文件系统的名称。
 


### PR DESCRIPTION
单机模式文档中存储默认路径"$HOME/.juicefs/local"，"/var/jfs" 或 "C:/jfs/local"，实测下来，在linux下没找到路径"$HOME/.juicefs/local"，存在歧义，提交文档优化，补充操作系统类别以便区分说明。