### PR TITLE
warmup: evict sub command may remove stage incorrectly

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -1115,7 +1115,7 @@ func (store *cachedStore) EvictCache(id uint64, length uint32) error {
 	r := sliceForRead(id, int(length), store)
 	keys := r.keys()
 	for _, k := range keys {
-		store.bcache.remove(k)
+		store.bcache.removeReadCache(k)
 	}
 	return nil
 }

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -222,7 +222,7 @@ func (s *rSlice) Remove() error {
 		// any of them should succeed if any blocks is removed
 		key := s.key(i)
 		s.store.removePending(key)
-		s.store.bcache.remove(key)
+		s.store.bcache.remove(key, true)
 	}
 
 	var err error
@@ -1115,7 +1115,7 @@ func (store *cachedStore) EvictCache(id uint64, length uint32) error {
 	r := sliceForRead(id, int(length), store)
 	keys := r.keys()
 	for _, k := range keys {
-		store.bcache.removeReadCache(k)
+		store.bcache.remove(k, false)
 	}
 	return nil
 }

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -579,6 +579,11 @@ func (cache *cacheStore) removeReadCache(key string) {
 		return
 	}
 
+	// skip stage
+	if utils.Exists(cache.stagePath(key)) {
+		return
+	}
+
 	path := cache.doRemove(key)
 	if path != "" {
 		if err := cache.removeFile(path); err != nil && !os.IsNotExist(err) {

--- a/pkg/chunk/disk_cache_state.go
+++ b/pkg/chunk/disk_cache_state.go
@@ -240,7 +240,7 @@ func (dc *unstableDC) doProbe(key string, page *Page) {
 	}
 	defer reader.Close()
 	_, _ = reader.ReadAt(probeBuff, 0)
-	dc.cache.remove(key)
+	dc.cache.remove(key, false)
 }
 
 func (dc *unstableDC) beforeCacheOp() { dc.concurrency.Add(1) }

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -102,17 +102,13 @@ func (c *memcache) delete(key string, p *Page) {
 	delete(c.pages, key)
 }
 
-func (c *memcache) remove(key string) {
+func (c *memcache) remove(key string, staging bool) {
 	c.Lock()
 	defer c.Unlock()
 	if item, ok := c.pages[key]; ok {
 		c.delete(key, item.page)
 		logger.Debugf("remove %s from cache", key)
 	}
-}
-
-func (c *memcache) removeReadCache(key string) {
-	c.remove(key)
 }
 
 func (c *memcache) load(key string) (ReadCloser, error) {

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -111,6 +111,10 @@ func (c *memcache) remove(key string) {
 	}
 }
 
+func (c *memcache) removeReadCache(key string) {
+	c.remove(key)
+}
+
 func (c *memcache) load(key string) (ReadCloser, error) {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
Add a new interface to clear the read cache. 
Since there are already interfaces like remove and removeStage, a flag-based merge is not used to avoid too many API changes. Moreover, the read and write cache logic is actually quite independent, so it is better to keep them separate.