### PR TITLE
feat: WebDAV no need to call MkdirAll

### DIFF
--- a/pkg/object/webdav.go
+++ b/pkg/object/webdav.go
@@ -134,7 +134,7 @@ func (w *webdav) Put(key string, in io.Reader, getters ...AttrGetter) error {
 		return nil
 	}
 	if strings.HasSuffix(key, dirSuffix) {
-		return w.c.MkdirAll(key, 0)
+		return nil
 	}
 	return w.c.WriteStream(key, in, 0)
 }


### PR DESCRIPTION
WebDAV clients automatically create directories when writing files, so there's no need to call MkdirAll in advance.

https://github.com/studio-b12/gowebdav/blob/3b85fdfd9eece3af01775fb566e633a2065bc534/client.go#L421