### PR TITLE
fix: rm uploaded object files if committing meta failed with err code…

### DIFF
--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -205,7 +205,7 @@ func (c *chunkWriter) commitThread() {
 		if err != 0 {
 			if err == syscall.ENOENT {
 				f.Unlock()
-				f.w.store.Remove(s.id, int(s.length))
+				_ = f.w.store.Remove(s.id, int(s.length))
 				f.Lock()
 			} else if err != syscall.ENOSPC && err != syscall.EDQUOT {
 				logger.Warnf("write inode:%d error: %s", f.inode, err)

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -203,7 +203,11 @@ func (c *chunkWriter) commitThread() {
 
 		f.Lock()
 		if err != 0 {
-			if err != syscall.ENOENT && err != syscall.ENOSPC && err != syscall.EDQUOT {
+			if err == syscall.ENOENT {
+				f.Unlock()
+				f.w.store.Remove(s.id, int(s.length))
+				f.Lock()
+			} else if err != syscall.ENOSPC && err != syscall.EDQUOT {
 				logger.Warnf("write inode:%d error: %s", f.inode, err)
 				err = syscall.EIO
 			}

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -204,9 +204,9 @@ func (c *chunkWriter) commitThread() {
 		f.Lock()
 		if err != 0 {
 			if err == syscall.ENOENT {
-				f.Unlock()
-				_ = f.w.store.Remove(s.id, int(s.length))
-				f.Lock()
+				go func(id uint64, length int) {
+					_ = f.w.store.Remove(id, length)
+				}(s.id, int(s.length))
 			} else if err != syscall.ENOSPC && err != syscall.EDQUOT {
 				logger.Warnf("write inode:%d error: %s", f.inode, err)
 				err = syscall.EIO


### PR DESCRIPTION
If we fail to submit the meta with an error code ENOENT, it means that the file may have been deleted at another mount point, so we should delete the uploaded object files to prevent leakage.

https://github.com/juicedata/juicefs/issues/5132

