### PR TITLE
enhance: cache store check key exist before prefetch

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -819,6 +819,9 @@ func NewCachedStore(storage object.ObjectStorage, config Config, reg prometheus.
 		if size == 0 || size > store.conf.BlockSize {
 			return
 		}
+		if store.bcache.exist(key) {
+			return
+		}
 		p := NewOffPage(size)
 		defer p.Release()
 		_ = store.load(key, p, true, true)

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -332,6 +332,9 @@ func TestCacheManager(t *testing.T) {
 	defer p1.Release()
 	m.cache(k1, p1, true, false)
 
+	exist := m.exist(k1)
+	require.True(t, exist)
+
 	s1 := m.getStore(k1)
 	require.NotNil(t, s1)
 

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -103,6 +103,9 @@ func (c *memcache) delete(key string, p *Page) {
 }
 
 func (c *memcache) remove(key string, staging bool) {
+	if c.capacity == 0 {
+		return
+	}
 	c.Lock()
 	defer c.Unlock()
 	if item, ok := c.pages[key]; ok {
@@ -112,6 +115,9 @@ func (c *memcache) remove(key string, staging bool) {
 }
 
 func (c *memcache) load(key string) (ReadCloser, error) {
+	if c.capacity == 0 {
+		return nil, errors.New("not found")
+	}
 	c.Lock()
 	defer c.Unlock()
 	if item, ok := c.pages[key]; ok {
@@ -119,6 +125,16 @@ func (c *memcache) load(key string) (ReadCloser, error) {
 		return NewPageReader(item.page), nil
 	}
 	return nil, errors.New("not found")
+}
+
+func (c *memcache) exist(key string) bool {
+	if c.capacity == 0 {
+		return false
+	}
+	c.Lock()
+	_, ok := c.pages[key]
+	c.Unlock()
+	return ok
 }
 
 // locked


### PR DESCRIPTION
random read will cause repeat prefetch same blocks，which will case bandwidth amplification

https://github.com/juicedata/juicefs/issues/5134