### PR TITLE
Access log for read op also outputs file handle

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -710,7 +710,7 @@ func (v *VFS) Read(ctx Context, ino Ino, buf []byte, off uint64, fh uint64) (n i
 
 	defer func() {
 		readSizeHistogram.Observe(float64(n))
-		logit(ctx, "read", err, "(%d,%d,%d): (%d)", ino, size, off, n)
+		logit(ctx, "read", err, "(%d,%d,%d,%d): (%d)", ino, size, off, fh, n)
 	}()
 	h := v.findHandle(ino, fh)
 	if h == nil {


### PR DESCRIPTION
Two reasons:
1. To align with the write op.
2. Admin can know read concurrency of the same file.