### PR TITLE
Docs: fix JuiceFS vs. GlusterFS doc

### DIFF
--- a/docs/en/introduction/comparison/juicefs_vs_glusterfs.md
+++ b/docs/en/introduction/comparison/juicefs_vs_glusterfs.md
@@ -6,11 +6,11 @@ description: This document compares the design and features of GlusterFS and Jui
 
 [GlusterFS](https://github.com/gluster/glusterfs) is an open-source software-defined distributed storage solution. It can support data storage of PiB levels within a single cluster.
 
-[JuiceFS](https://github.com/juicedata/juicefs) is an open-source, high-performance distributed file system designed for the cloud. It delivers massive, elastic, and high-performance storage at low cost.
+JuiceFS is an open-source, high-performance distributed file system designed for the cloud. It delivers massive, elastic, and high-performance storage at low cost.
 
 This document compares the key attributes of JuiceFS and GlusterFS in a table and then explores them in detail, offering insights to aid your team in the technology selection process. You can easily see their main differences in the table below and delve into specific topics you're interested in within this article.
 
-## A quick summary of GlusterFS vs. JuiceFS
+## A quick summary of GlusterFS vs. JuiceFS {#a-quick-summary-of-glusterfs-vs-juicefs}
 
 The table below provides a quick overview of the differences between GlusterFS and JuiceFS:
 
@@ -35,11 +35,11 @@ The table below provides a quick overview of the differences between GlusterFS a
 | Trash | Supported | Supported |
 | Primary maintainer | Red Hat, Inc | Juicedata, Inc |
 | Development language | C | Go |
-| Open source license | GPLV2 and LGPLV3+ | Apache License 2.0 |
+| Open source license | GPLv2 and LGPLv3+ | Apache License 2.0 |
 
-## System architecture comparison
+## System architecture comparison {#system-architecture-comparison}
 
-### GlusterFS' architecture
+### GlusterFS' architecture {#glusterfs-architectire}
 
 GlusterFS employs a fully distributed architecture without centralized nodes. A GlusterFS cluster consists of the server and the client. The server side manages and stores data, often referred to as the Trusted Storage Pool. This pool comprises a set of server nodes, each running two types of processes:
 
@@ -52,42 +52,42 @@ The client side, which mounts GlusterFS, presents a unified namespace to applica
 
 ![GlusterFS architecture](../../images/glusterfs-architecture.jpg)
 
-### JuiceFS' architecture
+### JuiceFS' architecture {#juicefs-architecture}
 
-JuiceFS adopts an architecture that separates its data and metadata storage. File data is split and stored in object storage systems like Amazon S3, while metadata is stored in a user-selected database like Redis or MySQL. By sharing the same database and object storage, JuiceFS achieves a strongly consistent distributed file system with features like full POSIX compatibility and high performance. For details about JuiceFS architecture, see its [document](https://juicefs.com/docs/community/architecture).
+JuiceFS adopts an architecture that separates its data and metadata storage. File data is split and stored in object storage systems like Amazon S3, while metadata is stored in a user-selected database like Redis or MySQL. By sharing the same database and object storage, JuiceFS achieves a strongly consistent distributed file system with features like full POSIX compatibility and high performance. For a more detailed introduction, see [the documentation](../architecture.md).
 
 ![JuiceFS architecture](../../images/juicefs-arch-new.png)
 
-## Metadata management comparison
+## Metadata management comparison {#metadata-management-comparison}
 
-**GlusterFS:**
+### GlusterFS {#glusterfs}
 
 Metadata in GlusterFS is purely distributed, lacking a centralized metadata service. Clients use file name hashing to determine the associated brick. When requests require access across multiple bricks, for example, `mv` and `ls`, the client is responsible for coordination. While this design is simple, it can lead to performance bottlenecks as the system scales. For instance, listing a large directory might require accessing multiple bricks, and any latency in one brick can slow down the entire request. Additionally, ensuring metadata consistency when performing cross-brick modifications in the event of failures can be challenging, and severe failures may lead to split-brain scenarios, requiring [manual data recovery](https://docs.gluster.org/en/latest/Troubleshooting/resolving-splitbrain) to achieve a consistent version.
 
-**JuiceFS:**
+### JuiceFS {#juicefs}
 
-JuiceFS metadata is stored in an independent database, which is called the metadata engine. Clients transform file metadata operations into transactions within this database, leveraging its transactional capabilities to ensure operation atomicity. This design simplifies JuiceFS implementation but places higher demands on the metadata engine. JuiceFS currently supports three categories of transactional databases. For details, see the [metadata engine document](https://juicefs.com/docs/community/databases_for_metadata).
+JuiceFS metadata is stored in an independent database, which is called the metadata engine. Clients transform file metadata operations into transactions within this database, leveraging its transactional capabilities to ensure operation atomicity. This design simplifies JuiceFS implementation but places higher demands on the metadata engine. JuiceFS currently supports three categories of transactional databases. For details, see the [metadata engine document](../../reference/how_to_set_up_metadata_engine.md).
 
-## Data management comparison
+## Data management comparison {#data-management-comparison}
 
 GlusterFS stores data by integrating multiple server nodes' bricks (typically built on local file systems like XFS). Therefore, it provides certain data management features, including distribution management, redundancy protection, fault switching, and silent error detection.
 
 JuiceFS, on the other hand, does not use physical disks directly but manages data through integration with various object storage systems. Most of its features rely on the capabilities of its object storage.
 
-### Large file splitting
+### Large file splitting {#large-file-splitting}
 
 In distributed systems, splitting large files into smaller chunks and storing them on different nodes is a common optimization technique. This often leads to higher concurrency and bandwidth when applications access such files.
 
 * GlusterFS does not split large files (although it used to support Striped Volumes for large files, this feature is no longer supported).
-* JuiceFS splits files into 64 MiB chunks by default, and each chunk is further divided into 4 MiB blocks based on the write pattern. For details, see [How JuiceFS stores files](https://juicefs.com/docs/community/architecture/#how-juicefs-store-files).
+* JuiceFS splits files into 64 MiB chunks by default, and each chunk is further divided into 4 MiB blocks based on the write pattern. For details, see [How JuiceFS stores files](../architecture.md#how-juicefs-store-files).
 
-### Redundancy protection
+### Redundancy protection {#redundancy-protection}
 
 GlusterFS supports both replication (Replicated Volume) and erasure coding (Dispersed Volume).
 
 JuiceFS relies on the redundancy capabilities of the underlying object storage it uses.
 
-### Data compression
+### Data compression {#data-compression}
 
 GlusterFS:
 
@@ -96,62 +96,62 @@ GlusterFS:
 
 JuiceFS supports both transport-layer and storage-layer compression. Data compression and decompression are performed on the client side.
 
-### Data encryption
+### Data encryption {#data-encryption}
 
 GlusterFS:
 
 * Supports only [transport-layer encryption](https://docs.gluster.org/en/latest/Administrator-Guide/SSL), relying on SSL/TLS.
 * Previously supported [storage-layer encryption](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/Disk%20Encryption.md), but it is no longer supported.
 
-JuiceFS supports both [transport-layer and storage-layer encryption](https://juicefs.com/docs/community/security/encryption). Data encryption and decryption are performed on the client side.
+JuiceFS supports both [transport-layer and storage-layer encryption](../../security/encryption.md). Data encryption and decryption are performed on the client side.
 
-## Access protocols
+## Access protocols {#access-protocols}
 
-### POSIX compatibility
+### POSIX compatibility {#posix-compatibility}
 
-Both [GlusterFS](https://docs.gluster.org/en/latest/glossary/#posix) and [JuiceFS](https://juicefs.com/docs/community/posix_compatibility) offer POSIX compatibility.
+Both [GlusterFS](https://docs.gluster.org/en/latest/glossary) and [JuiceFS](../../reference/posix_compatibility.md) offer POSIX compatibility.
 
-### NFS protocol
+### NFS protocol {#nfs-protocol}
 
 GlusterFS previously had embedded support for NFSv3 but now it is [no longer recommended](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.8/gluster-nfs-off.md). Instead, it is suggested to export the mount point using an NFS server.
 
-JuiceFS does not provide direct support for NFS and requires mounting followed by [export via another NFS server](https://juicefs.com/docs/community/deployment/nfs).
+JuiceFS does not provide direct support for NFS and requires mounting followed by [export via another NFS server](../../deployment/nfs.md).
 
-### CIFS protocol
+### CIFS protocol {#cifs-protocol}
 
 GlusterFS embeds support for Windows, Linux Samba clients, and macOS CLI access (excluding macOS Finder). However, it is recommended to [use Samba for exporting mount points](https://docs.gluster.org/en/latest/Administrator-Guide/Setting-Up-Clients/#testing-mounted-volumes).
 
-JuiceFS does not offer direct support for CIFS and requires mounting followed by [export via Samba](https://juicefs.com/docs/community/deployment/samba).
+JuiceFS does not offer direct support for CIFS and requires mounting followed by [export via Samba](../../deployment/samba.md).
 
-### S3 protocol
+### S3 protocol {#s3-protocol}
 
-GlusterFS supports S3 through the [gluster-swift](https://github.com/gluster/gluster-swift) project, but the project hasn't seen recent updates since November 2017.
+GlusterFS supports S3 through the [`gluster-swift`](https://github.com/gluster/gluster-swift) project, but the project hasn't seen recent updates since November 2017.
 
-JuiceFS [supports S3 through integration with the MinIO S3 gateway](https://juicefs.com/docs/community/s3_gateway).
+JuiceFS supports S3 through the [S3 gateway](../../deployment/s3_gateway.md).
 
-### HDFS compatibility
+### HDFS compatibility {#hdfs-compatibility}
 
 GlusterFS offers HDFS compatibility through the [`glusterfs-hadoop`](https://github.com/gluster/glusterfs-hadoop) project, but the project hasn't seen recent updates since May 2015.
 
-JuiceFS provides [full compatibility with the HDFS API](https://juicefs.com/docs/community/hadoop_java_sdk).
+JuiceFS provides [full compatibility with the HDFS API](../../deployment/hadoop_java_sdk.md).
 
-### CSI Driver
+### CSI Driver {#csi-driver}
 
 GlusterFS [previously supported CSI Driver](https://github.com/gluster/gluster-csi-driver) but the latest version was released in November 2018, and the repository is marked as DEPRECATED.
 
 JuiceFS supports CSI Driver. For details, see the [document](https://juicefs.com/docs/csi/introduction).
 
-## Extended features
+## Extended features {#extended-features}
 
-### POSIX ACLs
+### POSIX ACLs {#posix-acls}
 
 In Linux, file access permissions are typically controlled by three entities: the file owner, the group owner, and others. However, when more complex requirements arise, such as the need to assign specific permissions to a particular user within the others category, this standard mechanism does not work. POSIX Access Control Lists (ACLs) offer enhanced permission management capabilities, allowing you to assign permissions to any user or user group as needed.
 
 GlusterFS [supports ACLs](https://docs.gluster.org/en/main/Administrator-Guide/Access-Control-Lists), including access ACLs and default ACLs.
 
-JuiceFS does not support POSIX ACLs.
+JuiceFS supports the [POSIX ACLs](../../security/posix_acl.md) feature starting from v1.2.
 
-### Cross-cluster replication
+### Cross-cluster replication {#cross-cluster-replication}
 
 Cross-cluster replication indicates replicating data between two independent clusters, often used for geographically distributed disaster recovery.
 
@@ -159,18 +159,18 @@ GlusterFS [supports one-way asynchronous incremental replication](https://docs.g
 
 JuiceFS depends on the capabilities of the metadata engine and the object storage, allowing one-way replication.
 
-### Directory quotas
+### Directory quotas {#directory-quotas}
 
-Both [GlusterFS](https://docs.gluster.org/en/main/Administrator-Guide/Directory-Quota) and [JuiceFS](https://juicefs.com/docs/community/guide/quota) support directory quotas, including capacity and/or file count limits.
+Both [GlusterFS](https://docs.gluster.org/en/main/Administrator-Guide/Directory-Quota) and [JuiceFS](../../guide/quota.md#directory-quota) support directory quotas, including capacity and/or file count limits.
 
-### Snapshots
+### Snapshots {#snapshots}
 
 GlusterFS supports [volume-level snapshots](https://docs.gluster.org/en/main/Administrator-Guide/Managing-Snapshots) and requires all bricks to be deployed on LVM thinly provisioned volumes.
 
-JuiceFS does not support snapshots but offers directory-level cloning.
+JuiceFS does not support snapshots but offers [directory-level cloning](../../guide/clone.md).
 
-### Trash
+### Trash {#trash}
 
 GlusterFS [supports the trash functionality](https://docs.gluster.org/en/main/Administrator-Guide/Trash), which is disabled by default.
 
-JuiceFS [supports the trash functionality](https://juicefs.com/docs/community/security/trash), which is enabled by default.
+JuiceFS [supports the trash functionality](../../security/trash.md), which is enabled by default.

--- a/docs/zh_cn/introduction/comparison/juicefs_vs_glusterfs.md
+++ b/docs/zh_cn/introduction/comparison/juicefs_vs_glusterfs.md
@@ -6,13 +6,15 @@ description: 本文对比 JuiceFS 和 GlusterFS 的架构、元数据管理、�
 
 [GlusterFS](https://github.com/gluster/glusterfs) 是一款开源的软件定义分布式存储解决方案，能够在单个集群中支持高达 PiB 级别的数据存储。
 
-[JuiceFS](https://juicefs.com/docs/zh/community/introduction) 是一款专为云端设计的开源、高性能分布式文件系统，以较低的成本提供了大规模、弹性和高性能的存储能力。
+JuiceFS 是一款专为云端设计的开源、高性能分布式文件系统，以较低的成本提供了大规模、弹性和高性能的存储能力。
 
 本文先通过一份表格简要对比 JuiceFS 和 GlusterFS 的主要特点，然后进行详细探讨。你可以通过下表速查二者的关键特性对比，然后在本文中选取感兴趣的话题详细阅读。
 
-## JuiceFS 和 GlusterFS 对比一览
+## JuiceFS 和 GlusterFS 对比一览 {#a-quick-summary-of-glusterfs-vs-juicefs}
 
-| **对比项** | **GlusterFS** | **JuiceFS** |
+下表快速概述了 GlusterFS 和 JuiceFS 之间的差异：
+
+| 对比项 | GlusterFS | JuiceFS |
 | :--- | :--- | :--- |
 | 元数据 | 纯分布式 | 独立数据库服务 |
 | 数据存储 | 自主管理 | 依赖对象存储服务 |
@@ -33,11 +35,11 @@ description: 本文对比 JuiceFS 和 GlusterFS 的架构、元数据管理、�
 | 回收站 | 支持 | 支持 |
 | 主要维护者 | Red Hat, Inc | Juicedata, Inc |
 | 开发语言 | C | Go |
-| 开源协议 | GPLV2 and LGPLV3+ | Apache License 2.0 |
+| 开源协议 | GPLv2 and LGPLv3+ | Apache License 2.0 |
 
-## **系统架构对比**
+## 系统架构对比 {#system-architecture-comparison}
 
-### **GlusterFS**
+### GlusterFS 的架构 {#glusterfs-architectire}
 
 GlusterFS 采用的是全分布式的架构，没有中心化节点。GlusterFS 集群主要由服务端和客户端两大部分组成。其中服务端负责管理和存储数据，通常被称为可信存储池（Trusted Storage Pool）。这个存储池由一系列对等的 Server 节点组成，一般会运行两类进程：
 
@@ -50,111 +52,125 @@ GlusterFS 采用的是全分布式的架构，没有中心化节点。GlusterFS 
 
 ![Gluster 架构](../../images/glusterfs-architecture.jpg)
 
-### **JuiceFS**
+### JuiceFS 的架构 {#juicefs-architecture}
 
-JuiceFS 采用「数据」与「元数据」分离存储的架构，文件数据本身会被切分保存在对象存储（如 Amazon S3）当中，而元数据则是会被保存在用户自行选择的数据库里（如 Redis、MySQL）。通过共享同一个份数据库与对象存储，JuiceFS 实现了一个强一致性保证的分布式文件系统，同时还具有「POSIX 完全兼容」、「高性能」等诸多特性。JuiceFS 的架构，在其[文档](https://juicefs.com/docs/zh/community/architecture)有更详细的介绍。
+JuiceFS 采用「数据」与「元数据」分离存储的架构，文件数据本身会被切分保存在对象存储（如 Amazon S3）当中，而元数据则是会被保存在用户自行选择的数据库里（如 Redis、MySQL）。通过共享同一个份数据库与对象存储，JuiceFS 实现了一个强一致性保证的分布式文件系统，同时还具有「POSIX 完全兼容」、「高性能」等诸多特性。更详细的介绍参见[文档](../architecture.md)。
 
 ![JuiceFS 架构](../../images/juicefs-arch-new.png)
 
-## **元数据管理对比**
+## 元数据管理对比 {#metadata-management-comparison}
+
+### GlusterFS {#glusterfs}
 
 GlusterFS 元数据是纯分布式的，没有集中的元数据服务。客户端通过对文件名哈希确定其所属的 Brick；当请求需要跨多个 Bricks 访问（如 mv，ls 等）时，由客户端负责协调。这种设计架构上比较简单，但当系统规模扩大时，往往会带来性能瓶颈。比如，ls 一个大目录时可能会需要访问多个 Bricks 来获得完整的结果，其中任何一个的卡顿都会导致整个请求变慢。另外，跨 Bricks 修改操作在途中遇到故障时，元数据一致性也比较难保证。在严重故障时，还可能出现脑裂，需要[手动恢复](https://docs.gluster.org/en/latest/Troubleshooting/resolving-splitbrain)数据到统一版本。
 
-JuiceFS 的元数据存储在一个独立的数据库（称为元数据引擎）中，客户端会将文件元数据操作转换成此数据库的一个事务，借助数据库的事务能力来保证操作的原子性。这种设计使得 JuiceFS 的实现变得简单，但对元数据引擎提出了较高的要求。目前 JuiceFS 支持三大类 10 种事务型数据库，具体可参见[元数据引擎文档](https://juicefs.com/docs/zh/community/databases_for_metadata)。
+### JuiceFS {#juicefs}
 
-## **数据管理对比**
+JuiceFS 的元数据存储在一个独立的数据库（称为元数据引擎）中，客户端会将文件元数据操作转换成此数据库的一个事务，借助数据库的事务能力来保证操作的原子性。这种设计使得 JuiceFS 的实现变得简单，但对元数据引擎提出了较高的要求。目前 JuiceFS 支持三大类 10 种事务型数据库，具体可参见[元数据引擎文档](../../reference/how_to_set_up_metadata_engine.md)。
 
-GlusterFS 通过整合多个服务端节点的 Bricks（一般构建在本地文件系统之上，如 XFS）来存储数据。因此，它本身提供了一定的数据管理功能，如分布管理、冗余保护、故障切换、静默错误检测等。JuiceFS 则不直接使用硬盘，而是通过对接各种对象存储来管理数据，大部分特性都依赖于对象存储自身的实现。
+## 数据管理对比 {#data-management-comparison}
 
-### **大文件拆分**
+GlusterFS 通过整合多个服务端节点的 Bricks（一般构建在本地文件系统之上，如 XFS）来存储数据。因此，它本身提供了一定的数据管理功能，如分布管理、冗余保护、故障切换、静默错误检测等。
+
+JuiceFS 则不直接使用硬盘，而是通过对接各种对象存储来管理数据，大部分特性都依赖于对象存储自身的实现。
+
+### 大文件拆分 {#large-file-splitting}
 
 在分布式系统中，将大文件拆分成多个小块散列存储在不同节点中是一种常见的优化手段。这往往能让应用在访问此文件时有更高的并发度和整体带宽。
 
 * GlusterFS：不拆分（曾有过 Striped Volume 会拆分大文件，现已不再支持）。
-* JuiceFS：文件先按大小拆成 64 MiB 的 Chunks，每个 Chunk 再根据写入模式进一步拆成默认 4 MiB 的 Blocks；具体可参见[架构文档](https://juicefs.com/docs/zh/community/architecture/#how-juicefs-store-files)。
+* JuiceFS：文件先按大小拆成 64 MiB 的 Chunks，每个 Chunk 再根据写入模式进一步拆成默认 4 MiB 的 Blocks；具体可参见[架构文档](../architecture.md#how-juicefs-store-files)。
 
-### **冗余保护**
+### 冗余保护 {#redundancy-protection}
 
-* GlusterFS：支持副本（Replicated Volume）和纠删码（Dispersed Volume）两种类型。
-* JuiceFS：依赖于使用的对象存储。
+GlusterFS 支持副本（Replicated Volume）和纠删码（Dispersed Volume）两种类型。
 
-### **数据压缩**
+JuiceFS 依赖于使用的对象存储。
 
-* GlusterFS：
+### 数据压缩 {#data-compression}
 
-  * 仅支持传输层压缩，文件由客户端执行压缩，传输到服务端后再由 Brick 负责解压缩。
-  * 不直接实现存储层压缩，而是依赖于 Brick 使用的底层文件系统，如 [ZFS](https://docs.gluster.org/en/latest/Administrator-Guide/Gluster-On-ZFS)。
+GlusterFS：
 
-* JuiceFS：同时支持传输层压缩和存储层压缩，数据的压缩和解压缩都在客户端执行。
+* 仅支持传输层压缩，文件由客户端执行压缩，传输到服务端后再由 Brick 负责解压缩。
+* 不直接实现存储层压缩，而是依赖于 Brick 使用的底层文件系统，如 [ZFS](https://docs.gluster.org/en/latest/Administrator-Guide/Gluster-On-ZFS)。
 
-### **数据加密**
+JuiceFS 同时支持传输层压缩和存储层压缩，数据的压缩和解压缩都在客户端执行。
 
-* GlusterFS：
+### 数据加密 {#data-encryption}
 
-  * 仅支持[传输层加密](https://docs.gluster.org/en/latest/Administrator-Guide/SSL)，依赖于 SSL/TLS。
-  * 曾支持过[存储层加密](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/Disk%20Encryption.md)，但现已不再支持。
+GlusterFS：
 
-* JuiceFS：同时支持[传输层加密和存储层加密](https://juicefs.com/docs/zh/community/security/encrypt)，数据的加密和解密都在客户端进行。
+* 仅支持[传输层加密](https://docs.gluster.org/en/latest/Administrator-Guide/SSL)，依赖于 SSL/TLS。
+* 曾支持过[存储层加密](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.5/Disk%20Encryption.md)，但现已不再支持。
 
-## **访问协议**
+JuiceFS 同时支持[传输层加密和存储层加密](../../security/encryption.md)，数据的加密和解密都在客户端进行。
 
-### **POSIX 兼容性**
+## 访问协议 {#access-protocols}
 
-* GlusterFS：[兼容](https://docs.gluster.org/en/latest/glossary/#posix)。
-* JuiceFS：[兼容](https://juicefs.com/docs/zh/community/posix_compatibility)。
+### POSIX 兼容性 {#posix-compatibility}
 
-### **NFS 协议**
+[GlusterFS](https://docs.gluster.org/en/latest/glossary) 和 [JuiceFS](../../reference/posix_compatibility.md) 都提供 POSIX 兼容性。
 
-* GlusterFS：曾有内嵌服务来支持 NFSv3，但现已[不再推荐使用](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.8/gluster-nfs-off.md)，而是建议用 NFS server 将挂载点导出。
-* JuiceFS：不直接支持，需要挂载后[通过其他 NFS server 导出](https://juicefs.com/docs/zh/community/deployment/nfs)。
+### NFS 协议 {#nfs-protocol}
 
-### **CIFS 协议**
+GlusterFS 曾有内嵌服务来支持 NFSv3，但现已[不再推荐使用](https://github.com/gluster/glusterfs-specs/blob/master/done/GlusterFS%203.8/gluster-nfs-off.md)，而是建议用 NFS server 将挂载点导出。
 
-* GlusterFS：内嵌支持 Windows，Linux Samba client 和 macOS 的 CLI 访问，不支持 macOS Finder。然而，文档中建议用[通过 Samba 将挂载点导出](https://docs.gluster.org/en/latest/Administrator-Guide/Setting-Up-Clients/#testing-mounted-volumes)的方式使用。
-* JuiceFS：不直接支持，需要挂载后[通过 Samba 导出](https://juicefs.com/docs/zh/community/deployment/samba)。
+JuiceFS 不直接支持，需要挂载后[通过其他 NFS server 导出](../../deployment/nfs.md)。
 
-### **S3 协议**
+### CIFS 协议 {#cifs-protocol}
 
-* GlusterFS：通过 [gluster-swift](https://github.com/gluster/gluster-swift) 项目支持，但其最近更新停留在 2017 年 11 月。
-* JuiceFS：通过[结合 MinIO S3 网关](https://juicefs.com/docs/zh/community/s3_gateway)支持。
+GlusterFS 内嵌支持 Windows，Linux Samba client 和 macOS 的 CLI 访问，不支持 macOS Finder。然而，文档中建议用[通过 Samba 将挂载点导出](https://docs.gluster.org/en/latest/Administrator-Guide/Setting-Up-Clients/#testing-mounted-volumes)的方式使用。
 
-### **HDFS 兼容性**
+JuiceFS 不直接支持，需要挂载后[通过 Samba 导出](../../deployment/samba.md)。
 
-* GlusterFS：通过 [`glusterfs-hadoop`](https://github.com/gluster/glusterfs-hadoop) 项目支持，但其最近更新停留在 2015 年 5 月。
-* JuiceFS：完整[兼容 HDFS API](https://juicefs.com/docs/zh/community/hadoop_java_sdk)。
+### S3 协议 {#s3-protocol}
 
-### **CSI 驱动**
+GlusterFS 通过 [`gluster-swift`](https://github.com/gluster/gluster-swift) 项目支持，但其最近更新停留在 2017 年 11 月。
 
-* GlusterFS：曾[支持过](https://github.com/gluster/gluster-csi-driver)，但最近版本发布于 2018 年 11 月，且仓库已被标记 DEPRECATED。
-* JuiceFS：支持，具体可参见 [JuiceFS CSI 驱动文档](https://juicefs.com/docs/zh/csi/introduction)。
+JuiceFS 通过 [S3 网关](../../deployment/s3_gateway.md)支持。
 
-## **扩展功能**
+### HDFS 兼容性 {#hdfs-compatibility}
 
-### **POSIX ACLs**
+GlusterFS 通过 [`glusterfs-hadoop`](https://github.com/gluster/glusterfs-hadoop) 项目支持，但其最近更新停留在 2015 年 5 月。
+
+JuiceFS 完整[兼容 HDFS API](../../deployment/hadoop_java_sdk.md)。
+
+### CSI 驱动 {#csi-driver}
+
+GlusterFS 曾[支持过](https://github.com/gluster/gluster-csi-driver)，但最近版本发布于 2018 年 11 月，且仓库已被标记 DEPRECATED。
+
+JuiceFS 支持，具体可参见 [JuiceFS CSI 驱动文档](https://juicefs.com/docs/zh/csi/introduction)。
+
+## 扩展功能 {#extended-features}
+
+### POSIX ACLs {#posix-acls}
 
 Linux 下对文件的访问权限控制一般有三类实体，即文件拥有者（owner）、拥有组（group）和其他（other）。当我们有更复杂的需求，比如要给本属于 other 的某个特定用户单独赋予权限时，这套机制就做不到了。POSIX Access Control Lists (ACLs) 提供增强的权限管理功能，可用来为任意用户/用户组指定权限。
 
-* GlusterFS：[支持](https://docs.gluster.org/en/main/Administrator-Guide/Access-Control-Lists)，且支持 access ACLs 和 default ACLs。
-* JuiceFS：不支持。
+GlusterFS [支持](https://docs.gluster.org/en/main/Administrator-Guide/Access-Control-Lists)，且支持 access ACLs 和 default ACLs。
 
-### **跨域复制**
+JuiceFS 从 v1.2 版本开始支持 [POSIX ACLs](../../security/posix_acl.md) 特性。
+
+### 跨域复制 {#cross-cluster-replication}
 
 跨域复制是指在两套独立的集群间进行数据复制，一般被用来实现异地灾备。
 
-* GlusterFS：[支持单向的异步增量复制](https://docs.gluster.org/en/main/Administrator-Guide/Geo-Replication)，但需要两边是同版本的 Gluster 集群。
-* JuiceFS：依赖元数据引擎和对象存储自身的复制能力，可以做单向复制。
+GlusterFS [支持单向的异步增量复制](https://docs.gluster.org/en/main/Administrator-Guide/Geo-Replication)，但需要两边是同版本的 Gluster 集群。
 
-### **目录配额**
+JuiceFS 依赖元数据引擎和对象存储自身的复制能力，可以做单向复制。
 
-* GlusterFS：[支持](https://docs.gluster.org/en/main/Administrator-Guide/Directory-Quota)，且支持限制容量和/或文件数。
-* JuiceFS：[支持](https://ejuicefs.com/docs/zh/community/guide/quota/#directory-quota)，且支持限制容量和/或文件数。
+### 目录配额 {#directory-quotas}
 
-### **快照**
+[GlusterFS](https://docs.gluster.org/en/main/Administrator-Guide/Directory-Quota) 和 [JuiceFS](../../guide/quota.md#directory-quota) 都支持目录配额，包括容量和/或文件数限制。
 
-* GlusterFS：仅[支持存储卷级别的快照](https://docs.gluster.org/en/main/Administrator-Guide/Managing-Snapshots)，而且需要所有 Bricks 部署在 LVM 精简卷（Thinly-Provisioned LVM）上。
-* JuiceFS：不支持快照，但支持目录级别的克隆。
+### 快照 {#snapshots}
 
-### **回收站**
+GlusterFS 仅[支持存储卷级别的快照](https://docs.gluster.org/en/main/Administrator-Guide/Managing-Snapshots)，而且需要所有 Bricks 部署在 LVM 精简卷（Thinly-Provisioned LVM）上。
 
-* GlusterFS：[支持](https://docs.gluster.org/en/main/Administrator-Guide/Trash)，且默认关闭。
-* JuiceFS：支持，且默认打开。
+JuiceFS 不支持快照，但支持[目录级别的克隆](../../guide/clone.md)。
+
+### 回收站 {#trash}
+
+GlusterFS [支持](https://docs.gluster.org/en/main/Administrator-Guide/Trash)，且默认关闭。
+
+JuiceFS [支持](../../security/trash.md)，且默认打开。


### PR DESCRIPTION
Fixed an issue in the documentation stating that JuiceFS does not support the POSIX ACLs feature.
