### PR TITLE
Kill mount process and dump its stack when mount point is not ready in time

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -506,7 +506,7 @@ func (cache *cacheStore) createDir(dir string) {
 				cache.createDir(filepath.Dir(dir))
 			}
 			_ = os.Mkdir(dir, mode)
-			// umask may remove some permisssions
+			// umask may remove some permissions
 			return os.Chmod(dir, mode)
 		} else if strings.HasPrefix(dir, cache.dir) && err == nil && st.Mode() != mode {
 			changeMode(dir, st, mode)


### PR DESCRIPTION
Occationally, the mount process hangs and we only get the following error message - it provides no clue as to why.

```
<FATAL>: The mount point is not ready in 10 seconds ...
```

We added a patch to the `checkMountpoint` function, which dumps stack trace of the mount process and **KILLs** it when it's not ready in time. This patch helps us to spot several environmental issues that may be causing the mount to hang.

Issue #5166 shows a similar issue. So I think this patch should also benefit other users in the community.