### PR TITLE
fix(redis): supports pass the tls server name for redis tls connection

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -117,6 +117,7 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 	certFile := query.pop("tls-cert-file")
 	keyFile := query.pop("tls-key-file")
 	caCertFile := query.pop("tls-ca-cert-file")
+	tlsServerName := query.pop("tls-server-name")
 	u.RawQuery = values.Encode()
 
 	hosts := u.Host
@@ -125,7 +126,7 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 		return nil, fmt.Errorf("redis parse %s: %s", uri, err)
 	}
 	if opt.TLSConfig != nil {
-		opt.TLSConfig.ServerName = "" // use the host of each connection as ServerName
+		opt.TLSConfig.ServerName = tlsServerName // use the host of each connection as ServerName
 		opt.TLSConfig.InsecureSkipVerify = skipVerify != ""
 		if certFile != "" {
 			cert, err := tls.LoadX509KeyPair(certFile, keyFile)


### PR DESCRIPTION
Because connecting to Azure Cache requires a [TLS server name](https://github.com/redis/go-redis/issues/1698), I'm not sure why this [PR](https://github.com/juicedata/juicefs/pull/3194/files) leaves the TLS server name empty. To avoid making disruptive updates, I added a separate query for users to specify the TLS server name.