### PR TITLE
Fix: os.Chmod is called on every cache/stage write

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -503,7 +503,7 @@ func (cache *cacheStore) createDir(dir string) {
 			_ = os.Mkdir(dir, mode)
 			// umask may remove some permissions
 			return os.Chmod(dir, mode)
-		} else if strings.HasPrefix(dir, cache.dir) && err == nil && st.Mode() != mode {
+		} else if strings.HasPrefix(dir, cache.dir) && err == nil && st.Mode().Perm() != mode.Perm() { // check permission only
 			changeMode(dir, st, mode)
 		}
 		return err


### PR DESCRIPTION
`st.Mode()` represents a directory, whereat `cache.mode` is a file mode - they are **always** not equal.

This issue causes one extra syscall/IO on every cache write. Especially causes conflicts on staging writes with high concurrency.