### PR TITLE
Fix(openfile): avoid returning stale slice caches

### DIFF
--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -199,6 +199,10 @@ func (o *openfiles) ReadChunk(ino Ino, indx uint32) ([]Slice, bool) {
 	if !ok {
 		return nil, false
 	}
+	if time.Since(time.Unix(of.lastCheck, 0)) >= o.expire {
+		of.invalidateChunk()
+		return nil, false
+	}
 	if indx == 0 {
 		return of.first, of.first != nil
 	} else {
@@ -222,6 +226,7 @@ func (o *openfiles) CacheChunk(ino Ino, indx uint32, cs []Slice) {
 		}
 		of.chunks[indx] = cs
 	}
+	of.lastCheck = time.Now().Unix()
 }
 
 func (o *openfiles) InvalidateChunk(ino Ino, indx uint32) {


### PR DESCRIPTION
Some users cache opened files for a long time for performance reasons, which causes them read stale slices from `openfiles` cache - we only check expiration when opening a file, not reading slices.

One scenario is one client opens a file and reads occasionally - the read slices are cached forever. Another client compacts the file and old slices are deleted after `trash-days`. Now when the first client reads the file again, it gets stale slices. The penalty of false positive cache is one-second delay of a successful read. We could avoid this by applying `expire` to slices cache as well.

https://github.com/juicedata/juicefs/blob/ad6cf901579d65d89075619f1116069dabe2bdd3/pkg/chunk/cached_store.go#L711-L720