### PR TITLE
cmd/gc: fix the issue that pending delete objects are misclassified as leaked

### DIFF
--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -142,7 +142,7 @@ func fsck(ctx *cli.Context) error {
 	// List all slices in metadata engine
 	sliceCSpin := progress.AddCountSpinner("Listed slices")
 	slices := make(map[meta.Ino][]meta.Slice)
-	r := m.ListSlices(c, slices, false, sliceCSpin.Increment)
+	r := m.ListSlices(c, slices, false, false, sliceCSpin.Increment)
 	if r != 0 {
 		logger.Fatalf("list all slices: %s", r)
 	}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -1486,7 +1486,7 @@ func testCompaction(t *testing.T, m Meta, trash bool) {
 	}
 	p.Done()
 	sliceMap := make(map[Ino][]Slice)
-	if st := m.ListSlices(ctx, sliceMap, false, nil); st != 0 {
+	if st := m.ListSlices(ctx, sliceMap, false, false, nil); st != 0 {
 		t.Fatalf("list all slices: %s", st)
 	}
 
@@ -1694,7 +1694,7 @@ func testTruncateAndDelete(t *testing.T, m Meta) {
 	}
 	var total int64
 	slices := make(map[Ino][]Slice)
-	m.ListSlices(ctx, slices, false, func() { total++ })
+	m.ListSlices(ctx, slices, false, false, func() { total++ })
 	var totalSlices int
 	for _, ss := range slices {
 		totalSlices += len(ss)
@@ -1709,7 +1709,7 @@ func testTruncateAndDelete(t *testing.T, m Meta) {
 
 	time.Sleep(time.Millisecond * 100)
 	slices = make(map[Ino][]Slice)
-	m.ListSlices(ctx, slices, false, nil)
+	m.ListSlices(ctx, slices, false, false, nil)
 	totalSlices = 0
 	for _, ss := range slices {
 		totalSlices += len(ss)

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -418,7 +418,7 @@ type Meta interface {
 	Compact(ctx Context, inode Ino, concurrency int, preFunc, postFunc func()) syscall.Errno
 
 	// ListSlices returns all slices used by all files.
-	ListSlices(ctx Context, slices map[Ino][]Slice, delete bool, showProgress func()) syscall.Errno
+	ListSlices(ctx Context, slices map[Ino][]Slice, scanPending, delete bool, showProgress func()) syscall.Errno
 	// Remove all files and directories recursively.
 	// count represents the number of attempted deletions of entries (even if failed).
 	Remove(ctx Context, parent Ino, name string, count *uint64) syscall.Errno


### PR DESCRIPTION
fix #5194 