### PR TITLE
Fix warning log when creating a new cache dir

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -496,17 +496,12 @@ func (cache *cacheStore) createDir(dir string) {
 		mode := cache.mode | (readmode >> 2) | (readmode >> 1)
 		var st os.FileInfo
 		var err error
+		dir = filepath.Clean(dir)
 		if st, err = os.Stat(dir); os.IsNotExist(err) {
-			if len(dir) > 1 && strings.HasSuffix(dir, string(filepath.Separator)) {
-				dir = dir[:len(dir)-1] // CacheManager appends "/" to dir, remove it so that `filepath.Dir` returns the parent dir
-			}
 			if filepath.Dir(dir) != dir {
 				cache.createDir(filepath.Dir(dir))
 			}
-			if err = os.Mkdir(dir, mode); err != nil {
-				logger.Warnf("create cache dir %s: %s", dir, err)
-				return err
-			}
+			_ = os.Mkdir(dir, mode)
 			// umask may remove some permissions
 			return os.Chmod(dir, mode)
 		} else if strings.HasPrefix(dir, cache.dir) && err == nil && st.Mode().Perm() != mode.Perm() { // check permission only

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -496,7 +496,7 @@ func (cache *cacheStore) createDir(dir string) {
 		mode := cache.mode | (readmode >> 2) | (readmode >> 1)
 		var st os.FileInfo
 		var err error
-		dir = filepath.Clean(dir)
+		dir = filepath.Clean(dir) // `CacheManager` appends "/" to dir, remove it so that following `filepath.Dir` returns the parent dir
 		if st, err = os.Stat(dir); os.IsNotExist(err) {
 			if filepath.Dir(dir) != dir {
 				cache.createDir(filepath.Dir(dir))

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -497,6 +497,9 @@ func (cache *cacheStore) createDir(dir string) {
 		var st os.FileInfo
 		var err error
 		if st, err = os.Stat(dir); os.IsNotExist(err) {
+			if len(dir) > 1 && strings.HasSuffix(dir, string(filepath.Separator)) {
+				dir = dir[:len(dir)-1] // CacheManager appends "/" to dir, remove it so that `filepath.Dir` returns the parent dir
+			}
 			if filepath.Dir(dir) != dir {
 				cache.createDir(filepath.Dir(dir))
 			}


### PR DESCRIPTION
After updating to the latest master branch, a lot of warning logs show up (see attached screenshot). 

This happens because `dir` is appended with "/" in the CacheManager (I don't know why), and when calling `filepath.Dir` on a string ending with "/", the function returns the same dir (with "/" trimed). So same dir is passed to `os.Mkdir` twice, and the second call will raise a warning log. This may cause confusion to users.

<img width="1584" alt="image" src="https://github.com/user-attachments/assets/1e11b772-0a8d-499c-a982-b1e86e0c225e">
