### PR TITLE
Dedup prefetch/partial read with full block read to reduce read amplification

### DIFF
--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -65,6 +65,12 @@ func testStore(t *testing.T, store ChunkStore) {
 	} else if string(p.Data[:n]) != "world" {
 		t.Fatalf("not expected: %s", string(p.Data[:n]))
 	}
+	p = NewPage(make([]byte, 5))
+	if n, err := reader.ReadAt(context.Background(), p, 0); n != 5 || err != nil {
+		t.Fatalf("read failed: %d %s", n, err)
+	} else if string(p.Data[:n]) != "hello" {
+		t.Fatalf("not expected: %s", string(p.Data[:n]))
+	}
 	p = NewPage(make([]byte, 20))
 	if n, err := reader.ReadAt(context.Background(), p, offset); n != 11 || err != nil && err != io.EOF {
 		t.Fatalf("read failed: %d %s", n, err)

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -85,7 +85,7 @@ func GetHttpClient() *http.Client {
 
 func cleanup(response *http.Response) {
 	if response != nil && response.Body != nil {
-		_, _ = io.ReadAll(response.Body)
+		_, _ = io.Copy(io.Discard, response.Body)
 		_ = response.Body.Close()
 	}
 }


### PR DESCRIPTION
Prefetch/partial/full read are three ways to read from oss. In current implementation, they may overlap with each other. On sequential read when readahead is triggered, the overlap is trivial. But on other cases, the overlap may cost extra network bandwidth.

This PR groups them in a singleflight to avoid the read amplification.

<img width="1558" alt="image" src="https://github.com/user-attachments/assets/f30a17fe-a02f-46e2-a86f-e172332de422">
