### PR TITLE
sync: when using the jfs protocol header, close the session before the program exits

### DIFF
--- a/.github/scripts/sync/sync_cluster.sh
+++ b/.github/scripts/sync/sync_cluster.sh
@@ -118,7 +118,11 @@ skip_test_sync_between_oss(){
 check_sync_log(){
     grep "<FATAL>" sync.log && exit 1 || true
     file_count=$1
-    file_copied=$(tail -1 sync.log  | sed 's/.*copied: \([0-9]*\).*/\1/' )
+    if tail -1 sync.log | grep -q "close session"; then
+      file_copied=$(tail -2 sync.log | grep head -n 1  | sed 's/.*copied: \([0-9]*\).*/\1/' )
+    else
+      file_copied=$(tail -1 sync.log  | sed 's/.*copied: \([0-9]*\).*/\1/' )
+    fi
     if [ "$file_copied" != "$file_count" ]; then
         echo "file_copied not equal, $file_copied, $file_count"
         exit 1

--- a/.github/scripts/sync/sync_cluster.sh
+++ b/.github/scripts/sync/sync_cluster.sh
@@ -119,7 +119,7 @@ check_sync_log(){
     grep "<FATAL>" sync.log && exit 1 || true
     file_count=$1
     if tail -1 sync.log | grep -q "close session"; then
-      file_copied=$(tail -2 sync.log | grep head -n 1  | sed 's/.*copied: \([0-9]*\).*/\1/' )
+      file_copied=$(tail -n 2 sync.log | head -n 1  | sed 's/.*copied: \([0-9]*\).*/\1/' )
     else
       file_copied=$(tail -1 sync.log  | sed 's/.*copied: \([0-9]*\).*/\1/' )
     fi

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -373,6 +373,10 @@ func getDefaultChunkConf(format *meta.Format) *chunk.Config {
 	return chunkConf
 }
 
+func (j *juiceFS) Shutdown() {
+	_ = j.jfs.Meta().CloseSession()
+}
+
 func newJFS(endpoint, accessKey, secretKey, token string) (object.ObjectStorage, error) {
 	metaUrl := os.Getenv(endpoint)
 	if metaUrl == "" {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -466,6 +466,10 @@ func doSync(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		object.Shutdown(src)
+		object.Shutdown(dst)
+	}()
 	if config.StorageClass != "" {
 		if os, ok := dst.(object.SupportStorageClass); ok {
 			err := os.SetStorageClass(config.StorageClass)


### PR DESCRIPTION
fix #5203