### PR TITLE
cmd/mount: add `max-readahead` option to set the max buffer of each readahead

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -174,7 +174,6 @@ func dataCacheFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:  "max-readahead",
-			Value: "32M",
 			Usage: "max buffering for read ahead in MiB",
 		},
 		&cli.IntFlag{

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -172,6 +172,11 @@ func dataCacheFlags() []cli.Flag {
 			Value: "300M",
 			Usage: "total read/write buffering in MiB",
 		},
+		&cli.StringFlag{
+			Name:  "max-readahead",
+			Value: "32M",
+			Usage: "max buffering for read ahead in MiB",
+		},
 		&cli.IntFlag{
 			Name:  "prefetch",
 			Value: 1,

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -341,6 +341,7 @@ func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 		Writeback:     c.Bool("writeback"),
 		Prefetch:      c.Int("prefetch"),
 		BufferSize:    utils.ParseBytes(c, "buffer-size", 'M'),
+		Readahead:     int(utils.ParseBytes(c, "max-readahead", 'M')),
 		UploadLimit:   utils.ParseMbps(c, "upload-limit") * 1e6 / 8,
 		DownloadLimit: utils.ParseMbps(c, "download-limit") * 1e6 / 8,
 		UploadDelay:   utils.Duration(c.String("upload-delay")),

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -702,7 +702,7 @@ func NewDataReader(conf *Config, m meta.Meta, store chunk.ChunkStore) DataReader
 		readAheadTotal = int(conf.Chunk.BufferSize / 10 * 8) // 80% of total buffer
 	}
 	if conf.Chunk.Readahead > 0 {
-		readAheadMax = conf.Chunk.Readahead
+		readAheadMax = utils.Min(conf.Chunk.Readahead, readAheadTotal)
 	}
 	r := &dataReader{
 		m:              m,


### PR DESCRIPTION
#5224