### PR TITLE
Allow user to disable readahead by setting `max-readahead` smaller than blocksize

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -174,7 +174,7 @@ func dataCacheFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:  "max-readahead",
-			Usage: "max buffering for read ahead in MiB",
+			Usage: "max buffering for read ahead in MiB per read session",
 		},
 		&cli.IntFlag{
 			Name:  "prefetch",

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -418,7 +418,7 @@ func (f *fileReader) checkReadahead(block *frange) int {
 	seqdata := ses.total
 	readahead := ses.readahead
 	used := uint64(atomic.LoadInt64(&readBufferUsed))
-	if readahead == 0 && (block.off == 0 || seqdata > block.len) { // begin with read-ahead turned on
+	if readahead == 0 && f.r.blockSize <= f.r.readAheadMax && (block.off == 0 || seqdata > block.len) { // begin with read-ahead turned on
 		ses.readahead = f.r.blockSize
 	} else if readahead < f.r.readAheadMax && seqdata >= readahead && f.r.readAheadTotal-used > readahead*4 {
 		ses.readahead *= 2


### PR DESCRIPTION
Allow user to disable read-ahead when he is doing random read - to reduce read amplification and improve read latency.