### PR TITLE
object/ufile: implement limits interface  for us3 to support the multipart upload

### DIFF
--- a/pkg/object/ufile.go
+++ b/pkg/object/ufile.go
@@ -45,6 +45,17 @@ func (u *ufile) String() string {
 	return fmt.Sprintf("ufile://%s/", uri.Host)
 }
 
+func (u *ufile) Limits() Limits {
+	// only support 4MB part size and max object size: 5TB
+	return Limits{
+		IsSupportMultipartUpload: true,
+		IsSupportUploadPartCopy:  false,
+		MinPartSize:              4 << 20,
+		MaxPartSize:              4 << 20,
+		MaxPartCount:             1310720,
+	}
+}
+
 func ufileSigner(req *http.Request, accessKey, secretKey, signName string) {
 	if accessKey == "" {
 		return


### PR DESCRIPTION

<img width="1480" alt="image" src="https://github.com/user-attachments/assets/d6ec531d-1d89-4312-baa0-0a4e8be1944d">

close https://github.com/juicedata/juicefs/issues/5234