### PR TITLE
feat: Add ability to configure client TLS

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -238,30 +238,15 @@ func createStorage(format meta.Format) (object.ObjectStorage, error) {
 		}
 
 		// Configure client TLS when params are provided
-		caCerts := values.Get("ca-certs")
-		if os.Getenv("JFS_CA_CERTS") != "" {
-			caCerts = os.Getenv("JFS_CA_CERTS")
-		}
+		if values.Get("ca-certs") != "" && values.Get("ssl-cert") != "" && values.Get("ssl-key") != "" {
 
-		sslCert := values.Get("ssl-cert")
-		if os.Getenv("JFS_SSL_CERT") != "" {
-			sslCert = os.Getenv("JFS_SSL_CERT")
-		}
-
-		sslKey := values.Get("ssl-key")
-		if os.Getenv("JFS_SSL_KEY") != "" {
-			sslKey = os.Getenv("JFS_SSL_KEY")
-		}
-
-		if caCerts != "" && sslCert != "" && sslKey != "" {
-
-			clientTLSCert, err := tls.LoadX509KeyPair(sslCert, sslKey)
+			clientTLSCert, err := tls.LoadX509KeyPair(values.Get("ssl-cert"), values.Get("ssl-key"))
 			if err != nil {
 				return nil, fmt.Errorf("error loading certificate and key file: %s", err.Error())
 			}
 
 			certPool := x509.NewCertPool()
-			caCertPEM, err := os.ReadFile(caCerts)
+			caCertPEM, err := os.ReadFile(values.Get("ca-certs"))
 			if err != nil {
 				return nil, fmt.Errorf("error loading CA cert file: %s", err.Error())
 			}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -141,18 +141,6 @@ func formatStorageFlags() []cli.Flag {
 			Name:  "storage-class",
 			Usage: "the default storage class",
 		},
-		&cli.StringFlag{
-			Name:  "ca-certs",
-			Usage: "Path to SSL CA certificate file",
-		},
-		&cli.StringFlag{
-			Name:  "ssl-cert",
-			Usage: "Path to client own SSL certificate file",
-		},
-		&cli.StringFlag{
-			Name:  "ssl-key",
-			Usage: "Path to client own SSL certificate private key file",
-		},
 	})
 }
 
@@ -229,6 +217,7 @@ func fixObjectSize(s uint64) uint64 {
 }
 
 func createStorage(format meta.Format) (object.ObjectStorage, error) {
+
 	if err := format.Decrypt(); err != nil {
 		return nil, fmt.Errorf("format decrypt: %s", err)
 	}
@@ -247,28 +236,43 @@ func createStorage(format meta.Format) (object.ObjectStorage, error) {
 			u.RawQuery = values.Encode()
 			format.Bucket = u.String()
 		}
-	}
 
-	// Configure client TLS when params are provided
-	if format.CaCerts != "" && format.SslCert != "" && format.SslKey != "" {
-
-		clientTLSCert, err := tls.LoadX509KeyPair(format.SslCert, format.SslKey)
-		if err != nil {
-			return nil, fmt.Errorf("error loading certificate and key file: %s", err.Error())
+		// Configure client TLS when params are provided
+		caCerts := values.Get("ca-certs")
+		if os.Getenv("JFS_CA_CERTS") != "" {
+			caCerts = os.Getenv("JFS_CA_CERTS")
 		}
 
-		certPool := x509.NewCertPool()
-		caCertPEM, err := os.ReadFile(format.CaCerts)
-		if err != nil {
-			return nil, fmt.Errorf("error loading CA cert file: %s", err.Error())
+		sslCert := values.Get("ssl-cert")
+		if os.Getenv("JFS_SSL_CERT") != "" {
+			sslCert = os.Getenv("JFS_SSL_CERT")
 		}
 
-		if certAdded := certPool.AppendCertsFromPEM(caCertPEM); !certAdded {
-			return nil, fmt.Errorf("error appending CA cert to pool: %s", err.Error())
+		sslKey := values.Get("ssl-key")
+		if os.Getenv("JFS_SSL_KEY") != "" {
+			sslKey = os.Getenv("JFS_SSL_KEY")
 		}
 
-		object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.RootCAs = certPool
-		object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{clientTLSCert}
+		if caCerts != "" && sslCert != "" && sslKey != "" {
+
+			clientTLSCert, err := tls.LoadX509KeyPair(sslCert, sslKey)
+			if err != nil {
+				return nil, fmt.Errorf("error loading certificate and key file: %s", err.Error())
+			}
+
+			certPool := x509.NewCertPool()
+			caCertPEM, err := os.ReadFile(caCerts)
+			if err != nil {
+				return nil, fmt.Errorf("error loading CA cert file: %s", err.Error())
+			}
+
+			if certAdded := certPool.AppendCertsFromPEM(caCertPEM); !certAdded {
+				return nil, fmt.Errorf("error appending CA cert to pool")
+			}
+
+			object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.RootCAs = certPool
+			object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{clientTLSCert}
+		}
 	}
 
 	if format.Shards > 1 {
@@ -434,12 +438,6 @@ func format(c *cli.Context) error {
 					logger.Warnf("decrypt secrets: %s", err)
 				}
 				format.SecretKey = c.String(flag)
-			case "ca-certs":
-				format.CaCerts = c.String(flag)
-			case "ssl-cert":
-				format.SslCert = c.String(flag)
-			case "ssl-key":
-				format.SslKey = c.String(flag)
 			case "session-token":
 				encrypted = format.KeyEncrypted
 				if err := format.Decrypt(); err != nil && strings.Contains(err.Error(), "secret was removed") {
@@ -472,9 +470,6 @@ func format(c *cli.Context) error {
 			Bucket:           c.String("bucket"),
 			AccessKey:        c.String("access-key"),
 			SecretKey:        c.String("secret-key"),
-			CaCerts:          c.String("ca-certs"),
-			SslCert:          c.String("ssl-cert"),
-			SslKey:           c.String("ssl-key"),
 			SessionToken:     c.String("session-token"),
 			EncryptKey:       loadEncrypt(c.String("encrypt-rsa-key")),
 			EncryptAlgo:      c.String("encrypt-algo"),

--- a/docs/en/reference/how_to_set_up_object_storage.md
+++ b/docs/en/reference/how_to_set_up_object_storage.md
@@ -32,6 +32,9 @@ juicefs format --storage s3 \
 
 When executing the `juicefs format` or `juicefs mount` command, you can set some special options in the form of URL parameters in the `--bucket` option, such as `tls-insecure-skip-verify=true` in `https://myjuicefs.s3.us-east-2.amazonaws.com?tls-insecure-skip-verify=true` is to skip the certificate verification of HTTPS requests.
 
+Client certificates are also supported as they are commonly used for mTLS connections, for example:
+`https://myjuicefs.s3.us-east-2.amazonaws.com?ca-certs=./path/to/ca&ssl-cert=./path/to/cert&ssl-key=./path/to/privatekey`
+
 ## Enable data sharding {#enable-data-sharding}
 
 When creating a file system, multiple buckets can be defined as the underlying storage of the file system through the [`--shards`](../reference/command_reference.mdx#format-data-format-options) option. In this way, the system will distribute the files to multiple buckets based on the hashed value of the file name. Data sharding technology can distribute the load of concurrent writing of large-scale data to multiple buckets, thereby improving the writing performance.

--- a/docs/zh_cn/reference/how_to_set_up_object_storage.md
+++ b/docs/zh_cn/reference/how_to_set_up_object_storage.md
@@ -32,6 +32,9 @@ juicefs format --storage s3 \
 
 在执行 `juicefs format` 或 `juicefs mount` 命令时，可以在 `--bucket` 选项中以 URL 参数的形式设置一些特别的选项，比如 `https://myjuicefs.s3.us-east-2.amazonaws.com?tls-insecure-skip-verify=true` 中的 `tls-insecure-skip-verify=true` 即为跳过 HTTPS 请求的证书验证环节。
 
+客户端证书也受支持，因为它们通常用于 mTLS 连接，例如：
+`https://myjuicefs.s3.us-east-2.amazonaws.com?ca-certs=./path/to/ca&ssl-cert=./path/to/cert&ssl-key=./path/to/privatekey`
+
 ## 配置数据分片（Sharding） {#enable-data-sharding}
 
 创建文件系统时，可以通过 [`--shards`](../reference/command_reference.mdx#format-data-format-options) 选项定义多个 Bucket 作为文件系统的底层存储。这样一来，系统会根据文件名哈希值将文件分散到多个 Bucket 中。数据分片技术可以将大规模数据并发写的负载分散到多个 Bucket 中，从而提高写入性能。

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -78,6 +78,9 @@ type Format struct {
 	Bucket           string
 	AccessKey        string `json:",omitempty"`
 	SecretKey        string `json:",omitempty"`
+	CaCerts          string `json:",omitempty"`
+	SslCert          string `json:",omitempty"`
+	SslKey           string `json:",omitempty"`
 	SessionToken     string `json:",omitempty"`
 	BlockSize        int
 	Compression      string `json:",omitempty"`

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -78,9 +78,6 @@ type Format struct {
 	Bucket           string
 	AccessKey        string `json:",omitempty"`
 	SecretKey        string `json:",omitempty"`
-	CaCerts          string `json:",omitempty"`
-	SslCert          string `json:",omitempty"`
-	SslKey           string `json:",omitempty"`
 	SessionToken     string `json:",omitempty"`
 	BlockSize        int
 	Compression      string `json:",omitempty"`


### PR DESCRIPTION
Hello there! :)

There is no issue for this PR yet (I think I will create it)

This PR adds support for TLS client certificates at transport level. It's intended for those S3 endpoints that are behind mTLS protection. This has been already tested in our endpoints and it's working well

![Screenshot from 2024-10-21 13-46-01](https://github.com/user-attachments/assets/cfb20125-6a8c-46be-b778-b20a05d5710f)

I have added those params as flags under `format` command as this is more expectable by the user. 
I saw you stored some of them as query params, for example `tls-insecure-skip-verify` but equally they are stored in metadata settings

WDYT?

CC: @davies @SandyXSD @zhijian-pro I mention you all as you are the top contributors, so I dunno who to invoke