### PR TITLE
Fix dirHandler: readOff and index offset are not comparable

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -3032,7 +3032,7 @@ func (h *dirHandler) Delete(name string) {
 		return
 	}
 
-	if idx, ok := h.batch.indexes[name]; ok && idx >= h.readOff {
+	if idx, ok := h.batch.indexes[name]; ok && idx+h.batch.offset >= h.readOff {
 		delete(h.batch.indexes, name)
 		n := len(h.batch.entries)
 		if idx < n-1 {
@@ -3058,7 +3058,7 @@ func (h *dirHandler) Insert(inode Ino, name string, attr *Attr) {
 }
 
 func (h *dirHandler) Read(offset int) {
-	h.readOff = offset - len(h.initEntries)
+	h.readOff = offset - len(h.initEntries) // TODO: what if fuse only reads one entry?
 }
 
 func (h *dirHandler) Close() {


### PR DESCRIPTION
* For the redis implementation, they are the same.
* For the kv implementation, `h.batch.indexes` are local offset to the `h.batch.entries`. But `h.readOff` is the global offset (minus the `h.initEntries`). They are not comparable.