### PR TITLE
Fix endless restart loop on exit when user holds a file handler

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -728,7 +728,8 @@ func installHandler(mp string, v *vfs.VFS, blob object.ObjectStorage) {
 				if err := v.FlushAll(""); err != nil {
 					logger.Errorf("flush all: %s", err)
 				}
-				logger.Fatalf("exit after received %s,but umount not finished after 30 seconds, force exit", sig)
+				logger.Errorf("exit after receiving signal %s, but umount does not finish in 30 seconds, force exit", sig)
+				os.Exit(meta.UmountCode)
 			}()
 			go func() { _ = doUmount(mp, true) }()
 		}


### PR DESCRIPTION
The supervisor process will always restart mount process even if it exits after receiving SIGTERM, is it expected?

We observe lots of restart in the logs - it will exit finally, but the restart causes lots of alerts.
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/535e0ca8-0507-4700-9645-4ee4a32beea5">
