### PR TITLE
Fix warmup only has one writer regardless of the number of `--threads` specified

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -146,7 +146,7 @@ func newCacheStore(m *cacheManagerMetrics, dir string, cacheSize int64, pendingP
 		c.dir, humanize.IBytes(uint64(c.capacity)), int(c.freeRatio*100), humanize.FtoaWithDigits(float64((1-br)*100), 1), humanize.FtoaWithDigits(float64((1-fr)*100), 1), pendingPages)
 	c.createLockFile()
 	go c.checkLockFile()
-	go c.flush()
+	go c.flusher()
 	go c.checkFreeSpace()
 	if c.cacheExpire > 0 {
 		go c.cleanupExpire()
@@ -624,9 +624,8 @@ func (cache *cacheStore) stagePath(key string) string {
 }
 
 // flush cached block into disk
-func (cache *cacheStore) flush() {
-	for {
-		w := <-cache.pending
+func (cache *cacheStore) flusher() {
+	for w := range cache.pending {
 		cache.flushFile(w)
 	}
 }

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -407,14 +407,14 @@ func (cache *cacheStore) cache(key string, p *Page, force, dropCache bool) {
 	p.Acquire()
 	cache.pages[key] = p
 	atomic.AddInt64(&cache.totalPages, int64(cap(p.Data)))
-	if force {
-		cache.Unlock()
-		cache.flushFile(pendingFile{key, p, dropCache}) // Write directly and concurrently
-		cache.Lock()
-	} else {
-		select {
-		case cache.pending <- pendingFile{key, p, dropCache}:
-		default:
+	select {
+	case cache.pending <- pendingFile{key, p, dropCache}:
+	default:
+		if force {
+			cache.Unlock()
+			cache.flushFile(pendingFile{key, p, dropCache}) // Write directly and concurrently
+			cache.Lock()
+		} else {
 			// does not have enough bandwidth to write it into disk, discard it
 			logger.Debugf("Caching queue is full (%s), drop %s (%d bytes)", cache.dir, key, len(p.Data))
 			cache.m.cacheDrops.Add(1)


### PR DESCRIPTION
`warmup` is very slow regardless of the number of concurrent workers. It is because `warmup` has many readers but only one writer - the cache flusher.

So instead of waiting for the single writer to drain the queue, we can write directly and concurrently to the cache. I suppose this is the smallest change to make `warmup` obey the `--threads` flag.