### PR TITLE
Support cache blocks after uploading

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -219,8 +219,8 @@ func dataCacheFlags() []cli.Flag {
 			Usage: "cache only random/small read",
 		},
 		&cli.BoolFlag{
-			Name:  "cache-on-write",
-			Usage: "cache blocks after uploading",
+			Name:  "cache-large-write",
+			Usage: "cache full blocks after uploading",
 		},
 		&cli.StringFlag{
 			Name:  "verify-cache-checksum",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -218,6 +218,10 @@ func dataCacheFlags() []cli.Flag {
 			Name:  "cache-partial-only",
 			Usage: "cache only random/small read",
 		},
+		&cli.BoolFlag{
+			Name:  "cache-on-write",
+			Usage: "cache blocks after uploading",
+		},
 		&cli.StringFlag{
 			Name:  "verify-cache-checksum",
 			Value: "full",

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -352,7 +352,7 @@ func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 		FreeSpace:         float32(c.Float64("free-space-ratio")),
 		CacheMode:         os.FileMode(cm),
 		CacheFullBlock:    !c.Bool("cache-partial-only"),
-		CacheOnWrite:      c.Bool("cache-on-write"),
+		CacheLargeWrite:   c.Bool("cache-large-write"),
 		CacheChecksum:     c.String("verify-cache-checksum"),
 		CacheEviction:     c.String("cache-eviction"),
 		CacheScanInterval: utils.Duration(c.String("cache-scan-interval")),

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -352,6 +352,7 @@ func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 		FreeSpace:         float32(c.Float64("free-space-ratio")),
 		CacheMode:         os.FileMode(cm),
 		CacheFullBlock:    !c.Bool("cache-partial-only"),
+		CacheOnWrite:      c.Bool("cache-on-write"),
 		CacheChecksum:     c.String("verify-cache-checksum"),
 		CacheEviction:     c.String("cache-eviction"),
 		CacheScanInterval: utils.Duration(c.String("cache-scan-interval")),

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -391,7 +391,7 @@ func (store *cachedStore) upload(key string, block *Page, s *wSlice) error {
 		buf.Acquire()
 	}
 	defer buf.Release()
-	if sync && blen < store.conf.BlockSize {
+	if sync && (blen < store.conf.BlockSize || store.conf.CacheOnWrite) {
 		// block will be freed after written into disk
 		store.bcache.cache(key, block, false, false)
 	}
@@ -568,6 +568,7 @@ type Config struct {
 	GetTimeout        time.Duration
 	PutTimeout        time.Duration
 	CacheFullBlock    bool
+	CacheOnWrite      bool
 	BufferSize        uint64
 	Readahead         int
 	Prefetch          int

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -391,7 +391,7 @@ func (store *cachedStore) upload(key string, block *Page, s *wSlice) error {
 		buf.Acquire()
 	}
 	defer buf.Release()
-	if sync && (blen < store.conf.BlockSize || store.conf.CacheOnWrite) {
+	if sync && (blen < store.conf.BlockSize || store.conf.CacheLargeWrite) {
 		// block will be freed after written into disk
 		store.bcache.cache(key, block, false, false)
 	}
@@ -568,7 +568,7 @@ type Config struct {
 	GetTimeout        time.Duration
 	PutTimeout        time.Duration
 	CacheFullBlock    bool
-	CacheOnWrite      bool
+	CacheLargeWrite   bool
 	BufferSize        uint64
 	Readahead         int
 	Prefetch          int


### PR DESCRIPTION
Benefit scenario: read the most recently written files. One good use case is save/load checkpoint.