### PR TITLE
fix: initialize staging_write_bytes metric as Counter instead of Gauge

### DIFF
--- a/pkg/chunk/metrics.go
+++ b/pkg/chunk/metrics.go
@@ -88,7 +88,7 @@ func (c *cacheManagerMetrics) initMetrics() {
 		Name: "staging_block_bytes",
 		Help: "Total bytes of blocks in the staging path.",
 	})
-	c.stageWriteBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+	c.stageWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "staging_write_bytes",
 		Help: "write bytes of blocks in the staging path.",
 	})


### PR DESCRIPTION
The variable for the `staging_write_bytes` metric is intended to be `prometheus.Counter`, but the code uses Gauge.


https://github.com/juicedata/juicefs/blob/9ddc6d422d1511b0d861849535afcb286bd1af05/pkg/chunk/metrics.go#L32

https://github.com/juicedata/juicefs/blob/9ddc6d422d1511b0d861849535afcb286bd1af05/pkg/chunk/metrics.go#L91-L94

close https://github.com/juicedata/juicefs/issues/5268