### PR TITLE
Fix gc tool never compacts keys with hash-prefix

### DIFF
--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
-	"github.com/juicedata/juicefs/pkg/chunk"
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/object"
 	osync "github.com/juicedata/juicefs/pkg/sync"
@@ -91,15 +89,8 @@ func fsck(ctx *cli.Context) error {
 		return m.Check(c, p, ctx.Bool("repair"), ctx.Bool("recursive"), ctx.Bool("sync-dir-stat"))
 	}
 
-	chunkConf := chunk.Config{
-		BlockSize:  format.BlockSize * 1024,
-		Compress:   format.Compression,
-		GetTimeout: time.Second * 60,
-		PutTimeout: time.Second * 60,
-		MaxUpload:  20,
-		BufferSize: 300 << 20,
-		CacheDir:   "memory",
-	}
+	chunkConf := *getDefaultChunkConf(format)
+	chunkConf.CacheDir = "memory"
 
 	blob, err := createStorage(*format)
 	if err != nil {

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -84,15 +84,8 @@ func gc(ctx *cli.Context) error {
 		logger.Fatalf("load setting: %s", err)
 	}
 
-	chunkConf := chunk.Config{
-		BlockSize:  format.BlockSize * 1024,
-		Compress:   format.Compression,
-		GetTimeout: time.Second * 60,
-		PutTimeout: time.Second * 60,
-		MaxUpload:  20,
-		BufferSize: 300 << 20,
-		CacheDir:   "memory",
-	}
+	chunkConf := *getDefaultChunkConf(format)
+	chunkConf.CacheDir = "memory"
 
 	blob, err := createStorage(*format)
 	if err != nil {

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -68,7 +68,7 @@ func getFileCount(dir string) int {
 
 func TestGc(t *testing.T) {
 	var bucket string
-	mountTemp(t, &bucket, []string{"--trash-days=0"}, nil)
+	mountTemp(t, &bucket, []string{"--trash-days=0", "--hash-prefix"}, nil)
 	defer umountTemp(t)
 
 	if err := writeSmallBlocks(testMountPoint); err != nil {


### PR DESCRIPTION
GC tool hard-coded `chunk.Config` fields with:
```go
chunkConf := chunk.Config{
	BlockSize:  format.BlockSize * 1024,
	Compress:   format.Compression,
	GetTimeout: time.Second * 60,
	PutTimeout: time.Second * 60,
	MaxUpload:  20,
	BufferSize: 300 << 20,
	CacheDir:   "memory",
}
```

This is error-prone - it may miss some fields from `format` added in the future. One such case is `HashPrefix`, where user sets it in the format but the gc tool doesnot pass it to `chunkConf`, which causes the `compact` sub-command never works.