### PR TITLE
Avoid too many error logs - "os: process already finished"

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -790,7 +790,7 @@ func launchMount(mp string, conf *vfs.Config) error {
 					return
 				}
 				logger.Infof("received signal %s, propagating to child process %d...", sig.String(), mountPid)
-				if err := cmd.Process.Signal(sig); err != nil {
+				if err := cmd.Process.Signal(sig); err != nil && !errors.Is(err, os.ErrProcessDone) {
 					logger.Errorf("send signal %s to %d: %s", sig.String(), mountPid, err)
 				}
 			}


### PR DESCRIPTION
Too many error logs:

```
juicefs[1] <ERROR>: send signal terminated to 48: os: process already finished [mount_unix.go:794]
```