### PR TITLE
Avoid concurrency between CloseSession and flushStats

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -221,6 +221,8 @@ type baseMeta struct {
 
 	dirStatsLock sync.Mutex
 	dirStats     map[Ino]dirStat
+
+	fsStatsLock sync.Mutex
 	*fsStat
 
 	parentMu   sync.Mutex     // protect dirParents
@@ -577,7 +579,7 @@ func (m *baseMeta) CloseSession() error {
 	if m.conf.ReadOnly {
 		return nil
 	}
-	m.en.doFlushStats()
+	m.doFlushStats()
 	m.doFlushDirStat()
 	m.doFlushQuotas()
 	m.sesMu.Lock()

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -220,8 +220,14 @@ func (m *baseMeta) doFlushDirStat() {
 func (m *baseMeta) flushStats() {
 	for {
 		time.Sleep(time.Second)
-		m.en.doFlushStats()
+		m.doFlushStats()
 	}
+}
+
+func (m *baseMeta) doFlushStats() {
+	m.fsStatsLock.Lock()
+	m.en.doFlushStats()
+	m.fsStatsLock.Unlock()
 }
 
 func (m *baseMeta) checkQuota(ctx Context, space, inodes int64, parents ...Ino) syscall.Errno {


### PR DESCRIPTION
It is possible that same fs stats will be increased/decreased twice, when `CloseSession` and `flushStats` run concurrently.