### PR TITLE
fix warm up reset batch bug

### DIFF
--- a/cmd/warmup.go
+++ b/cmd/warmup.go
@@ -282,7 +282,7 @@ func warmup(ctx *cli.Context) error {
 		if len(batch) >= batchMax {
 			resp := sendCommand(controller, action, batch, threads, background, dspin)
 			total.Add(resp)
-			batch = batch[0:]
+			batch = batch[:0]
 		}
 	}
 	if len(batch) > 0 {


### PR DESCRIPTION
fix when warm up paths more then batchMax, fill same file repeat.