### PR TITLE
nit(cgroup): correct device path construction for cgroup management

### DIFF
--- a/pkg/fuse/device_linux.go
+++ b/pkg/fuse/device_linux.go
@@ -70,8 +70,8 @@ func grantAccess() error {
 		return errors.Errorf("fail to find device cgroup")
 	}
 
-	deviceListPath := path.Join("/sys/fs/cgroup/devices" + deviceCgroup + "/devices.list")
-	deviceAllowPath := "/sys/fs/cgroup/devices" + deviceCgroup + "/devices.allow"
+	deviceListPath := path.Join("/sys/fs/cgroup/devices", deviceCgroup, "/devices.list")
+	deviceAllowPath := path.Join("/sys/fs/cgroup/devices", deviceCgroup, "/devices.allow")
 
 	// check if fuse is already allowed
 	deviceListFile, err := os.OpenFile(deviceListPath, os.O_RDONLY, 0)


### PR DESCRIPTION
This commit fixes incorrect device path construction in `cgroup` management. In the original code, [`path.Join`](https://pkg.go.dev/path#Join) was used incorrectly with a single concatenated string, rather than passing individual path components as separate arguments.