### PR TITLE
Avoid txn conflicts between write and compact on the same inode

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2794,7 +2794,7 @@ func (m *dbMeta) doCompactChunk(inode Ino, indx uint32, origin []byte, ss []*sli
 			}
 		}
 		return nil
-	}))
+	}, inode))
 	// there could be false-negative that the compaction is successful, double-check
 	if st != 0 && st != syscall.EINVAL {
 		var ok bool

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2365,7 +2365,7 @@ func (m *kvMeta) doCompactChunk(inode Ino, indx uint32, buf []byte, ss []*slice,
 			}
 		}
 		return nil
-	}))
+	}, inode)) // less conflicts with `write`
 	// there could be false-negative that the compaction is successful, double-check
 	if st != 0 && st != syscall.EINVAL {
 		refs, e := m.get(m.sliceKey(id, size))


### PR DESCRIPTION
We observed many txn conflicts between `write` and `compact` when using TiKV, especially when users have many small IOs. TiKV's txn conflicts are very expensive, we can avoid them on the client side by using inode-granularity locks.
One downside of this change is that compaction between chunks within an inode cannot be performed concurrently, but considering chunks are 64M, so the probability of small IOs spanning multiple chunks is relatively low.

```
method: doCompactChunk, error: write conflict { start_ts:453879141784617034 conflict_ts:453879141784617033 primary:"xia\375A\013\000\003\000\000\000\000\000C\000\000\000\000" reason:Optimistic
```