### PR TITLE
Donot hang when showing stack traces

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -59,12 +59,16 @@ func showThreadStack(agentAddr string) {
 	if agentAddr == "" {
 		return
 	}
-	resp, err := http.Get(fmt.Sprintf("http://%s/debug/pprof/goroutine?debug=2", agentAddr))
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(fmt.Sprintf("http://%s/debug/pprof/goroutine?debug=2", agentAddr))
 	if err != nil {
 		logger.Warnf("list goroutine from %s: %s", agentAddr, err)
 	} else {
 		grs, _ := io.ReadAll(resp.Body)
 		logger.Infof("list goroutines from %s:\n%s", agentAddr, string(grs))
+		_ = resp.Body.Close()
 	}
 }
 


### PR DESCRIPTION
Mount process and supervisor process occasionally hang and require manual killing. It turns out the supervisor process hangs while accessing mount process's pprof interface. A timeout is needed to prevent it from waiting indefinitely.

![img_v3_02gt_23b633fc-a613-4588-bc1c-0953eb1638bg](https://github.com/user-attachments/assets/06b26b68-574d-4d77-a226-b5892c689981)
