### PR TITLE
vfs/setxattr: ignore all unsupported xattr flags on the MacOS platform

### DIFF
--- a/pkg/meta/utils_darwin.go
+++ b/pkg/meta/utils_darwin.go
@@ -18,4 +18,5 @@ const (
 	XattrCreate          = sys.XATTR_CREATE
 	XattrReplace         = sys.XATTR_REPLACE
 	XattrNoSecurity      = sys.XATTR_NOSECURITY
+	XattrNoFollow        = sys.XATTR_NOFOLLOW
 )

--- a/pkg/meta/utils_darwin.go
+++ b/pkg/meta/utils_darwin.go
@@ -17,10 +17,4 @@ const (
 	XattrCreateOrReplace = 0
 	XattrCreate          = sys.XATTR_CREATE
 	XattrReplace         = sys.XATTR_REPLACE
-
-	//not supported
-	XattrNoSecurity      = sys.XATTR_NOSECURITY
-	XattrNODEFAULT       = sys.XATTR_NODEFAULT
-	XattrNoFollow        = sys.XATTR_NOFOLLOW
-	XattrSHOWCOMPRESSION = sys.XATTR_SHOWCOMPRESSION
 )

--- a/pkg/meta/utils_darwin.go
+++ b/pkg/meta/utils_darwin.go
@@ -17,6 +17,10 @@ const (
 	XattrCreateOrReplace = 0
 	XattrCreate          = sys.XATTR_CREATE
 	XattrReplace         = sys.XATTR_REPLACE
+
+	//not supported
 	XattrNoSecurity      = sys.XATTR_NOSECURITY
+	XattrNODEFAULT       = sys.XATTR_NODEFAULT
 	XattrNoFollow        = sys.XATTR_NOFOLLOW
+	XattrSHOWCOMPRESSION = sys.XATTR_SHOWCOMPRESSION
 )

--- a/pkg/meta/utils_linux.go
+++ b/pkg/meta/utils_linux.go
@@ -17,8 +17,4 @@ const (
 	XattrCreateOrReplace = 0
 	XattrCreate          = sys.XATTR_CREATE
 	XattrReplace         = sys.XATTR_REPLACE
-	XattrNoSecurity      = 8
-	XattrNODEFAULT       = 10
-	XattrNoFollow        = 16
-	XattrSHOWCOMPRESSION = 20
 )

--- a/pkg/meta/utils_linux.go
+++ b/pkg/meta/utils_linux.go
@@ -18,5 +18,7 @@ const (
 	XattrCreate          = sys.XATTR_CREATE
 	XattrReplace         = sys.XATTR_REPLACE
 	XattrNoSecurity      = 8
+	XattrNODEFAULT       = 10
 	XattrNoFollow        = 16
+	XattrSHOWCOMPRESSION = 20
 )

--- a/pkg/meta/utils_linux.go
+++ b/pkg/meta/utils_linux.go
@@ -18,4 +18,5 @@ const (
 	XattrCreate          = sys.XATTR_CREATE
 	XattrReplace         = sys.XATTR_REPLACE
 	XattrNoSecurity      = 8
+	XattrNoFollow        = 16
 )

--- a/pkg/meta/utils_windows.go
+++ b/pkg/meta/utils_windows.go
@@ -31,4 +31,5 @@ const (
 	XattrCreate          = 1
 	XattrReplace         = 2
 	XattrNoSecurity      = 8
+	XattrNoFollow        = 16
 )

--- a/pkg/meta/utils_windows.go
+++ b/pkg/meta/utils_windows.go
@@ -31,5 +31,7 @@ const (
 	XattrCreate          = 1
 	XattrReplace         = 2
 	XattrNoSecurity      = 8
+	XattrNODEFAULT       = 10
 	XattrNoFollow        = 16
+	XattrSHOWCOMPRESSION = 20
 )

--- a/pkg/meta/utils_windows.go
+++ b/pkg/meta/utils_windows.go
@@ -30,8 +30,4 @@ const (
 	XattrCreateOrReplace = 0
 	XattrCreate          = 1
 	XattrReplace         = 2
-	XattrNoSecurity      = 8
-	XattrNODEFAULT       = 10
-	XattrNoFollow        = 16
-	XattrSHOWCOMPRESSION = 20
 )

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1036,7 +1036,7 @@ const (
 	xattrMaxSize = 65536
 )
 
-var macUnSupportFlags = meta.XattrNoSecurity | meta.XattrNODEFAULT | meta.XattrNoFollow | meta.XattrSHOWCOMPRESSION
+var macSupportFlags = meta.XattrCreateOrReplace | meta.XattrCreate | meta.XattrReplace
 
 func (v *VFS) SetXattr(ctx Context, ino Ino, name string, value []byte, flags uint32) (err syscall.Errno) {
 	defer func() { logit(ctx, "setxattr", err, "(%d,%s,%d,%d)", ino, name, len(value), flags) }()
@@ -1080,9 +1080,9 @@ func (v *VFS) SetXattr(ctx Context, ino Ino, name string, value []byte, flags ui
 		err = v.Meta.SetFacl(ctx, ino, aclType, rule)
 		v.invalidateAttr(ino)
 	} else {
-		// ignore unsupported flags
-		if runtime.GOOS == "darwin" && (flags&uint32(macUnSupportFlags) != 0) {
-			flags &= ^uint32(macUnSupportFlags)
+		// only retain supported flags
+		if runtime.GOOS == "darwin" {
+			flags &= uint32(macSupportFlags)
 		}
 		err = v.Meta.SetXattr(ctx, ino, name, value, flags)
 	}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1082,6 +1082,9 @@ func (v *VFS) SetXattr(ctx Context, ino Ino, name string, value []byte, flags ui
 		if runtime.GOOS == "darwin" && (flags&meta.XattrNoSecurity) != 0 {
 			flags &= ^uint32(meta.XattrNoSecurity)
 		}
+		if runtime.GOOS == "darwin" && (flags&meta.XattrNoFollow) != 0 {
+			flags &= ^uint32(meta.XattrNoFollow)
+		}
 		err = v.Meta.SetXattr(ctx, ino, name, value, flags)
 	}
 	return


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/5328
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/cf7d1d1f-8545-4feb-8842-f89be38aef47">
