### PR TITLE
log ErrReplicating

### DIFF
--- a/pkg/object/hdfs.go
+++ b/pkg/object/hdfs.go
@@ -175,7 +175,11 @@ func (h *hdfsclient) Put(key string, in io.Reader, getters ...AttrGetter) (err e
 
 func IsErrReplicating(err error) bool {
 	pe, ok := err.(*os.PathError)
-	return ok && pe.Err == hdfs.ErrReplicating
+	if ok && pe.Err == hdfs.ErrReplicating {
+		logger.Warnf("close: %s", err)
+		return true
+	}
+	return false
 }
 
 func (h *hdfsclient) Delete(key string, getters ...AttrGetter) error {


### PR DESCRIPTION
When data has been acked from datanode and not reported to namenode. ErrReplicating will be returned. It's safe to ignore this and let the hdfs lease expire on its own