### PR TITLE
Reduce scan interval in cleanupDeletedFiles

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -608,14 +608,18 @@ func (m *baseMeta) cleanupDeletedFiles() {
 		if ok, err := m.en.setIfSmall("lastCleanupFiles", time.Now().Unix(), int64(time.Hour.Seconds())*9/10); err != nil {
 			logger.Warnf("checking counter lastCleanupFiles: %s", err)
 		} else if ok {
-			files, err := m.en.doFindDeletedFiles(time.Now().Add(-time.Hour).Unix(), 10000)
+			files, err := m.en.doFindDeletedFiles(time.Now().Add(-time.Hour).Unix(), 6e5)
 			if err != nil {
 				logger.Warnf("scan deleted files: %s", err)
 				continue
 			}
+			start := time.Now()
 			for inode, length := range files {
 				logger.Debugf("cleanup chunks of inode %d with %d bytes", inode, length)
 				m.en.doDeleteFileData(inode, length)
+				if time.Since(start) > 50*time.Minute { // Yield my time slice to avoid conflicts with other clients
+					break
+				}
 			}
 		}
 	}

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -604,8 +604,8 @@ func (m *baseMeta) Init(format *Format, force bool) error {
 
 func (m *baseMeta) cleanupDeletedFiles() {
 	for {
-		utils.SleepWithJitter(time.Minute)
-		if ok, err := m.en.setIfSmall("lastCleanupFiles", time.Now().Unix(), int64(time.Minute.Seconds())*9/10); err != nil {
+		utils.SleepWithJitter(time.Hour)
+		if ok, err := m.en.setIfSmall("lastCleanupFiles", time.Now().Unix(), int64(time.Hour.Seconds())*9/10); err != nil {
 			logger.Warnf("checking counter lastCleanupFiles: %s", err)
 		} else if ok {
 			files, err := m.en.doFindDeletedFiles(time.Now().Add(-time.Hour).Unix(), 10000)


### PR DESCRIPTION
In most cases, `cleanupDeletedFiles` runs without doing anything. We can reduce scan calls to meta engine by decreasing the check frequency to an hourly basis.