### PR TITLE
fix(obj-gluster): use OpenDir for directories, avoid segmentation fault

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/json-iterator/go v1.1.12
 	github.com/juicedata/godaemon v0.0.0-20210629045518-3da5144a127d
-	github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825
+	github.com/juicedata/gogfapi v0.0.0-20241204082332-ecd102647f80
 	github.com/juju/ratelimit v1.0.2
 	github.com/ks3sdklib/aws-sdk-go v1.2.2
 	github.com/l0wl3vel/bunny-storage-go-sdk v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/juicedata/go-nfs-client v0.0.0-20231018052507-dbca444fa7e8 h1:mVVipCb
 github.com/juicedata/go-nfs-client v0.0.0-20231018052507-dbca444fa7e8/go.mod h1:xOMqi3lOrcGe9uZLnSzgaq94Vc3oz6VPCNDLJUnXpKs=
 github.com/juicedata/godaemon v0.0.0-20210629045518-3da5144a127d h1:kpQMvNZJKGY3PTt7OSoahYc4nM0HY67SvK0YyS0GLwA=
 github.com/juicedata/godaemon v0.0.0-20210629045518-3da5144a127d/go.mod h1:dlxKkLh3qAIPtgr2U/RVzsZJDuXA1ffg+Njikfmhvgw=
-github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825 h1:7KrwI4HPqvNLKVcfkfDMLQQmT0GrnCs8T9EX+XCdZnM=
-github.com/juicedata/gogfapi v0.0.0-20230626071140-fc28e5537825/go.mod h1:Ho5G4KgrgbMKW0buAJdOmYoJcOImkzznJQaLiATrsx4=
+github.com/juicedata/gogfapi v0.0.0-20241204082332-ecd102647f80 h1:EPg/f3lhbAOjE2M0WpVi47Fk62mEmmPejRuGVdOFQww=
+github.com/juicedata/gogfapi v0.0.0-20241204082332-ecd102647f80/go.mod h1:Ho5G4KgrgbMKW0buAJdOmYoJcOImkzznJQaLiATrsx4=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible h1:2/ttSmYoX+QMegpNyAJR0Y6aHcVk57F7RJit5xN2T/s=
 github.com/juicedata/huaweicloud-sdk-go-obs v3.22.12-0.20230228031208-386e87b5c091+incompatible/go.mod h1:Ukwa8ffRQLV6QRwpqGioPjn2Wnf7TBDA4DbennDOqHE=
 github.com/juicedata/minio v0.0.0-20240912134328-6a47725331ab h1:cmTF/dm61Yrivgmr/5tGB4GsChiF7j30VjKf7nEnD5k=

--- a/pkg/object/gluster.go
+++ b/pkg/object/gluster.go
@@ -162,7 +162,7 @@ func (g *gluster) Delete(key string, getters ...AttrGetter) error {
 // a sorted list of directory entries.
 func (g *gluster) readDirSorted(dirname string, followLink bool) ([]*mEntry, error) {
 	v := g.vol()
-	f, err := v.Open(dirname)
+	f, err := v.OpenDir(dirname)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
close #5211 #4043 

This problem with libgfapi is caused by this PR https://github.com/gluster/glusterfs/pull/3755.

glfd->entries should be initiated at first like in [pub_glfs_opendir](https://github.com/anoopcs9/glusterfs/blob/0b3e23d67f7a307b0b5b5bad6ad152f2a50188ee/api/src/glfs-fops.c#L3320).
In [pub_glfs_open](https://github.com/anoopcs9/glusterfs/blob/0b3e23d67f7a307b0b5b5bad6ad152f2a50188ee/api/src/glfs-fops.c#L420), it's not initiated and returned without error, which leads to segmentation when calling readdir.