### PR TITLE
Fix watchdog thread for umount may hang

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -736,7 +736,13 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 				logger.Errorf("exit after receiving signal %s, but umount does not finish in 30 seconds, force exit", sig)
 				os.Exit(meta.UmountCode)
 			}()
-			go func() { _ = doUmount(mp, true) }()
+			go func() {
+				if err := doUmount(mp, true); err != nil {
+					logger.Warnf("Umount failed: %s", err)
+				}
+				time.Sleep(time.Second * 30)
+				os.Exit(meta.UmountCode) // Just in case the above watchdog thread hangs
+			}()
 		}
 	}()
 }

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -739,9 +739,9 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 			go func() {
 				if err := doUmount(mp, true); err != nil {
 					logger.Warnf("Umount failed: %s", err)
+					time.Sleep(time.Second * 30)
+					os.Exit(meta.UmountCode) // Just in case the above watchdog thread hangs
 				}
-				time.Sleep(time.Second * 30)
-				os.Exit(meta.UmountCode) // Just in case the above watchdog thread hangs
 			}()
 		}
 	}()


### PR DESCRIPTION
We still observe unkillable juicefs processes in our environment, here is one scenario:

1. `doUmount` call has finished, but it failed.
2. watch dog thread for `doUmount` stucks in `FlushAll`.

The watch dog thread is used to monitor `doUmount` thread, but I think a reverse watch mechanism also needed.

<img width="702" alt="image" src="https://github.com/user-attachments/assets/a2185bdd-8e06-4135-a9f8-aed1e86ae705">