### PR TITLE
Hadoop: fix background task thread leak

### DIFF
--- a/.github/workflows/mutate-test-sdk.yml
+++ b/.github/workflows/mutate-test-sdk.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
 
       - name: Run Redis

--- a/.github/workflows/sdktest.yml
+++ b/.github/workflows/sdktest.yml
@@ -63,9 +63,9 @@ jobs:
           ln -s inner_sym_target inner_sym_link 
           mkdir etc
           chmod 777 etc
-          echo `hostname` > /jfs/etc/nodes
-          echo "tom:3001" > /jfs/etc/users
-          echo "g1:2001:tom" > /jfs/etc/groups
+          echo `hostname` > etc/nodes
+          echo "tom:3001" > users
+          echo "g1:2001:tom" > groups
 
       - name: Sdk Test
         run: |

--- a/.github/workflows/sdktest.yml
+++ b/.github/workflows/sdktest.yml
@@ -63,7 +63,9 @@ jobs:
           ln -s inner_sym_target inner_sym_link 
           mkdir etc
           chmod 777 etc
-          echo `hostname` > etc/nodes
+          echo `hostname` > /jfs/etc/nodes
+          echo "tom:3001" > /jfs/etc/users
+          echo "g1:2001:tom" > /jfs/etc/groups
 
       - name: Sdk Test
         run: |

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystem.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystem.java
@@ -66,7 +66,8 @@ public class JuiceFileSystem extends FilterFileSystem {
   public void initialize(URI uri, Configuration conf) throws IOException {
     super.initialize(uri, conf);
     fileChecksumEnabled = Boolean.parseBoolean(getConf(conf, "file.checksum", "false"));
-    if (!Boolean.parseBoolean(getConf(conf, "disable-trash-emptier", "false"))) {
+    boolean asBgTask = conf.getBoolean("juicefs.internal-bg-task", false);
+    if (!asBgTask && !Boolean.parseBoolean(getConf(conf, "disable-trash-emptier", "false"))) {
       try {
         Configuration newConf = new Configuration(conf);
         newConf.setBoolean("juicefs.internal-bg-task", true);

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -450,7 +450,9 @@ public class JuiceFileSystemImpl extends FileSystem {
       throw new IOException("JuiceFS initialized failed for jfs://" + name);
     }
     boolean asBgTask = conf.getBoolean("juicefs.internal-bg-task", false);
-    if (!asBgTask) {
+    if (asBgTask) {
+      LOG.debug("background fs {}|({})", name, handle);
+    } else {
       BgTaskUtil.register(name, handle);
     }
     homeDirPrefix = conf.get("dfs.user.home.dir.prefix", "/user");

--- a/sdk/java/src/main/java/io/juicefs/utils/BgTaskUtil.java
+++ b/sdk/java/src/main/java/io/juicefs/utils/BgTaskUtil.java
@@ -48,7 +48,9 @@ public class BgTaskUtil {
     synchronized (runningInstance) {
       LOG.debug("register instance for {}({})", volName, handle);
       if (!runningInstance.containsKey(volName)) {
-        runningInstance.put(volName, new HashSet<>());
+        Set<Long> handles = new HashSet<>();
+        handles.add(handle);
+        runningInstance.put(volName, handles);
       } else {
         runningInstance.get(volName).add(handle);
       }

--- a/sdk/java/src/main/java/io/juicefs/utils/NodesFetcher.java
+++ b/sdk/java/src/main/java/io/juicefs/utils/NodesFetcher.java
@@ -18,7 +18,6 @@ package io.juicefs.utils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import sun.net.www.protocol.http.Handler;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -39,8 +38,6 @@ public abstract class NodesFetcher {
   protected File cacheFolder = new File("/tmp/.juicefs");
   protected File cacheFile;
   private String jfsName;
-
-  private static Handler handler = new Handler();
 
   public NodesFetcher(String jfsName) {
     this.jfsName = jfsName;
@@ -121,7 +118,7 @@ public abstract class NodesFetcher {
 
     HttpURLConnection con = null;
     try {
-      con = (HttpURLConnection) new URL(null, url, handler).openConnection();
+      con = (HttpURLConnection) new URL(url).openConnection();
       con.setConnectTimeout(timeout * 1000);
       con.setReadTimeout(timeout * 1000);
 

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemBgTaskTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemBgTaskTest.java
@@ -1,3 +1,18 @@
+/*
+ * JuiceFS, Copyright 2024 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.juicefs;
 
 import io.juicefs.utils.BgTaskUtil;

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemBgTaskTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemBgTaskTest.java
@@ -20,8 +20,8 @@ public class JuiceFileSystemBgTaskTest extends TestCase {
     conf.addResource(JuiceFileSystemTest.class.getClassLoader().getResourceAsStream("core-site.xml"));
     conf.set(FS_TRASH_INTERVAL_KEY, "6");
     conf.set(FS_TRASH_CHECKPOINT_INTERVAL_KEY, "2");
-    conf.set("juicefs.users", "jfs://dev/etc/users");
-    conf.set("juicefs.groups", "jfs://dev/etc/groups");
+    conf.set("juicefs.users", "jfs://dev/users");
+    conf.set("juicefs.groups", "jfs://dev/groups");
     conf.set("juicefs.discover-nodes-url", "jfs://dev/etc/nodes");
     int threads = 100;
     int instances = 1000;
@@ -32,7 +32,7 @@ public class JuiceFileSystemBgTaskTest extends TestCase {
         try (JuiceFileSystem jfs = new JuiceFileSystem()) {
           jfs.initialize(URI.create("jfs://dev/"), conf);
           if (ThreadLocalRandom.current().nextInt(10)%2==0) {
-            jfs.getFileBlockLocations(jfs.getFileStatus(new Path("jfs://dev/etc/users")), 0, 1000);
+            jfs.getFileBlockLocations(jfs.getFileStatus(new Path("jfs://dev/users")), 0, 1000);
           }
         } catch (Exception e) {
           fail("unexpected exception");

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemBgTaskTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemBgTaskTest.java
@@ -1,0 +1,52 @@
+package io.juicefs;
+
+import io.juicefs.utils.BgTaskUtil;
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_CHECKPOINT_INTERVAL_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
+
+public class JuiceFileSystemBgTaskTest extends TestCase {
+  public void testJuiceFileSystemBgTask() throws Exception {
+    FileSystem.closeAll();
+    Configuration conf = new Configuration();
+    conf.addResource(JuiceFileSystemTest.class.getClassLoader().getResourceAsStream("core-site.xml"));
+    conf.set(FS_TRASH_INTERVAL_KEY, "6");
+    conf.set(FS_TRASH_CHECKPOINT_INTERVAL_KEY, "2");
+    conf.set("juicefs.users", "jfs://dev/etc/users");
+    conf.set("juicefs.groups", "jfs://dev/etc/groups");
+    conf.set("juicefs.discover-nodes-url", "jfs://dev/etc/nodes");
+    int threads = 100;
+    int instances = 1000;
+    CountDownLatch latch = new CountDownLatch(instances);
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    for (int i = 0; i < instances; i++) {
+      pool.submit(() -> {
+        try (JuiceFileSystem jfs = new JuiceFileSystem()) {
+          jfs.initialize(URI.create("jfs://dev/"), conf);
+          if (ThreadLocalRandom.current().nextInt(10)%2==0) {
+            jfs.getFileBlockLocations(jfs.getFileStatus(new Path("jfs://dev/etc/users")), 0, 1000);
+          }
+        } catch (Exception e) {
+          fail("unexpected exception");
+        }
+        latch.countDown();
+      });
+    }
+    latch.await();
+    Map<String, ScheduledExecutorService> bgThreadForName = BgTaskUtil.getBgThreadForName();
+    for (String s : bgThreadForName.keySet()) {
+      System.out.println(s);
+    }
+    assertEquals(0, bgThreadForName.size());
+    assertEquals(0, BgTaskUtil.getRunningInstance().size());
+    pool.shutdown();
+  }
+}

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -755,17 +755,21 @@ public class JuiceFileSystemTest extends TestCase {
     Path f = new Path("/test_foo");
     fooFs.create(f).close();
     assertEquals("foo", fooFs.getFileStatus(f).getOwner());
+    fooFs.close();
 
     ou = fs.create(new Path("/etc/users"));
     ou.write("foo:10001\n".getBytes());
     ou.close();
-    FileSystem newFS = FileSystem.newInstance(newConf);
-    assertEquals("10000", fooFs.getFileStatus(f).getOwner());
+    fs.close();
 
-    fooFs.delete(f, false);
+    FileSystem newFS = FileSystem.newInstance(newConf);
+    assertEquals("10000", newFS.getFileStatus(f).getOwner());
+    newFS.delete(f, false);
+    newFS.close();
   }
 
   public void testGuidMappingFromString() throws Exception {
+    fs.close();
     Configuration newConf = new Configuration(cfg);
 
     newConf.set("juicefs.users", "bar:10000;foo:20000;baz:30000");
@@ -778,14 +782,16 @@ public class JuiceFileSystemTest extends TestCase {
     fooFs.setOwner(f, "foo", "user");
     assertEquals("foo", fooFs.getFileStatus(f).getOwner());
     assertEquals("user", fooFs.getFileStatus(f).getGroup());
+    fooFs.close();
 
     newConf.set("juicefs.users", "foo:20001");
     newConf.set("juicefs.groups", "user:1001:foo,bar;admin:2001:baz");
     FileSystem newFS = FileSystem.newInstance(newConf);
-    assertEquals("20000", fooFs.getFileStatus(f).getOwner());
-    assertEquals("1000", fooFs.getFileStatus(f).getGroup());
+    assertEquals("20000", newFS.getFileStatus(f).getOwner());
+    assertEquals("1000", newFS.getFileStatus(f).getGroup());
 
-    fooFs.delete(f, false);
+    newFS.delete(f, false);
+    newFS.close();
   }
 
   public void testTrash() throws Exception {

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -75,6 +75,7 @@ public class JuiceFileSystemTest extends TestCase {
 
   public void tearDown() throws Exception {
     fs.close();
+    FileSystem.closeAll();
   }
 
   public void testFsStatus() throws IOException {

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -18,7 +18,6 @@ package io.juicefs;
 
 import com.google.common.collect.Lists;
 import io.juicefs.utils.AclTransformation;
-import io.juicefs.utils.BgTaskUtil;
 import junit.framework.TestCase;
 import org.apache.commons.io.IOUtils;
 import org.apache.flink.runtime.fs.hdfs.HadoopRecoverableWriter;
@@ -38,7 +37,9 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,7 +49,6 @@ import static org.apache.hadoop.fs.permission.AclEntryScope.ACCESS;
 import static org.apache.hadoop.fs.permission.AclEntryScope.DEFAULT;
 import static org.apache.hadoop.fs.permission.AclEntryType.*;
 import static org.apache.hadoop.fs.permission.FsAction.*;
-import static org.apache.hadoop.fs.permission.FsAction.ALL;
 import static org.junit.Assert.assertArrayEquals;
 
 public class JuiceFileSystemTest extends TestCase {

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -18,6 +18,7 @@ package io.juicefs;
 
 import com.google.common.collect.Lists;
 import io.juicefs.utils.AclTransformation;
+import io.juicefs.utils.BgTaskUtil;
 import junit.framework.TestCase;
 import org.apache.commons.io.IOUtils;
 import org.apache.flink.runtime.fs.hdfs.HadoopRecoverableWriter;
@@ -37,9 +38,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -668,6 +668,7 @@ public class JuiceFileSystemTest extends TestCase {
     writeFile(fs, groups1, "group1:3001:user1\n");
     writeFile(fs, users2, "user2:2001\n");
     writeFile(fs, groups2, "group2:3001:user2\n");
+    fs.close();
 
     Configuration conf = new Configuration(cfg);
     conf.set("juicefs.users", users1.toUri().getPath());
@@ -954,10 +955,12 @@ public class JuiceFileSystemTest extends TestCase {
 
     writeFile(fs, users, "tom:2001\n");
     writeFile(fs, groups, "groupa:3001:tom\ngroupb:3002:tom");
+    fs.close();
 
     Configuration conf = new Configuration(cfg);
     conf.set("juicefs.users", users.toUri().getPath());
     conf.set("juicefs.groups", groups.toUri().getPath());
+    conf.set("juicefs.debug", "true");
 
     FileSystem superFs = createNewFs(conf, "hdfs", new String[]{"hadoop"});
     Path testDir = new Path("/test_multi_group/d1");

--- a/sdk/java/src/test/java/io/juicefs/utils/BgTaskUtilTest.java
+++ b/sdk/java/src/test/java/io/juicefs/utils/BgTaskUtilTest.java
@@ -27,7 +27,8 @@ public class BgTaskUtilTest extends TestCase {
         String volName = volNames[ThreadLocalRandom.current().nextInt(100) % volNames.length];
         try {
           BgTaskUtil.register(volName, handle);
-          BgTaskUtil.startTrashEmptier(volName, FileSystem.get(URI.create("file:///"), new Configuration()), () -> {
+          BgTaskUtil.startTrashEmptier(volName, () -> {
+            LOG.info("tid {} running trash empiter for {}", Thread.currentThread().getId(), volName);
             while (true) {
               try {
                 Thread.sleep(100);

--- a/sdk/java/src/test/java/io/juicefs/utils/BgTaskUtilTest.java
+++ b/sdk/java/src/test/java/io/juicefs/utils/BgTaskUtilTest.java
@@ -1,0 +1,75 @@
+package io.juicefs.utils;
+
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.concurrent.*;
+
+public class BgTaskUtilTest extends TestCase {
+  private static final Logger LOG = LoggerFactory.getLogger(BgTaskUtilTest.class);
+
+  public void testBgTask() throws Exception {
+    String[] volNames = new String[]{"fs1", "fs2", "fs3"};
+    String[] taskNames = new String[]{"task1", "task2", "task3"};
+    int threads = 20;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+    int instances = 100;
+    CountDownLatch latch = new CountDownLatch(instances);
+
+    for (int i = 0; i < instances; i++) {
+      int handle = i + 1;
+      pool.submit(() -> {
+        String volName = volNames[ThreadLocalRandom.current().nextInt(100) % volNames.length];
+        try {
+          BgTaskUtil.register(volName, handle);
+          BgTaskUtil.startTrashEmptier(volName, FileSystem.get(URI.create("file:///"), new Configuration()), () -> {
+            while (true) {
+              try {
+                Thread.sleep(100);
+              } catch (InterruptedException e) {
+                break;
+              }
+            }
+          }, 0, TimeUnit.MINUTES);
+          // put many tasks
+          for (int j = 0; j < 10; j++) {
+            String taskName = taskNames[ThreadLocalRandom.current().nextInt(100) % taskNames.length];
+            BgTaskUtil.putTask(volName,
+                taskName,
+                () -> {
+                  LOG.info("running {}|{}", volName, taskName);
+                  try {
+                    Thread.sleep(ThreadLocalRandom.current().nextInt(2000));
+                  } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                  }
+                },
+                0, 1, TimeUnit.MINUTES
+            );
+          }
+        } catch (Exception e) {
+          LOG.error("unexpected", e);
+        } finally {
+          BgTaskUtil.unregister(volName, handle, () -> {
+            LOG.info("clean {}", volName);
+          });
+          latch.countDown();
+        }
+      });
+    }
+    latch.await();
+    assertEquals(0, BgTaskUtil.getBgThreadForName().size());
+    assertEquals(0, BgTaskUtil.getRunningInstance().size());
+
+    for (StackTraceElement[] elements : Thread.getAllStackTraces().values()) {
+      for (StackTraceElement e : elements) {
+        assertFalse("ClassName: " + e.getClassName(), e.getClassName().contains("juicefs") && !e.getClassName().equals("io.juicefs.utils.BgTaskUtilTest"));
+      }
+    }
+  }
+}

--- a/sdk/java/src/test/resources/log4j.properties
+++ b/sdk/java/src/test/resources/log4j.properties
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppenderk
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n


### PR DESCRIPTION
BgTaskUtil：
    对于同一个 volname 的后台任务只会启动一个实例运行。BgTaskUtil 的 runningInstance 存储了每个 volname 和 handles 之间的映射，当同一个 volname 的所有实例全部关闭，即 BgTaskUtil 内 volname 没有任何 handle 时，清理该 volname 对应的所有后台任务。确保当所有 JuiceFileSystem instance 关闭时，没有线程泄漏。

juicefs.users 和 juicefs.groups 配置的全局 guid 映射会缓存在 main.go 的 ``userGroupCache  // name -> (user -> groups)``  里，每个实例 user  的 groups 会优先查询此 map，如果没有找到，才会使用 java 传入的 group。Java 端后台任务会定期更新 
userGroupCache，默认 1 分钟一次


