### PR TITLE
meta: fix the issue that trash files may be dangling

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2502,7 +2502,7 @@ func (m *baseMeta) scanTrashFiles(ctx Context, scan trashFileScan) error {
 }
 
 func (m *baseMeta) doCleanupTrash(days int, force bool) {
-	edge := time.Now().Add(-time.Duration(24*days+1) * time.Hour)
+	edge := time.Now().Add(-time.Duration(24*days+2) * time.Hour)
 	if force {
 		edge = time.Now()
 	}


### PR DESCRIPTION
Assume the current time is just before 11:00, it's possible that
```
t1(10.999): A checkTrash, using trash directory xxx-10
t2(11.001): B cleanup, removing the trash directory one hour before, which is xxx-10
t3(11.002): A unlink, moving the file F under (already deleted) xxx-10, then F becomes dangling
```