### PR TITLE
meta/sql: retry txn for mariadb when conflict

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -800,6 +800,9 @@ func (m *dbMeta) shouldRetry(err error) bool {
 		logger.Warnf("transaction failed: %s, will retry it. please increase the max number of connections in your database, or use a connection pool.", msg)
 		return true
 	}
+	if strings.Contains(msg, "error 1020 (hy000)") {
+		return true
+	}
 	switch m.Name() {
 	case "sqlite3":
 		return errors.Is(err, errBusy) || strings.Contains(msg, "database is locked")

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -800,16 +800,14 @@ func (m *dbMeta) shouldRetry(err error) bool {
 		logger.Warnf("transaction failed: %s, will retry it. please increase the max number of connections in your database, or use a connection pool.", msg)
 		return true
 	}
-	if strings.Contains(msg, "error 1020 (hy000)") {
-		return true
-	}
 	switch m.Name() {
 	case "sqlite3":
 		return errors.Is(err, errBusy) || strings.Contains(msg, "database is locked")
 	case "mysql":
 		// MySQL, MariaDB or TiDB
+		// error 1020 for MariaDB when conflict
 		return strings.Contains(msg, "try restarting transaction") || strings.Contains(msg, "try again later") ||
-			strings.Contains(msg, "duplicate entry")
+			strings.Contains(msg, "duplicate entry") || strings.Contains(msg, "error 1020 (hy000)")
 	case "postgres":
 		return strings.Contains(msg, "current transaction is aborted") || strings.Contains(msg, "deadlock detected") ||
 			strings.Contains(msg, "duplicate key value") || strings.Contains(msg, "could not serialize access") ||


### PR DESCRIPTION
close #5442

Transaction should have an X lock and wait for it, but MariaDB’s behavior is somewhat inconsistent and it reported an error.

Case: removeDir may conflict on child node (dirStat)