### PR TITLE
Allow kernel to cache readdir entries to reduce overhead of meta engines

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -349,6 +349,10 @@ func metaCacheFlags(defaultEntryCache float64) []cli.Flag {
 			Value: "1.0s",
 			Usage: "dir entry cache timeout",
 		},
+		&cli.BoolFlag{
+			Name:  "readdir-cache",
+			Usage: "enable kernel caching of readdir entries, with timeout controlled by attr-cache flag",
+		},
 		&cli.StringFlag{
 			Name:  "open-cache",
 			Value: "0s",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -351,7 +351,7 @@ func metaCacheFlags(defaultEntryCache float64) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  "readdir-cache",
-			Usage: "enable kernel caching of readdir entries, with timeout controlled by attr-cache flag",
+			Usage: "enable kernel caching of readdir entries, with timeout controlled by attr-cache flag (require linux kernel 4.20+)",
 		},
 		&cli.StringFlag{
 			Name:  "open-cache",

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -844,6 +844,7 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 	conf.AttrTimeout = utils.Duration(c.String("attr-cache"))
 	conf.EntryTimeout = utils.Duration(c.String("entry-cache"))
 	conf.DirEntryTimeout = utils.Duration(c.String("dir-entry-cache"))
+	conf.ReaddirCache = c.Bool("readdir-cache")
 	conf.NonDefaultPermission = c.Bool("non-default-permission")
 	rootSquash := c.String("root-squash")
 	if rootSquash != "" {

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -845,6 +845,15 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 	conf.EntryTimeout = utils.Duration(c.String("entry-cache"))
 	conf.DirEntryTimeout = utils.Duration(c.String("dir-entry-cache"))
 	conf.ReaddirCache = c.Bool("readdir-cache")
+	if conf.ReaddirCache {
+		if conf.AttrTimeout == 0 {
+			logger.Warnf("readdir-cache is enabled without attr-cache, it's performance may be affected")
+		}
+		major, minor := utils.GetKernelVersion()
+		if major < 4 || (major == 4 && minor < 20) {
+			logger.Warnf("readdir-cache requires kernel version 4.20 or higher, current version: %d.%d", major, minor)
+		}
+	}
 	conf.NonDefaultPermission = c.Bool("non-default-permission")
 	rootSquash := c.String("root-squash")
 	if rootSquash != "" {

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -347,6 +347,9 @@ func (fs *fileSystem) OpenDir(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse
 	defer releaseContext(ctx)
 	fh, err := fs.v.Opendir(ctx, Ino(in.NodeId), in.Flags)
 	out.Fh = fh
+	if fs.conf.ReaddirCache {
+		out.OpenFlags |= fuse.FOPEN_CACHE_DIR | fuse.FOPEN_KEEP_CACHE // both flags are required
+	}
 	return fuse.Status(err)
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -128,6 +128,7 @@ type Config struct {
 	AttrTimeout          time.Duration
 	DirEntryTimeout      time.Duration
 	EntryTimeout         time.Duration
+	ReaddirCache         bool
 	BackupMeta           time.Duration
 	BackupSkipTrash      bool
 	FastResolve          bool   `json:",omitempty"`
@@ -422,7 +423,7 @@ func (v *VFS) UpdateLength(inode Ino, attr *meta.Attr) {
 }
 
 func (v *VFS) Readdir(ctx Context, ino Ino, size uint32, off int, fh uint64, plus bool) (entries []*meta.Entry, readAt time.Time, err syscall.Errno) {
-	defer func() { logit(ctx, "readdir", err, "(%d,%d,%d): (%d)", ino, size, off, len(entries)) }()
+	defer func() { logit(ctx, "readdir", err, "(%d,%d,%d,%t): (%d)", ino, size, off, plus, len(entries)) }()
 	h := v.findHandle(ino, fh)
 	if h == nil {
 		err = syscall.EBADF


### PR DESCRIPTION
Some programs rely on frequent `readdir` calls to obtain updates from other processes. One example is [TensorBoard](https://www.tensorflow.org/tensorboard), which is widely used in machine learning area. This imposes a significant load on the backend metadata engine. In our environment, we observed over 200k QPS, but most directories are cold. Therefore, it is necessary to introduce a caching feature to reduce the metadata load.