### PR TITLE
Fix `cleanupDelayedSlices` to respect time limits as expected

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2914,10 +2914,10 @@ func (r *redisMeta) doCleanupDelayedSlices(edge int64) (int, error) {
 					r.deleteSlice(s.Id, s.Size)
 					count++
 				}
+				if time.Since(start) > 50*time.Minute {
+					return stop
+				}
 			}
-		}
-		if time.Since(start) > 50*time.Minute {
-			return stop
 		}
 		return nil
 	})

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2869,9 +2869,12 @@ func (m *dbMeta) doCleanupDelayedSlices(edge int64) (int, error) {
 					m.deleteSlice(s.Id, s.Size)
 					count++
 				}
+				if time.Since(start) > 50*time.Minute {
+					return count, nil
+				}
 			}
 		}
-		if len(result) < batch || time.Since(start) > 50*time.Minute {
+		if len(result) < batch {
 			break
 		}
 	}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2338,9 +2338,12 @@ func (m *kvMeta) doCleanupDelayedSlices(edge int64) (int, error) {
 					m.deleteSlice(s.Id, s.Size)
 					count++
 				}
+				if time.Since(start) > 50*time.Minute {
+					return count, nil
+				}
 			}
 		}
-		if len(keys) < batch || time.Since(start) > 50*time.Minute {
+		if len(keys) < batch {
 			break
 		}
 	}


### PR DESCRIPTION
`m.deleteSlice` may take much longer than limited to delete a large batch, which causes unnecessary txn conflicts. We can avoid that by checking earlier.
![img_v3_02hu_addc8a8d-be03-40c4-bc57-9f30dad3624g](https://github.com/user-attachments/assets/6bc4b1ae-7b0c-40a5-9c5e-08fff8226c93)
