### PR TITLE
Fix link error during stage writing should be considered as failure

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -718,7 +718,7 @@ func (cache *cacheStore) stage(key string, data []byte, keepCache bool) (string,
 		if cache.capacity > 0 && keepCache {
 			path := cache.cachePath(key)
 			cache.createDir(filepath.Dir(path))
-			if err := os.Link(stagingPath, path); err == nil {
+			if err = os.Link(stagingPath, path); err == nil {
 				cache.add(key, -int32(len(data)), uint32(time.Now().Unix()))
 			} else {
 				logger.Warnf("link %s to %s failed: %s", stagingPath, path, err)


### PR DESCRIPTION
When link fails, user won't be able to read the written block until background upload finishes. During this delay, an `EIO` error may occur.