### PR TITLE
Fix a copy-paste error when refactoring `cache-items` flag

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -214,7 +214,7 @@ func (c *cacheStore) enabled() bool {
 }
 
 func (c *cacheStore) full() bool {
-	return c.used > c.capacity || (c.maxItems != 0 && int64(len(c.pages)) > c.maxItems)
+	return c.used > c.capacity || (c.maxItems != 0 && int64(len(c.keys)) > c.maxItems)
 }
 
 func (cache *cacheStore) checkErr(f func() error) error {


### PR DESCRIPTION
`diskcache.full()` is copied from `memcache` implementation.