### PR TITLE
meta/perm: remove x-permission check for readdirplus

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1754,11 +1754,7 @@ func (m *baseMeta) Readdir(ctx Context, inode Ino, plus uint8, entries *[]*Entry
 		return err
 	}
 	defer m.timeit("Readdir", time.Now())
-	var mmask uint8 = MODE_MASK_R
-	if plus != 0 {
-		mmask |= MODE_MASK_X
-	}
-	if st := m.Access(ctx, inode, mmask, &attr); st != 0 {
+	if st := m.Access(ctx, inode, MODE_MASK_R, &attr); st != 0 {
 		return st
 	}
 	if inode == m.root {
@@ -3040,12 +3036,7 @@ func (m *baseMeta) NewDirHandler(ctx Context, inode Ino, plus bool, initEntries 
 		return nil, st
 	}
 	defer m.timeit("NewDirHandler", time.Now())
-	var mmask uint8 = MODE_MASK_R
-	if plus {
-		mmask |= MODE_MASK_X
-	}
-
-	if st = m.Access(ctx, inode, mmask, &attr); st != 0 {
+	if st = m.Access(ctx, inode, MODE_MASK_R, &attr); st != 0 {
 		return nil, st
 	}
 	if inode == m.root {


### PR DESCRIPTION
close #5470

ReaddirPlus does not require checking the directory’s execute (x) permission，it only needs to be checked during lookup entries

The following is a trace of executing 'ls -l test' on a local filesystem, where the mode of test dir is 444. It shows that getdents64 succeeds, but statx fails.
```shell
openat(AT_FDCWD, "test", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 3
newfstatat(3, "", {st_mode=S_IFDIR|0444, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(3, 0x5877af775320 /* 3 entries */, 32768) = 72
statx(AT_FDCWD, "test/f1", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT, STATX_MODE|STATX_NLINK|STATX_UID|STATX_GID|STATX_MTIME|STATX_SIZE, 0x7ffdb3deeb90) = -1 EACCES (Permission denied)
```