### PR TITLE
object: remove leading slash of object key for upload copy

### DIFF
--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -313,6 +313,7 @@ func (s *s3client) UploadPart(key string, uploadID string, num int, body []byte)
 }
 
 func (s *s3client) UploadPartCopy(key string, uploadID string, num int, srcKey string, off, size int64) (*Part, error) {
+	srcKey = strings.TrimPrefix(srcKey, "/")
 	resp, err := s.s3.UploadPartCopy(&s3.UploadPartCopyInput{
 		Bucket:          aws.String(s.bucket),
 		CopySource:      aws.String(s.bucket + "/" + srcKey),


### PR DESCRIPTION
A leading '/' is added for file objects, and UploadPartCopy also add a '/' in CopySource, which leads to the following error.
This patch stripe the leading '/'. 

```
XMinioInvalidObjectName: Object name contains a leading slash.
 status code: 400, request id: 181758CE95205B1E, host id:
```
Tests:
1. sync from file to minio.
2. sync from minio to file.

Tests was done in a hack way to test the upload copy code path.