### PR TITLE
cmd/gc: use MaxDeletes as remove concurrency

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2540,7 +2540,7 @@ func (m *baseMeta) CleanupTrashBefore(ctx Context, edge time.Time, increProgress
 			}
 			for _, se := range subEntries {
 				var c uint64
-				st = m.Remove(ctx, e.Inode, string(se.Name), false, RmrDefaultThreads, &c)
+				st = m.Remove(ctx, e.Inode, string(se.Name), false, m.conf.MaxDeletes, &c)
 				if st == 0 {
 					count += int(c)
 					if increProgress != nil {


### PR DESCRIPTION
use MaxDeletes as remove concurrency, the default value is hardcoded as 50.