### PR TITLE
Gateway - avoid one extra unnecessary delete request

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -548,7 +548,9 @@ func (n *jfsObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBu
 	}
 	defer func() {
 		_ = f.Close(mctx)
-		_ = n.fs.Delete(mctx, tmp)
+		if err != nil {
+			_ = n.fs.Delete(mctx, tmp)
+		}
 	}()
 
 	_, eno = n.fs.CopyFileRange(mctx, src, 0, tmp, 0, 1<<63)
@@ -736,7 +738,11 @@ func (n *jfsObjects) putObject(ctx context.Context, bucket, object string, r *mi
 		err = eno
 		return
 	}
-	defer func() { _ = n.fs.Delete(mctx, tmpname) }()
+	defer func() {
+		if err != nil {
+			_ = n.fs.Delete(mctx, tmpname)
+		}
+	}()
 	var buf = buffPool.Get().(*[]byte)
 	defer buffPool.Put(buf)
 	for {


### PR DESCRIPTION
When everything works fine, it's unnecessary.
```log
2025.01.10 14:27:38.429215 [uid:0,gid:0,pid:0] Create (/.sys/tmp/077b2a5b-b48b-4e4e-a464-a9ed1f6cdbea,666): OK <0.001698>
2025.01.10 14:27:38.431234 [uid:0,gid:0,pid:0] Write (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,1048576): (1048576,OK) <0.000617>
2025.01.10 14:27:38.433948 [uid:0,gid:0,pid:0] Write (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,1048576): (1048576,OK) <0.000604>
2025.01.10 14:27:38.436660 [uid:0,gid:0,pid:0] Write (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,1048576): (1048576,OK) <0.000591>
2025.01.10 14:27:38.443178 [uid:0,gid:0,pid:0] Write (/.sys/tmp/214616a8-d8d9-4fb9-be24-8a71a6ade98c,1048576): (1048576,OK) <0.000113>
2025.01.10 14:27:38.448607 [uid:0,gid:0,pid:0] Write (/.sys/tmp/81bcda59-e571-411d-abcf-11f8deb8b585,1048576): (1048576,OK) <0.000612>
2025.01.10 14:27:38.451519 [uid:0,gid:0,pid:0] Write (/.sys/tmp/81bcda59-e571-411d-abcf-11f8deb8b585,1048576): (1048576,OK) <0.000597>
2025.01.10 14:27:38.454385 [uid:0,gid:0,pid:0] Write (/.sys/tmp/81bcda59-e571-411d-abcf-11f8deb8b585,1048576): (1048576,OK) <0.000565>
2025.01.10 14:27:38.457195 [uid:0,gid:0,pid:0] Write (/.sys/tmp/81bcda59-e571-411d-abcf-11f8deb8b585,1048576): (1048576,OK) <0.000571>
2025.01.10 14:27:38.461097 [uid:0,gid:0,pid:0] Write (/.sys/tmp/3fb3c4f0-7959-48e1-bf86-0949a4f2a1ab,1048576): (1048576,OK) <0.000633>
2025.01.10 14:27:38.463841 [uid:0,gid:0,pid:0] Write (/.sys/tmp/3fb3c4f0-7959-48e1-bf86-0949a4f2a1ab,1048576): (1048576,OK) <0.000599>
2025.01.10 14:27:38.478738 [uid:0,gid:0,pid:0] Write (/.sys/tmp/9c60f7d1-8ba3-4a13-8c13-082751e8fd33,1048576): (1048576,OK) <0.000150>
2025.01.10 14:27:38.481337 [uid:0,gid:0,pid:0] Write (/.sys/tmp/756e46bd-235e-4f58-a82e-b200fd976aa9,1048576): (1048576,OK) <0.000142>
2025.01.10 14:27:38.482807 [uid:0,gid:0,pid:0] Write (/.sys/tmp/81bcda59-e571-411d-abcf-11f8deb8b585,1048576): (1048576,OK) <0.000697>
2025.01.10 14:27:38.483871 [uid:0,gid:0,pid:0] Write (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,1048576): (1048576,OK) <0.000715>
2025.01.10 14:27:38.487114 [uid:0,gid:0,pid:0] Write (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,1048576): (1048576,OK) <0.000684>
2025.01.10 14:27:38.494309 [uid:0,gid:0,pid:0] Close (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b): OK <0.007182>
2025.01.10 14:27:38.495738 [uid:0,gid:0,pid:0] SetXAttr (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,s3-etag,32,0): OK <0.001412>
2025.01.10 14:27:38.497729 [uid:0,gid:0,pid:0] Rename (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b,/.sys/uploads/843dab15-b82e-4a21-b380-26c870c079f8/31,0): OK <0.001977>
2025.01.10 14:27:38.498327 [uid:0,gid:0,pid:0] Delete (/.sys/tmp/7c76ca25-7d65-48a4-a57f-3d5c7fc1b46b): no such file or directory <0.001070>
```