### PR TITLE
fix readahead bug then trying to turn off readahead totally

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,6 +41,14 @@ func Min(a, b int) int {
 	return b
 }
 
+// Max returns max of 2 int
+func Max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func Min64(a, b uint64) uint64 {
 	if a < b {
 		return a

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -697,10 +697,10 @@ type dataReader struct {
 
 func NewDataReader(conf *Config, m meta.Meta, store chunk.ChunkStore) DataReader {
 	var readAheadTotal = 256 << 20
-	var readAheadMax = utils.Min(utils.Max(0, conf.Chunk.Readahead), readAheadTotal)
 	if conf.Chunk.BufferSize > 0 {
 		readAheadTotal = int(conf.Chunk.BufferSize / 10 * 8) // 80% of total buffer
 	}
+	var readAheadMax = utils.Min(utils.Max(0, conf.Chunk.Readahead), readAheadTotal)
 	r := &dataReader{
 		m:              m,
 		store:          store,

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -697,12 +697,9 @@ type dataReader struct {
 
 func NewDataReader(conf *Config, m meta.Meta, store chunk.ChunkStore) DataReader {
 	var readAheadTotal = 256 << 20
-	var readAheadMax = conf.Chunk.BlockSize * 8
+	var readAheadMax = utils.Min(utils.Max(0, conf.Chunk.Readahead), readAheadTotal)
 	if conf.Chunk.BufferSize > 0 {
 		readAheadTotal = int(conf.Chunk.BufferSize / 10 * 8) // 80% of total buffer
-	}
-	if conf.Chunk.Readahead > 0 {
-		readAheadMax = utils.Min(conf.Chunk.Readahead, readAheadTotal)
 	}
 	r := &dataReader{
 		m:              m,


### PR DESCRIPTION
When you try to turn off readahead, you still get traffic you don't expect.
in this fix we limit readaheadMax to zero in case any readahead is turned off.

The question remains what is the expected behavior in the case of the max-readahead==0 parameter