### PR TITLE
build juicefs arm64 binary staticly linked

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,8 +54,8 @@ builds:
       - amd64
   - id: juicefs-linux-arm64
     env:
-      - CC=aarch64-linux-gnu-gcc
-    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}}
+      - CC=/usr/local/aarch64-linux-musl-cross/bin/aarch64-linux-musl-cc
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}} -linkmode external -extldflags '-static'
     main: .
     goos:
       - linux

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/gythialy/golang-cross:v1.21.9-0
 
-RUN apt-get update && apt-get install -y musl-tools && apt -y autoremove && \
+RUN apt-get update && apt-get install -y musl-tools && apt-get -y autoremove && \
     apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    git config --global --add safe.directory /go/src/github.com/juicedata/juicefs
+    git config --global --add safe.directory /go/src/github.com/juicedata/juicefs && \
+    curl -fsSL -o /tmp/aarch64-linux-musl-cross.tgz https://musl.cc/aarch64-linux-musl-cross.tgz && \
+    tar -xf /tmp/aarch64-linux-musl-cross.tgz -C /usr/local/ && rm -f /tmp/aarch64-linux-musl-cross.tgz


### PR DESCRIPTION
* Add arm64 musl-libc cross C compiler toolchain to the build container image
* Using the musl-libc cross C compiler for building in `.goreleaser.yml`