### PR TITLE
Fix send on closed channel panic

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2407,7 +2407,11 @@ func (m *baseMeta) deleteSlice(id uint64, size uint32) {
 		return
 	}
 	if m.dslices != nil {
-		m.dslices <- Slice{Id: id, Size: size}
+		select {
+		case <-m.sessCtx.Done():
+			return
+		case m.dslices <- Slice{Id: id, Size: size}:
+		}
 	} else {
 		m.deleteSlice_(id, size)
 	}


### PR DESCRIPTION
When process terminates and it's deleting slices, a panic happens:

<img width="799" alt="image" src="https://github.com/user-attachments/assets/3837fa6c-cfb4-429f-8ca1-db1d4ecb82b8" />