### PR TITLE
Fix concurrent cache write

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -414,6 +414,10 @@ func (cache *cacheStore) cache(key string, p *Page, force, dropCache bool) {
 	if _, ok := cache.pages[key]; ok {
 		return
 	}
+	k := cache.getCacheKey(key)
+	if _, ok := cache.keys[k]; ok {
+		return
+	}
 	p.Acquire()
 	cache.pages[key] = p
 	atomic.AddInt64(&cache.totalPages, int64(cap(p.Data)))

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -127,7 +127,7 @@ func (c *memcache) load(key string) (ReadCloser, error) {
 		c.pages[key] = memItem{time.Now(), item.page}
 		return NewPageReader(item.page), nil
 	}
-	return nil, errors.New("not found")
+	return nil, errNotCached
 }
 
 func (c *memcache) exist(key string) bool {


### PR DESCRIPTION
Process of cache write:
1. Write `cache.pages`
2. Write `cache.keys`
3. Delete `cache.pages`

When concurrently caching the same key, since we only check existence of `cache.pages`, not `cache.keys`, the same key can be written multiple times, resulting in wasted IO.

This additional overhead is easily reproducible. It can be frequently observed after adding more logs:
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/9c2ff337-aa8e-4bb2-9106-8599421781e6" />

