### PR TITLE
Windows: fixed incorrect permission error returned; fix #5599

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ pkg/meta/testdata
 /juicefs
 /juicefs.ceph
 /juicefs.exe
+/juicefsd.exe
 /juicefs.lite
 dist/

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -30,6 +30,10 @@ func mountFlags() []cli.Flag {
 			Name:  "o",
 			Usage: "other FUSE options",
 		},
+		&cli.StringFlag{
+			Name:  "access-log",
+			Usage: "Access log file",
+		},
 		&cli.BoolFlag{
 			Name:  "as-root",
 			Usage: "Access files as administrator",
@@ -61,6 +65,7 @@ func getDaemonStage() int {
 }
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
+	v.Conf.AccessLog = c.String("access-log")
 	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"))
 }
 


### PR DESCRIPTION
The Winfsp expects a fuse error code returned, however, the juicefs return a syscall error code, leading almost all error codes being converted to the default error code "permission denied".

https://github.com/winfsp/winfsp/blob/4fdec4d37fb4e56b6d810714f5a201e275211aaf/src/dll/fuse/fuse.c#L1127

This Pr extends the original errorconv function, the changes are based on the error.i file from WinFSP. 

https://github.com/winfsp/winfsp/blob/4fdec4d37fb4e56b6d810714f5a201e275211aaf/src/dll/fuse/errno.i#L1

meanwhile, this Pr adds an "access-log" mount option allowing the access log to be written into a file.

## Test

- [x] git init
- [x] Set a small quota and copy a large file. the File Explorer can now correctly display the disk not enough message.
- [x] Mount with the "access-log" option, and confirm the logs are written.  