### PR TITLE
Remove one unnecessary `GetAttr` when deleting from trash

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1356,7 +1356,7 @@ func (m *baseMeta) Unlink(ctx Context, parent Ino, name string, skipCheckTrash .
 	parent = m.checkRoot(parent)
 	var attr Attr
 	err := m.en.doUnlink(ctx, parent, name, &attr, skipCheckTrash...)
-	if err == 0 {
+	if err == 0 && !parent.IsTrash() {
 		var diffLength uint64
 		if attr.Typ == TypeFile {
 			diffLength = attr.Length

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1356,13 +1356,15 @@ func (m *baseMeta) Unlink(ctx Context, parent Ino, name string, skipCheckTrash .
 	parent = m.checkRoot(parent)
 	var attr Attr
 	err := m.en.doUnlink(ctx, parent, name, &attr, skipCheckTrash...)
-	if err == 0 && !parent.IsTrash() {
+	if err == 0 {
 		var diffLength uint64
 		if attr.Typ == TypeFile {
 			diffLength = attr.Length
 		}
 		m.updateDirStat(ctx, parent, -int64(diffLength), -align4K(diffLength), -1)
-		m.updateDirQuota(ctx, parent, -align4K(diffLength), -1)
+		if !parent.IsTrash() {
+			m.updateDirQuota(ctx, parent, -align4K(diffLength), -1)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Currently, we do not have statistics on the trash directory, so it is unnecessary to update the statistics info for trash directory during unlink, and metadata operations can be eliminated to `Lookup` and `Unlink`.

Before:

![img_v3_02j1_96769416-0f9d-44b2-862b-bf01d8a3210g](https://github.com/user-attachments/assets/45f5fdeb-238e-4b8a-b781-5ca9783068eb)
![img_v3_02j1_d40e6752-97ba-4285-a399-b8c4f805032g](https://github.com/user-attachments/assets/ae00fb88-d547-4bbb-8e31-8b08949ba3d3)

