### PR TITLE
Windows: add option to startup juicefs as system service. fix #347, link #1546

### DIFF
--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -70,7 +70,7 @@ func getDaemonStage() int {
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
 	if c.Bool("as-svc") {
-		winfsp.RunAsSystemSerivce(v.Conf.Format.Name)
+		winfsp.RunAsSystemSerivce(v.Conf.Format.Name, c.Args().Get(1))
 		return
 	}
 

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -47,6 +47,10 @@ func mountFlags() []cli.Flag {
 			Name:  "delay-close",
 			Usage: "delay file closing in seconds.",
 		},
+		&cli.BoolFlag{
+			Name:  "as-svc",
+			Usage: "If run as a system service. (support ONLY 1 volume mounting at the same time)",
+		},
 	}
 }
 
@@ -65,6 +69,11 @@ func getDaemonStage() int {
 }
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
+	if c.Bool("as-svc") {
+		winfsp.RunAsSystemSerivce(v.Conf.Format.Name)
+		return
+	}
+
 	v.Conf.AccessLog = c.String("access-log")
 	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"))
 }

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -673,7 +673,7 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	_ = host.Mount(conf.Meta.MountPoint, []string{"-o", options})
 }
 
-func RunAsSystemSerivce(name string) {
+func RunAsSystemSerivce(name string, mountpoint string) {
 	// https://winfsp.dev/doc/WinFsp-Service-Architecture/
 	logger.Info("Running as Windows system service.")
 
@@ -722,14 +722,13 @@ func RunAsSystemSerivce(name string) {
 		logger.Fatalf("Failed to set registry key: %s", err)
 	}
 
-	// calling net use to start service
 	logger.Debug("Starting juicefs service.")
-	cmd := exec.Command("net", "use", "x:", "\\\\juicefs\\"+name)
+	cmd := exec.Command("net", "use", mountpoint, "\\\\juicefs\\"+name)
 	err = cmd.Run()
 	if err != nil {
 		logger.Fatalf("Failed to start service: %s", err)
 	}
 
-	logger.Info("System service started successfully.")
+	logger.Info("Juicefs system service started successfully.")
 
 }

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -22,6 +22,7 @@ package winfsp
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"runtime"
 	"strings"
@@ -35,6 +36,8 @@ import (
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juicedata/juicefs/pkg/vfs"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 var logger = utils.GetLogger("juicefs")
@@ -668,4 +671,65 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	host.SetCapReaddirPlus(true)
 	logger.Debugf("mount point: %s, options: %s", conf.Meta.MountPoint, options)
 	_ = host.Mount(conf.Meta.MountPoint, []string{"-o", options})
+}
+
+func RunAsSystemSerivce(name string) {
+	// https://winfsp.dev/doc/WinFsp-Service-Architecture/
+	logger.Info("Running as Windows system service.")
+
+	cmdLine := strings.Join(os.Args[1:], " ")
+	cmdLine = strings.ReplaceAll(cmdLine, "--as-svc", "")
+	cmdLine = strings.ReplaceAll(cmdLine, "-as-svc", "")
+
+	regKeyPath := "SOFTWARE\\WOW6432Node\\WinFsp\\Services\\juicefs"
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.ALL_ACCESS)
+	if err != nil {
+		if err == syscall.ERROR_FILE_NOT_FOUND || err == syscall.ERROR_PATH_NOT_FOUND {
+			logger.Info("Registry key not found, create it")
+			k, _, err = registry.CreateKey(registry.LOCAL_MACHINE, regKeyPath, registry.ALL_ACCESS)
+			if err != nil {
+				logger.Fatalf("Failed to create registry key: %s", err)
+			}
+		} else {
+			logger.Fatalf("Failed to open registry key: %s", err)
+		}
+	}
+	defer k.Close()
+
+	err = k.SetStringValue("CommandLine", cmdLine)
+	if err != nil {
+		logger.Fatalf("Failed to set registry key: %s", err)
+	}
+
+	securityDescriptor := "D:P(A;;RPWPLC;;;WD)"
+	err = k.SetStringValue("Security", securityDescriptor)
+	if err != nil {
+		logger.Fatalf("Failed to set registry key: %s", err)
+	}
+
+	filePath, err := os.Executable()
+	if err != nil {
+		logger.Fatalf("Failed to get current file path: %s", err)
+	}
+
+	err = k.SetStringValue("Executable", filePath)
+	if err != nil {
+		logger.Fatalf("Failed to set registry key: %s", err)
+	}
+
+	err = k.SetDWordValue("JobControl", 1)
+	if err != nil {
+		logger.Fatalf("Failed to set registry key: %s", err)
+	}
+
+	// calling net use to start service
+	logger.Debug("Starting juicefs service.")
+	cmd := exec.Command("net", "use", "x:", "\\\\juicefs\\"+name)
+	err = cmd.Run()
+	if err != nil {
+		logger.Fatalf("Failed to start service: %s", err)
+	}
+
+	logger.Info("System service started successfully.")
+
 }


### PR DESCRIPTION
When the --as-svc mount option is specified, the juicefs mount command updates the Windows registry to prepare the service definition needed by the Winfsp Launcher. After updating the registry, the juicefs mount process invokes net use to trigger the mount behavior.

https://github.com/winfsp/winfsp/wiki/WinFsp-Service-Architecture

Known limitations:
* Only one volume can be mounted at a time when using --as-svc. Mounting more than one volume may cause unexpected behavior depending on the implementation of winfsp.
* We essentially write the same command line to the winfsp service registry value, except for the --as-svc option, including the mount point. Therefore, when users use the “Map a network drive” feature in File Explorer, the mount process will ignore the mount point.

## Test

- [x] Run command with "--as-svr" option to mount volume 1 at x:.
- [x] Disconnect volume 1 mounting from File Explorer.
- [x] Run command with "--as-svr" option to mount volume 2 at y:
