### PR TITLE
Delete trash exits timely

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2556,7 +2556,7 @@ func (m *baseMeta) CleanupTrashBefore(ctx Context, edge time.Time, increProgress
 					rmdir = false
 					continue
 				}
-				if count%10000 == 0 && time.Since(now) > 50*time.Minute {
+				if time.Since(now) > 50*time.Minute {
 					return
 				}
 			}


### PR DESCRIPTION
These warning logs appear frequently during massive deletions. CleanupTrash should exit timely like other deletion routines.

![img_v3_02je_95bf4fbe-f1de-45d4-af9e-8d6b67ca33dg](https://github.com/user-attachments/assets/6ef1301d-482d-49b5-ac22-875dcd6198f4)
