### PR TITLE
Windows: hide the  dot files by default. fix #2013

### DIFF
--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -48,9 +48,13 @@ func mountFlags() []cli.Flag {
 			Usage: "delay file closing in seconds.",
 		},
 		&cli.BoolFlag{
-			Name:  "d",
+			Name:    "d",
 			Aliases: []string{"background"},
-			Usage: "run in background(Windows: as a system service. support ONLY 1 volume mounting at the same time)",
+			Usage:   "run in background(Windows: as a system service. support ONLY 1 volume mounting at the same time)",
+		},
+		&cli.BoolFlag{
+			Name:  "hide-dot-files",
+			Usage: "If set, dot files will be hidden",
 		},
 	}
 }
@@ -70,7 +74,7 @@ func getDaemonStage() int {
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
 	v.Conf.AccessLog = c.String("access-log")
-	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"))
+	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("hide-dot-files"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -53,8 +53,8 @@ func mountFlags() []cli.Flag {
 			Usage:   "run in background(Windows: as a system service. support ONLY 1 volume mounting at the same time)",
 		},
 		&cli.BoolFlag{
-			Name:  "hide-dot-files",
-			Usage: "If set, dot files will be hidden",
+			Name:  "show-dot-files",
+			Usage: "If set, dot files will not be treated as hidden files",
 		},
 	}
 }
@@ -74,7 +74,7 @@ func getDaemonStage() int {
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
 	v.Conf.AccessLog = c.String("access-log")
-	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("hide-dot-files"))
+	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("show-dot-files"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -641,7 +641,7 @@ func (j *juice) Releasedir(path string, fh uint64) (e int) {
 	return
 }
 
-func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayClose int) {
+func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayClose int, hideDotFiles bool) {
 	var jfs juice
 	conf := v.Conf
 	jfs.conf = conf
@@ -666,6 +666,9 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	}
 	if fuseOpt != "" {
 		options += "," + fuseOpt
+	}
+	if hideDotFiles {
+		options += ",dothidden"
 	}
 	host.SetCapCaseInsensitive(strings.HasSuffix(conf.Meta.MountPoint, ":"))
 	host.SetCapReaddirPlus(true)

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -641,7 +641,7 @@ func (j *juice) Releasedir(path string, fh uint64) (e int) {
 	return
 }
 
-func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayClose int, hideDotFiles bool) {
+func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayClose int, showDotFiles bool) {
 	var jfs juice
 	conf := v.Conf
 	jfs.conf = conf
@@ -667,7 +667,7 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	if fuseOpt != "" {
 		options += "," + fuseOpt
 	}
-	if hideDotFiles {
+	if !showDotFiles {
 		options += ",dothidden"
 	}
 	host.SetCapCaseInsensitive(strings.HasSuffix(conf.Meta.MountPoint, ":"))


### PR DESCRIPTION
close #2013 

## Test

- [x] 1. Mount without the --show-dot-files option and confirm that no dot files are showing in the File Explorer.
- [x] 2. Enter the absolute path "x:\.trash" to access the hidden file folder.
- [x] 3. Enable the "Show hidden items" option in the File Explorer settings and confirm that the dot files are visible again.
