### PR TITLE
Better to keep `context.WithValue` constant

### DIFF
--- a/pkg/fuse/context.go
+++ b/pkg/fuse/context.go
@@ -126,8 +126,10 @@ func (c *fuseContext) Canceled() bool {
 	}
 }
 
-func (c *fuseContext) WithValue(k, v interface{}) {
-	c.Context = context.WithValue(c.Context, k, v)
+func (c *fuseContext) WithValue(k, v interface{}) meta.Context {
+	wc := *c // gids is a const, so it's safe to shallow copy
+	wc.Context = context.WithValue(c.Context, k, v)
+	return &wc
 }
 
 func (c *fuseContext) Err() error {

--- a/pkg/meta/context.go
+++ b/pkg/meta/context.go
@@ -28,7 +28,7 @@ type Context interface {
 	Gids() []uint32
 	Uid() uint32
 	Pid() uint32
-	WithValue(k, v interface{})
+	WithValue(k, v interface{}) Context // should remain const semantics, so user can chain it
 	Cancel()
 	Canceled() bool
 	CheckPermission() bool
@@ -70,8 +70,10 @@ func (c *wrapContext) Canceled() bool {
 	return c.Err() != nil
 }
 
-func (c *wrapContext) WithValue(k, v interface{}) {
-	c.Context = context.WithValue(c.Context, k, v)
+func (c *wrapContext) WithValue(k, v interface{}) Context {
+	wc := *c // gids is a const, so it's safe to shallow copy
+	wc.Context = context.WithValue(c.Context, k, v)
+	return &wc
 }
 
 func (c *wrapContext) CheckPermission() bool {

--- a/pkg/meta/sql_bak.go
+++ b/pkg/meta/sql_bak.go
@@ -57,7 +57,7 @@ func (m *dbMeta) dump(ctx Context, opt *DumpOption, ch chan<- *dumpedResult) err
 		m.dumpDirStat,
 	}
 
-	ctx.WithValue(txMaxRetryKey{}, 3)
+	ctx = ctx.WithValue(txMaxRetryKey{}, 3)
 	if opt.Threads == 1 {
 		// use same txn for all dumps
 		sess := m.db.NewSession()
@@ -76,7 +76,7 @@ func (m *dbMeta) dump(ctx Context, opt *DumpOption, ch chan<- *dumpedResult) err
 			}
 		}
 		defer sess.Rollback() //nolint:errcheck
-		ctx.WithValue(txSessionKey{}, sess)
+		ctx = ctx.WithValue(txSessionKey{}, sess)
 	} else {
 		logger.Warnf("dump database with %d threads, please make sure that it's readonly, "+
 			"otherwise the dumped metadata will be inconsistent", opt.Threads)

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -222,7 +222,7 @@ func (w *wrapper) withPid(pid int64) meta.Context {
 	// mapping Java Thread ID to global one
 	ctx := meta.NewContext(w.ctx.Pid()*1000+uint32(pid), w.ctx.Uid(), w.ctx.Gids())
 	if caller == CALLER_JAVA {
-		ctx.WithValue(meta.CtxKey("behavior"), BEHAVIOR_HADOOP)
+		ctx = ctx.WithValue(meta.CtxKey("behavior"), BEHAVIOR_HADOOP)
 	}
 	return ctx
 }


### PR DESCRIPTION
In stdlib, `context.WithValue` returns a derived context that points to the parent `Context`, and the parent `Context` is not modified.

In JuiceFS, `context.WithValue` mutates itself by stacking the `Context` field. This is error-prone as no one can clean the stack chain.

Especially in the `gateway` scenario where `meta.Context` is a global variable - its value chain can grow infinitely as `gateway` runs long enough. This causes a memory leak and makes searching for a non-existent key very expensive.

It's better to follow best practices in the Go community.
