### PR TITLE
cache: inherit atime and track logic size when re-scan

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -886,10 +886,7 @@ func (cache *cacheStore) uploadStaging() {
 func (cache *cacheStore) scanCached() {
 	cache.Lock()
 	cache.used = 0
-	lastAccessed := make(map[cacheKey]uint32, len(cache.keys))
-	for k, v := range cache.keys { // atime in memory is more accurate than on disk, inherit it for the next round
-		lastAccessed[k] = v.atime
-	}
+	lastAccessed := cache.keys // atime in memory is more accurate than on disk, inherit it for the next round
 	cache.keys = make(map[cacheKey]cacheItem)
 	cache.scanned = false
 	cache.Unlock()
@@ -918,7 +915,7 @@ func (cache *cacheStore) scanCached() {
 					key = strings.ReplaceAll(key, "\\", "/")
 				}
 				atime := uint32(getAtime(fi).Unix())
-				if memAtime := lastAccessed[cache.getCacheKey(key)]; memAtime > atime {
+				if memAtime := lastAccessed[cache.getCacheKey(key)].atime; memAtime > atime {
 					atime = memAtime
 				}
 				size := parseObjOrigSize(key) // track logical size

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -609,20 +609,16 @@ func (cache *cacheStore) load(key string) (ReadCloser, error) {
 
 	var f *cacheFile
 	var err error
-	size := parseObjOrigSize(key)
 	err = cache.checkErr(func() error {
-		f, err = openCacheFile(cache.cachePath(key), size, cache.checksum)
+		f, err = openCacheFile(cache.cachePath(key), parseObjOrigSize(key), cache.checksum)
 		return err
 	})
 
 	cache.Lock()
 	if err == nil {
-		// update atime
 		if it, ok := cache.keys[k]; ok {
+			// update atime
 			cache.keys[k] = cacheItem{it.size, uint32(time.Now().Unix())}
-		} else {
-			cache.keys[k] = cacheItem{int32(size), uint32(time.Now().Unix())}
-			cache.used += int64(size + 4096)
 		}
 	} else if it, ok := cache.keys[k]; ok {
 		if it.size > 0 {


### PR DESCRIPTION
Scanning from disk overwrites `size` and `atime` of existing cache items in memory:

1. `size` is overwritten by the physical size of the file, which includes the logical size plus the CRC footer. However, when adding cache in other places, we use the logical size. I suppose it's better to be consistent on which size to use.

2. The granularity of file system's `atime` is relatively coarse (relatime), and some even have atime disabled (noatime). However, `atime` recorded in memory has finer granularity and is more accurate in most cases. Overwriting `atime` in memory blindly would cause the expire eviction strategy not working as expected.