### PR TITLE
Windows: fix issue when creating an existing file

### DIFF
--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -278,7 +278,7 @@ func (j *juice) Create(p string, flags int, mode uint32) (e int, fh uint64) {
 		e = errorconv(err)
 		return
 	}
-	entry, fh, errno := j.vfs.Create(ctx, parent.Inode(), path.Base(p), uint16(mode), 0, uint32(flags))
+	entry, fh, errno := j.vfs.Create(ctx, parent.Inode(), path.Base(p), uint16(mode), 0, uint32(flags|syscall.O_EXCL))
 	if errno == 0 {
 		j.Lock()
 		j.handlers[fh] = entry.Inode


### PR DESCRIPTION
fix #https://github.com/juicedata/juicefs/issues/5682


following is the create disposition defined for a create IRP (from system wdm.h file )
```
//
// Define the create disposition values
//

#define FILE_SUPERSEDE                  0x00000000
#define FILE_OPEN                       0x00000001
#define FILE_CREATE                     0x00000002
#define FILE_OPEN_IF                    0x00000003
#define FILE_OVERWRITE                  0x00000004
#define FILE_OVERWRITE_IF               0x00000005
#define FILE_MAXIMUM_DISPOSITION        0x00000005
```

When calling ```CreateFileW(filename, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, 0);``` twice, WinFsp receives the Create IRP with FILE_CREATE disposition value twice, so it calls juicefs.create twice; the second call should return a "File exists" error.
