### PR TITLE
Windows: add win attrs support;

### DIFF
--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -94,8 +94,11 @@ const (
 )
 
 const (
-	FlagImmutable = 1 << iota
+	FlagImmutable = 1 << iota // same as Windows FILE_ATTRIBUTE_READONLY
 	FlagAppend
+	FlagWindowsHidden
+	FlagWindowsSystem
+	FlagWindowsArchive
 )
 
 const (

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -512,6 +512,9 @@ func (v *VFS) Create(ctx Context, parent Ino, name string, mode uint16, cumask u
 
 	var inode Ino
 	var attr = &Attr{}
+	if runtime.GOOS == "windows" {
+		attr.Flags = meta.FlagWindowsArchive
+	}
 	err = v.Meta.Create(ctx, parent, name, mode&07777, cumask, flags, &inode, attr)
 	if runtime.GOOS == "darwin" && err == syscall.ENOENT {
 		err = syscall.EACCES

--- a/pkg/vfs/vfs_windows.go
+++ b/pkg/vfs/vfs_windows.go
@@ -16,5 +16,33 @@
 
 package vfs
 
+import (
+	"syscall"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+)
+
 const O_ACCMODE = 0xff
 const F_UNLCK = 0x01
+
+func (v *VFS) ChFlags(ctx Context, ino Ino, flags uint8) (err syscall.Errno) {
+	defer func() {
+		logit(ctx, "chflags", err, "(%d):%d", ino, flags)
+	}()
+	if IsSpecialNode(ino) {
+		err = syscall.EPERM
+		return
+	}
+
+	err = syscall.EINVAL
+	var attr = &Attr{Flags: flags}
+
+	if ctx.CheckPermission() {
+		if err = v.Meta.CheckSetAttr(ctx, ino, meta.SetAttrFlag, *attr); err != 0 {
+			return
+		}
+	}
+
+	err = v.Meta.SetAttr(ctx, ino, meta.SetAttrFlag, 0, attr)
+	return
+}


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/5693

## Background

* When setting attributes for a file or folder, winfsp call juicefs.chflags() and pass the attribute flags to juicefs.
* According to this [article,](https://support.microsoft.com/en-us/topic/you-cannot-view-or-change-the-read-only-or-the-system-attributes-of-folders-in-windows-server-2003-in-windows-xp-in-windows-vista-or-in-windows-7-55bd5ec5-d19e-6173-0df1-8f5b49247165) on windows sytem, the readonly attribute for a folder basically doesn't have any effect. 

<img width="664" alt="image" src="https://github.com/user-attachments/assets/ca791598-2a64-4cd0-be82-8dea6d4fbfa8" />


## Test

run ```winfsp-test --fuse-external create*```

* before this PR, it failed for the create_fileattr_test and create_readonly_test.
* after this PR, the failed tests passed. [tested on redis and sqlite, **didn't** test on tikv]


## Discussion

* Maybe we can ignore the FlagWindowsArchive? This is not used by any modern system accroding to this [topic](https://groups.google.com/g/winfsp/c/9QYSSxWo2r8). but if we want to align the behavior of samba client for windows, this should be kept.