### PR TITLE
Windows: remove set_umask default value;

### DIFF
--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -656,8 +656,7 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	host := fuse.NewFileSystemHost(&jfs)
 	jfs.host = host
 	var options = "volname=" + conf.Format.Name
-	// create_umask 022 results in 755 for directories and 644 for files, see https://github.com/winfsp/sshfs-win/issues/14
-	options += ",ExactFileSystemName=JuiceFS,create_umask=022,ThreadCount=16"
+	options += ",ExactFileSystemName=JuiceFS,ThreadCount=16"
 	options += ",DirInfoTimeout=1000,VolumeInfoTimeout=1000,KeepFileCache"
 	options += fmt.Sprintf(",FileInfoTimeout=%d", int(fileCacheTo*1000))
 	options += ",VolumePrefix=/juicefs/" + conf.Format.Name


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/5723


The reason why the wrong permission was set is that we have a default create_umask=022 option. With this option, all permissions for newly created files would be set to 0755 according to the [ winfsp source code.](https://github.com/winfsp/winfsp/blob/4fdec4d37fb4e56b6d810714f5a201e275211aaf/src/dll/fuse/fuse_intf.c#L479)


