### PR TITLE
Windows: fixed incorrect flags when creat/open a file

### DIFF
--- a/pkg/vfs/vfs_windows.go
+++ b/pkg/vfs/vfs_windows.go
@@ -19,10 +19,11 @@ package vfs
 import (
 	"syscall"
 
+	"github.com/billziss-gh/cgofuse/fuse"
 	"github.com/juicedata/juicefs/pkg/meta"
 )
 
-const O_ACCMODE = 0xff
+const O_ACCMODE = uint32(fuse.O_ACCMODE)
 const F_UNLCK = 0x01
 
 func (v *VFS) ChFlags(ctx Context, ino Ino, flags uint8) (err syscall.Errno) {


### PR DESCRIPTION
The previous PR https://github.com/juicedata/juicefs/pull/5714 added an flag "O_EXCL" manually while creating a new file, resulting in the incorrect behavior handler.writer  = nil when creating a file handler.

According to the source code of [winfsp](https://github.com/winfsp/winfsp/blob/4fdec4d37fb4e56b6d810714f5a201e275211aaf/src/dll/fuse/fuse_intf.c#L951) 

```
    if ('C' == f->env->environment) /* Cygwin */
        fi.flags = 0x0200 | 0x0800 | 2 /*O_CREAT|O_EXCL|O_RDWR*/;
    else
        fi.flags = 0x0100 | 0x0400 | 2 /*O_CREAT|O_EXCL|O_RDWR*/;
```



Winfsp will pass the O_EXCL flag to juicefs, so all we need to do is only convert those flags to syscall flags.

## reference 

https://github.com/winfsp/cgofuse/blob/b8358bce7bce407a8f5a9445723df52ebca32337/fuse/fsop_nocgo_windows.go#L101C1-L111C2

```
// Flags used in FileSystemInterface.Create and FileSystemInterface.Open.
const (
	O_RDONLY  = 0x0000
	O_WRONLY  = 0x0001
	O_RDWR    = 0x0002
	O_APPEND  = 0x0008
	O_CREAT   = 0x0100
	O_TRUNC   = 0x0200
	O_EXCL    = 0x0400
	O_ACCMODE = O_RDONLY | O_WRONLY | O_RDWR
)
```

