### PR TITLE
Fix the issue that the username cannot contain the "@" character

### DIFF
--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -541,7 +541,7 @@ func Register(name string, register Creator) {
 }
 
 func setPasswordFromEnv(uri string) (string, error) {
-	atIndex := strings.Index(uri, "@")
+	atIndex := strings.LastIndex(uri, "@")
 	if atIndex == -1 {
 		return "", fmt.Errorf("invalid uri: %s", uri)
 	}


### PR DESCRIPTION
If the username contains the "@" character, JuiceFS cannot correctly identify the username. I want to add support for usernames that contain the "@" character.
As shown in the following figure, the username is "user@name", but JuiceFS recognizes the username as "user", which results in the inability to log in to the database.
![image](https://github.com/user-attachments/assets/deb49370-fdd5-4cf7-9770-aa454e98c9a9)
After the modification, the user name without the @ character and the user name with the @ character can be recognized.
username contains '@' characters
![image](https://github.com/user-attachments/assets/e55dbb27-5df7-4f4a-bb25-2dce4bc3ca69)
username does not contains '@' characters
![image](https://github.com/user-attachments/assets/a9542997-99ba-48ed-aacf-becad8084868)
