### PR TITLE
Show method label on transaction conflict metric

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -259,7 +259,7 @@ type baseMeta struct {
 	totalSpaceG  prometheus.Gauge
 	totalInodesG prometheus.Gauge
 	txDist       prometheus.Histogram
-	txRestart    prometheus.Counter
+	txRestart    *prometheus.CounterVec
 	opDist       prometheus.Histogram
 	opCount      *prometheus.CounterVec
 	opDuration   *prometheus.CounterVec
@@ -308,10 +308,10 @@ func newBaseMeta(addr string, conf *Config) *baseMeta {
 			Help:    "Transactions latency distributions.",
 			Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
 		}),
-		txRestart: prometheus.NewCounter(prometheus.CounterOpts{
+		txRestart: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "transaction_restart",
 			Help: "The number of times a transaction is restarted.",
-		}),
+		}, []string{"method"}),
 		opDist: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "meta_ops_durations_histogram_seconds",
 			Help:    "Operation latency distributions.",

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -62,7 +62,7 @@ func TestRedisClient(t *testing.T) {
 	testMeta(t, m)
 }
 
-func TestKeyDB(t *testing.T) { //skip mutate
+func TestKeyDB(t *testing.T) { // skip mutate
 	if os.Getenv("SKIP_NON_CORE") == "true" {
 		t.Skipf("skip non-core test")
 	}
@@ -107,7 +107,7 @@ func TestKeyDB(t *testing.T) { //skip mutate
 	}
 }
 
-func TestRedisCluster(t *testing.T) { //skip mutate
+func TestRedisCluster(t *testing.T) { // skip mutate
 	if os.Getenv("SKIP_NON_CORE") == "true" {
 		t.Skipf("skip non-core test")
 	}
@@ -2636,10 +2636,10 @@ func testDirStat(t *testing.T, m Meta) {
 }
 
 func testClone(t *testing.T, m Meta) {
-	//$ tree cloneDir
-	//.
-	//├── dir
-	//└── dir1
+	// $ tree cloneDir
+	// .
+	// ├── dir
+	// └── dir1
 	//    ├── dir2
 	//    │ ├── dir3
 	//    │ │ └── file3

--- a/pkg/meta/redis_lock.go
+++ b/pkg/meta/redis_lock.go
@@ -32,6 +32,7 @@ import (
 func (r *redisMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, block bool) syscall.Errno {
 	ikey := r.flockKey(inode)
 	lkey := r.ownerKey(owner)
+	ctx = ctx.WithValue(txMethodKey{}, "Flock"+strconv.Itoa(int(ltype)))
 	if ltype == F_UNLCK {
 		return errno(r.txn(ctx, func(tx *redis.Tx) error {
 			lkeys, err := tx.HKeys(ctx, ikey).Result()
@@ -135,6 +136,7 @@ func (r *redisMeta) Getlk(ctx Context, inode Ino, owner uint64, ltype *uint32, s
 func (r *redisMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype uint32, start, end uint64, pid uint32) syscall.Errno {
 	ikey := r.plockKey(inode)
 	lkey := r.ownerKey(owner)
+	ctx = ctx.WithValue(txMethodKey{}, "Setlk"+strconv.Itoa(int(ltype)))
 	var err error
 	lock := plockRecord{ltype, pid, start, end}
 	for {

--- a/pkg/meta/tkv_lock.go
+++ b/pkg/meta/tkv_lock.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"context"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -53,6 +54,7 @@ func unmarshalFlock(buf []byte) map[lockOwner]byte {
 
 func (m *kvMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, block bool) syscall.Errno {
 	ikey := m.flockKey(inode)
+	ctx = ctx.WithValue(txMethodKey{}, "Flock"+strconv.Itoa(int(ltype)))
 	var err error
 	lkey := lockOwner{m.sid, owner}
 	for {
@@ -167,6 +169,7 @@ func (m *kvMeta) Getlk(ctx Context, inode Ino, owner uint64, ltype *uint32, star
 
 func (m *kvMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltype uint32, start, end uint64, pid uint32) syscall.Errno {
 	ikey := m.plockKey(inode)
+	ctx = ctx.WithValue(txMethodKey{}, "Setlk"+strconv.Itoa(int(ltype)))
 	var err error
 	lock := plockRecord{ltype, pid, start, end}
 	lkey := lockOwner{m.sid, owner}

--- a/pkg/meta/utils_test.go
+++ b/pkg/meta/utils_test.go
@@ -17,6 +17,7 @@
 package meta
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -86,4 +87,18 @@ func TestAtimeNeedsUpdate(t *testing.T) {
 	if m.atimeNeedsUpdate(attr, now) {
 		t.Fatal("atime updated for strictatime when < 1s")
 	}
+}
+
+func Test_getCallerName(t *testing.T) {
+	ctx := context.WithValue(context.Background(), txMethodKey{}, "test")
+	method := callerName(ctx)
+	if method != "test" {
+		t.Fatalf("expected %q, got %q", "test", method)
+	}
+	func() {
+		method := callerName(context.Background())
+		if method != "Test_getCallerName" {
+			t.Fatalf("expected %q, got %q", "Test_getCallerName", method)
+		}
+	}()
 }

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -74,7 +74,7 @@ func (l *logHandle) Format(e *logrus.Entry) ([]byte, error) {
 		l.pid,
 		lvlStr,
 		strings.TrimRight(e.Message, "\n"),
-		methodName(caller.Function),
+		MethodName(caller.Function),
 		path.Base(caller.File),
 		caller.Line)
 
@@ -88,7 +88,7 @@ func (l *logHandle) Format(e *logrus.Entry) ([]byte, error) {
 }
 
 // Returns a human-readable method name, removing internal markers added by Go
-func methodName(fullFuncName string) string {
+func MethodName(fullFuncName string) string {
 	firstSlash := strings.Index(fullFuncName, "/")
 	if firstSlash != -1 && firstSlash < len(fullFuncName)-1 {
 		fullFuncName = fullFuncName[firstSlash+1:]
@@ -100,14 +100,14 @@ func methodName(fullFuncName string) string {
 	method := fullFuncName[lastDot+1:]
 	// avoid func1
 	if strings.HasPrefix(method, "func") && method[4] >= '0' && method[4] <= '9' {
-		candidate := methodName(fullFuncName[:lastDot])
+		candidate := MethodName(fullFuncName[:lastDot])
 		if candidate != "" {
 			method = candidate
 		}
 	}
-	// aoid init.3
+	// avoid init.3
 	if len(method) == 1 && method[0] >= '0' && method[0] <= '9' {
-		candidate := methodName(fullFuncName[:lastDot])
+		candidate := MethodName(fullFuncName[:lastDot])
 		if candidate != "" {
 			method = candidate
 		}

--- a/pkg/utils/logger_test.go
+++ b/pkg/utils/logger_test.go
@@ -88,8 +88,8 @@ func TestMethodName(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := methodName(tt.args.fullFuncName); got != tt.want {
-				t.Errorf("methodName() = %v, want %v", got, tt.want)
+			if got := MethodName(tt.args.fullFuncName); got != tt.want {
+				t.Errorf("MethodName() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
`txRestart` happens a lot in a busy cluster. Some are expected (incrCounter of usedSpace), some are not (doWrite) - they all mix together in the same metric, we cannot set up an alert for the latter.

This PR adds few labels to `txRestart` metric. It helps to understand the reason of transaction conflicts and gives a hint how to avoid/fix them, e.g. conflicts:

- `doCleanupDelayedSlices` - `cleanupDelayedSlices` doesnot respect time limits as expected, it can be fixed by modifying code, see #5463.
- `doMknod` - user is creating in the same directory simultaneously, this conflict hurts performance, and can be avoided sometimes, see #5549, #5330.
- `doWrite`/`doTruncate` - user is modifying the same file from different nodes accidentally. He must be notified to avoid data corruption and even `EIO`.

etc.