### PR TITLE
cache/writeback: upload directly to object storage when compact

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -274,13 +274,15 @@ type wSlice struct {
 	errors      chan error
 	uploadError error
 	pendings    int
+	forceUpload bool // force upload to object storage
 }
 
-func sliceForWrite(id uint64, store *cachedStore) *wSlice {
+func sliceForWrite(id uint64, store *cachedStore, forceUpload bool) *wSlice {
 	return &wSlice{
-		rSlice: rSlice{id, 0, store},
-		pages:  make([][]*Page, chunkSize/store.conf.BlockSize),
-		errors: make(chan error, chunkSize/store.conf.BlockSize),
+		rSlice:      rSlice{id, 0, store},
+		pages:       make([][]*Page, chunkSize/store.conf.BlockSize),
+		errors:      make(chan error, chunkSize/store.conf.BlockSize),
+		forceUpload: forceUpload,
 	}
 }
 
@@ -444,7 +446,7 @@ func (s *wSlice) upload(indx int) {
 		if off != blen {
 			panic(fmt.Sprintf("block length does not match: %v != %v", off, blen))
 		}
-		if s.store.conf.Writeback {
+		if !s.forceUpload && s.store.conf.Writeback {
 			stagingPath := "unknown"
 			stageFailed := false
 			block.Acquire()
@@ -1099,8 +1101,8 @@ func (store *cachedStore) NewReader(id uint64, length int) Reader {
 	return sliceForRead(id, length, store)
 }
 
-func (store *cachedStore) NewWriter(id uint64) Writer {
-	return sliceForWrite(id, store)
+func (store *cachedStore) NewWriter(id uint64, forceUpload bool) Writer {
+	return sliceForWrite(id, store, forceUpload)
 }
 
 func (store *cachedStore) Remove(id uint64, length int) error {

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func forgetSlice(store ChunkStore, sliceId uint64, size int) error {
-	w := store.NewWriter(sliceId, false)
+	w := store.NewWriter(sliceId)
 	buf := bytes.Repeat([]byte{0x41}, size)
 	if _, err := w.WriteAt(buf, 0); err != nil {
 		return err
@@ -40,7 +40,7 @@ func forgetSlice(store ChunkStore, sliceId uint64, size int) error {
 }
 
 func testStore(t *testing.T, store ChunkStore) {
-	writer := store.NewWriter(1, false)
+	writer := store.NewWriter(1)
 	data := []byte("hello world")
 	if n, err := writer.WriteAt(data, 0); n != 11 || err != nil {
 		t.Fatalf("write fail: %d %s", n, err)
@@ -217,7 +217,7 @@ func TestForceUpload(t *testing.T) {
 	}
 
 	// write to cache
-	w := store.NewWriter(1, false)
+	w := store.NewWriter(1)
 	if _, err := w.WriteAt(make([]byte, 1024), 0); err != nil {
 		t.Fatalf("write fail: %s", err)
 	}
@@ -230,7 +230,8 @@ func TestForceUpload(t *testing.T) {
 	}
 
 	// write to os
-	w = store.NewWriter(2, true)
+	w = store.NewWriter(2)
+	w.SetWriteback(false)
 	if _, err := w.WriteAt(make([]byte, 1024), 0); err != nil {
 		t.Fatalf("write fail: %s", err)
 	}
@@ -340,7 +341,7 @@ func BenchmarkCachedRead(b *testing.B) {
 	config := defaultConf
 	config.BlockSize = 4 << 20
 	store := NewCachedStore(blob, config, nil)
-	w := store.NewWriter(1, false)
+	w := store.NewWriter(1)
 	if _, err := w.WriteAt(make([]byte, 1024), 0); err != nil {
 		b.Fatalf("write fail: %s", err)
 	}
@@ -364,7 +365,7 @@ func BenchmarkUncachedRead(b *testing.B) {
 	config.BlockSize = 4 << 20
 	config.CacheSize = 0
 	store := NewCachedStore(blob, config, nil)
-	w := store.NewWriter(2, false)
+	w := store.NewWriter(2)
 	if _, err := w.WriteAt(make([]byte, 1024), 0); err != nil {
 		b.Fatalf("write fail: %s", err)
 	}

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -29,6 +29,7 @@ type Writer interface {
 	io.WriterAt
 	ID() uint64
 	SetID(id uint64)
+	SetWriteback(enabled bool)
 	FlushTo(offset int) error
 	Finish(length int) error
 	Abort()
@@ -36,7 +37,7 @@ type Writer interface {
 
 type ChunkStore interface {
 	NewReader(id uint64, length int) Reader
-	NewWriter(id uint64, forceUpload bool) Writer
+	NewWriter(id uint64) Writer
 	Remove(id uint64, length int) error
 	FillCache(id uint64, length uint32) error
 	EvictCache(id uint64, length uint32) error

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -36,7 +36,7 @@ type Writer interface {
 
 type ChunkStore interface {
 	NewReader(id uint64, length int) Reader
-	NewWriter(id uint64) Writer
+	NewWriter(id uint64, forceUpload bool) Writer
 	Remove(id uint64, length int) error
 	FillCache(id uint64, length uint32) error
 	EvictCache(id uint64, length uint32) error

--- a/pkg/vfs/compact.go
+++ b/pkg/vfs/compact.go
@@ -62,7 +62,8 @@ func Compact(conf chunk.Config, store chunk.ChunkStore, slices []meta.Slice, id 
 	compactSizeHistogram.Observe(float64(size))
 	logger.Debugf("compact %d slices (%d bytes) to new slice %d", len(slices), size, id)
 
-	writer := store.NewWriter(id, true)
+	writer := store.NewWriter(id)
+	writer.SetWriteback(false)
 
 	var pos int
 	for i, s := range slices {

--- a/pkg/vfs/compact.go
+++ b/pkg/vfs/compact.go
@@ -62,7 +62,7 @@ func Compact(conf chunk.Config, store chunk.ChunkStore, slices []meta.Slice, id 
 	compactSizeHistogram.Observe(float64(size))
 	logger.Debugf("compact %d slices (%d bytes) to new slice %d", len(slices), size, id)
 
-	writer := store.NewWriter(id)
+	writer := store.NewWriter(id, true)
 
 	var pos int
 	for i, s := range slices {

--- a/pkg/vfs/compact_test.go
+++ b/pkg/vfs/compact_test.go
@@ -46,7 +46,7 @@ func TestCompact(t *testing.T) {
 			buf[j] = byte(i)
 		}
 		cid := uint64(i)
-		w := store.NewWriter(cid)
+		w := store.NewWriter(cid, false)
 		if n, e := w.WriteAt(buf, 0); e != nil {
 			t.Fatalf("write chunk %d: %s", cid, e)
 		} else {

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -261,7 +261,7 @@ func (f *fileWriter) writeChunk(ctx meta.Context, indx uint32, off uint32, data 
 		s = &sliceWriter{
 			chunk:   c,
 			off:     off,
-			writer:  f.w.store.NewWriter(0, false),
+			writer:  f.w.store.NewWriter(0),
 			notify:  utils.NewCond(&f.Mutex),
 			started: time.Now(),
 		}

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -261,7 +261,7 @@ func (f *fileWriter) writeChunk(ctx meta.Context, indx uint32, off uint32, data 
 		s = &sliceWriter{
 			chunk:   c,
 			off:     off,
-			writer:  f.w.store.NewWriter(0),
+			writer:  f.w.store.NewWriter(0, false),
 			notify:  utils.NewCond(&f.Mutex),
 			started: time.Now(),
 		}


### PR DESCRIPTION
close #2562