### PR TITLE
CI: Add Windows tests

### DIFF
--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -145,7 +145,7 @@ jobs:
       
       - name: Run Winfsp Test
         run: |
-          cd "Z:\"
+          cd Z:
           & "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient --case-insensitive-cmp
       
       - name: Download winfstest

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Juicefs Mount
         run: |
           $env:PATH+=";C:\Program Files (x86)\WinFsp\bin"
-          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 myjfs z:
+          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z:
 
       - name: Test Juicefs
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Download winsw
         run: |
-          wget https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe -O winsw.exe
+          wget https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe -q --show-progress -O winsw.exe
           ls winsw.exe
 
       - name: Start Redis
@@ -105,7 +105,7 @@ jobs:
 
       - name: Download MinGW
         run: |
-          wget https://github.com/niXman/mingw-builds-binaries/releases/download/14.2.0-rt_v12-rev1/x86_64-14.2.0-release-win32-seh-msvcrt-rt_v12-rev1.7z -O mingw.7z
+          wget https://github.com/niXman/mingw-builds-binaries/releases/download/14.2.0-rt_v12-rev1/x86_64-14.2.0-release-win32-seh-msvcrt-rt_v12-rev1.7z -q --show-progress -O mingw.7z
           7z.exe x mingw.7z -oC:\mingw64
           ls C:\mingw64\bin
 
@@ -138,7 +138,7 @@ jobs:
 
       - name: Download Winfsp Test Binary
         run: |
-          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -O "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
+          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
           ls "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
       
       - name: Run Winfsp Test
@@ -148,7 +148,7 @@ jobs:
       
       - name: Download winfstest
         run: |
-          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64.zip -O Z:\TestSuite-x64.zip
+          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64.zip -q --show-progress -O Z:\TestSuite-x64.zip
           ls Z:\TestSuite-x64.zip
           cd Z:\
           Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite
@@ -159,7 +159,7 @@ jobs:
       - name: Run FSX Test
         run: |
           cd Z:\
-          wget https://github.com/chenjie4255/fstools/releases/download/v0.0.1/fsx-x64.exe -O fsx.exe
+          wget https://github.com/chenjie4255/fstools/releases/download/v0.0.1/fsx-x64.exe -q --show-progress -O fsx.exe
           ls fsx.exe
           ./fsx.exe -d 180 -p 10000 -F 100000 fsxtest
           

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -130,25 +130,14 @@ jobs:
           $env:PATH+=";C:\Program Files (x86)\WinFsp\bin"
           ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z:
 
-      - name: Test Juicefs
+      - name: Run Winfsp Tests
         run: |
-          mkdir "Z:\dir"
-          dir "Z:\dir"
-          echo "hello" > "Z:\dir\hello.txt"
-          dir "Z:\dir\hello.txt"
-          type "Z:\dir\hello.txt"
-
-      - name: Download Winfsp Test Binary
-        run: |
-          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64-dbg.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
+          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
           ls "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
-      
-      - name: Run Winfsp Test
-        run: |
           cd Z:
           & "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient --case-insensitive-cmp
       
-      - name: Download winfstest
+      - name: Run winfstest
         run: |
           wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64.zip -q --show-progress -O Z:\TestSuite-x64.zip
           ls Z:\TestSuite-x64.zip

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -139,7 +139,7 @@ jobs:
       
       - name: Run winfstest
         run: |
-          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64.zip -q --show-progress -O Z:\TestSuite-x64.zip
+          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64-v2.zip -q --show-progress -O Z:\TestSuite-x64.zip
           ls Z:\TestSuite-x64.zip
           cd Z:\
           Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -58,9 +58,9 @@ jobs:
 
       - name: Install WinFsp
         run: |
-          msiexec.exe /i "C:\wfsp\winfsp.msi" /qn /norestart INSTALLLEVEL=1000
-          ls "C:\Program Files (x86)\WinFsp"
-          ls "C:\Program Files (x86)\WinFsp\bin"
+          msiexec.exe /i "C:\wfsp\winfsp.msi" /qn /norestart /Lw "C:\wfsp\install.log"
+          #ls "C:\Program Files (x86)\WinFsp"
+          #ls "C:\Program Files (x86)\WinFsp\bin"
 
       - name: Set up Include Headers
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -59,9 +59,9 @@ jobs:
 
       - name: Install WinFsp
         run: |
-          msiexec.exe /jm "C:\wfsp\winfsp.msi" /qn /norestart /Lw "C:\wfsp\install.log" INSTALLLEVEL=32767
-          #ls "C:\Program Files (x86)\WinFsp"
-          #ls "C:\Program Files (x86)\WinFsp\bin"
+          Start-Process msiexec.exe -Wait -ArgumentList '/i /qn /l*v C:\wfsp\install.log C:\wfsp\winfsp.msi'
+          ls "C:\Program Files (x86)\WinFsp"
+          ls "C:\Program Files (x86)\WinFsp\bin"
 
       - name: Set up Include Headers
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install WinFsp
         run: |
-          msiexec.exe /i "C:\wfsp\winfsp.msi" /qn /norestart /Lw "C:\wfsp\install.log"
+          msiexec.exe /jm "C:\wfsp\winfsp.msi" /qn /norestart /Lw "C:\wfsp\install.log" INSTALLLEVEL=32767
           #ls "C:\Program Files (x86)\WinFsp"
           #ls "C:\Program Files (x86)\WinFsp\bin"
 

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -7,6 +7,13 @@ on:
       - 'release-**'
     paths:
       - '**/wintest.yml'
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
   pull_request:
     branches:
       - 'main'
@@ -99,6 +106,14 @@ jobs:
       - name: Build Juicefs
         run: |
           go build -ldflags="-s -w" -o juicefs.exe .
+      
+      - name: Install Python2
+        run: |
+          choco install python2 -y
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Juicefs Format
         run: |
@@ -115,10 +130,6 @@ jobs:
           echo "hello" > "Z:\dir\hello.txt"
           dir "Z:\dir\hello.txt"
           type "Z:\dir\hello.txt"
-        
-      - name: Install Python2
-        run: |
-          choco install python2 -y
 
       - name: Download Winfsp Test Binary
         run: |
@@ -140,7 +151,7 @@ jobs:
           cd Z:\TestSuite
           ./run-winfstest
 
-      - name: Download FSX
+      - name: Run FSX Test
         run: |
           cd Z:\
           wget https://github.com/chenjie4255/fstools/releases/download/v0.0.1/fsx-x64.exe -O fsx.exe

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Download Winfsp Test Binary
         run: |
-          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
+          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64-dbg.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
           ls "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
       
       - name: Run Winfsp Test

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Juicefs Mount
         run: |
-          ./juicefs.exe mount redis://127.0.0.1:6379/1 -d myjfs Z:
+          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 myjfs z:
 
       - name: Test Juicefs
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Juicefs Mount
         run: |
-          ./juicefs.exe mount redis://127.0.0.1:6379/1 myjfs Z:
+          ./juicefs.exe mount redis://127.0.0.1:6379/1 -d myjfs Z:
 
       - name: Test Juicefs
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -104,18 +104,7 @@ jobs:
 
       - name: Juicefs Mount
         run: |
-          echo "C:\Program Files (x86)\WinFsp\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          copy winsw.exe juicefs-service.exe
-          echo  "<service>"   >> juicefs-service.xml
-          echo  "<id>juicefs</id>"  >> juicefs-service.xml
-          echo  "<name>juicefs</name>"  >> juicefs-service.xml
-          echo  "<description>juicefs</description>"  >> juicefs-service.xml
-          echo  "<executable>$PWD\juicefs.exe</executable>"  >> juicefs-service.xml
-          echo  "<arguments>mount redis://127.0.0.1:6379/1 Z: --no-usage-report</arguments>"  >> juicefs-service.xml
-          echo  "<logmode>rotate</logmode>"  >> juicefs-service.xml
-          echo  "</service>"  >> juicefs-service.xml
-          .\juicefs-service.exe install
-          net start juicefs
+          ./juicefs.exe mount redis://127.0.0.1:6379/1 myjfs Z:
 
       - name: Test Juicefs
         run: |
@@ -124,6 +113,46 @@ jobs:
           echo "hello" > "Z:\dir\hello.txt"
           dir "Z:\dir\hello.txt"
           type "Z:\dir\hello.txt"
+        
+      - name: Install Python2
+        run: |
+          choco install python2 -y
+
+      - name: Download Winfsp Test Binary
+        run: |
+          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -O "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
+          ls "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
+      
+      - name: Run Winfsp Test
+        run: |
+          cd "Z:\"
+          "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient
+      
+      - name: Download winfstest
+        run: |
+          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64.zip -O Z:\TestSuite-x64.zip
+          ls Z:\TestSuite-x64.zip
+          cd Z:\
+          Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite
+          ls Z:\TestSuite
+          cd Z:\TestSuite
+          ./run-winfstest
+
+      - name: Download FSX
+        run: |
+          cd Z:\
+          wget https://github.com/chenjie4255/fstools/releases/download/v0.0.1/fsx-x64.exe -O fsx.exe
+          ls fsx.exe
+          ./fsx.exe -d 180 -p 10000 -F 100000 fsxtest
+          
+
+        
+
+
+
+
+
+          
 
       #there is go-fuse compile error with unit test
       #- name: Unit Test

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Install WinFsp
         run: |
-          Start-Process msiexec.exe -Wait -ArgumentList '/i /qn /l*v C:\wfsp\install.log C:\wfsp\winfsp.msi'
+          # call start-process to install winfsp.msi
+          Start-Process -Wait -FilePath "C:\wfsp\winfsp-2.0.23075.msi" -ArgumentList "/quiet /norestart"
           ls "C:\Program Files (x86)\WinFsp"
           ls "C:\Program Files (x86)\WinFsp\bin"
 

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -139,7 +139,8 @@ jobs:
       
       - name: Run winfstest
         run: |
-          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64-v2.zip -q --show-progress -O Z:\TestSuite-x64.zip
+          wget https://github.com/juicedat
+          a/winfstest/releases/download/testing_20250313/TestSuite-x64-v3.zip -q --show-progress -O Z:\TestSuite-x64.zip
           ls Z:\TestSuite-x64.zip
           cd Z:\
           Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -139,8 +139,7 @@ jobs:
       
       - name: Run winfstest
         run: |
-          wget https://github.com/juicedat
-          a/winfstest/releases/download/testing_20250313/TestSuite-x64-v3.zip -q --show-progress -O Z:\TestSuite-x64.zip
+          wget https://github.com/juicedata/winfstest/releases/download/testing_20250313/TestSuite-x64-v3.zip -q --show-progress -O Z:\TestSuite-x64.zip
           ls Z:\TestSuite-x64.zip
           cd Z:\
           Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -144,7 +144,7 @@ jobs:
           cd Z:\
           Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite
           ls Z:\TestSuite
-          cd Z:\TestSuite
+          cd Z:\TestSuite\TestSuite
           ./run-winfstest.ps1
 
       - name: Run FSX Test

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -110,10 +110,6 @@ jobs:
         run: |
           choco install python2 -y
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-
       - name: Juicefs Format
         run: |
           ./juicefs.exe format redis://127.0.0.1:6379/1 myjfs
@@ -157,14 +153,9 @@ jobs:
           ls fsx.exe
           ./fsx.exe -d 180 -p 10000 -F 100000 fsxtest
           
-
-        
-
-
-
-
-
-          
+      - name: Setup tmate session
+        if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
 
       #there is go-fuse compile error with unit test
       #- name: Unit Test

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -15,11 +15,11 @@ on:
       - '**/wintest.yml'
   workflow_dispatch:
     inputs:
-    debug_enabled:
-      type: boolean
-      description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-      required: false
-      default: false
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
   schedule:
     - cron: '0 17 * * 0'
 

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -7,13 +7,6 @@ on:
       - 'release-**'
     paths:
       - '**/wintest.yml'
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
   pull_request:
     branches:
       - 'main'
@@ -21,6 +14,12 @@ on:
     paths:
       - '**/wintest.yml'
   workflow_dispatch:
+    inputs:
+    debug_enabled:
+      type: boolean
+      description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+      required: false
+      default: false
   schedule:
     - cron: '0 17 * * 0'
 

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -127,6 +127,7 @@ jobs:
 
       - name: Juicefs Mount
         run: |
+          $env:PATH+=";C:\Program Files (x86)\WinFsp\bin"
           ./juicefs.exe mount -d redis://127.0.0.1:6379/1 myjfs z:
 
       - name: Test Juicefs

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -140,13 +140,13 @@ jobs:
 
       - name: Download Winfsp Test Binary
         run: |
-          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
-          ls "C:\Program Files (x86)\WinFsp\bin\winfstest.exe"
+          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
+          ls "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
       
       - name: Run Winfsp Test
         run: |
           cd "Z:\"
-          "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient
+          & "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient --case-insensitive-cmp
       
       - name: Download winfstest
         run: |
@@ -156,7 +156,7 @@ jobs:
           Expand-Archive -Path .\TestSuite-x64.zip -DestinationPath .\TestSuite
           ls Z:\TestSuite
           cd Z:\TestSuite
-          ./run-winfstest
+          ./run-winfstest.ps1
 
       - name: Run FSX Test
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           choco install wget
           mkdir "C:\wfsp\"
-          wget -O winfsp.msi  https://github.com/billziss-gh/winfsp/releases/download/v1.9/winfsp-1.9.21096.msi
+          wget -O winfsp.msi https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.msi
           copy winfsp.msi "C:\wfsp\"
 
       - name: Install WinFsp

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -55,6 +55,7 @@ jobs:
           mkdir "C:\wfsp\"
           wget -O winfsp.msi https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.msi
           copy winfsp.msi "C:\wfsp\"
+          choco install 7zip -y
 
       - name: Install WinFsp
         run: |
@@ -102,8 +103,17 @@ jobs:
           .\redis-service.exe install
           net start redisredis
 
+      - name: Download MinGW
+        run: |
+          wget https://github.com/niXman/mingw-builds-binaries/releases/download/14.2.0-rt_v12-rev1/x86_64-14.2.0-release-win32-seh-msvcrt-rt_v12-rev1.7z -O mingw.7z
+          7z.exe x mingw.7z -oC:\mingw64
+          ls C:\mingw64\bin
+
+
       - name: Build Juicefs
         run: |
+          $env:CGO_ENABLED=1
+          $env:PATH+=";C:\mingw64\bin"
           go build -ldflags="-s -w" -o juicefs.exe .
       
       - name: Install Python2

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install WinFsp
         run: |
           # call start-process to install winfsp.msi
-          Start-Process -Wait -FilePath "C:\wfsp\winfsp-2.0.23075.msi" -ArgumentList "/quiet /norestart"
+          Start-Process -Wait -FilePath "C:\wfsp\winfsp.msi" -ArgumentList "/quiet /norestart"
           ls "C:\Program Files (x86)\WinFsp"
           ls "C:\Program Files (x86)\WinFsp\bin"
 

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Install WinFsp
         run: |
           msiexec.exe /i "C:\wfsp\winfsp.msi" /qn /norestart INSTALLLEVEL=1000
+          ls "C:\Program Files (x86)\WinFsp"
+          ls "C:\Program Files (x86)\WinFsp\bin"
 
       - name: Set up Include Headers
         run: |

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -808,7 +808,7 @@ func RunAsSystemSerivce(name string, mountpoint string) error {
 	cmd := exec.Command("net", "use", mountpoint, "\\\\juicefs\\"+name)
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Failed to mount juicefs: %s", err)
+		return fmt.Errorf("Failed to call system command %s, %s", cmd.String(), err)
 	}
 
 	logger.Info("Juicefs system service started successfully.")


### PR DESCRIPTION
## Description

* This pr introduces three tests for juicefs, winfsp test, winfstest, fsx. I modified the source code of these tests to make sure the current version of juicefs can pass all of them (to build a baseline). The following are the 3 repos that I forked.
  * https://github.com/juicedata/winfsp
  * https://github.com/juicedata/winfstest
  * https://github.com/chenjie4255/fstools 

The reason that I did not fork the fstools is because I didn't make any changes to the source code, but only created a release to save the build result (exe file)

## test

* https://github.com/juicedata/juicefs/actions/runs/13850669232/job/38757277730