### PR TITLE
Allow kernel to cache negative dir entry lookups

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -354,6 +354,10 @@ func metaCacheFlags(defaultEntryCache float64) []cli.Flag {
 			Value: "1.0s",
 			Usage: "dir entry cache timeout",
 		},
+		&cli.StringFlag{
+			Name:  "negative-dir-entry-cache",
+			Usage: "cache timeout for negative dir entry lookups",
+		},
 		&cli.BoolFlag{
 			Name:  "readdir-cache",
 			Usage: "enable kernel caching of readdir entries, with timeout controlled by attr-cache flag (require linux kernel 4.20+)",

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -913,6 +913,7 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 	conf.AttrTimeout = utils.Duration(c.String("attr-cache"))
 	conf.EntryTimeout = utils.Duration(c.String("entry-cache"))
 	conf.DirEntryTimeout = utils.Duration(c.String("dir-entry-cache"))
+	conf.NegDirEntryTimeout = utils.Duration(c.String("negative-dir-entry-cache"))
 	conf.ReaddirCache = c.Bool("readdir-cache")
 	if conf.ReaddirCache {
 		if conf.AttrTimeout == 0 {

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -752,6 +752,7 @@ func (fs *FileSystem) lookup(ctx meta.Context, parent Ino, name string, inode *I
 		es[name] = &entryCache{*inode, attr.Typ, expire}
 		fs.cacheM.Unlock()
 	}
+	// TODO: support for `negative_dentry_cache`?
 	return err
 }
 

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -87,6 +87,11 @@ func (fs *fileSystem) Lookup(cancel <-chan struct{}, header *fuse.InHeader, name
 	defer releaseContext(ctx)
 	entry, err := fs.v.Lookup(ctx, Ino(header.NodeId), name)
 	if err != 0 {
+		if fs.conf.NegDirEntryTimeout != 0 && err == syscall.ENOENT {
+			out.NodeId = 0 // zero nodeid is same as ENOENT, but with valid timeout
+			out.SetEntryTimeout(fs.conf.NegDirEntryTimeout)
+			return 0
+		}
 		return fuse.Status(err)
 	}
 	return fs.replyEntry(ctx, out, entry)

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -129,6 +129,7 @@ type Config struct {
 	Version              string
 	AttrTimeout          time.Duration
 	DirEntryTimeout      time.Duration
+	NegDirEntryTimeout   time.Duration
 	EntryTimeout         time.Duration
 	ReaddirCache         bool
 	BackupMeta           time.Duration


### PR DESCRIPTION
When `lookup` a non-existent file, current code only returns the error. However, kernel allows an empty dentry with a timeout to be returned, which acts as a negative lookup cache.
  
One use case of this negative cache in our environment is to accelerate `ffmpeg` - it looks up many non-existent files in the working directory. With hundreds of instances, those negative lookups cause lots of overhead to meta engine, and slows down all `ffmpeg` instances.

Also, `libfuse` has a similar option `negative_timeout` - https://man7.org/linux/man-pages/man8/mount.fuse3.8.html