### PR TITLE
windows: fixed access denied for '.control' file

### DIFF
--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -461,6 +461,10 @@ func (j *juice) getAttrForControlFile(ctx vfs.LogContext, p string, stat *fuse.S
 	}
 
 	j.vfs.UpdateLength(inode, attr)
+
+	attr.Gid = ctx.Gid()
+	attr.Uid = ctx.Uid()
+
 	attrToStat(inode, attr, stat)
 	return
 }


### PR DESCRIPTION
The previous [fix](https://github.com/juicedata/juicefs/pull/5376) for juicefs subcommand was tested with as-root option. when this option is removed, calling ```juicefs info``` or other sub commands results in the "Access denied" error.

According to this [disscustion](https://github.com/winfsp/winfsp/issues/40) , even we have the mode "0666" for the ".control" file, because we didn't set the correct uid & gid, the permission mapping doesn't work.


