### PR TITLE
Access log also displays caller's proc name

### DIFF
--- a/pkg/meta/context.go
+++ b/pkg/meta/context.go
@@ -171,5 +171,8 @@ func ProcOf(pid uint32) (proc string) {
 	if sp := bytes.IndexByte(buf[:p], ' '); sp > 0 { // some are separated by space
 		p = sp
 	}
+	if len(buf[:p]) == 0 { // some are empty
+		return ""
+	}
 	return filepath.Base(string(buf[:p])) // some are full path
 }

--- a/pkg/vfs/accesslog.go
+++ b/pkg/vfs/accesslog.go
@@ -18,12 +18,13 @@ package vfs
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
-	"strconv"
-	"strings"
 
+	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -91,7 +92,11 @@ func logit(ctx Context, method string, err syscall.Errno, format string, args ..
 	if ctx.Pid() != 0 && used >= time.Second*10 {
 		logger.Infof("slow operation: %s", cmd)
 	}
-	line := []byte(fmt.Sprintf("%s [uid:%d,gid:%d,pid:%d] %s\n", ts, ctx.Uid(), ctx.Gid(), ctx.Pid(), cmd))
+	procDesc := ""
+	if userProc := meta.ProcOf(ctx.Pid()); userProc != "" {
+		procDesc = fmt.Sprintf(",proc:%s", userProc)
+	}
+	line := []byte(fmt.Sprintf("%s [uid:%d,gid:%d,pid:%d%s] %s\n", ts, ctx.Uid(), ctx.Gid(), ctx.Pid(), procDesc, cmd))
 
 	for _, r := range readers {
 		select {

--- a/pkg/vfs/accesslog_test.go
+++ b/pkg/vfs/accesslog_test.go
@@ -48,7 +48,7 @@ func TestAccessLog(t *testing.T) {
 
 	// read whole line, block for 1 second
 	n = readAccessLog(1, buf[10:])
-	if n != 66 {
+	if n < 66 {
 		t.Fatalf("partial read: %d", n)
 	}
 	logs := string(buf[:10+n])

--- a/pkg/vfs/accesslog_test.go
+++ b/pkg/vfs/accesslog_test.go
@@ -48,7 +48,7 @@ func TestAccessLog(t *testing.T) {
 
 	// read whole line, block for 1 second
 	n = readAccessLog(1, buf[10:])
-	if n < 66 {
+	if n != 66 {
 		t.Fatalf("partial read: %d", n)
 	}
 	logs := string(buf[:10+n])


### PR DESCRIPTION
Pid in the access log does not provide much intuitive information, especially when reviewing the access log afterward. A more intuitive approach is to display the caller's process name.

This process name is particularly helpful when investigating accidental deletions afterward.

![img_v3_02kk_2d5af1a3-6eee-40eb-9026-aa1a6816e8fg](https://github.com/user-attachments/assets/fb797a7f-eb96-4b72-8c4e-52de8d9a90fb)

