### PR TITLE
windows: fix time accruacy bug

### DIFF
--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Run Winfsp Tests
         run: |
-          wget https://github.com/juicedata/winfsp/releases/download/testing_20250312/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
+          wget https://github.com/juicedata/winfsp/releases/download/testing_suit_20250324/winfsp-tests-x64.exe -q --show-progress -O "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
           ls "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe"
           cd Z:
           & "C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient --case-insensitive-cmp
@@ -157,35 +157,3 @@ jobs:
       - name: Setup tmate session
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         uses: mxschmitt/action-tmate@v3
-
-      #there is go-fuse compile error with unit test
-      #- name: Unit Test
-      #  run: |
-      #    rm pkg/meta/redis_test.go
-      #    rm pkg/meta/sql_test.go
-      #    rm pkg/meta/tkv_test.go
-      #    go test -v -cover ./pkg/... ./cmd/...
-
-      # - name: Install Python2
-      #   run: |
-      #     choco install python2 -y
-
-      # - name: Build and Run Winfstest
-      #   run: |
-      #     git clone https://github.com/sanwan/winfstest.git
-      #     cd winfstest
-      #     msbuild.exe winfstest.sln
-      #     cd TestSuite
-      #     .\run-winfstest
-
-      #cannot write file because of some permission question with winfsp
-      #- name: Build and Run Winfstest in Jfs Directory
-      #  run: |
-      #    Z:
-      #    mkdir "Z:\tmptmp"
-      #    cd tmptmp
-      #    git clone https://github.com/sanwan/winfstest.git
-      #    cd winfstest
-      #    msbuild.exe winfstest.sln
-      #    cd TestSuite
-      #    .\run-winfstest

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -291,7 +291,7 @@ func (j *juice) Utimens(path string, tmsp []fuse.Timespec) (e int) {
 	if err != 0 {
 		e = errorconv(err)
 	} else {
-		e = errorconv(f.Utime(ctx, tmsp[0].Sec*1000+tmsp[0].Nsec/1e6, tmsp[1].Sec*1000+tmsp[1].Nsec/1e6))
+		e = errorconv(f.Utime2(ctx, tmsp[0].Sec, tmsp[0].Nsec, tmsp[1].Sec, tmsp[1].Nsec))
 	}
 	return
 }


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/5822

## Reason

* Calling the original function: ```func (f *File) Utime(ctx meta.Context, atime, mtime int64) (err syscall.Errno) ``` results in the loss of accuracy for the nanosecond (nsec) part.
* This PR introduces a new utime2 method, allowing the direct setting of both the second (sec) and nanosecond (nsec) parts.

## Tests

- [x] Confirmed that the test code from https://github.com/juicedata/juicefs/issues/5822 passes.

- [x] The accesstime and lastwritetime tests in the winfsp-tests suite now pass.

- [x] https://github.com/juicedata/juicefs/actions/runs/14028699548/job/39271818776 the updated CI test which now includes the setfiletime tests.