### PR TITLE
windows:  add pprof & log file collection for debug command

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -295,10 +295,6 @@ func reqAndSaveMetric(name string, metric metricItem, outDir string, timeout tim
 	return writer.Flush()
 }
 
-func isUnix() bool {
-	return runtime.GOOS == "linux" || runtime.GOOS == "darwin"
-}
-
 func checkAgent(cmd string) bool {
 	for _, field := range strings.Fields(cmd) {
 		if field == "--no-agent" {

--- a/cmd/debug_windows.go
+++ b/cmd/debug_windows.go
@@ -51,7 +51,7 @@ func getprocessCommandLine(pid int) (string, error) {
 		return sline, nil
 	}
 
-	return "", fmt.Errorf("cannot find command line for pid %d", pid)
+	return "", fmt.Errorf("cannot find command line for pid %d. If the juicefs are mounted at background, Please rerun this with the admin permission.", pid)
 }
 
 func findMountProcess(mp string) (int, error) {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -534,7 +534,7 @@ func getDefaultLogDir() string {
 			break
 		}
 		fallthrough
-	case "darwin":
+	case "darwin", "windows":
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			logger.Fatalf("%v", err)

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -761,7 +761,7 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	_ = host.Mount(conf.Meta.MountPoint, []string{"-o", options})
 }
 
-func RunAsSystemSerivce(name string, mountpoint string) error {
+func RunAsSystemSerivce(name string, mountpoint string, logPath string) error {
 	// https://winfsp.dev/doc/WinFsp-Service-Architecture/
 	logger.Info("Running as Windows system service.")
 
@@ -814,6 +814,19 @@ func RunAsSystemSerivce(name string, mountpoint string) error {
 	err = k.SetDWordValue("JobControl", 1)
 	if err != nil {
 		return fmt.Errorf("Failed to set registry key: %s", err)
+	}
+
+	if logPath != "" {
+		err = k.SetStringValue("Stderr", logPath)
+		if err != nil {
+			return fmt.Errorf("Failed to set registry key: %s", err)
+		}
+	} else {
+		err = k.DeleteValue("Stderr")
+		if err != nil {
+			return fmt.Errorf("Failed to delete registry key: %s", err)
+		}
+
 	}
 
 	logger.Debug("Starting juicefs service.")


### PR DESCRIPTION
fix #5869

* Winfsp provides a "stderr" param, allowing us to redirect the output of a managed application to a file. We can use it when running in the background to save the log output.
* for the replacement of the 'tail' command on Windows, this pr uses 'Get-Content' command, which has a similar effect as the 'tail' command on UNIX.

## Tests

- [x] mount juicefs in the background and call juicefs debug, confirmed the output folder contains the pprof file and the log file.

