### PR TITLE
windows: fixed meta backup

### DIFF
--- a/pkg/vfs/backup.go
+++ b/pkg/vfs/backup.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -101,7 +102,7 @@ func backup(m meta.Meta, blob object.ObjectStorage, now time.Time, fast, skipTra
 		localDir += "/"
 	}
 	fp, err := os.Create(filepath.Join(localDir, "meta", name))
-	if errors.Is(err, syscall.ENOENT) {
+	if errors.Is(err, syscall.ENOENT) || (errors.Is(err, syscall.ENOTDIR) && runtime.GOOS == "windows") {
 		if err = os.MkdirAll(filepath.Join(localDir, "meta"), 0755); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
fix #5875 

When a parent directory does not exist, the os package will return syscall.ENOTDIR on windows platform.  see this [link](https://go-review.googlesource.com/c/go/+/381957)


## test

Now can see a successful backup log.

```
C:\Users\....\Workspace\juicefs>juicefs.exe mount redis://192.168.31.134:6379/2 x: --backup-meta 5m
2025/03/27 16:39:07.964517 juicefs[21180] <INFO>: Meta address: redis://192.168.31.134:6379/2 [NewClient@interface.go:578]
2025/03/27 16:39:07.968331 juicefs[21180] <INFO>: Ping redis latency: 561.1µs [checkServerConfig@redis.go:3653]
2025/03/27 16:39:07.976978 juicefs[21180] <INFO>: Data use minio://192.168.31.134:9000/jfscevol2/myjfs2/ [mount@mount.go:664]
2025/03/27 16:39:07.976978 juicefs[21180] <INFO>: JuiceFS version 1.3.0-dev+unknown [mount@mount.go:707]
2025/03/27 16:39:07.978488 juicefs[21180] <WARNING>: not enough space (8%) or inodes (100%) for caching in C:\Users\chenj\.juicefs\cache\d9206921-b56d-49d7-a0c6-0168d6e446a7\: free ratio should be >= 10% [newCacheStore@disk_cache.go:145]
2025/03/27 16:39:07.978488 juicefs[21180] <INFO>: Disk cache (C:\Users\chenj\.juicefs\cache\d9206921-b56d-49d7-a0c6-0168d6e446a7\): used ratio - [space 91.2%, inode 0%] [newCacheStore@disk_cache.go:147]
2025/03/27 16:39:08.031410 juicefs[21180] <INFO>: Create session 105 OK with version: 1.3.0-dev+unknown [NewSession@base.go:519]
2025/03/27 16:39:08.040177 juicefs[21180] <INFO>: Prometheus metrics listening on 127.0.0.1:9567 [exposeMetrics@mount.go:135]
The service juicefs has been started.
2025/03/27 16:39:38.442970 juicefs[21180] <WARNING>: Secret key is removed for the sake of safety [DumpMeta@redis.go:4026]
Dumped entries: 68/68 [==============================================================]  5241.5/s used: 12.9733ms
2025/03/27 16:39:38.504612 juicefs[21180] <INFO>: backup metadata succeed, fast mode: true, path: "minio://192.168.31.134:9000/jfscevol2/myjfs2/meta/dump-2025-03-27-083938.json.gz", used 64.9078ms [Backup@backup.go:87]
2025/03/27 16:45:07.486145 juicefs[21180] <WARNING>: Secret key is removed for the sake of safety [DumpMeta@redis.go:4026]
Dumped entries: 68/68 [==============================================================]  6187.3/s used: 10.9903ms
2025/03/27 16:45:07.510320 juicefs[21180] <INFO>: backup metadata succeed, fast mode: true, path: "minio://192.168.31.134:9000/jfscevol2/myjfs2/meta/dump-2025-03-27-084507.json.gz", used 27.3595ms [Backup@backup.go:87]
```
