### PR TITLE
windows: fix restore command

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -42,7 +43,7 @@ $ juicefs restore redis://localhost/1 2023-05-10-01`,
 
 func restore(ctx *cli.Context) error {
 	setup(ctx, 2)
-	if os.Getuid() != 0 {
+	if os.Getuid() != 0 && runtime.GOOS != "windows" {
 		return fmt.Errorf("only root can restore files from trash")
 	}
 	removePassword(ctx.Args().Get(0))


### PR DESCRIPTION
fix #5863 

I am not sure if we can simply skip the user checking on the windows platform? or we still need an advanced method to check if the current application is elevated?

## Tests

The restore command succeed with the changes of this PR.

```
C:\Users\chenj\Workspace\juicefs> .\juicefs.exe restore redis://192.168.31.134:6379/2 2025-03-27-09 --put-back
2025/03/27 17:53:55.064499 juicefs[22748] <INFO>: Meta address: redis://192.168.31.134:6379/2 [NewClient@interface.go:578]
2025/03/27 17:53:55.067726 juicefs[22748] <INFO>: Ping redis latency: 512µs [checkServerConfig@redis.go:3653]
2025/03/27 17:53:55.068246 juicefs[22748] <INFO>: restore files in 2025-03-27-09 ... [doRestore@restore.go:70]
restored: 2/2 [==============================================================]  463.9/s used: 4.3113ms                                                                                                                                                                                 
 skipped: 0   0.0/s                                                                                                                                                                                                                                                                    
  failed: 0   0.0/s                                                                                                                                                                                                                                                                    
2025/03/27 17:53:55.074125 juicefs[22748] <INFO>: restored 2 files in 2025-03-27-09 [doRestore@restore.go:142]
2025/03/27 17:53:55.074125 juicefs[22748] <INFO>: restored 2 files to "/" [doRestore@restore.go:144]
2025/03/27 17:53:55.074634 juicefs[22748] <INFO>: flush session 0: [FlushSession@base.go:700]
2025/03/27 17:53:55.074634 juicefs[22748] <INFO>: close session 0: <nil> [CloseSession@base.go:689]
```