### PR TITLE
Fix fuse_fd_comm was never cleaned up

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -775,6 +775,7 @@ func launchMount(mp string, conf *vfs.Config) error {
 	}
 	os.Setenv("_FUSE_FD_COMM", serverAddress)
 	serveFuseFD(serverAddress)
+	defer os.Remove(serverAddress)
 
 	path, err := os.Executable()
 	if err != nil {

--- a/cmd/passfd.go
+++ b/cmd/passfd.go
@@ -162,7 +162,6 @@ func serveFuseFD(path string) {
 		return
 	}
 	go func() {
-		defer os.Remove(path)
 		defer sock.Close()
 		for {
 			conn, err := sock.Accept()


### PR DESCRIPTION
When main thread exits, deferred statements in child threads won't execute.