### PR TITLE
Release memory timely to avoid OOM

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -1128,11 +1128,11 @@ func (store *cachedStore) FillCache(id uint64, length uint32) error {
 			continue
 		}
 		p := NewOffPage(size)
-		defer p.Release()
 		if e := store.load(k, p, true, true); e != nil {
 			logger.Warnf("Failed to load key: %s %s", k, e)
 			err = e
 		}
+		p.Release()
 	}
 	return err
 }


### PR DESCRIPTION
Warmup now have too many concurrency than expected by default (50x50, introduced in #5713), which makes peak memory usage prone to trigger OOM. This patch alleviates part of the memory usage.

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/7c353007-1f3b-424d-b966-ba4c7a342f40" />

<img width="1382" alt="image" src="https://github.com/user-attachments/assets/8269125c-d3a4-4974-977e-4ed617a45693" />
