### PR TITLE
Optimize `PowerOf2` to use a msb lookup table

### DIFF
--- a/pkg/utils/alloc.go
+++ b/pkg/utils/alloc.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"math/bits"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -63,14 +64,13 @@ func AllocMemory() int64 {
 
 var pools []*sync.Pool
 
+// PowerOf2 returns the smallest power of 2 that is >= s
 func PowerOf2(s int) int {
-	var bits int
-	var p int = 1
-	for p < s {
-		bits++
-		p *= 2
+	if s <= 0 {
+		return 0
 	}
-	return bits
+	// Find position of the most significant bit (MSB)
+	return bits.Len(uint(s - 1))
 }
 
 func init() {

--- a/pkg/utils/alloc_test.go
+++ b/pkg/utils/alloc_test.go
@@ -16,7 +16,9 @@
 
 package utils
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestAlloc(t *testing.T) {
 	old := AllocMemory()
@@ -28,4 +30,32 @@ func TestAlloc(t *testing.T) {
 	if AllocMemory()-old != 0 {
 		t.Fatalf("free all allocated memory, but got %d", AllocMemory()-old)
 	}
+}
+
+func PowerOf2Loop(s int) int {
+	var bits int
+	var p int = 1
+	for p < s {
+		bits++
+		p *= 2
+	}
+	return bits
+}
+
+func BenchmarkPowerOf2(b *testing.B) {
+	b.Run("bits.Len", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < 100000; j++ {
+				_ = PowerOf2(j)
+			}
+		}
+	})
+
+	b.Run("Loop", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < 100000; j++ {
+				_ = PowerOf2Loop(j)
+			}
+		}
+	})
 }


### PR DESCRIPTION
BenchmarkPowerOf2
BenchmarkPowerOf2/bits.Len
BenchmarkPowerOf2/bits.Len-8         	   38287	     29290 ns/op
BenchmarkPowerOf2/Loop
BenchmarkPowerOf2/Loop-8             	    1995	    578712 ns/op