### PR TITLE
cmd/sync: fix the bug where use the jfs protocol header loses soft link information during task distribution

### DIFF
--- a/.github/scripts/sync/sync_cluster.sh
+++ b/.github/scripts/sync/sync_cluster.sh
@@ -214,9 +214,11 @@ test_sync_files_from_file(){
     ./juicefs mount -d $META_URL /jfs
     mkdir /jfs/test || true
     mkdir /jfs/test2 || true
-    sudo -u juicedata ./random-test runOp -baseDir /jfs/test -files 500000 -ops 5000000 -threads 50 -dirSize 100000 -duration 60s -createOp 30,uniform \
+    ./random-test runOp -baseDir /jfs/test -files 500000 -ops 5000000 -threads 50 -dirSize 100000 -duration 30s -createOp 30,uniform \
     -deleteOp 5,end --linkOp 10,uniform --symlinkOp 20,uniform --setXattrOp 10,uniform --truncateOp 10,uniform
-    sudo ls /jfs/test > files
+    chmod -R 777 /jfs/test
+    chmod -R 777 /jfs/test2
+    echo 'dir' > files
     sudo -u juicedata meta_url=$META_URL ./juicefs sync jfs://meta_url/test/ jfs://meta_url/test2/ \
          --manager-addr 172.20.0.1:8081 --worker juicedata@172.20.0.2,juicedata@172.20.0.3 \
          --list-threads 10 --list-depth 5 --check-all --links --dirs --files-from files \

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -73,6 +73,7 @@ func TestMarshal(t *testing.T) {
 		&obj{key: "test"},
 		&withSize{&obj{key: "test1", size: 100}, -4},
 		&withFSize{&obj{key: "test2", size: 200}, -1},
+		&withSize{&obj{key: "test3", size: 101, isSymlink: true}, -4},
 	}
 	d, err := marshalObjects(objs)
 	if err != nil {
@@ -86,9 +87,12 @@ func TestMarshal(t *testing.T) {
 		t.Fatalf("expect test but got %s", objs2[0].Key())
 	}
 	if objs2[1].Key() != "test1" || objs2[1].Size() != -4 || objs2[1].(*withSize).Object.Size() != 100 {
-		t.Fatalf("expect withSize but got %s", objs2[0].Key())
+		t.Fatalf("expect withSize but got %s", objs2[1].Key())
 	}
 	if objs2[2].Key() != "test2" || objs2[2].Size() != -1 || objs2[2].(*withFSize).File.Size() != 200 {
-		t.Fatalf("expect withFSize but got %s", objs2[0].Key())
+		t.Fatalf("expect withFSize but got %s", objs2[2].Key())
+	}
+	if objs2[3].Key() != "test3" || objs2[3].Size() != -4 || objs2[3].(*withSize).Object.Size() != 101 && objs2[3].IsSymlink() != true {
+		t.Fatalf("expect withFSize but got %s", objs2[3].Key())
 	}
 }


### PR DESCRIPTION
close #5861
close #5889