### PR TITLE
windows: fix rename bugs

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -641,7 +641,9 @@ func mount(c *cli.Context) error {
 	var metaCli meta.Meta
 	var blob object.ObjectStorage
 	metaConf := getMetaConf(c, mp, c.Bool("read-only") || utils.StringContains(strings.Split(c.String("o"), ","), "ro"))
-	metaConf.CaseInsensi = strings.HasSuffix(mp, ":") && runtime.GOOS == "windows"
+	if runtime.GOOS == "windows" {
+		metaConf.CaseInsensi = !c.Bool("case-sensitive")
+	}
 	// stage 0: check the connection to fail fast
 	// stage 2: need the volume name to check if it's already mounted
 	// stage 3: the real service process

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -41,8 +41,8 @@ func mountFlags() []cli.Flag {
 			Usage: "path of log file when running in background",
 		},
 		&cli.StringFlag{
-			Name:  "access-log",
-			Usage: "Access log file",
+			Name:  "fuse-trace-log",
+			Usage: "FUSE trace log file",
 		},
 		&cli.BoolFlag{
 			Name:  "as-root",
@@ -68,8 +68,9 @@ func mountFlags() []cli.Flag {
 			Value: min(runtime.NumCPU()*2, 16),
 		},
 		&cli.BoolFlag{
-			Name:  "case-sensitive",
-			Usage: "If set, the file system will be case sensitive",
+			Name:   "case-sensitive",
+			Usage:  "If set, the file system will be case sensitive",
+			Hidden: true,
 		},
 	}
 }
@@ -104,13 +105,12 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 	dirCacheTimeout := utils.Duration(c.String("dir-entry-cache"))
 	delayCloseTime := utils.Duration(c.String("delay-close"))
 
-	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(), c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"), c.Int("winfsp-threads"))
-	acLog := c.String("access-log")
-	if acLog != "" {
-		winfsp.SetTraceOutput(acLog)
+	traceLog := c.String("fuse-trace-log")
+	if traceLog != "" {
+		winfsp.SetTraceOutput(traceLog)
 	}
 
-	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("show-dot-files"), c.Bool("case-sensitive"))
+	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(), c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"), c.Int("winfsp-threads"), c.Bool("case-sensitive"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -67,6 +67,10 @@ func mountFlags() []cli.Flag {
 			Usage: "WinFsp threads count option, Default is min(cpu core * 2, 16)",
 			Value: min(runtime.NumCPU()*2, 16),
 		},
+		&cli.BoolFlag{
+			Name:  "case-sensitive",
+			Usage: "If set, the file system will be case sensitive",
+		},
 	}
 }
 
@@ -101,6 +105,12 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 	delayCloseTime := utils.Duration(c.String("delay-close"))
 
 	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(), c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"), c.Int("winfsp-threads"))
+	acLog := c.String("access-log")
+	if acLog != "" {
+		winfsp.SetTraceOutput(acLog)
+	}
+
+	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("show-dot-files"), c.Bool("case-sensitive"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1732,7 +1732,7 @@ func (m *redisMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentD
 		dbuf, err := tx.HGet(ctx, m.entryKey(parentDst), nameDst).Bytes()
 		if err == redis.Nil && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
-				if parentDst != parentSrc || !strings.EqualFold(nameDst, nameSrc) {
+				if e.Inode != ino {
 					nameDst = string(e.Name)
 					dbuf = m.packEntry(e.Attr.Typ, e.Inode)
 					err = nil
@@ -1762,11 +1762,7 @@ func (m *redisMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentD
 		}
 		if dino > 0 {
 			if ino == dino {
-				if m.conf.CaseInsensi && nameSrc != nameDst {
-					dino = 0
-				} else {
-					return errno(nil)
-				}
+				return errno(nil)
 			}
 			if exchange {
 			} else if typ == TypeDirectory && dtyp != TypeDirectory {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1732,7 +1732,7 @@ func (m *redisMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentD
 		dbuf, err := tx.HGet(ctx, m.entryKey(parentDst), nameDst).Bytes()
 		if err == redis.Nil && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
-				if e.Inode != ino {
+				if (nameSrc != string(e.Name)) || parentDst != parentSrc {
 					nameDst = string(e.Name)
 					dbuf = m.packEntry(e.Attr.Typ, e.Inode)
 					err = nil

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2132,10 +2132,12 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		}
 		if !ok && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
-				ok = true
-				de.Inode = e.Inode
-				de.Type = e.Attr.Typ
-				de.Name = e.Name
+				if e.Inode != se.Inode {
+					ok = true
+					de.Inode = e.Inode
+					de.Type = e.Attr.Typ
+					de.Name = e.Name
+				}
 			}
 		}
 		var supdate, dupdate bool

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2085,10 +2085,12 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		}
 		if !ok && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentSrc, nameSrc); e != nil {
-				ok = true
-				se.Inode = e.Inode
-				se.Type = e.Attr.Typ
-				se.Name = e.Name
+				if string(e.Name) != nameSrc || parentSrc != parentDst {
+					ok = true
+					se.Inode = e.Inode
+					se.Type = e.Attr.Typ
+					se.Name = e.Name
+				}
 			}
 		}
 		if !ok {
@@ -2132,7 +2134,7 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		}
 		if !ok && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
-				if e.Inode != se.Inode {
+				if string(e.Name) != nameSrc || parentSrc != parentDst {
 					ok = true
 					de.Inode = e.Inode
 					de.Type = e.Attr.Typ

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1561,7 +1561,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		dbuf := tx.get(m.entryKey(parentDst, nameDst))
 		if dbuf == nil && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
-				if e.Inode != ino {
+				if string(e.Name) != nameSrc || parentDst != parentSrc {
 					nameDst = string(e.Name)
 					dbuf = m.packEntry(e.Attr.Typ, e.Inode)
 				}
@@ -1601,11 +1601,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 					}
 				}
 			} else if dino == ino {
-				if m.conf.CaseInsensi && nameSrc != nameDst {
-					dino = 0
-				} else {
-					return nil
-				}
+				return nil
 			} else if typ == TypeDirectory && dtyp != TypeDirectory {
 				return syscall.ENOTDIR
 			} else if typ != TypeDirectory && dtyp == TypeDirectory {

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -751,14 +751,18 @@ func (j *juice) Getpath(p string, fh uint64) (e int, ret string) {
 		return
 	}
 
+	retCandidicate := paths[0]
+
 	for _, path := range paths {
-		if strings.EqualFold(path, p) {
+		if p == path {
 			ret = path
 			return
+		} else if strings.EqualFold(path, p) {
+			retCandidicate = path
 		}
 	}
 
-	ret = paths[0]
+	ret = retCandidicate
 	return
 }
 

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -727,7 +727,29 @@ func (j *juice) Chflags(path string, flags uint32) (e int) {
 	return
 }
 
-func Serve(v *vfs.VFS, fuseOpt string, fileCacheTimeoutSec float64, dirCacheTimeoutSec float64, asRoot bool, delayCloseSec int, showDotFiles bool, threadsCount int) {
+func (j *juice) Getpath(p string, fh uint64) (e int, ret string) {
+	defer trace(p, fh)(&e, &ret)
+	ino := j.h2i(&fh)
+	ctx := j.newContext()
+	if ino == 0 {
+		fi, err := j.fs.Stat(ctx, p)
+		if err != 0 {
+			e = errorconv(err)
+			return
+		}
+		ino = fi.Inode()
+	}
+
+	paths := j.vfs.Meta.GetPaths(ctx, ino)
+	if len(paths) == 0 {
+		ret = p
+		return
+	}
+	ret = path.Join(paths...)
+	return
+}
+
+func Serve(v *vfs.VFS, fuseOpt string, fileCacheTimeoutSec float64, dirCacheTimeoutSec float64, asRoot bool, delayCloseSec int, showDotFiles bool, threadsCount int, caseSensitive bool) {
 	var jfs juice
 	conf := v.Conf
 	jfs.conf = conf
@@ -755,7 +777,7 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTimeoutSec float64, dirCacheTime
 	if !showDotFiles {
 		options += ",dothidden"
 	}
-	host.SetCapCaseInsensitive(strings.HasSuffix(conf.Meta.MountPoint, ":"))
+	host.SetCapCaseInsensitive(!caseSensitive)
 	host.SetCapReaddirPlus(true)
 	logger.Debugf("mount point: %s, options: %s", conf.Meta.MountPoint, options)
 	_ = host.Mount(conf.Meta.MountPoint, []string{"-o", options})

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -745,7 +745,20 @@ func (j *juice) Getpath(p string, fh uint64) (e int, ret string) {
 		ret = p
 		return
 	}
-	ret = path.Join(paths...)
+
+	if len(paths) == 1 {
+		ret = paths[0]
+		return
+	}
+
+	for _, path := range paths {
+		if strings.EqualFold(path, p) {
+			ret = path
+			return
+		}
+	}
+
+	ret = paths[0]
 	return
 }
 


### PR DESCRIPTION
fix #5871 

This PR adjusts the following behaviors:

* Fixed a crash issue on Windows when renaming a.txt to A.TXT. The crash was caused by the original line 1736. see comment.
* After fixing the crash, it also fixed the issue where renaming had no effect (because the code returned early when ino == dino).
* Fixed a problem where the file name became all uppercase after renaming in File Explorer. (Solved by implementing the getpath interface.)
* Adjusted the original --access-log feature: instead of logging from the FS layer, it now logs from the WinFS layer.
* Added a case-sensitive parameter. (It is disabled by default, and can be enabled when needed.)

## Known issue:

* When case-sensitive is enabled, renaming a file to a similar name with different casing (e.g., a.txt → A.TXT) will cause the file to disappear in File Explorer. The notification sent from the WinFSP kernel contains both the old and new filenames correctly. The reason for the disappearance is currently unknown.

---

## updates 1:

* Setting windows registry hklm\system\currentcontrolset\sessionmanager\kernel\obcaseinsensitive=0 didn't help with the known issue 
