### PR TITLE
windows: fix clone perm issue.

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/juicedata/juicefs/pkg/meta"
@@ -50,7 +51,8 @@ $ juicefs clone -p /mnt/jfs/file1 /mnt/jfs/file2`,
 			&cli.BoolFlag{
 				Name:    "preserve",
 				Aliases: []string{"p"},
-				Usage:   "preserve the uid, gid, and mode of the file"},
+				Usage:   "preserve the uid, gid, and mode of the file. (This is forced on Windows)",
+			},
 		},
 	}
 }
@@ -107,7 +109,7 @@ func clone(ctx *cli.Context) error {
 	}
 	var cmode uint8
 	umask := utils.GetUmask()
-	if ctx.Bool("preserve") {
+	if ctx.Bool("preserve") || runtime.GOOS == "windows" {
 		cmode |= meta.CLONE_MODE_PRESERVE_ATTR
 	}
 	headerSize := 4 + 4


### PR DESCRIPTION
fix #5896

* WinFsp doesn’t support getting the UID/GID during I/O calls (read/write). See: https://github.com/winfsp/winfsp/issues/99#issuecomment-321215011
* When the mount process receives the write callback to the .control file, it tries to get the UID through fuse.getcontext(). Because of the previous "bug," it results in the write operation being performed as root (uid=0).
* The clone message handler processes it as the root user, which causes the file to become inaccessible on Windows.
* This pr simply force the "preserve" mode on windows.


## Discussion

* Maybe in the future we can extend the clone message and pass the current UID/GID with it.