### PR TITLE
windows: elevate some winfsp perf-related params

### DIFF
--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/object"
@@ -64,6 +65,16 @@ func mountFlags() []cli.Flag {
 			Name:  "show-dot-files",
 			Usage: "If set, dot files will not be treated as hidden files",
 		},
+		&cli.IntFlag{
+			Name:  "winfsp-threads",
+			Usage: "WinFsp threads count option, Default is min(cpu core * 2, 16)",
+			Value: min(runtime.NumCPU()*2, 16),
+		},
+		&cli.Float64Flag{
+			Name:  "dirinfo-cache-to",
+			Usage: "Dir information timeout in seconds",
+			Value: 1,
+		},
 	}
 }
 
@@ -92,7 +103,8 @@ func getDaemonStage() int {
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
 	v.Conf.AccessLog = c.String("access-log")
-	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("show-dot-files"))
+
+	winfsp.Serve(v, c.String("o"), c.Float64("file-cache-to"), c.Float64("dirinfo-cache-to"), c.Bool("as-root"), c.Int("delay-close"), c.Bool("show-dot-files"), c.Int("winfsp-threads"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -727,7 +727,7 @@ func (j *juice) Chflags(path string, flags uint32) (e int) {
 	return
 }
 
-func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayClose int, showDotFiles bool) {
+func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, dirCacheTo float64, asRoot bool, delayClose int, showDotFiles bool, threadsCount int) {
 	var jfs juice
 	conf := v.Conf
 	jfs.conf = conf
@@ -742,8 +742,8 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTo float64, asRoot bool, delayCl
 	host := fuse.NewFileSystemHost(&jfs)
 	jfs.host = host
 	var options = "volname=" + conf.Format.Name
-	options += ",ExactFileSystemName=JuiceFS,ThreadCount=16"
-	options += ",DirInfoTimeout=1000,VolumeInfoTimeout=1000,KeepFileCache"
+	options += fmt.Sprintf(",ExactFileSystemName=JuiceFS,ThreadCount=%d", threadsCount)
+	options += fmt.Sprintf(",DirInfoTimeout=%d,VolumeInfoTimeout=1000,KeepFileCache", int(dirCacheTo*1000))
 	options += fmt.Sprintf(",FileInfoTimeout=%d", int(fileCacheTo*1000))
 	options += ",VolumePrefix=/juicefs/" + conf.Format.Name
 	if asRoot {


### PR DESCRIPTION

## tests

* Running juicefs bench with winfsp_threads = 16 vs 32, didn't see any significant improvement. This pr may be useful for some certain cases.