### PR TITLE
pysdk: add command status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -33,13 +33,13 @@ func cmdStatus() *cli.Command {
 		Usage:     "Show status of a volume",
 		ArgsUsage: "META-URL",
 		Description: `
- It shows basic setting of the target volume, and a list of active sessions (including mount, SDK,
- S3-gateway and WebDAV) that are connected with the metadata engine.
- 
- NOTE: Read-only session is not listed since it cannot register itself in the metadata.
- 
- Examples:
- $ juicefs status redis://localhost`,
+It shows basic setting of the target volume, and a list of active sessions (including mount, SDK,
+S3-gateway and WebDAV) that are connected with the metadata engine.
+
+NOTE: Read-only session is not listed since it cannot register itself in the metadata.
+
+Examples:
+$ juicefs status redis://localhost`,
 		Flags: []cli.Flag{
 			&cli.Uint64Flag{
 				Name:    "session",
@@ -69,11 +69,10 @@ func status(ctx *cli.Context) error {
 	removePassword(metaUrl)
 	m := meta.NewClient(metaUrl, nil)
 
-	sessionId := ctx.Uint64("session")
-	if sessionId != 0 {
-		s, err := m.GetSession(sessionId, true)
+	if sid := ctx.Uint64("session"); sid != 0 {
+		s, err := m.GetSession(sid, true)
 		if err != nil {
-			logger.Fatalf("get session: %v", err)
+			logger.Fatalf("get session: %s", err)
 		}
 		printJson(s)
 		return nil

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -22,7 +22,29 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/juicedata/juicefs/pkg/meta"
 )
+
+type statistic struct {
+	UsedSpace                uint64
+	AvailableSpace           uint64
+	UsedInodes               uint64
+	AvailableInodes          uint64
+	TrashFileCount           int64 `json:",omitempty"`
+	TrashFileSize            int64 `json:",omitempty"`
+	PendingDeletedFileCount  int64 `json:",omitempty"`
+	PendingDeletedFileSize   int64 `json:",omitempty"`
+	TrashSliceCount          int64 `json:",omitempty"`
+	TrashSliceSize           int64 `json:",omitempty"`
+	PendingDeletedSliceCount int64 `json:",omitempty"`
+	PendingDeletedSliceSize  int64 `json:",omitempty"`
+}
+
+type sections struct {
+	Setting   *meta.Format
+	Sessions  []*meta.Session
+	Statistic *statistic
+}
 
 func TestStatus(t *testing.T) {
 	tmpFile, err := os.CreateTemp("/tmp", "")

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -25,27 +25,6 @@ import (
 	"github.com/juicedata/juicefs/pkg/meta"
 )
 
-type statistic struct {
-	UsedSpace                uint64
-	AvailableSpace           uint64
-	UsedInodes               uint64
-	AvailableInodes          uint64
-	TrashFileCount           int64 `json:",omitempty"`
-	TrashFileSize            int64 `json:",omitempty"`
-	PendingDeletedFileCount  int64 `json:",omitempty"`
-	PendingDeletedFileSize   int64 `json:",omitempty"`
-	TrashSliceCount          int64 `json:",omitempty"`
-	TrashSliceSize           int64 `json:",omitempty"`
-	PendingDeletedSliceCount int64 `json:",omitempty"`
-	PendingDeletedSliceSize  int64 `json:",omitempty"`
-}
-
-type sections struct {
-	Setting   *meta.Format
-	Sessions  []*meta.Session
-	Statistic *statistic
-}
-
 func TestStatus(t *testing.T) {
 	tmpFile, err := os.CreateTemp("/tmp", "")
 	if err != nil {
@@ -68,7 +47,7 @@ func TestStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read file failed: %s", err)
 	}
-	s := sections{}
+	s := meta.Sections{}
 	if err = json.Unmarshal(content, &s); err != nil {
 		t.Fatalf("json unmarshal failed: %s", err)
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -19,7 +19,6 @@ package fs
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -990,38 +989,6 @@ func (fs *FileSystem) Close() error {
 		close(buffer)
 	}
 	return nil
-}
-
-func (fs *FileSystem) Status(ctx meta.Context, trash bool, sessionId uint64) ([]byte, error) {
-	var err error
-	var output []byte
-	defer trace.StartRegion(context.TODO(), "fs.Status").End()
-	l := vfs.NewLogContext(ctx)
-	defer func() {
-		fs.log(l, "Status (%t): %s", trash, errstr(err))
-	}()
-
-	if sessionId != 0 {
-		s, err := fs.m.GetSession(sessionId, true)
-		if err != nil {
-			return nil, fmt.Errorf("get session: %v", err)
-		}
-		output, err = json.Marshal(s)
-		if err != nil {
-			return nil, fmt.Errorf("marshal session: %v", err)
-		}
-	} else {
-		sections := &meta.Sections{}
-		err = meta.Status(ctx, fs.m, trash, sections)
-		if err != nil {
-			logger.Fatalf("get status: %s", err)
-		}
-		output, err = json.Marshal(sections)
-		if err != nil {
-			return nil, fmt.Errorf("marshal session: %v", err)
-		}
-	}
-	return output, nil
 }
 
 func (fs *FileSystem) Clone(ctx meta.Context, src, dst string, preserve bool) (err syscall.Errno) {

--- a/pkg/meta/status.go
+++ b/pkg/meta/status.go
@@ -1,4 +1,3 @@
-// meta/status.go
 /*
  * JuiceFS, Copyright 2021 Juicedata, Inc.
  *
@@ -26,6 +25,7 @@ import (
 	"github.com/juicedata/juicefs/pkg/utils"
 )
 
+// Statistic contains the statistics of the filesystem
 type Statistic struct {
 	UsedSpace                uint64
 	AvailableSpace           uint64
@@ -47,6 +47,7 @@ type Sections struct {
 	Stat     *Statistic
 }
 
+// Status retrieves the status of the filesystem
 func Status(ctx context.Context, m Meta, trash bool, sections *Sections) error {
 	format, err := m.Load(true)
 	if err != nil {

--- a/pkg/meta/status.go
+++ b/pkg/meta/status.go
@@ -1,0 +1,117 @@
+// meta/status.go
+/*
+ * JuiceFS, Copyright 2021 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package meta
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/utils"
+)
+
+type Statistic struct {
+	UsedSpace                uint64
+	AvailableSpace           uint64
+	UsedInodes               uint64
+	AvailableInodes          uint64
+	TrashFileCount           int64 `json:",omitempty"`
+	TrashFileSize            int64 `json:",omitempty"`
+	PendingDeletedFileCount  int64 `json:",omitempty"`
+	PendingDeletedFileSize   int64 `json:",omitempty"`
+	TrashSliceCount          int64 `json:",omitempty"`
+	TrashSliceSize           int64 `json:",omitempty"`
+	PendingDeletedSliceCount int64 `json:",omitempty"`
+	PendingDeletedSliceSize  int64 `json:",omitempty"`
+}
+
+type Sections struct {
+	Setting  *Format
+	Sessions []*Session
+	Stat     *Statistic
+}
+
+func Status(ctx context.Context, m Meta, trash bool, sections *Sections) error {
+	format, err := m.Load(true)
+	if err != nil {
+		return fmt.Errorf("load setting: %v", err)
+	}
+	format.RemoveSecret()
+
+	sessions, err := m.ListSessions()
+	if err != nil {
+		return fmt.Errorf("list sessions: %v", err)
+	}
+
+	stat := &Statistic{}
+	var totalSpace uint64
+	if err = m.StatFS(Background(), RootInode, &totalSpace, &stat.AvailableSpace, &stat.UsedInodes, &stat.AvailableInodes); err != syscall.Errno(0) {
+		return fmt.Errorf("stat fs: %v", err)
+	}
+	stat.UsedSpace = totalSpace - stat.AvailableSpace
+
+	if trash {
+		progress := utils.NewProgress(false)
+		trashFileSpinner := progress.AddDoubleSpinner("Trash Files")
+		pendingDeletedFileSpinner := progress.AddDoubleSpinner("Pending Deleted Files")
+		trashSlicesSpinner := progress.AddDoubleSpinner("Trash Slices")
+		pendingDeletedSlicesSpinner := progress.AddDoubleSpinner("Pending Deleted Slices")
+		err = m.ScanDeletedObject(
+			WrapContext(ctx),
+			func(ss []Slice, _ int64) (bool, error) {
+				for _, s := range ss {
+					trashSlicesSpinner.IncrInt64(int64(s.Size))
+				}
+				return false, nil
+			},
+			func(_ uint64, size uint32) (bool, error) {
+				pendingDeletedSlicesSpinner.IncrInt64(int64(size))
+				return false, nil
+			},
+			func(_ Ino, size uint64, _ time.Time) (bool, error) {
+				trashFileSpinner.IncrInt64(int64(size))
+				return false, nil
+			},
+			func(_ Ino, size uint64, _ int64) (bool, error) {
+				pendingDeletedFileSpinner.IncrInt64(int64(size))
+				return false, nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("statistic: %v", err)
+		}
+
+		trashSlicesSpinner.Done()
+		pendingDeletedSlicesSpinner.Done()
+		trashFileSpinner.Done()
+		pendingDeletedFileSpinner.Done()
+		progress.Done()
+		stat.TrashSliceCount, stat.TrashSliceSize = trashSlicesSpinner.Current()
+		stat.PendingDeletedSliceCount, stat.PendingDeletedSliceSize = pendingDeletedSlicesSpinner.Current()
+		stat.TrashFileCount, stat.TrashFileSize = trashFileSpinner.Current()
+		stat.PendingDeletedFileCount, stat.PendingDeletedFileSize = pendingDeletedFileSpinner.Current()
+	}
+
+	if sections != nil {
+		sections.Setting = format
+		sections.Sessions = sessions
+		sections.Stat = stat
+	}
+	return nil
+}

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -1601,6 +1601,25 @@ func jfs_clone(pid int64, h int64, _src *C.char, _dst *C.char, preserve bool) in
 	return errno(err)
 }
 
+//export jfs_status
+func jfs_status(pid int64, h int64, trash bool, session uint64, p_buf **byte) int32 {
+	w := F(h)
+	if w == nil {
+		return EINVAL
+	}
+	ctx := w.withPid(pid)
+	res, err := w.Status(ctx, trash, session)
+	if err != nil {
+		logger.Errorf("status %s: %s", ctx, err)
+		return errno(err)
+	}
+
+	*p_buf = (*byte)(C.malloc(C.size_t(len(res))))
+	buf := unsafe.Slice(*p_buf, len(res))
+
+	return int32(copy(buf, res))
+}
+
 //export jfs_lseek
 func jfs_lseek(pid int64, fd int32, offset int64, whence int64) int64 {
 	filesLock.Lock()

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -1608,16 +1608,37 @@ func jfs_status(pid int64, h int64, trash bool, session uint64, p_buf **byte) in
 		return EINVAL
 	}
 	ctx := w.withPid(pid)
-	res, err := w.Status(ctx, trash, session)
-	if err != nil {
-		logger.Errorf("status %s: %s", ctx, err)
-		return errno(err)
+
+	var err error
+	var output []byte
+	if session != 0 {
+		s, err := w.Meta().GetSession(session, true)
+		if err != nil {
+			logger.Errorf("get session %d: %s", session, err)
+			return errno(syscall.EIO)
+		}
+		output, err = json.Marshal(s)
+		if err != nil {
+			logger.Errorf("marshal session: %v", err)
+			return errno(syscall.EIO)
+		}
+	} else {
+		sections := &meta.Sections{}
+		err = meta.Status(ctx, w.Meta(), trash, sections)
+		if err != nil {
+			logger.Errorf("get status: %s", err)
+			return errno(syscall.EIO)
+		}
+		output, err = json.Marshal(sections)
+		if err != nil {
+			logger.Errorf("marshal sessions: %v", err)
+			return errno(syscall.EIO)
+		}
 	}
 
-	*p_buf = (*byte)(C.malloc(C.size_t(len(res))))
-	buf := unsafe.Slice(*p_buf, len(res))
-
-	return int32(copy(buf, res))
+	*p_buf = (*byte)(C.malloc(C.size_t(len(output))))
+	buf := unsafe.Slice(*p_buf, len(output))
+	return int32(copy(buf, output))
 }
 
 //export jfs_lseek

--- a/sdk/python/juicefs/juicefs/juicefs.py
+++ b/sdk/python/juicefs/juicefs/juicefs.py
@@ -389,18 +389,10 @@ class Client(object):
         self.lib.free(buf)
         return res
 
-
-    def status(self, trash = False, session = 0):
+    def status(self, trash=False, session=0):
+        """Get the status of the volume and client sessions."""
         buf = c_void_p()
-        try:
-            n = self.lib.jfs_status(c_int64(_tid()), c_int64(self.h), c_bool(trash), c_bool(session), byref(buf))
-        except OSError as e:
-            if e.errno == errno.ENOMEM:
-                buf = None
-            if buf is not None:
-                self.lib.free(buf)
-            err_msg = os.strerror(-n) if os.name == 'posix' else f"Error code: {n}"
-            raise OSError(-n, f"jfs_status failed: {err_msg}")
+        n = self.lib.jfs_status(c_int64(_tid()), c_int64(self.h), c_bool(trash), c_bool(session), byref(buf))
         res = json.loads(str(string_at(buf, n), encoding='utf-8'))
         self.lib.free(buf)
         return res
@@ -664,6 +656,7 @@ def test():
     volume = os.getenv("JFS_VOLUME", "test")
     meta = os.getenv("JFS_META", "redis://localhost")
     v = Client(volume, meta, access_log="/tmp/jfs.log")
+    print(v.status())
     st = v.stat("/")
     print(st)
     if v.exists("/d"):

--- a/sdk/python/juicefs/juicefs/juicefs.py
+++ b/sdk/python/juicefs/juicefs/juicefs.py
@@ -390,6 +390,21 @@ class Client(object):
         return res
 
 
+    def status(self, trash = False, session = 0):
+        buf = c_void_p()
+        try:
+            n = self.lib.jfs_status(c_int64(_tid()), c_int64(self.h), c_bool(trash), c_bool(session), byref(buf))
+        except OSError as e:
+            if e.errno == errno.ENOMEM:
+                buf = None
+            if buf is not None:
+                self.lib.free(buf)
+            err_msg = os.strerror(-n) if os.name == 'posix' else f"Error code: {n}"
+            raise OSError(-n, f"jfs_status failed: {err_msg}")
+        res = json.loads(str(string_at(buf, n), encoding='utf-8'))
+        self.lib.free(buf)
+        return res
+
 class File(object):
     """A JuiceFS file."""
     def __init__(self, lib, fd, path, mode, flag, length, buffering, encoding, errors):


### PR DESCRIPTION
rel https://github.com/juicedata/juicefs/issues/5815

New modification points:
1. move the specific implementation of status to meta.
2. add exception handling to the PySDK code.
3. simplify the calling code for JSON serialization and deserialization.