### PR TITLE
Rewriting arm-oriented Dockerfile with golang images

### DIFF
--- a/sdk/python/Dockerfile.builder.arm
+++ b/sdk/python/Dockerfile.builder.arm
@@ -1,11 +1,17 @@
-FROM centos:7
+FROM golang:1.24
 
-RUN yum install -y make gcc python3 && \
-    curl -L https://static.juicefs.com/misc/go1.19.13.linux-arm64.tar.gz -o go1.19.13.linux-arm64.tar.gz && \
-    tar -C /usr/local -xzf go1.19.13.linux-arm64.tar.gz && \
-    rm go1.19.13.linux-arm64.tar.gz && \
-    ln -s /usr/local/go/bin/go /usr/bin/go && \
-    go version && \
-    python3 -m pip install --upgrade pip && \
-    python3 -m pip install --upgrade setuptools && \
-    pip install wheel
+RUN apt update && \
+    apt install -y --no-install-recommends \
+        git \
+        make \
+        gcc \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        python3-build \
+        python3-venv \
+        ca-certificates \
+    && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Compiling the Python SDK relies on golang, and the dockerfile for arm is old.
I rewrote the file with a golang image and successfully compiled it on macOS.