### PR TITLE
meta/setXattr: avoid write operation when nothing changes

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -3509,6 +3509,7 @@ func (m *dbMeta) doSetXattr(ctx Context, inode Ino, name string, value []byte, f
 		if err != nil {
 			return err
 		}
+		existing := k.Value
 		k.Value = nil
 		switch flags {
 		case XattrCreate:
@@ -3522,6 +3523,9 @@ func (m *dbMeta) doSetXattr(ctx Context, inode Ino, name string, value []byte, f
 			}
 			_, err = s.Update(&x, k)
 		default:
+			if bytes.Equal(existing, value) {
+				return nil
+			}
 			if ok {
 				_, err = s.Update(&x, k)
 			} else {


### PR DESCRIPTION
A minor patch:
1. avoid write operation when nothing changes
2. avoid txn conflict when multiple clients set the same KV concurrently