### PR TITLE
cmd/mount: umask option parsed as octal

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -285,7 +285,7 @@ func getVfsConf(c *cli.Context, metaConf *meta.Config, format *meta.Format, chun
 	}
 
 	if c.IsSet("umask") {
-		umask, err := utils.ParseMode(c.String("umask"))
+		umask, err := strconv.ParseUint(c.String("umask"), 8, 16)
 		if err != nil {
 			logger.Fatalf("invalid umask %s: %s", c.String("umask"), err)
 		}

--- a/pkg/utils/humanize.go
+++ b/pkg/utils/humanize.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"errors"
 	"strconv"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -112,11 +111,4 @@ func Mbps(val int64) string {
 		return strconv.FormatFloat(v/1e6, 'f', 1, 64) + " Tbps"
 	}
 	return strconv.FormatFloat(v/1e9, 'f', 1, 64) + " Pbps"
-}
-
-func ParseMode(mode string) (uint64, error) {
-	if strings.HasPrefix(mode, "0") {
-		return strconv.ParseUint(mode, 8, 16)
-	}
-	return strconv.ParseUint(mode, 10, 16)
 }


### PR DESCRIPTION
close #5933

Maintain consistent behavior with the ‘umask’ command and the ‘gateway’ parameter.