### PR TITLE
windows: fix incorrect error code;

### DIFF
--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -176,7 +176,7 @@ func (j *juice) Mknod(p string, mode uint32, dev uint64) (e int) {
 		return
 	}
 	_, errno := j.vfs.Mknod(ctx, parent.Inode(), path.Base(p), uint16(mode), 0, uint32(dev))
-	e = -int(errno)
+	e = errorconv(errno)
 	return
 }
 
@@ -218,7 +218,7 @@ func (j *juice) Symlink(target string, newpath string) (e int) {
 		return
 	}
 	_, errno := j.vfs.Symlink(ctx, target, parent.Inode(), path.Base(newpath))
-	e = -int(errno)
+	e = errorconv(errno)
 	return
 }
 
@@ -501,7 +501,7 @@ func (j *juice) Getattr(p string, stat *fuse.Stat_t, fh uint64) (e int) {
 	}
 	entry, errrno := j.vfs.GetAttr(ctx, ino, 0)
 	if errrno != 0 {
-		e = -int(errrno)
+		e = errorconv(errrno)
 		return
 	}
 	j.vfs.UpdateLength(entry.Inode, entry.Attr)
@@ -518,7 +518,7 @@ func (j *juice) Truncate(path string, size int64, fh uint64) (e int) {
 		e = -fuse.EBADF
 		return
 	}
-	e = -int(j.vfs.Truncate(ctx, ino, size, 0, nil))
+	e = errorconv(j.vfs.Truncate(ctx, ino, size, 0, nil))
 	return
 }
 
@@ -721,7 +721,7 @@ func (j *juice) Chflags(path string, flags uint32) (e int) {
 	ino := fi.Inode()
 	err = j.vfs.ChFlags(ctx, ino, flagSet)
 	if err != 0 {
-		e = -int(err)
+		e = errorconv(err)
 	}
 
 	return


### PR DESCRIPTION
fix #5932 

## some additional info

When testing the dd behavior, I found the following "bug":

[Mingw-msys] When the dir capacity reached to 80%(8MB/10MB), calling ```dd if=/dev/zero of=test bs=1M count=10``` would not report an error. However, the file was created but the content is still empty.

It seems that the implement for the dd command on Windows platform might not properly call flush() before closing the file handle, this could be confirmed by the kernel IRP packages(see the screenshot below). The same issue occurs when using the cp command.

![image](https://github.com/user-attachments/assets/7f094376-0a84-4bbf-aa3d-d261a7526c6c)

I also tested the Windows "copy" command and it can report "no enought space on the disk" correctly.



