### PR TITLE
sync: custom cluster manager-addr port without ip

### DIFF
--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -216,6 +216,13 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 	if !strings.Contains(addr, ":") {
 		addr += ":"
 	}
+	if strings.HasPrefix(addr, ":") || strings.Contains(addr, "0.0.0.0") {
+		ip, err := utils.GetLocalIp(net.JoinHostPort(config.Workers[0], "22"))
+		if err != nil {
+			return "", fmt.Errorf("get local ip: %s", err)
+		}
+		addr = ip + addr
+	}
 
 	l, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -200,10 +200,19 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 		_, _ = w.Write([]byte("OK"))
 	})
 	var addr string
+	u, err := url.Parse("ssh://" + config.Workers[0])
+	if err != nil {
+		return "", fmt.Errorf("invalid worker address %s: %s", config.Workers[0], err)
+	}
 	if config.ManagerAddr != "" {
 		addr = config.ManagerAddr
-	} else if u, err := url.Parse("ssh://" + config.Workers[0]); err != nil {
-		return "", fmt.Errorf("invalid worker address %s: %s", config.Workers[0], err)
+		if strings.HasPrefix(addr, ":") || strings.Contains(addr, "0.0.0.0") {
+			ip, err := utils.GetLocalIp(net.JoinHostPort(u.Host, "22"))
+			if err != nil {
+				return "", fmt.Errorf("get local ip: %s", err)
+			}
+			addr = ip + addr
+		}
 	} else {
 		ip, err := utils.GetLocalIp(net.JoinHostPort(u.Host, "22"))
 		if err != nil {
@@ -215,13 +224,6 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 
 	if !strings.Contains(addr, ":") {
 		addr += ":"
-	}
-	if strings.HasPrefix(addr, ":") || strings.Contains(addr, "0.0.0.0") {
-		ip, err := utils.GetLocalIp(net.JoinHostPort(config.Workers[0], "22"))
-		if err != nil {
-			return "", fmt.Errorf("get local ip: %s", err)
-		}
-		addr = ip + addr
 	}
 
 	l, err := net.Listen("tcp", addr)


### PR DESCRIPTION
Currently, when we need to custom the manager-addr port, we must pass the manager's IP address; otherwise, an invalid address is passed to the worker

now, support custom manager port without ip like `--manager-addr=:1234`