### PR TITLE
cmd/sync: fix missing support of specifying user name in worker addr

### DIFF
--- a/docs/en/guide/sync.md
+++ b/docs/en/guide/sync.md
@@ -284,7 +284,7 @@ juicefs sync --worker bob@192.168.1.20,tom@192.168.8.10 s3://ABCDEFG:HIJKLMN@aaa
 
 The synchronization workload between the two object storage services is shared by the manager machine and two workers, `bob@192.168.1.20` and `tom@192.168.8.10`.
 
-The above command demonstrates object → object sychronization, if you need to sync via FUSE mount points, then you need to mount the file system in all worker nodes, and then run the following command to achieve distributed sync:
+The above command demonstrates object → object synchronization, if you need to sync via FUSE mount points, then you need to mount the file system in all worker nodes, and then run the following command to achieve distributed sync:
 
 ```shell
 # Source file system needs better read performance, increase its buffer-size

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -201,11 +202,14 @@ func startManager(config *Config, tasks <-chan object.Object) (string, error) {
 	var addr string
 	if config.ManagerAddr != "" {
 		addr = config.ManagerAddr
+	} else if u, err := url.Parse("ssh://" + config.Workers[0]); err != nil {
+		return "", fmt.Errorf("invalid worker address %s: %s", config.Workers[0], err)
 	} else {
-		ip, err := utils.GetLocalIp(net.JoinHostPort(config.Workers[0], "22"))
+		ip, err := utils.GetLocalIp(net.JoinHostPort(u.Host, "22"))
 		if err != nil {
 			return "", fmt.Errorf("not found local ip: %s", err)
 		}
+		logger.Debugf("Use local ip %s", ip)
 		addr = ip
 	}
 

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -50,7 +50,7 @@ func TestCluster(t *testing.T) {
 	// manager
 	todo := make(chan object.Object, 100)
 	var conf Config
-	conf.Workers = []string{"127.0.0.1"}
+	conf.Workers = []string{"root@127.0.0.1"}
 	addr, err := startManager(&conf, todo)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The [document](https://juicefs.com/docs/community/guide/sync/) says we can specifying user name in the `--worker` option:

`juicefs sync --worker bob@192.168.1.20,tom@192.168.8.10 s3://ABCDEFG:HIJKLMN@aaa.s3.us-west-1.amazonaws.com oss://ABCDEFG:HIJKLMN@bbb.oss-cn-hangzhou.aliyuncs.com`

Previous version also supports this syntax, but the master branch lost this support.