### PR TITLE
cmd/sync: fix large buffer prevents sync throughput from scaling with the number of workers

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1577,7 +1577,8 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 
 	var bufferSize = 10240
 	if config.Manager != "" {
-		bufferSize = 100
+		// No support for work-stealing, so workers shouldnot buffer tasks to prevent piling up in their own queues, which could cause imbalance among workers.
+		bufferSize = 0
 	}
 	tasks := make(chan object.Object, bufferSize)
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Since version 1.2, we have observed that even when specifying multiple workers using the `--worker` option, the throughput of sync tool does not scale any more. Debugging revealed that because each worker's buffer is very large, a single worker might fetch (almost) all tasks into its own buffer, causing other workers to remain idle:

![img_v3_02l6_4defac40-41f0-4aea-9d6a-1b9f13fb886g](https://github.com/user-attachments/assets/76007ea4-d17a-46b5-96d0-e51ac9088ce2)

After removing the buffer, workers can fetch as demand now:

![img_v3_02l6_9994ff9f-a7a5-45af-bd96-1712ca24d8cg](https://github.com/user-attachments/assets/4644bed8-add8-4e0b-8c65-7538c57b0b74)
