### PR TITLE
windows: added "enable-get-path" mount option

### DIFF
--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -73,8 +73,8 @@ func mountFlags() []cli.Flag {
 			Hidden: true,
 		},
 		&cli.BoolFlag{
-			Name:  "enable-get-path",
-			Usage: "If set, it will improve the accuracy of letter case when returning file paths. (May incur a performance lost)",
+			Name:  "report-case",
+			Usage: "If set, juicefs will report the correct case of a file path for a case-insensitive filesystem. (May incur a performance lost)",
 		},
 	}
 }
@@ -116,7 +116,7 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 
 	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(),
 		c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"),
-		c.Int("winfsp-threads"), c.Bool("case-sensitive"), c.Bool("enable-get-path"))
+		c.Int("winfsp-threads"), c.Bool("case-sensitive"), c.Bool("report-case"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -72,6 +72,10 @@ func mountFlags() []cli.Flag {
 			Usage:  "If set, the file system will be case sensitive",
 			Hidden: true,
 		},
+		&cli.BoolFlag{
+			Name:  "enable-get-path",
+			Usage: "If set, it will improve the accuracy of letter case when returning file paths. (May incur a performance lost)",
+		},
 	}
 }
 
@@ -110,7 +114,9 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 		winfsp.SetTraceOutput(traceLog)
 	}
 
-	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(), c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"), c.Int("winfsp-threads"), c.Bool("case-sensitive"))
+	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(),
+		c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"),
+		c.Int("winfsp-threads"), c.Bool("case-sensitive"), c.Bool("enable-get-path"))
 }
 
 func checkMountpoint(name, mp, logPath string, background bool) {}


### PR DESCRIPTION
From the tests that I ran, I found that when disabling the get-get callback, the small file reading performance in the bench test could earn an improvement of about 30% on my machine. 

Since we are running a case-insensitive file system on Windows, I think it is better to disable this feature by default to get a better default performance.