### PR TITLE
cmd: modify params to support apptainer fusemount

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -162,7 +162,12 @@ func dataCacheFlags() []cli.Flag {
 		}
 		fallthrough
 	case "darwin":
-		fallthrough
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			logger.Warn(err)
+			homeDir = defaultCacheDir
+		}
+		defaultCacheDir = path.Join(homeDir, ".juicefs", "cache")
 	case "windows":
 		homeDir, err := os.UserHomeDir()
 		if err != nil {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -108,7 +108,8 @@ func formatStorageFlags() []cli.Flag {
 	case "darwin":
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			logger.Fatalf("%v", err)
+			logger.Warn(err)
+			homeDir = defaultBucket
 		}
 		defaultBucket = path.Join(homeDir, ".juicefs", "local")
 	case "windows":

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -495,7 +495,14 @@ func getDefaultLogDir() string {
 			break
 		}
 		fallthrough
-	case "darwin", "windows":
+	case "darwin":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			logger.Warn(err)
+			homeDir = defaultLogDir
+		}
+		defaultLogDir = path.Join(homeDir, ".juicefs")
+	case "windows":
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			logger.Fatalf("%v", err)

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -366,6 +366,12 @@ func fuseFlags() []cli.Flag {
 func mountFlags() []cli.Flag {
 	selfFlags := []cli.Flag{
 		&cli.BoolFlag{
+			Name:    "f",
+			Aliases: []string{"foreground"},
+			Hidden:  true,
+			Usage:   "run in foreground",
+		},
+		&cli.BoolFlag{
 			Name:    "d",
 			Aliases: []string{"background"},
 			Usage:   "run in background",

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -24,9 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
-	"github.com/baidubce/bce-sdk-go/services/bos/api"
-	"github.com/huaweicloud/huaweicloud-sdk-go-obs/obs"
 	"io"
 	"math"
 	"os"
@@ -37,6 +34,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/baidubce/bce-sdk-go/services/bos/api"
+	"github.com/huaweicloud/huaweicloud-sdk-go-obs/obs"
 
 	"github.com/colinmarc/hdfs/v2/hadoopconf"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -755,15 +756,6 @@ func TestAzure(t *testing.T) { //skip mutate
 	testStorage(t, abs)
 }
 
-func TestJSS(t *testing.T) { //skip mutate
-	if os.Getenv("JSS_ACCESS_KEY") == "" {
-		t.SkipNow()
-	}
-	jss, _ := newJSS(os.Getenv("JSS_ENDPOINT"),
-		os.Getenv("JSS_ACCESS_KEY"), os.Getenv("JSS_SECRET_KEY"), "")
-	testStorage(t, jss)
-}
-
 func TestB2(t *testing.T) { //skip mutate
 	if os.Getenv("B2_ACCOUNT_ID") == "" {
 		t.SkipNow()
@@ -1052,14 +1044,6 @@ func TestWASABI(t *testing.T) { //skip mutate
 		t.SkipNow()
 	}
 	s, _ := newWasabi(os.Getenv("WASABI_ENDPOINT"), os.Getenv("WASABI_ACCESS_KEY"), os.Getenv("WASABI_SECRET_KEY"), "")
-	testStorage(t, s)
-}
-
-func TestSCS(t *testing.T) { //skip mutate
-	if os.Getenv("SCS_ENDPOINT") == "" {
-		t.SkipNow()
-	}
-	s, _ := newSCS(os.Getenv("SCS_ENDPOINT"), os.Getenv("SCS_ACCESS_KEY"), os.Getenv("SCS_SECRET_KEY"), "")
 	testStorage(t, s)
 }
 


### PR DESCRIPTION
ref #5014 https://github.com/rfjakob/gocryptfs/issues/590

test:
apptainer run --fusemount "host:juicefs mount sqlite3:///[path]/test.db --cache-dir=/tmp/cache /mnt" docker://ubuntu
will convert to "juicefs mount sqlite3:///[path]/test.db /dev/fd/number -f"