### PR TITLE
cmd/mount: fix mount timeout

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -223,7 +223,7 @@ func checkMountpoint(name, mp, logPath string, background bool) {
 		return
 	}
 	_, oldConf, _ := loadConfig(mp)
-	mountTimeOut := getMountTimeout() + 3 // add 3 extra seconds
+	mountTimeOut := getMountTimeout() + 3 // wait for 3 extra seconds
 	interval := 500                       // check every 500 Millisecond
 	if tStr, ok := os.LookupEnv("JFS_MOUNT_TIMEOUT"); ok {
 		if t, err := strconv.ParseInt(tStr, 10, 64); err == nil {


### PR DESCRIPTION
close #5965

case: parent process may timeout in checkMountpoint and show failed log, but daemon still running and finally mount success.

test: add time.Sleep(11*time.Second) at the beginning of launchMount.