### PR TITLE
Separate read and write buffers to avoid mutual interference

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1346,10 +1346,10 @@ func initVFSMetrics(v *VFS, writer DataWriter, reader DataReader, registerer pro
 func InitMemoryBufferMetrics(writer DataWriter, reader DataReader, registerer prometheus.Registerer) {
 	usedBufferSize := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "used_buffer_size_bytes",
-		Help: "size of currently used buffer.",
+		Help: "size of currently used buffer for read and write",
 	}, func() float64 {
 		if dw, ok := writer.(*dataWriter); ok {
-			return float64(dw.usedBufferSize())
+			return float64(utils.AllocMemory() - dw.store.UsedMemory())
 		}
 		return 0.0
 	})

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -287,8 +288,8 @@ func (f *fileWriter) totalSlices() int {
 	return cnt
 }
 
-func (w *dataWriter) usedBufferSize() int64 {
-	return utils.AllocMemory() - w.store.UsedMemory()
+func (w *dataWriter) usedBufferSize() int64 { // used buffer by writers
+	return utils.AllocMemory() - w.store.UsedMemory() - atomic.LoadInt64(&readBufferUsed)
 }
 
 func (f *fileWriter) Write(ctx meta.Context, off uint64, data []byte) syscall.Errno {


### PR DESCRIPTION
In a mixed read-write workload, write requests are easily affected by read requests, even if the backend object storage does not have such issue. This is because when the buffer is heavily used, write requests will be blocked until some buffers are released. However, the current read-ahead mechanism can easily cause read requests to occupy most of the buffer (up to 80%), regardless of whether these background read requests are useful.

It is better for the blocking conditions of read and write requests to be independent to avoid mutual interference.