### PR TITLE
windows: disable symbollink by default

### DIFF
--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -212,6 +212,7 @@ func (j *juice) Rmdir(path string) (e int) {
 }
 
 func (j *juice) Symlink(target string, newpath string) (e int) {
+	return -fuse.ENOSYS
 	ctx := j.newContext()
 	defer trace(target, newpath)(&e)
 	parent, err := j.fs.Open(ctx, path.Dir(newpath), 0)

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -60,6 +60,7 @@ type juice struct {
 	asRoot         bool
 	delayClose     int
 	enabledGetPath bool
+	disableSymlink bool
 }
 
 // Init is called when the file system is created.
@@ -121,7 +122,7 @@ func errorconv(err syscall.Errno) int {
 	case syscall.EIO:
 		return -fuse.EIO
 	case syscall.EINVAL:
-		return -fuse.ENXIO
+		return -fuse.EINVAL
 	case syscall.EBADFD:
 		return -fuse.EBADF
 	case syscall.EDQUOT:
@@ -226,6 +227,10 @@ func (j *juice) Symlink(target string, newpath string) (e int) {
 func (j *juice) Readlink(path string) (e int, target string) {
 	ctx := j.newContext()
 	defer trace(path)(&e, &target)
+	if path == "/" && j.disableSymlink {
+		e = -fuse.ENOSYS
+		return
+	}
 	fi, err := j.fs.Stat(ctx, path)
 	if err != 0 {
 		e = errorconv(err)
@@ -783,6 +788,7 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTimeoutSec float64, dirCacheTime
 	if err != nil {
 		logger.Fatalf("Initialize FileSystem failed: %s", err)
 	}
+	jfs.disableSymlink = os.Getenv("JUICEFS_ENABLE_SYMLINK") != "1"
 	jfs.asRoot = asRoot
 	jfs.delayClose = delayCloseSec
 	host := fuse.NewFileSystemHost(&jfs)


### PR DESCRIPTION
From the previous [test ](https://github.com/juicedata/juicefs/issues/5252)we did, lots of getattr requests were made due to the parsing of the potential symbol link. Since we don't support symbolic links on the Windows platform for now, we can disable this feature to gain a small performance boost.

According to the source code of WinFsp, to disable the symbolic link feature, we need to return the ENOSYS for the readlink("/") request.

```
    if (0 != f->ops.readlink)
    {
        char buf[FSP_FSCTL_TRANSACT_PATH_SIZEMAX / sizeof(WCHAR)];
        int err;

        /* this should always fail with ENOSYS or EINVAL */
        err = f->ops.readlink("/", buf, sizeof buf);
        f->has_symlinks = -ENOSYS_(f->env) != err;
```

Since this is a temporary workaround before we add the symbol link support, this PR uses an environment variable instead of mount options.


## Cmp

### 

Small files write performance increased from 68 files/s to 80 files/s.

![image](https://github.com/user-attachments/assets/c86c3c56-9073-478a-a2ea-37a748b3cbf8)
(symbol link feature disabled)
 
![image](https://github.com/user-attachments/assets/89055bc6-128c-467a-8726-bf0927b369b2)
(symbol link feature enabled)


## Test 

- [x] This pr passed the current windows ci [test](https://github.com/juicedata/juicefs/actions/runs/14568951372/job/40862609870). 
