### PR TITLE
Exit compact timely and log a message when long-running background tasks start

### DIFF
--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -829,7 +829,7 @@ func (m *kvMeta) txn(ctx context.Context, f func(tx *kvTxn) error, inodes ...Ino
 			time.Sleep(time.Millisecond * time.Duration(rand.Int()%((i+1)*(i+1))))
 			continue
 		} else if err == nil && i > 1 {
-			logger.Warnf("Transaction succeeded after %d tries (%s), inodes: %v, error: %s", i+1, time.Since(start), inodes, lastErr)
+			logger.Warnf("Transaction succeeded after %d tries (%s), inodes: %v, method: %s, error: %s", i+1, time.Since(start), inodes, method, lastErr)
 		}
 		return err
 	}

--- a/pkg/vfs/backup.go
+++ b/pkg/vfs/backup.go
@@ -80,7 +80,9 @@ func Backup(m meta.Meta, blob object.ObjectStorage, interval time.Duration, skip
 				logger.Warnf("setxattr inode 1 key %s: %s", key, st)
 				continue
 			}
-			logger.Debugf("backup metadata started")
+			if iused >= 1e5 {
+				logger.Infof("backup metadata started, inodes=%d", iused)
+			}
 			if fpath, err := backup(m, blob, now, iused < 1e5, skipTrash); err == nil {
 				go cleanupBackups(blob, now) // only cleanup on success
 				LastBackupTimeG.Set(float64(now.UnixNano()) / 1e9)

--- a/pkg/vfs/fill.go
+++ b/pkg/vfs/fill.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/juicedata/juicefs/pkg/chunk"
 
 	"github.com/juicedata/juicefs/pkg/meta"

--- a/pkg/vfs/fill.go
+++ b/pkg/vfs/fill.go
@@ -172,7 +172,7 @@ func (c *CacheFiller) Cache(ctx meta.Context, action CacheAction, paths []string
 	if ctx.Canceled() {
 		logger.Infof("%s cancelled", action)
 	}
-	logger.Infof("%s %s (%s) in %s", action, strings.Join(paths, ","), humanize.IBytes(resp.TotalBytes), time.Since(start))
+	logger.Infof("%s %d paths in %s", action, len(paths), time.Since(start))
 }
 
 func sendFile(ctx meta.Context, todo chan _file, f _file) error {

--- a/pkg/vfs/fill.go
+++ b/pkg/vfs/fill.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/juicedata/juicefs/pkg/chunk"
 
 	"github.com/juicedata/juicefs/pkg/meta"
@@ -129,8 +130,6 @@ func (c *CacheFiller) cacheFile(ctx meta.Context, action CacheAction, resp *Cach
 }
 
 func (c *CacheFiller) Cache(ctx meta.Context, action CacheAction, paths []string, threads int, resp *CacheResponse) {
-	logger.Infof("start to %s %d paths with %d workers", action, len(paths), threads)
-
 	if resp == nil {
 		resp = &CacheResponse{Locations: make(map[string]uint64)}
 	}
@@ -173,7 +172,7 @@ func (c *CacheFiller) Cache(ctx meta.Context, action CacheAction, paths []string
 	if ctx.Canceled() {
 		logger.Infof("%s cancelled", action)
 	}
-	logger.Infof("%s %d paths in %s", action, len(paths), time.Since(start))
+	logger.Infof("%s %s (%s) in %s", action, strings.Join(paths, ","), humanize.IBytes(resp.TotalBytes), time.Since(start))
 }
 
 func sendFile(ctx meta.Context, todo chan _file, f _file) error {


### PR DESCRIPTION
Two minor fixes:
- When user cancels the `cmd/compact`, the compact task in the background just won't stop because of a deep queue(10000). It should exit timely as other cmd tasks.
- It's better to have a log message for background tasks when they start, so we can know what's happening when ceertain resources spike (cpu/memory/meta ops).