### PR TITLE
cmd/warmup: fix handling files with holes

### DIFF
--- a/pkg/vfs/fill.go
+++ b/pkg/vfs/fill.go
@@ -334,6 +334,9 @@ func (iter *sliceIterator) Iterate(handler sliceHandler, concurrent chan token) 
 	var wg sync.WaitGroup
 	for iter.hasNext() {
 		s := iter.next()
+		if s.Id == 0 {
+			continue
+		}
 		atomic.AddUint64(&iter.stat.SliceCount, 1)
 		atomic.AddUint64(&iter.stat.TotalBytes, uint64(s.Size))
 


### PR DESCRIPTION
`cmd/warmup` doesnot support hole in file - there should be no GET requests for slice ID 0.
```
warmup cache error : inode 3282947 slice 0 : get chunks/0/0/0_0_1024: NoSuchKey: The specified key does not exist.
```