### PR TITLE
cmd/fsck: `sync-dir-stat` should also update total inodes

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -123,7 +123,7 @@ type engine interface {
 	// @trySync: try sync dir stat if broken or not existed
 	doGetDirStat(ctx Context, ino Ino, trySync bool) (*dirStat, syscall.Errno)
 	doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno)
-	doSyncUsedSpace(ctx Context) error
+	doSyncVolumeStat(ctx Context) error
 
 	scanTrashSlices(Context, trashSliceScan) error
 	scanPendingSlices(Context, pendingSliceScan) error
@@ -2116,7 +2116,7 @@ func (m *baseMeta) Check(ctx Context, fpath string, repair bool, recursive bool,
 	}
 	wg.Wait()
 	if fpath == "/" && repair && recursive && statAll {
-		if err := m.syncUsedSpace(ctx); err != nil {
+		if err := m.syncVolumeStat(ctx); err != nil {
 			logger.Errorf("Sync used space: %s", err)
 			hasError = true
 		}

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -250,8 +250,8 @@ func (m *baseMeta) doFlushStats() {
 	m.fsStatsLock.Unlock()
 }
 
-func (m *baseMeta) syncUsedSpace(ctx Context) error {
-	return m.en.doSyncUsedSpace(ctx)
+func (m *baseMeta) syncVolumeStat(ctx Context) error {
+	return m.en.doSyncVolumeStat(ctx)
 }
 
 func (m *baseMeta) checkQuota(ctx Context, space, inodes int64, parents ...Ino) syscall.Errno {


### PR DESCRIPTION
Fix missing update for total inodes in `--sync-dir-stat`.

File usage in .trash is also missed as reported in #6035.