### PR TITLE
cmd/info: add file offset column

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -181,7 +181,7 @@ func info(ctx *cli.Context) error {
 		if len(resp.Objects) > 0 {
 			fmt.Println(" objects:")
 			results := make([][]string, 0, 1+len(resp.Objects))
-			results = append(results, []string{"chunkIndex", "objectName", "size", "offset", "foff", "length"})
+			results = append(results, []string{"chunkIndex", "objectName", "size", "offset", "length", "pos"})
 			var chunkOffset, lastChunk uint64
 			for _, o := range resp.Objects {
 				if lastChunk != o.ChunkIndex {
@@ -193,8 +193,8 @@ func info(ctx *cli.Context) error {
 					o.Key,
 					strconv.FormatUint(uint64(o.Size), 10),
 					strconv.FormatUint(uint64(o.Off), 10),
-					strconv.FormatUint(chunkOffset+o.ChunkIndex*meta.ChunkSize, 10),
 					strconv.FormatUint(uint64(o.Len), 10),
+					strconv.FormatUint(chunkOffset+o.ChunkIndex*meta.ChunkSize, 10),
 				})
 				chunkOffset += uint64(o.Len)
 			}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -181,15 +181,22 @@ func info(ctx *cli.Context) error {
 		if len(resp.Objects) > 0 {
 			fmt.Println(" objects:")
 			results := make([][]string, 0, 1+len(resp.Objects))
-			results = append(results, []string{"chunkIndex", "objectName", "size", "offset", "length"})
+			results = append(results, []string{"chunkIndex", "objectName", "size", "offset", "foff", "length"})
+			var chunkOffset, lastChunk uint64
 			for _, o := range resp.Objects {
+				if lastChunk != o.ChunkIndex {
+					chunkOffset = 0
+				}
+				lastChunk = o.ChunkIndex
 				results = append(results, []string{
 					strconv.FormatUint(o.ChunkIndex, 10),
 					o.Key,
 					strconv.FormatUint(uint64(o.Size), 10),
 					strconv.FormatUint(uint64(o.Off), 10),
+					strconv.FormatUint(chunkOffset+o.ChunkIndex*meta.ChunkSize, 10),
 					strconv.FormatUint(uint64(o.Len), 10),
 				})
+				chunkOffset += uint64(o.Len)
 			}
 			printResult(results, 1, false)
 		}


### PR DESCRIPTION
Currently the `offset` field in cmd/info output is hard coded to `0` - it doesn't provide any useful information. It's better to display absolute offsets in the file, so when some chunk is corrupted, we can easily identify which part of the file is affected.

<img width="818" alt="image" src="https://github.com/user-attachments/assets/cb63b700-0283-48fd-a463-57a3c8c46b12" />
