### PR TITLE
windows: add attr, entry and dir-entry cache;

### DIFF
--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Juicefs Mount
         run: |
           $env:PATH+=";C:\Program Files (x86)\WinFsp\bin"
-          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z: --fuse-trace-log c:/fuse.log
+          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z: --fuse-trace-log c:/fuse.log --dir-entry-cache 0s --entry-cache 0s
 
       - name: Run Winfsp Tests
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Juicefs Mount
         run: |
           $env:PATH+=";C:\Program Files (x86)\WinFsp\bin"
-          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z: --fuse-trace-log c:/fuse.log --dir-entry-cache 0s --entry-cache 0s
+          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z: --fuse-trace-log c:/fuse.log
 
       - name: Run Winfsp Tests
         run: |

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Juicefs Mount
         run: |
           $env:PATH+=";C:\Program Files (x86)\WinFsp\bin"
-          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z:
+          ./juicefs.exe mount -d redis://127.0.0.1:6379/1 z: --fuse-trace-log c:/fuse.log
 
       - name: Run Winfsp Tests
         run: |

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -428,8 +428,14 @@ func bench(ctx *cli.Context) error {
 	progress.Done()
 
 	/* --- Clean-up --- */
-	if err := exec.Command("rm", "-rf", bm.tmpdir).Run(); err != nil {
-		logger.Warnf("Failed to cleanup %s: %s", bm.tmpdir, err)
+	if runtime.GOOS == "windows" {
+		if err := exec.Command("cmd", "/C", "rd", "/s", "/q", bm.tmpdir).Run(); err != nil {
+			logger.Warnf("Failed to cleanup %s: %s", bm.tmpdir, err)
+		}
+	} else {
+		if err := exec.Command("rm", "-rf", bm.tmpdir).Run(); err != nil {
+			logger.Warnf("Failed to cleanup %s: %s", bm.tmpdir, err)
+		}
 	}
 
 	/* --- Report --- */

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -104,9 +104,10 @@ func getDaemonStage() int {
 
 func mountMain(v *vfs.VFS, c *cli.Context) {
 	v.Conf.AccessLog = c.String("access-log")
+	v.Conf.AttrTimeout = utils.Duration(c.String("attr-cache"))
+	v.Conf.EntryTimeout = utils.Duration(c.String("entry-cache"))
+	v.Conf.DirEntryTimeout = utils.Duration(c.String("dir-entry-cache"))
 
-	fileCacheTimeout := utils.Duration(c.String("entry-cache"))
-	dirCacheTimeout := utils.Duration(c.String("dir-entry-cache"))
 	delayCloseTime := utils.Duration(c.String("delay-close"))
 
 	traceLog := c.String("fuse-trace-log")
@@ -114,7 +115,7 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 		winfsp.SetTraceOutput(traceLog)
 	}
 
-	winfsp.Serve(v, c.String("o"), fileCacheTimeout.Seconds(), dirCacheTimeout.Seconds(),
+	winfsp.Serve(v, c.String("o"),
 		c.Bool("as-root"), int(delayCloseTime.Seconds()), c.Bool("show-dot-files"),
 		c.Int("winfsp-threads"), c.Bool("case-sensitive"), c.Bool("report-case"))
 }

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -254,7 +254,7 @@ func (fs *FileSystem) cleanupCache() {
 	}
 }
 
-func (fs *FileSystem) invalidateEntry(parent Ino, name string) {
+func (fs *FileSystem) InvalidateEntry(parent Ino, name string) {
 	fs.cacheM.Lock()
 	defer fs.cacheM.Unlock()
 	es, ok := fs.entries[parent]
@@ -455,7 +455,7 @@ func (fs *FileSystem) Mkdir(ctx meta.Context, p string, mode uint16, umask uint1
 		if fs.conf.DirEntryTimeout > 0 {
 			parent := parentDir(p)
 			if fi, err := fs.resolve(ctx, parentDir(parent), true); err == 0 {
-				fs.invalidateEntry(fi.inode, path.Base(parent))
+				fs.InvalidateEntry(fi.inode, path.Base(parent))
 			}
 		}
 		if fi2, e := fs.resolve(ctx, parentDir(p), true); e != 0 {
@@ -464,7 +464,7 @@ func (fs *FileSystem) Mkdir(ctx meta.Context, p string, mode uint16, umask uint1
 			err = fs.m.Mkdir(ctx, fi2.inode, path.Base(p), mode, umask, 0, &inode, nil)
 		}
 	}
-	fs.invalidateEntry(fi.inode, path.Base(p))
+	fs.InvalidateEntry(fi.inode, path.Base(p))
 	return
 }
 
@@ -518,7 +518,7 @@ func (fs *FileSystem) Delete0(ctx meta.Context, p string, callByUnlink bool) (er
 	} else {
 		err = fs.m.Unlink(ctx, parent.inode, path.Base(p))
 	}
-	fs.invalidateEntry(parent.inode, path.Base(p))
+	fs.InvalidateEntry(parent.inode, path.Base(p))
 	return
 }
 
@@ -531,7 +531,7 @@ func (fs *FileSystem) Rmdir(ctx meta.Context, p string) (err syscall.Errno) {
 		return
 	}
 	err = fs.m.Rmdir(ctx, parent.inode, path.Base(p))
-	fs.invalidateEntry(parent.inode, path.Base(p))
+	fs.InvalidateEntry(parent.inode, path.Base(p))
 	return
 }
 
@@ -544,7 +544,7 @@ func (fs *FileSystem) Rmr(ctx meta.Context, p string, skipTrash bool, numthreads
 		return
 	}
 	err = fs.m.Remove(ctx, parent.inode, path.Base(p), skipTrash, numthreads, nil)
-	fs.invalidateEntry(parent.inode, path.Base(p))
+	fs.InvalidateEntry(parent.inode, path.Base(p))
 	return
 }
 
@@ -603,8 +603,8 @@ func (fs *FileSystem) Rename(ctx meta.Context, oldpath string, newpath string, f
 		return err0
 	}
 	err = fs.m.Rename(ctx, oldfi.inode, path.Base(oldpath), newfi.inode, path.Base(newpath), flags, nil, nil)
-	fs.invalidateEntry(oldfi.inode, path.Base(oldpath))
-	fs.invalidateEntry(newfi.inode, path.Base(newpath))
+	fs.InvalidateEntry(oldfi.inode, path.Base(oldpath))
+	fs.InvalidateEntry(newfi.inode, path.Base(newpath))
 	return
 }
 
@@ -622,7 +622,7 @@ func (fs *FileSystem) Link(ctx meta.Context, src string, dst string) (err syscal
 		return
 	}
 	err = fs.m.Link(ctx, fi.inode, pi.inode, path.Base(dst), nil)
-	fs.invalidateEntry(pi.inode, path.Base(dst))
+	fs.InvalidateEntry(pi.inode, path.Base(dst))
 	return
 }
 
@@ -638,7 +638,7 @@ func (fs *FileSystem) Symlink(ctx meta.Context, target string, link string) (err
 		return
 	}
 	err = fs.m.Symlink(ctx, fi.inode, path.Base(link), target, nil, nil)
-	fs.invalidateEntry(fi.inode, path.Base(link))
+	fs.InvalidateEntry(fi.inode, path.Base(link))
 	return
 }
 
@@ -951,7 +951,7 @@ func (fs *FileSystem) Create(ctx meta.Context, p string, mode uint16, umask uint
 		if fs.conf.DirEntryTimeout > 0 {
 			parent := parentDir(p)
 			if fi, err := fs.resolve(ctx, parentDir(parent), true); err == 0 {
-				fs.invalidateEntry(fi.inode, path.Base(parent))
+				fs.InvalidateEntry(fi.inode, path.Base(parent))
 			}
 		}
 		if fi2, e := fs.resolve(ctx, parentDir(p), true); e != 0 {
@@ -970,7 +970,7 @@ func (fs *FileSystem) Create(ctx meta.Context, p string, mode uint16, umask uint
 		f.info = fi
 		f.fs = fs
 	}
-	fs.invalidateEntry(fi.inode, path.Base(p))
+	fs.InvalidateEntry(fi.inode, path.Base(p))
 	return
 }
 

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -266,7 +266,7 @@ func (fs *FileSystem) invalidateEntry(parent Ino, name string) {
 	}
 }
 
-func (fs *FileSystem) invalidateAttr(ino Ino) {
+func (fs *FileSystem) InvalidateAttr(ino Ino) {
 	fs.cacheM.Lock()
 	defer fs.cacheM.Unlock()
 	delete(fs.attrs, ino)
@@ -1091,7 +1091,7 @@ func (f *File) Chmod(ctx meta.Context, mode uint16) (err syscall.Errno) {
 	defer func() { f.fs.log(l, "Chmod (%s,%o): %s", f.path, mode, errstr(err)) }()
 	var attr = Attr{Mode: mode}
 	err = f.fs.m.SetAttr(ctx, f.inode, meta.SetAttrMode, 0, &attr)
-	f.fs.invalidateAttr(f.inode)
+	f.fs.InvalidateAttr(f.inode)
 	return
 }
 
@@ -1108,7 +1108,7 @@ func (f *File) Chown(ctx meta.Context, uid uint32, gid uint32) (err syscall.Errn
 	}
 	var attr = Attr{Uid: uid, Gid: gid}
 	err = f.fs.m.SetAttr(ctx, f.inode, flag, 0, &attr)
-	f.fs.invalidateAttr(f.inode)
+	f.fs.InvalidateAttr(f.inode)
 	return
 }
 
@@ -1132,7 +1132,7 @@ func (f *File) Utime(ctx meta.Context, atime, mtime int64) (err syscall.Errno) {
 	attr.Mtime = mtime / 1000
 	attr.Mtimensec = uint32(mtime%1000) * 1e6
 	err = f.fs.m.SetAttr(ctx, f.inode, flag, 0, &attr)
-	f.fs.invalidateAttr(f.inode)
+	f.fs.InvalidateAttr(f.inode)
 	return
 }
 
@@ -1158,7 +1158,7 @@ func (f *File) Utime2(ctx meta.Context, atimeSec, atimeNSec, mtimeSec, mtimeNsec
 	attr.Mtime = mtimeSec
 	attr.Mtimensec = uint32(mtimeNsec)
 	err = f.fs.m.SetAttr(ctx, f.inode, flag, 0, &attr)
-	f.fs.invalidateAttr(f.inode)
+	f.fs.InvalidateAttr(f.inode)
 	return
 }
 
@@ -1291,7 +1291,7 @@ func (f *File) Truncate(ctx meta.Context, length uint64) (err syscall.Errno) {
 		f.fs.writer.Truncate(f.inode, length)
 		f.fs.reader.Truncate(f.inode, length)
 		f.info.attr.Length = length
-		f.fs.invalidateAttr(f.inode)
+		f.fs.InvalidateAttr(f.inode)
 	}
 	return
 }
@@ -1306,7 +1306,7 @@ func (f *File) Flush(ctx meta.Context) (err syscall.Errno) {
 	l := vfs.NewLogContext(ctx)
 	defer func() { f.fs.log(l, "Flush (%s): %s", f.path, errstr(err)) }()
 	err = f.wdata.Flush(ctx)
-	f.fs.invalidateAttr(f.inode)
+	f.fs.InvalidateAttr(f.inode)
 	return
 }
 
@@ -1320,7 +1320,7 @@ func (f *File) Fsync(ctx meta.Context) (err syscall.Errno) {
 	l := vfs.NewLogContext(ctx)
 	defer func() { f.fs.log(l, "Fsync (%s): %s", f.path, errstr(err)) }()
 	err = f.wdata.Flush(ctx)
-	f.fs.invalidateAttr(f.inode)
+	f.fs.InvalidateAttr(f.inode)
 	return
 }
 
@@ -1340,7 +1340,7 @@ func (f *File) Close(ctx meta.Context) (err syscall.Errno) {
 		}
 		if f.wdata != nil {
 			err = f.wdata.Close(meta.Background())
-			f.fs.invalidateAttr(f.inode)
+			f.fs.InvalidateAttr(f.inode)
 			f.wdata = nil
 		}
 		_ = f.fs.m.Close(ctx, f.inode)

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -113,6 +113,8 @@ func (fs *FileStat) Gid() int         { return int(fs.attr.Gid) }
 func (fs *FileStat) Atime() int64 { return fs.attr.Atime*1000 + int64(fs.attr.Atimensec/1e6) }
 func (fs *FileStat) Mtime() int64 { return fs.attr.Mtime*1000 + int64(fs.attr.Mtimensec/1e6) }
 
+func (fs *FileStat) Attr() *Attr { return fs.attr }
+
 func AttrToFileInfo(inode Ino, attr *Attr) *FileStat {
 	return &FileStat{inode: inode, attr: attr}
 }

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -915,6 +915,7 @@ func Serve(v *vfs.VFS, fuseOpt string, asRoot bool, delayCloseSec int, showDotFi
 	var jfs juice
 	conf := v.Conf
 	jfs.attrCacheTimeout = v.Conf.AttrTimeout
+	v.Conf.AttrTimeout = time.Duration(0)
 	jfs.conf = conf
 	jfs.vfs = v
 	jfs.enabledGetPath = enabledGetPath

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -191,6 +191,9 @@ func (j *juice) Mknod(p string, mode uint32, dev uint64) (e int) {
 	}
 	_, errno := j.vfs.Mknod(ctx, parent.Inode(), path.Base(p), uint16(mode), 0, uint32(dev))
 	e = errorconv(errno)
+	if e == 0 {
+		j.fs.InvalidateEntry(parent.Inode(), path.Base(p))
+	}
 	return
 }
 
@@ -342,6 +345,9 @@ func (j *juice) Create(p string, flags int, mode uint32) (e int, fh uint64) {
 		j.Unlock()
 	}
 	e = errorconv(errno)
+	if e == 0 {
+		j.fs.InvalidateEntry(parent.Inode(), path.Base(p))
+	}
 	return
 }
 
@@ -628,6 +634,9 @@ func (j *juice) Truncate(path string, size int64, fh uint64) (e int) {
 		return
 	}
 	e = errorconv(j.vfs.Truncate(ctx, ino, size, 0, nil))
+	if e == 0 {
+		j.invalidateAttrCache(ino)
+	}
 	return
 }
 

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -924,7 +924,6 @@ func Serve(v *vfs.VFS, fuseOpt string, asRoot bool, delayCloseSec int, showDotFi
 	var jfs juice
 	conf := v.Conf
 	jfs.attrCacheTimeout = v.Conf.AttrTimeout
-	v.Conf.AttrTimeout = time.Duration(0)
 	jfs.conf = conf
 	jfs.vfs = v
 	jfs.enabledGetPath = enabledGetPath

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -40,7 +40,15 @@ import (
 
 var logger = utils.GetLogger("juicefs")
 
+const invalidFileHandle = uint64(0xffffffffffffffff)
+
 type Ino = meta.Ino
+
+type handleInfo struct {
+	ino           meta.Ino
+	cacheAttr     *meta.Attr
+	attrExpiredAt time.Time
+}
 
 func trace(vals ...interface{}) func(vals ...interface{}) {
 	uid, gid, pid := fuse.Getcontext()
@@ -49,24 +57,28 @@ func trace(vals ...interface{}) func(vals ...interface{}) {
 
 type juice struct {
 	fuse.FileSystemBase
-	sync.Mutex
-	conf     *vfs.Config
-	vfs      *vfs.VFS
-	fs       *fs.FileSystem
-	host     *fuse.FileSystemHost
-	handlers map[uint64]meta.Ino
-	badfd    map[uint64]uint64
+	sync.RWMutex
+	conf         *vfs.Config
+	vfs          *vfs.VFS
+	fs           *fs.FileSystem
+	host         *fuse.FileSystemHost
+	handlers     map[uint64]handleInfo
+	inoHandleMap map[meta.Ino][]uint64
+	badfd        map[uint64]uint64
 
 	asRoot         bool
 	delayClose     int
 	enabledGetPath bool
 	disableSymlink bool
+
+	attrCacheTimeout time.Duration
 }
 
 // Init is called when the file system is created.
 func (j *juice) Init() {
-	j.handlers = make(map[uint64]meta.Ino)
+	j.handlers = make(map[uint64]handleInfo)
 	j.badfd = make(map[uint64]uint64)
+	j.inoHandleMap = make(map[meta.Ino][]uint64)
 }
 
 func (j *juice) newContext() vfs.LogContext {
@@ -261,6 +273,9 @@ func (j *juice) Chmod(path string, mode uint32) (e int) {
 		return
 	}
 	e = errorconv(f.Chmod(ctx, uint16(mode)))
+	if e == 0 {
+		j.invalidateAttrCache(f.Inode())
+	}
 	return
 }
 
@@ -296,7 +311,11 @@ func (j *juice) Utimens(path string, tmsp []fuse.Timespec) (e int) {
 	if err != 0 {
 		e = errorconv(err)
 	} else {
+		defer f.Close(ctx)
 		e = errorconv(f.Utime2(ctx, tmsp[0].Sec, tmsp[0].Nsec, tmsp[1].Sec, tmsp[1].Nsec))
+		if e == 0 {
+			j.invalidateAttrCache(f.Inode())
+		}
 	}
 	return
 }
@@ -315,7 +334,12 @@ func (j *juice) Create(p string, flags int, mode uint32) (e int, fh uint64) {
 	entry, fh, errno := j.vfs.Create(ctx, parent.Inode(), path.Base(p), uint16(mode), 0, uint32(fuseFlagToSyscall(flags)))
 	if errno == 0 {
 		j.Lock()
-		j.handlers[fh] = entry.Inode
+		j.handlers[fh] = handleInfo{
+			ino:           entry.Inode,
+			cacheAttr:     entry.Attr,
+			attrExpiredAt: time.Now().Add(j.conf.AttrTimeout),
+		}
+		j.inoHandleMap[entry.Inode] = append(j.inoHandleMap[entry.Inode], fh)
 		j.Unlock()
 	}
 	e = errorconv(errno)
@@ -368,7 +392,12 @@ func (j *juice) OpenEx(p string, fi *fuse.FileInfo_t) (e int) {
 			fi.KeepCache = entry.Attr.KeepCache
 		}
 		j.Lock()
-		j.handlers[fh] = ino
+		j.handlers[fh] = handleInfo{
+			ino:           ino,
+			cacheAttr:     entry.Attr,
+			attrExpiredAt: time.Now().Add(j.conf.AttrTimeout),
+		}
+		j.inoHandleMap[ino] = append(j.inoHandleMap[ino], fh)
 		j.Unlock()
 	}
 	e = errorconv(errno)
@@ -429,19 +458,20 @@ func attrToStat(inode Ino, attr *meta.Attr, stat *fuse.Stat_t) {
 }
 
 func (j *juice) h2i(fh *uint64) meta.Ino {
-	defer j.Unlock()
-	j.Lock()
-	ino := j.handlers[*fh]
-	if ino == 0 {
+	defer j.RUnlock()
+	j.RLock()
+
+	entry := j.handlers[*fh]
+	if entry.ino == 0 {
 		newfh := j.badfd[*fh]
 		if newfh != 0 {
-			ino = j.handlers[newfh]
-			if ino > 0 {
+			entry = j.handlers[newfh]
+			if entry.ino > 0 {
 				*fh = newfh
 			}
 		}
 	}
-	return ino
+	return entry.ino
 }
 
 func (j *juice) reopen(p string, fh *uint64) meta.Ino {
@@ -453,7 +483,7 @@ func (j *juice) reopen(p string, fh *uint64) meta.Ino {
 	defer j.Unlock()
 	j.badfd[*fh] = newfh
 	*fh = newfh
-	return j.handlers[newfh]
+	return j.handlers[newfh].ino
 }
 
 // Getattr gets file attributes.
@@ -481,11 +511,77 @@ func (j *juice) getAttrForSpFile(ctx vfs.LogContext, p string, stat *fuse.Stat_t
 	return
 }
 
+func (j *juice) invalidateAttrCache(ino meta.Ino) {
+	if j.attrCacheTimeout == 0 || ino == 0 {
+		return
+	}
+	j.Lock()
+	defer j.Unlock()
+
+	hs := j.inoHandleMap[ino]
+	for _, fh := range hs {
+		if cache, ok := j.handlers[fh]; ok {
+			cache.cacheAttr = nil
+			cache.attrExpiredAt = time.Time{}
+			j.handlers[fh] = cache
+		}
+	}
+}
+
+func (j *juice) getAttrFromCache(fh uint64) (entry *meta.Entry) {
+	if j.attrCacheTimeout == 0 || fh == invalidFileHandle {
+		return nil
+	}
+	j.RLock()
+	defer j.RUnlock()
+	if cache, ok := j.handlers[fh]; ok && cache.cacheAttr != nil {
+		if time.Now().Before(cache.attrExpiredAt) {
+			entry = &meta.Entry{
+				Inode: cache.ino,
+				Attr:  cache.cacheAttr,
+			}
+			j.vfs.UpdateLength(cache.ino, cache.cacheAttr)
+			return entry
+		}
+	}
+	return nil
+}
+
+func (j *juice) setAttrCache(fh uint64, attr *meta.Attr) {
+	if j.attrCacheTimeout == 0 || fh == invalidFileHandle {
+		return
+	}
+
+	j.Lock()
+	defer j.Unlock()
+
+	if cache, ok := j.handlers[fh]; ok {
+		cache.cacheAttr = attr
+		cache.attrExpiredAt = time.Now().Add(j.attrCacheTimeout)
+		j.handlers[fh] = cache
+	}
+}
+
+func (j *juice) getAttrCache(ctx vfs.Context, fh uint64, ino Ino, opened uint8) (entry *meta.Entry, err syscall.Errno) {
+	if entry := j.getAttrFromCache(fh); entry != nil {
+		return entry, 0
+	}
+
+	if entry, err = j.vfs.GetAttr(ctx, ino, opened); err != 0 {
+		return nil, err
+	}
+
+	j.setAttrCache(fh, entry.Attr)
+
+	return entry, 0
+}
+
 // Getattr gets file attributes.
 func (j *juice) Getattr(p string, stat *fuse.Stat_t, fh uint64) (e int) {
 	ctx := j.newContext()
 	defer trace(p, fh)(stat, &e)
 	ino := j.h2i(&fh)
+
 	if ino == 0 {
 		// special case for .control file
 		if strings.HasSuffix(p, "/.control") {
@@ -505,8 +601,15 @@ func (j *juice) Getattr(p string, stat *fuse.Stat_t, fh uint64) (e int) {
 			return
 		}
 		ino = fi.Inode()
+		entry := fi.Attr()
+		if entry != nil {
+			j.vfs.UpdateLength(ino, entry)
+			attrToStat(ino, entry, stat)
+			return
+		}
 	}
-	entry, errrno := j.vfs.GetAttr(ctx, ino, 0)
+
+	entry, errrno := j.getAttrCache(ctx, fh, ino, 0)
 	if errrno != 0 {
 		e = errorconv(errrno)
 		return
@@ -569,6 +672,7 @@ func (j *juice) Write(path string, buff []byte, off int64, fh uint64) (e int) {
 	} else {
 		e = len(buff)
 	}
+
 	return
 }
 
@@ -598,6 +702,7 @@ func (j *juice) Release(path string, fh uint64) int {
 		time.Sleep(time.Second * time.Duration(j.delayClose))
 		j.Lock()
 		delete(j.handlers, fh)
+		delete(j.inoHandleMap, ino)
 		if orig != fh {
 			delete(j.badfd, orig)
 		}
@@ -632,7 +737,11 @@ func (j *juice) Opendir(path string) (e int, fh uint64) {
 	fh, errno := j.vfs.Opendir(ctx, f.Inode(), 0)
 	if errno == 0 {
 		j.Lock()
-		j.handlers[fh] = f.Inode()
+		j.handlers[fh] = handleInfo{
+			ino: f.Inode(),
+		}
+		j.inoHandleMap[f.Inode()] = append(j.inoHandleMap[f.Inode()], fh)
+
 		j.Unlock()
 	}
 	e = errorconv(errno)
@@ -696,6 +805,7 @@ func (j *juice) Releasedir(path string, fh uint64) (e int) {
 	}
 	j.Lock()
 	delete(j.handlers, fh)
+	delete(j.inoHandleMap, ino)
 	j.Unlock()
 	e = -int(j.vfs.Releasedir(j.newContext(), ino, fh))
 	return
@@ -729,6 +839,8 @@ func (j *juice) Chflags(path string, flags uint32) (e int) {
 	err = j.vfs.ChFlags(ctx, ino, flagSet)
 	if err != 0 {
 		e = errorconv(err)
+	} else {
+		j.invalidateAttrCache(ino)
 	}
 
 	return
@@ -786,10 +898,10 @@ func (j *juice) Getpath(p string, fh uint64) (e int, ret string) {
 	return
 }
 
-func Serve(v *vfs.VFS, fuseOpt string, fileCacheTimeoutSec float64, dirCacheTimeoutSec float64,
-	asRoot bool, delayCloseSec int, showDotFiles bool, threadsCount int, caseSensitive bool, enabledGetPath bool) {
+func Serve(v *vfs.VFS, fuseOpt string, asRoot bool, delayCloseSec int, showDotFiles bool, threadsCount int, caseSensitive bool, enabledGetPath bool) {
 	var jfs juice
 	conf := v.Conf
+	jfs.attrCacheTimeout = v.Conf.AttrTimeout
 	jfs.conf = conf
 	jfs.vfs = v
 	jfs.enabledGetPath = enabledGetPath
@@ -805,8 +917,8 @@ func Serve(v *vfs.VFS, fuseOpt string, fileCacheTimeoutSec float64, dirCacheTime
 	jfs.host = host
 	var options = "volname=" + conf.Format.Name
 	options += fmt.Sprintf(",ExactFileSystemName=JuiceFS,ThreadCount=%d", threadsCount)
-	options += fmt.Sprintf(",DirInfoTimeout=%d,VolumeInfoTimeout=1000,KeepFileCache", int(dirCacheTimeoutSec*1000))
-	options += fmt.Sprintf(",FileInfoTimeout=%d", int(fileCacheTimeoutSec*1000))
+	options += fmt.Sprintf(",DirInfoTimeout=%d,VolumeInfoTimeout=1000,KeepFileCache", int(conf.DirEntryTimeout.Seconds()*1000))
+	options += fmt.Sprintf(",FileInfoTimeout=%d", int(conf.EntryTimeout.Seconds()*1000))
 	options += ",VolumePrefix=/juicefs/" + conf.Format.Name
 	if asRoot {
 		options += ",uid=-1,gid=-1"

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -86,10 +86,10 @@ func (j *juice) newContext() vfs.LogContext {
 		return vfs.NewLogContext(meta.Background())
 	}
 	uid, gid, pid := fuse.Getcontext()
-	if uid == 0xffffffff {
+	if uid == 0xffffffff || uid == 18 {
 		uid = 0
 	}
-	if gid == 0xffffffff {
+	if gid == 0xffffffff || gid == 18 {
 		gid = 0
 	}
 	if pid == -1 {

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -359,7 +359,7 @@ func (j *juice) Open(path string, flags int) (e int, fh uint64) {
 // The flags are a combination of the fuse.O_* constants.
 func (j *juice) OpenEx(p string, fi *fuse.FileInfo_t) (e int) {
 	ctx := j.newContext()
-	defer trace(p, fi.Flags)(&e)
+	defer trace(p, fi.Flags)(&e, &fi.Fh)
 	ino := meta.Ino(0)
 	if strings.HasSuffix(p, "/.control") {
 		ino, _ = vfs.GetInternalNodeByName(".control")


### PR DESCRIPTION

## Test result

**NO CACHE**

  
![image](https://github.com/user-attachments/assets/73066d67-d14f-4701-9080-c82b8ba15e98)

**DEFAULT CACHE && DISABLE SYMBOLINK(not in this pr)**

![image](https://github.com/user-attachments/assets/1474cb76-3ca2-4d0c-98c2-64cf2b45e876)

**ANOTHER LINUX MACHINE WITH THE SAME HARDWARE & SOFTWARE CONFIGURATION (8C16G)**

![image](https://github.com/user-attachments/assets/03d68367-2a31-4aba-b445-be77ddff6652)

**In short:**

* The large-file write speed improved from 320MB/s to 430MB/s, but it is still much slower than the Linux version.

* Small-file read and write performance became 2 to 5 times faster.

* The speed of stat operations also increased significantly.


## DISCUSSION

1. The current implementation behaves inconsistently: some calls in WinFS pass through the FS layer, while others bypass it via the vfs layer. So after enabling caching, without adding a cache invalidation interface for the FS layer, certain winfsp-test cases will fail.

2. Additionally, during troubleshooting, it was found that when the system user (uid=18) attempts to start an .exe process, the operation fails due to missing special handling for uid=18. 
    * This issue existed before the PR but did not cause test failures, because it acted as a normal user, while after this PR the caller identity became SYSTEM. The exact reason for this behavior change is still unclear.
