### PR TITLE
gateway: delete intermediate temporary files timely to reduce inode sage

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -533,7 +533,7 @@ func (fs *FileSystem) Rmdir(ctx meta.Context, p string) (err syscall.Errno) {
 	return
 }
 
-func (fs *FileSystem) Rmr(ctx meta.Context, p string, numthreads int) (err syscall.Errno) {
+func (fs *FileSystem) Rmr(ctx meta.Context, p string, skipTrash bool, numthreads int) (err syscall.Errno) {
 	defer trace.StartRegion(context.TODO(), "fs.Rmr").End()
 	l := vfs.NewLogContext(ctx)
 	defer func() { fs.log(l, "Rmr (%s): %s", p, errstr(err)) }()
@@ -541,7 +541,7 @@ func (fs *FileSystem) Rmr(ctx meta.Context, p string, numthreads int) (err sysca
 	if err != 0 {
 		return
 	}
-	err = fs.m.Remove(ctx, parent.inode, path.Base(p), false, numthreads, nil)
+	err = fs.m.Remove(ctx, parent.inode, path.Base(p), skipTrash, numthreads, nil)
 	fs.invalidateEntry(parent.inode, path.Base(p))
 	return
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -233,7 +233,7 @@ func TestFileSystem(t *testing.T) {
 	if err := fs.Delete(ctx, "/d/f"); err == 0 || !IsNotExist(err) {
 		t.Fatalf("delete /d/f: %s", err)
 	}
-	if e := fs.Rmr(ctx, "/d", meta.RmrDefaultThreads); e != 0 {
+	if e := fs.Rmr(ctx, "/d", false, meta.RmrDefaultThreads); e != 0 {
 		t.Fatalf("delete /d -r: %s", e)
 	}
 
@@ -264,7 +264,7 @@ func TestFileSystem(t *testing.T) {
 	if err := fs.Rename(ctx, "/ddd/", "/ttt/", 0); err != 0 {
 		t.Fatalf("delete /ddd/: %s", err)
 	}
-	if err := fs.Rmr(ctx, "/ttt/", meta.RmrDefaultThreads); err != 0 {
+	if err := fs.Rmr(ctx, "/ttt/", false, meta.RmrDefaultThreads); err != 0 {
 		t.Fatalf("rmr /ttt/: %s", err)
 	}
 	if _, err := fs.Stat(ctx, "/ttt/"); err != syscall.ENOENT {

--- a/pkg/fs/http.go
+++ b/pkg/fs/http.go
@@ -125,7 +125,7 @@ func (hfs *webdavFS) OpenFile(ctx context.Context, name string, flag int, perm o
 }
 
 func (hfs *webdavFS) RemoveAll(ctx context.Context, name string) error {
-	return econv(hfs.fs.Rmr(hfs.ctx, name, hfs.config.MaxDeletes))
+	return econv(hfs.fs.Rmr(hfs.ctx, name, false, hfs.config.MaxDeletes))
 }
 
 func (hfs *webdavFS) Rename(ctx context.Context, oldName, newName string) error {
@@ -252,7 +252,7 @@ type WebdavConfig struct {
 	Password        string
 	CertFile        string
 	KeyFile         string
-	MaxDeletes	int
+	MaxDeletes      int
 }
 
 type indexHandler struct {
@@ -262,7 +262,7 @@ type indexHandler struct {
 
 func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	//http://www.webdav.org/specs/rfc4918.html#n-guidance-for-clients-desiring-to-authenticate
+	// http://www.webdav.org/specs/rfc4918.html#n-guidance-for-clients-desiring-to-authenticate
 	if h.Username != "" && h.Password != "" {
 		userName, pwd, ok := r.BasicAuth()
 		if !ok {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -1266,7 +1266,7 @@ func (n *jfsObjects) CompleteMultipartUpload(ctx context.Context, bucket, object
 	}
 
 	// remove parts
-	_ = n.fs.Rmr(mctx, n.upath(bucket, uploadID), meta.RmrDefaultThreads)
+	_ = n.fs.Rmr(mctx, n.upath(bucket, uploadID), true, meta.RmrDefaultThreads)
 	return minio.ObjectInfo{
 		Bucket:      bucket,
 		Name:        object,
@@ -1284,7 +1284,7 @@ func (n *jfsObjects) AbortMultipartUpload(ctx context.Context, bucket, object, u
 	if err = n.checkUploadIDExists(ctx, bucket, object, uploadID); err != nil {
 		return
 	}
-	eno := n.fs.Rmr(mctx, n.upath(bucket, uploadID), meta.RmrDefaultThreads)
+	eno := n.fs.Rmr(mctx, n.upath(bucket, uploadID), true, meta.RmrDefaultThreads)
 	return jfsToObjectErr(ctx, eno, bucket, object, uploadID)
 }
 
@@ -1329,7 +1329,7 @@ func (n *jfsObjects) cleanupDir(dir string) bool {
 			continue
 		}
 		if now.Sub(time.Unix(entry.Attr.Mtime, 0)) > 7*24*time.Hour {
-			if errno = n.fs.Rmr(mctx, dirPath, meta.RmrDefaultThreads); errno != 0 {
+			if errno = n.fs.Rmr(mctx, dirPath, true, meta.RmrDefaultThreads); errno != 0 {
 				logger.Errorf("failed to delete expired temporary files path: %s, err: %s", dirPath, errno)
 			} else {
 				deleted += 1

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -937,7 +937,7 @@ func jfs_rmr(pid int64, h int64, cpath *C.char) int32 {
 	if w == nil {
 		return EINVAL
 	}
-	return errno(w.Rmr(w.withPid(pid), C.GoString(cpath), MaxDeletes))
+	return errno(w.Rmr(w.withPid(pid), C.GoString(cpath), false, MaxDeletes))
 }
 
 //export jfs_rename


### PR DESCRIPTION
Many tools (e.g., rclone) use multipart upload to split files into smaller chunks when uploading. This amplifies number of inodes for those files, which can easily cause users to exceed their inode quota. We should promptly delete these intermediate files.