### PR TITLE
fix: update stats after creating trash time directory

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2464,6 +2464,7 @@ func (m *baseMeta) checkTrash(parent Ino, trash *Ino) syscall.Errno {
 	if st == syscall.ENOENT {
 		attr := Attr{Typ: TypeDirectory, Nlink: 2, Length: 4 << 10, Parent: TrashInode, Full: true}
 		st = m.en.doMknod(Background(), TrashInode, name, TypeDirectory, 0555, 0, "", trash, &attr)
+		m.en.updateStats(align4K(0), 1)
 	}
 
 	m.Lock()


### PR DESCRIPTION
The doMknod method of the metadata engine for sql and tkv types has not updated the stat value.