### PR TITLE
Fix: sha256 checksum in s3 is added again

### DIFF
--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -26,9 +26,11 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
 )
 
 type minio struct {
@@ -88,6 +90,9 @@ func newMinio(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.EndpointOptions.DisableHTTPS = !ssl
 		options.UsePathStyle = defaultPathStyle()
 		options.HTTPClient = httpClient
+		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
+			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+		})
 	})
 	if len(uri.Path) < 2 {
 		return nil, fmt.Errorf("no bucket name provided in %s", endpoint)

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -21,10 +21,6 @@ package object
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,6 +29,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
 	"github.com/qiniu/go-sdk/v7/auth"
 	"github.com/qiniu/go-sdk/v7/storage"
 )
@@ -211,6 +213,9 @@ func newQiniu(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.EndpointOptions.DisableHTTPS = uri.Scheme == "http"
 		options.UsePathStyle = true
 		options.HTTPClient = httpClient
+		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
+			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+		})
 
 	})
 	s3c := s3client{bucket: bucket, s3: client, region: region}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -32,11 +32,13 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -524,6 +526,9 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 	optFns = append(optFns, func(options *s3.Options) {
 		options.EndpointOptions.DisableHTTPS = !ssl
 		options.Region = region
+		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
+			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+		})
 	})
 
 	disable100Continue := strings.EqualFold(uri.Query().Get("disable-100-continue"), "true")

--- a/pkg/object/scw.go
+++ b/pkg/object/scw.go
@@ -21,13 +21,16 @@ package object
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
 )
 
 type scw struct {
@@ -79,6 +82,9 @@ func newScw(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		options.EndpointOptions.DisableHTTPS = !ssl
 		options.UsePathStyle = false
 		options.HTTPClient = httpClient
+		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
+			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+		})
 	})
 	return &scw{s3client{bucket: bucket, s3: client, region: region}}, nil
 }

--- a/pkg/object/space.go
+++ b/pkg/object/space.go
@@ -21,12 +21,15 @@ package object
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"net/url"
-	"strings"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
 )
 
 type space struct {
@@ -67,6 +70,9 @@ func newSpace(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.EndpointOptions.DisableHTTPS = !ssl
 		options.UsePathStyle = false
 		options.HTTPClient = httpClient
+		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
+			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+		})
 	})
 	return &space{s3client{bucket: bucket, s3: client, region: region}}, nil
 }


### PR DESCRIPTION
Sha256 checksum in object storages are added again by #5968, costing ~30% cpu time:
![img_v3_02m7_32dcb855-22fc-4ee5-95fc-3b1c9750338g](https://github.com/user-attachments/assets/7c4ce3f0-0cd6-4234-92ea-a14ea4f26278)

Sha256 is too heavy for a file system, crc checksum is enough.