### PR TITLE
fix burst bandwidth

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -798,10 +798,10 @@ func NewCachedStore(storage object.ObjectStorage, config Config, reg prometheus.
 	}
 	if config.UploadLimit > 0 {
 		// there are overheads coming from HTTP/TCP/IP
-		store.upLimit = ratelimit.NewBucketWithRate(float64(config.UploadLimit)*0.85, config.UploadLimit)
+		store.upLimit = ratelimit.NewBucketWithRate(float64(config.UploadLimit)*0.85, config.UploadLimit/10)
 	}
 	if config.DownloadLimit > 0 {
-		store.downLimit = ratelimit.NewBucketWithRate(float64(config.DownloadLimit)*0.85, config.DownloadLimit)
+		store.downLimit = ratelimit.NewBucketWithRate(float64(config.DownloadLimit)*0.85, config.DownloadLimit/10)
 	}
 	store.initMetrics()
 	if store.conf.CacheDir != "memory" && store.conf.Writeback {
@@ -1169,7 +1169,7 @@ func (store *cachedStore) UpdateLimit(upload, download int64) {
 		logger.Infof("Upload limit changed from %d to %d", store.conf.UploadLimit, upload)
 		store.conf.UploadLimit = upload
 		if upload > 0 {
-			store.upLimit = ratelimit.NewBucketWithRate(float64(upload)*0.85, upload)
+			store.upLimit = ratelimit.NewBucketWithRate(float64(upload)*0.85, upload/10)
 		} else {
 			store.upLimit = nil
 		}
@@ -1178,7 +1178,7 @@ func (store *cachedStore) UpdateLimit(upload, download int64) {
 		logger.Infof("Download limit changed from %d to %d", store.conf.DownloadLimit, download)
 		store.conf.DownloadLimit = download
 		if download > 0 {
-			store.downLimit = ratelimit.NewBucketWithRate(float64(download)*0.85, download)
+			store.downLimit = ratelimit.NewBucketWithRate(float64(download)*0.85, download/10)
 		} else {
 			store.downLimit = nil
 		}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1585,7 +1585,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 	concurrent = make(chan int, config.Threads)
 	if config.BWLimit > 0 {
 		bps := float64(config.BWLimit*1e6/8) * 0.85 // 15% overhead
-		limiter = ratelimit.NewBucketWithRate(bps, int64(bps)*3)
+		limiter = ratelimit.NewBucketWithRate(bps, int64(bps)/5)
 	}
 
 	progress := utils.NewProgress(config.Verbose || config.Quiet || config.Manager != "")

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1585,7 +1585,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 	concurrent = make(chan int, config.Threads)
 	if config.BWLimit > 0 {
 		bps := float64(config.BWLimit*1e6/8) * 0.85 // 15% overhead
-		limiter = ratelimit.NewBucketWithRate(bps, int64(bps)/5)
+		limiter = ratelimit.NewBucketWithRate(bps, int64(bps)/10)
 	}
 
 	progress := utils.NewProgress(config.Verbose || config.Quiet || config.Manager != "")


### PR DESCRIPTION
The capacity is used as a buffer for generated token, which could reduce the delay for incoming requests. But large capacity will cause burst traffic, which may cause packet loss.