### PR TITLE
Disable S3 SDK retries since JuiceFS has its own retry mechanism

### DIFF
--- a/pkg/object/eos.go
+++ b/pkg/object/eos.go
@@ -88,6 +88,7 @@ func newEos(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 
 	return &eos{s3client{bucket: bucket, s3: client, region: region}}, nil

--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -93,6 +93,7 @@ func newMinio(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 	if len(uri.Path) < 2 {
 		return nil, fmt.Errorf("no bucket name provided in %s", endpoint)

--- a/pkg/object/oos.go
+++ b/pkg/object/oos.go
@@ -97,6 +97,7 @@ func newOOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 	return &oos{s3client{bucket: bucket, s3: client, region: region}}, nil
 }

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -216,7 +216,7 @@ func newQiniu(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
-
+		options.RetryMaxAttempts = 1
 	})
 	s3c := s3client{bucket: bucket, s3: client, region: region}
 	cfg := storage.Config{

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -529,6 +529,7 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 
 	disable100Continue := strings.EqualFold(uri.Query().Get("disable-100-continue"), "true")

--- a/pkg/object/scw.go
+++ b/pkg/object/scw.go
@@ -85,6 +85,7 @@ func newScw(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 	return &scw{s3client{bucket: bucket, s3: client, region: region}}, nil
 }

--- a/pkg/object/space.go
+++ b/pkg/object/space.go
@@ -73,6 +73,7 @@ func newSpace(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 	return &space{s3client{bucket: bucket, s3: client, region: region}}, nil
 }

--- a/pkg/object/wasabi.go
+++ b/pkg/object/wasabi.go
@@ -72,6 +72,7 @@ func newWasabi(endpoint, accessKey, secretKey, token string) (ObjectStorage, err
 		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
 		})
+		options.RetryMaxAttempts = 1
 	})
 	return &wasabi{s3client{bucket: bucket, s3: client, region: region}}, nil
 }


### PR DESCRIPTION
Another breaking change after migrating to new sdk. Otherwise, we will have three times as many retries as before.