### PR TITLE
pkg/sync: fix copied counter

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -514,8 +514,7 @@ func doCopySingle(src, dst object.ObjectStorage, key string, size int64, calChks
 		if err != nil {
 			if _, e := src.Head(key); os.IsNotExist(e) {
 				logger.Debugf("Head src %s: %s", key, err)
-				copied.IncrInt64(-1)
-				err = nil
+				err = utils.ErrSkipped
 			}
 		}
 		return r.chksum, err
@@ -545,8 +544,7 @@ func doCopySingle0(src, dst object.ObjectStorage, key string, size int64, calChk
 		if err != nil {
 			if _, e := src.Head(key); os.IsNotExist(e) {
 				logger.Debugf("Head src %s: %s", key, err)
-				copied.IncrInt64(-1)
-				err = nil
+				err = utils.ErrSkipped
 			}
 			return 0, err
 		}


### PR DESCRIPTION
If the file does not exist, we return nil for the err here, and decrease the copied counter by -1. 

The checksum fails due to the non-existent file, resulting in a final negative number.

```
➜  JUICEFS1=redis://127.0.0.1:6379/0 JUICEFS2=redis://127.0.0.1:6379/1 ./juicefs sync jfs://JUICEFS1/ jfs://JUICEFS2/ --check-all
2025/05/19 14:52:36.803665 juicefs[95731] <INFO>: Meta address: redis://127.0.0.1:6379/0 [NewClient@interface.go:578]
2025/05/19 14:52:36.805974 juicefs[95731] <INFO>: Ping redis latency: 179.375µs [checkServerConfig@redis.go:3684]
2025/05/19 14:52:36.807000 juicefs[95731] <INFO>: Meta address: redis://127.0.0.1:6379/1 [NewClient@interface.go:578]
2025/05/19 14:52:36.810394 juicefs[95731] <INFO>: Ping redis latency: 308.625µs [checkServerConfig@redis.go:3684]
2025/05/19 14:52:36.811971 juicefs[95731] <INFO>: Prometheus metrics listening on 127.0.0.1:63619 [exposeMetrics@mount.go:134]
2025/05/19 14:52:36.812790 juicefs[95731] <INFO>: Syncing from jfs://local-mnt1/ to jfs://local-mnt2/ [Sync@sync.go:1739]
2025/05/19 14:52:41.819562 juicefs[95731] <ERROR>: Failed to check 1GB-file.links in 5.002002541s: dest get: no such file or directory [checkSum@sync.go:471]
2025/05/19 14:52:41.819752 juicefs[95731] <ERROR>: Failed to copy object 1GB-file.links: dest get: no such file or directory [worker@sync.go:914]
 Scanned objects: 1/1 [==============================================================]  0.2/s used: 5.008752083s
Excluded objects: 0                 0.0/s     
  Excluded bytes: 0.0 b (0 Bytes)   0.0 b/s   
 Skipped objects: 0                 0.0/s     
   Skipped bytes: 0.0 b (0 Bytes)   0.0 b/s   
   Extra objects: 1                 0.2/s     
     Extra bytes: 0.0 b (0 Bytes)   0.0 b/s   
 Pending objects: 0                 0.0/s     
  Copied objects: -1                -0.2/s    
    Copied bytes: 0.0 b (0 Bytes)   0.0 b/s   
 Checked objects: 0                 0.0/s     
   Checked bytes: 0.0 b (0 Bytes)   0.0 b/s   
  Failed objects: 1                 0.2/s  
```