### PR TITLE
cmd/sync: Fix the multi-threaded out-of-order bug when --delete-dst is set

### DIFF
--- a/.github/scripts/sync/sync.sh
+++ b/.github/scripts/sync/sync.sh
@@ -102,7 +102,7 @@ test_sync_with_deep_link(){
     rm -rf jfs_source/symlink_*
 }
 
-skip_test_sync_fsrand_with_mount_point(){
+test_sync_fsrand_with_mount_point(){
     generate_fsrand
     do_test_sync_fsrand_with_mount_point 
     do_test_sync_fsrand_with_mount_point --list-threads 10 --list-depth 5

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1115,6 +1115,14 @@ func produce(tasks chan<- object.Object, srckeys, dstkeys <-chan object.Object, 
 				dstobj = nil
 				continue
 			}
+
+			if config.DeleteDst && (dstobj.IsDir() != obj.IsDir()) {
+				tasks <- withSize(dstobj, markDeleteDst)
+				tasks <- obj
+				dstobj = nil
+				continue
+			}
+
 			if config.ForceUpdate ||
 				(config.Update && obj.Mtime().Unix() > dstobj.Mtime().Unix()) ||
 				(!config.Update && obj.Size() != dstobj.Size()) {


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs/issues/5851

Description:
When sync carries -- deletre-dst and --list-threads>1 and overwrites the directory with the same name in jfs with one file (or overwrites the file with the same name in jfs with one directory), multithreading cannot ensure the atomicity of the delete operation and the create operation.
