### PR TITLE
pkg/object: use string marshal object mtime

### DIFF
--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -72,7 +73,7 @@ func MarshalObject(o Object) map[string]interface{} {
 	m := make(map[string]interface{})
 	m["key"] = o.Key()
 	m["size"] = o.Size()
-	m["mtime"] = o.Mtime().UnixNano()
+	m["mtime"] = strconv.FormatInt(o.Mtime().UnixNano(), 10)
 	m["isdir"] = o.IsDir()
 	if f, ok := o.(File); ok {
 		m["mode"] = f.Mode()
@@ -84,7 +85,8 @@ func MarshalObject(o Object) map[string]interface{} {
 }
 
 func UnmarshalObject(m map[string]interface{}) Object {
-	mtime := time.Unix(0, int64(m["mtime"].(float64)))
+	mtime_int64, _ := strconv.ParseInt(m["mtime"].(string), 10, 64)
+	mtime := time.Unix(0, mtime_int64)
 	o := obj{
 		key:   m["key"].(string),
 		size:  int64(m["size"].(float64)),

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -81,8 +81,9 @@ func TestCluster(t *testing.T) {
 }
 
 func TestMarshal(t *testing.T) {
+	mtime := time.Now()
 	var objs = []object.Object{
-		&obj{key: "test"},
+		&obj{key: "test", mtime: mtime},
 		withSize(&obj{key: "test1", size: 100}, -4),
 		withSize(&file{obj{key: "test2", size: 200}}, -1),
 		withSize(&file{obj{key: "test3", size: 200, isSymlink: true}}, -1),
@@ -97,6 +98,9 @@ func TestMarshal(t *testing.T) {
 	}
 	if objs2[0].Key() != "test" {
 		t.Fatalf("expect test but got %s", objs2[0].Key())
+	}
+	if !objs2[0].Mtime().Equal(objs[0].Mtime()) {
+		t.Fatalf("expect %s but got %s", mtime, objs2[0].Mtime())
 	}
 	if objs2[1].Key() != "test1" || objs2[1].Size() != -4 || withoutSize(objs2[1]).Size() != 100 {
 		t.Fatalf("expect withSize but got %s", objs2[1].Key())


### PR DESCRIPTION
avoid precision issues caused by json

fix: https://github.com/juicedata/juicefs/issues/6126