### PR TITLE
pkg/sync: fix mtime comparison for check-change

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -927,9 +927,8 @@ func checkChange(src, dst object.ObjectStorage, obj object.Object, key string, c
 		}
 		equal := cur.Size() == obj.Size()
 		if equal && !cur.Mtime().Equal(obj.Mtime()) {
-			diff := cur.Mtime().Sub(obj.Mtime())
-			// Consider them equal if time difference is <1s and head time's millisecond part is 0
-			equal = math.Abs(float64(diff.Milliseconds())) < 1000 && cur.Mtime().UnixMilli()%1000 == 0
+			// Head of an object may not return the millisecond part of mtime as List
+			equal = cur.Mtime().Unix() == obj.Mtime().Unix() && cur.Mtime().UnixMilli()%1000 == 0
 		}
 		if !equal {
 			return fmt.Errorf("%s changed during sync. Original: size=%d, mtime=%s; Current: size=%d, mtime=%s",


### PR DESCRIPTION
For some objects, such as minio, head object, the milliseconds were removed, only retaining to the second.


Consider them equal if head time's millisecond part is 0 and there is the only difference


head: => https://github.com/minio/minio/blob/12a6ea89cc657eab17a01272892db4d3154eff48/cmd/api-headers.go#L117-L118
list: => https://github.com/minio/minio/blob/12a6ea89cc657eab17a01272892db4d3154eff48/cmd/api-response.go#L840-L841

fix: https://github.com/juicedata/juicefs/issues/6133