### PR TITLE
meta/tikv: simplify transactions in point get scenarios by reducing one RPC call

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -119,7 +119,9 @@ jobs:
         run: |
           git clone https://github.com/gofrs/flock.git
           mkdir /jfs/tmp
-          cd flock && go mod tidy && TMPDIR=/jfs/tmp go test .
+          cd flock && go mod tidy
+          sudo cat /jfs/.accesslog | grep -v '#' &
+          TMPDIR=/jfs/tmp go test .
 
       - name: make secfs.test
         run: |

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -56,6 +56,7 @@ type kvtxn interface {
 
 type tkvClient interface {
 	name() string
+	pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) error // should only be used for simple point get scenarios
 	txn(ctx context.Context, f func(*kvTxn) error, retry int) error
 	scan(prefix []byte, handler func(key, value []byte) bool) error
 	reset(prefix []byte) error
@@ -380,7 +381,7 @@ func (m *kvMeta) parseQuota(buf []byte) *Quota {
 
 func (m *kvMeta) get(key []byte) ([]byte, error) {
 	var value []byte
-	err := m.client.txn(Background(), func(tx *kvTxn) error {
+	err := m.client.pointGetTxn(Background(), func(tx *kvTxn) error {
 		value = tx.get(key)
 		return nil
 	}, 0)
@@ -911,7 +912,7 @@ func (m *kvMeta) doLookup(ctx Context, parent Ino, name string, inode *Ino, attr
 }
 
 func (m *kvMeta) doGetAttr(ctx Context, inode Ino, attr *Attr) syscall.Errno {
-	return errno(m.client.txn(ctx, func(tx *kvTxn) error {
+	return errno(m.client.pointGetTxn(ctx, func(tx *kvTxn) error {
 		val := tx.get(m.inodeKey(inode))
 		if val == nil {
 			return syscall.ENOENT
@@ -1827,7 +1828,7 @@ func (m *kvMeta) fillAttr(entries []*Entry) (err error) {
 		keys[i] = m.inodeKey(e.Inode)
 	}
 	var rs [][]byte
-	err = m.client.txn(Background(), func(tx *kvTxn) error {
+	err = m.client.pointGetTxn(Background(), func(tx *kvTxn) error {
 		rs = tx.gets(keys...)
 		return nil
 	}, 0)

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -148,7 +148,7 @@ func (c *badgerClient) config(key string) interface{} {
 	return nil
 }
 
-func (c *badgerClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+func (c *badgerClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
 	return c.txn(ctx, f, retry)
 }
 

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"time"
 
-	badger "github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4"
 	"github.com/juicedata/juicefs/pkg/utils"
 )
 
@@ -146,6 +146,10 @@ func (c *badgerClient) shouldRetry(err error) bool {
 
 func (c *badgerClient) config(key string) interface{} {
 	return nil
+}
+
+func (c *badgerClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	return c.txn(ctx, f, retry)
 }
 
 func (c *badgerClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -209,7 +209,7 @@ func (c *etcdClient) config(key string) interface{} {
 	return nil
 }
 
-func (c *etcdClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+func (c *etcdClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
 	return c.txn(ctx, f, retry)
 }
 

--- a/pkg/meta/tkv_etcd.go
+++ b/pkg/meta/tkv_etcd.go
@@ -209,6 +209,10 @@ func (c *etcdClient) config(key string) interface{} {
 	return nil
 }
 
+func (c *etcdClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	return c.txn(ctx, f, retry)
+}
+
 func (c *etcdClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
 	tx := &etcdTxn{
 		ctx,

--- a/pkg/meta/tkv_fdb.go
+++ b/pkg/meta/tkv_fdb.go
@@ -65,6 +65,10 @@ func (c *fdbClient) config(key string) interface{} {
 	return nil
 }
 
+func (c *fdbClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	return c.txn(ctx, f, retry)
+}
+
 func (c *fdbClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) error {
 	_, err := c.client.Transact(func(t fdb.Transaction) (interface{}, error) {
 		e := f(&kvTxn{&fdbTxn{t}, retry})

--- a/pkg/meta/tkv_fdb.go
+++ b/pkg/meta/tkv_fdb.go
@@ -65,7 +65,7 @@ func (c *fdbClient) config(key string) interface{} {
 	return nil
 }
 
-func (c *fdbClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+func (c *fdbClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
 	return c.txn(ctx, f, retry)
 }
 

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -203,7 +203,7 @@ func (c *memKV) set(key string, value []byte) {
 	}
 }
 
-func (c *memKV) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+func (c *memKV) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
 	return c.txn(ctx, f, retry)
 }
 

--- a/pkg/meta/tkv_mem.go
+++ b/pkg/meta/tkv_mem.go
@@ -203,6 +203,10 @@ func (c *memKV) set(key string, value []byte) {
 	}
 }
 
+func (c *memKV) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	return c.txn(ctx, f, retry)
+}
+
 func (c *memKV) txn(ctx context.Context, f func(*kvTxn) error, retry int) error {
 	tx := &memTxn{
 		store:    c,

--- a/pkg/meta/tkv_prefix.go
+++ b/pkg/meta/tkv_prefix.go
@@ -80,8 +80,8 @@ type prefixClient struct {
 	prefix []byte
 }
 
-func (c *prefixClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
-	return c.tkvClient.pointGetTxn(ctx, func(tx *kvTxn) error {
+func (c *prefixClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	return c.tkvClient.simpleTxn(ctx, func(tx *kvTxn) error {
 		return f(&kvTxn{&prefixTxn{tx, c.prefix}, retry})
 	}, retry)
 }

--- a/pkg/meta/tkv_prefix.go
+++ b/pkg/meta/tkv_prefix.go
@@ -80,6 +80,12 @@ type prefixClient struct {
 	prefix []byte
 }
 
+func (c *prefixClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	return c.tkvClient.pointGetTxn(ctx, func(tx *kvTxn) error {
+		return f(&kvTxn{&prefixTxn{tx, c.prefix}, retry})
+	}, retry)
+}
+
 func (c *prefixClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) error {
 	return c.tkvClient.txn(ctx, func(tx *kvTxn) error {
 		return f(&kvTxn{&prefixTxn{tx, c.prefix}, retry})

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -21,9 +21,12 @@ package meta
 
 import (
 	"context"
+	"math"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"strings"
+	"syscall"
 	"time"
 
 	plog "github.com/pingcap/log"
@@ -192,6 +195,31 @@ func (c *tikvClient) config(key string) interface{} {
 			return nil
 		}
 		return ts
+	}
+	return nil
+}
+
+func (c *tikvClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+	tx, err := c.client.Begin(tikv.WithStartTS(math.MaxUint64)) // math.MaxUint64 means to point get the latest committed data without PD access
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	tx.GetSnapshot().SetIsolationLevel(txnkv.RC) // RC isolation to skip lock checking in TiKV
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else {
+				err = errors.Errorf("panic in point get transaction: %v", r)
+			}
+		}
+	}()
+	if err = f(&kvTxn{&tikvTxn{tx}, retry}); err != nil {
+		return err
+	}
+	if !tx.IsReadOnly() {
+		logger.Errorf("TiKV point get transaction is read-only\n%s", debug.Stack()) // should not happen
+		return syscall.EINVAL
 	}
 	return nil
 }

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"net/url"
 	"os"
-	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -199,7 +198,7 @@ func (c *tikvClient) config(key string) interface{} {
 	return nil
 }
 
-func (c *tikvClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
+func (c *tikvClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
 	tx, err := c.client.Begin(tikv.WithStartTS(math.MaxUint64)) // math.MaxUint64 means to point get the latest committed data without PD access
 	if err != nil {
 		return errors.Wrap(err, "failed to begin transaction")
@@ -218,7 +217,6 @@ func (c *tikvClient) pointGetTxn(ctx context.Context, f func(*kvTxn) error, retr
 		return err
 	}
 	if !tx.IsReadOnly() {
-		logger.Errorf("TiKV point get transaction is read-only\n%s", debug.Stack()) // should not happen
 		return syscall.EINVAL
 	}
 	return nil


### PR DESCRIPTION
In the current implementation of TiKV, each transaction requires at least two RPCs: one to obtain start timestamp from PD, and another to read/write data from TiKV, even for the simplest point query scenarios such as `lookup/getattr`. Actually, TiKV has optimized for simple point query scenarios by allowing use of `math.MaxUint64` as a start timestamp, which internally means "to get the latest committed data." This way, we can eliminate one RPC call to PD, reducing latency and alleviating the load on PD.

This optimization corresponds to [simpleTxn](https://github.com/juicedata/juicefs/pull/5377) in SQL engine - to reduce transaction overhead for simple queries. It provides a significant improvement for read-heavy scenarios, such as LLM training. A simple `mdtest` benchmark shows that `stat` operations can achieve a 50%-60% performance improvement after this optimization.

Before:
```
SUMMARY rate: (of 5 iterations)
   Operation                     Max            Min           Mean        Std Dev
   ---------                     ---            ---           ----        -------
   Directory creation            555.637        500.848        535.327         21.022
   Directory stat              30217.822      24352.151      26544.440       2232.511
   Directory rename              521.461        493.811        509.121          9.932
   Directory removal             519.550        487.976        506.651         11.587
   File creation                 679.972        640.534        655.575         14.717
   File stat                   30788.481      26540.856      29316.366       1654.854
   File read                   37628.849      27392.933      35024.104       4340.994
   File removal                  749.882        703.259        724.518         23.567
   Tree creation                 592.254        483.587        544.636         41.305
   Tree removal                  527.064        495.100        511.837         15.593
```

After:
```
SUMMARY rate: (of 5 iterations)
   Operation                     Max            Min           Mean        Std Dev
   ---------                     ---            ---           ----        -------
   Directory creation            802.445        751.059        777.577         19.036
   Directory stat              47103.933      39174.624      44248.699       3093.214
   Directory rename              552.234        527.294        537.524          9.463
   Directory removal             541.498        512.040        524.373         13.788
   File creation                 791.234        731.998        768.850         23.305
   File stat                   45019.831      41267.642      43179.429       1789.069
   File read                   35994.526      27491.580      32485.700       3678.509
   File removal                  784.541        679.333        741.993         41.675
   Tree creation                 794.911        725.299        775.506         28.566
   Tree removal                  649.409        581.852        628.249         27.925
```