### PR TITLE
cmd/mount: disable transparent huge page

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -622,7 +622,7 @@ func mount(c *cli.Context) error {
 			daemonRun(c, addr, vfsConf) // only stage 0 needs the vfsConf
 		}
 		os.Setenv("JFS_SUPERVISOR", strconv.Itoa(os.Getppid()))
-		return launchMount(mp, vfsConf)
+		return launchMount(c, mp, vfsConf)
 	} else if runtime.GOOS == "windows" && c.Bool("background") {
 		daemonRun(c, addr, vfsConf)
 		return nil

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -126,7 +126,7 @@ func prepareMp(mp string) {}
 
 func setFuseOption(c *cli.Context, format *meta.Format, vfsConf *vfs.Config) {}
 
-func launchMount(mp string, conf *vfs.Config) error { return nil }
+func launchMount(c *cli.Context, mp string, conf *vfs.Config) error { return nil }
 
 func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorage) {}
 

--- a/pkg/utils/utils_darwin.go
+++ b/pkg/utils/utils_darwin.go
@@ -47,4 +47,6 @@ Hardware:
 
 func SetIOFlusher() {}
 
+func DisableTHP() {}
+
 func AdjustOOMKiller(score int) {}

--- a/pkg/utils/utils_linux.go
+++ b/pkg/utils/utils_linux.go
@@ -79,6 +79,23 @@ func SetIOFlusher() {
 	}
 }
 
+// Disable transparent huge page
+func DisableTHP() {
+	for {
+		err := unix.Prctl(unix.PR_SET_THP_DISABLE, 1, 0, 0, 0)
+		if err == nil {
+			break
+		}
+
+		if errors.Is(err, unix.EINTR) {
+			continue
+		} else {
+			logger.Warnf("Failed to disable transparent huge page: %s", err)
+			return
+		}
+	}
+}
+
 // AdjustOOMKiller: change oom_score_adj to avoid OOM-killer
 func AdjustOOMKiller(score int) {
 	if os.Getuid() != 0 {


### PR DESCRIPTION
In our production env, MADV_HUGEPAGE is being used to indicate the application is willing to wait for work for thp memory to be available.

When numpy[1] consumes the most of the huge pages that are produced by kcompactd, juicefs may take minutes to get a one. All these eventually leading to IO hang issues. And some times kcompactd itself is waiting for juicefs to finish an IO:

kernel: INFO: task kcompactd0:1175 blocked for more than 120 seconds.
kernel:       Tainted: P           OE     5.15.0-88-generic #98-Ubuntu
kernel: "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
kernel: task:kcompactd0      state:D stack:    0 pid: 1175 ppid:     2 flags:0x00004000
kernel: Call Trace:
kernel:  <TASK>
kernel:  __schedule+0x24e/0x590
kernel:  ? page_vma_mapped_walk+0x568/0xa20
kernel:  schedule+0x69/0x110
kernel:  io_schedule+0x46/0x80
kernel:  wait_on_page_bit_common+0x10c/0x3d0
kernel:  ? filemap_invalidate_unlock_two+0x50/0x50
kernel:  __lock_page+0x4c/0x60
kernel:  __unmap_and_move+0x228/0x340
kernel:  ? migrate_page_copy+0xb0/0xb0
kernel:  ? move_freelist_tail+0xd0/0xd0
kernel:  unmap_and_move+0x6d/0x2e0
kernel:  migrate_pages+0x323/0x4f0
kernel:  ? move_freelist_tail+0xd0/0xd0
kernel:  ? isolate_freepages+0x2d0/0x2d0
kernel:  compact_zone+0x28e/0x590
kernel:  proactive_compact_node+0x8a/0xd0
kernel:  kcompactd+0x21c/0x4c0
kernel:  ? wait_woken+0x70/0x70
kernel:  ? kcompactd_do_work+0x220/0x220
kernel:  kthread+0x127/0x150
kernel:  ? set_kthread_struct+0x50/0x50
kernel:  ret_from_fork+0x1f/0x30
kernel:  </TASK>

Fix the issue by disabling transparent huge page.

Fixes: #2414

[1] https://numpy.org/doc/2.0/reference/global_state.html#madvise-hugepage-on-linux