### PR TITLE
meta/sql: setXattr only update necessary columns

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -3544,12 +3544,12 @@ func (m *dbMeta) doSetXattr(ctx Context, inode Ino, name string, value []byte, f
 			if !ok {
 				return ENOATTR
 			}
-			_, err = s.Update(&x, k)
+			_, err = s.Cols("value").Update(&x, k)
 		default:
 			if !ok {
 				err = mustInsert(s, &x)
 			} else if !bytes.Equal(existing, value) {
-				_, err = s.Update(&x, k)
+				_, err = s.Cols("value").Update(&x, k)
 			}
 		}
 		return err


### PR DESCRIPTION
In the current implementation, the `sqlStr` of `setXattr()` is:

```sql
UPDATE `jfs_xattr` SET `inode` = ?, `name` = ?, `value` = ? WHERE `id`=? AND `inode`=? AND `name`=?"
```

The `inode` and `name` columns should not appear in the `SET` list.

This PR simply changes it to

```sql
UPDATE `jfs_xattr` SET `value` = ? WHERE `id`=? AND `inode`=? AND `name`=?
```