### PR TITLE
tikv: support `open-tso-follower-proxy` and `max-tso-batch-wait-interval` options

### DIFF
--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -92,13 +92,19 @@ func newTikvClient(addr string) (tkvClient, error) {
 	}
 
 	if strings.ToLower(query.Get("open-tso-follower-proxy")) == "true" {
-		logger.Infof("Enabling TSO Follower Proxy")
-		client.KVStore.GetPDClient().UpdateOption(pd.EnableTSOFollowerProxy, true)
+		if err := client.KVStore.GetPDClient().UpdateOption(pd.EnableTSOFollowerProxy, true); err != nil {
+			logger.Warnf("Failed to enable TSO Follower Proxy: %v", err)
+		} else {
+			logger.Infof("Enabling TSO Follower Proxy")
+		}
 
 		if waitStr := query.Get("max-tso-batch-wait-interval"); waitStr != "" {
 			if waitDur, err := time.ParseDuration(waitStr); err == nil {
-				client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur)
-				logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
+				if err := client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur); err != nil {
+					logger.Warnf("Failed to set MaxTSOBatchWaitInterval: %v", err)
+				} else {
+					logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
+				}
 			} else {
 				logger.Warnf("Failed to parse max-tso-batch-wait-interval (%s): %v", waitStr, err)
 			}

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -97,17 +97,17 @@ func newTikvClient(addr string) (tkvClient, error) {
 		} else {
 			logger.Infof("Enabling TSO Follower Proxy")
 		}
+	}
 
-		if waitStr := query.Get("max-tso-batch-wait-interval"); waitStr != "" {
-			if waitDur, err := time.ParseDuration(waitStr); err == nil {
-				if err := client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur); err != nil {
-					logger.Warnf("Failed to set MaxTSOBatchWaitInterval: %v", err)
-				} else {
-					logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
-				}
+	if waitStr := query.Get("max-tso-batch-wait-interval"); waitStr != "" {
+		if waitDur, err := time.ParseDuration(waitStr); err == nil {
+			if err := client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur); err != nil {
+				logger.Warnf("Failed to set MaxTSOBatchWaitInterval: %v", err)
 			} else {
-				logger.Warnf("Failed to parse max-tso-batch-wait-interval (%s): %v", waitStr, err)
+				logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
 			}
+		} else {
+			logger.Warnf("Failed to parse max-tso-batch-wait-interval (%s): %v", waitStr, err)
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for two configuration parameters to control TSO (Timestamp Oracle) behavior in TiKV:

- `open-tso-follower-proxy=true`: Enables TSO follower proxy mode in the PD client.
- `max-tso-batch-wait-interval=10ms`: Sets the maximum batching wait interval for TSO requests.


These options help reduce TSO-related bottlenecks in large-scale deployments by offloading timestamp allocation to follower PD nodes.

Example usage:
`tikv://pd-1,pd-2,pd-3?open-tso-follower-proxy=true&max-tso-batch-wait-interval=10ms`