### PR TITLE
meta: add a option `--fast-statfs` to speed up statfs

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -307,6 +307,11 @@ func metaFlags() []cli.Flag {
 			Name:  "sort-dir",
 			Usage: "sort entries within a directory by name",
 		},
+		&cli.BoolFlag{
+			Name:  "fast-statfs",
+			Value: false,
+			Usage: "Use local counters for statfs instead of querying metadata service",
+		},
 	})
 }
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -330,6 +330,7 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 	conf.SkipDirMtime = utils.Duration(c.String("skip-dir-mtime"))
 	conf.Sid, _ = strconv.ParseUint(os.Getenv("_JFS_META_SID"), 10, 64)
 	conf.SortDir = c.Bool("sort-dir")
+	conf.FastStatfs = c.Bool("fast-statfs")
 
 	atimeMode := c.String("atime-mode")
 	if atimeMode != meta.RelAtime && atimeMode != meta.StrictAtime && atimeMode != meta.NoAtime {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -813,21 +813,9 @@ func (m *baseMeta) StatFS(ctx Context, ino Ino, totalspace, availspace, iused, i
 
 func (m *baseMeta) statRootFs(ctx Context, totalspace, availspace, iused, iavail *uint64) syscall.Errno {
 	var used, inodes int64
-	var err error
-	err = utils.WithTimeout(func() error {
-		used, err = m.en.getCounter(usedSpace)
-		return err
-	}, time.Millisecond*150)
-	if err != nil {
-		used = atomic.LoadInt64(&m.usedSpace)
-	}
-	err = utils.WithTimeout(func() error {
-		inodes, err = m.en.getCounter(totalInodes)
-		return err
-	}, time.Millisecond*150)
-	if err != nil {
-		inodes = atomic.LoadInt64(&m.usedInodes)
-	}
+	used = atomic.LoadInt64(&m.usedSpace)
+	inodes = atomic.LoadInt64(&m.usedInodes)
+
 	used += atomic.LoadInt64(&m.newSpace)
 	inodes += atomic.LoadInt64(&m.newInodes)
 	if used < 0 {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -813,9 +813,27 @@ func (m *baseMeta) StatFS(ctx Context, ino Ino, totalspace, availspace, iused, i
 
 func (m *baseMeta) statRootFs(ctx Context, totalspace, availspace, iused, iavail *uint64) syscall.Errno {
 	var used, inodes int64
-	used = atomic.LoadInt64(&m.usedSpace)
-	inodes = atomic.LoadInt64(&m.usedInodes)
-
+	var err error
+	if !m.conf.FastStatfs {
+		err = utils.WithTimeout(func() error {
+			used, err = m.en.getCounter(usedSpace)
+			return err
+		}, time.Millisecond*150)
+		if err != nil {
+			used = atomic.LoadInt64(&m.usedSpace)
+		}
+		err = utils.WithTimeout(func() error {
+			inodes, err = m.en.getCounter(totalInodes)
+			return err
+		}, time.Millisecond*150)
+		if err != nil {
+			inodes = atomic.LoadInt64(&m.usedInodes)
+		}
+	} else {
+		used = atomic.LoadInt64(&m.usedSpace)
+		inodes = atomic.LoadInt64(&m.usedInodes)
+	}
+	
 	used += atomic.LoadInt64(&m.newSpace)
 	inodes += atomic.LoadInt64(&m.newInodes)
 	if used < 0 {

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	SkipDirMtime       time.Duration
 	Sid                uint64
 	SortDir            bool
+	FastStatfs         bool
 }
 
 func DefaultConf() *Config {

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -92,13 +92,19 @@ func newTikvClient(addr string) (tkvClient, error) {
 	}
 
 	if strings.ToLower(query.Get("open-tso-follower-proxy")) == "true" {
-		logger.Infof("Enabling TSO Follower Proxy")
-		client.KVStore.GetPDClient().UpdateOption(pd.EnableTSOFollowerProxy, true)
+		if err := client.KVStore.GetPDClient().UpdateOption(pd.EnableTSOFollowerProxy, true); err != nil {
+			logger.Warnf("Failed to enable TSO Follower Proxy: %v", err)
+		} else {
+			logger.Infof("Enabling TSO Follower Proxy")
+		}
 
 		if waitStr := query.Get("max-tso-batch-wait-interval"); waitStr != "" {
 			if waitDur, err := time.ParseDuration(waitStr); err == nil {
-				client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur)
-				logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
+				if err := client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur); err != nil {
+					logger.Warnf("Failed to set MaxTSOBatchWaitInterval: %v", err)
+				} else {
+					logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
+				}
 			} else {
 				logger.Warnf("Failed to parse max-tso-batch-wait-interval (%s): %v", waitStr, err)
 			}

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -97,17 +97,17 @@ func newTikvClient(addr string) (tkvClient, error) {
 		} else {
 			logger.Infof("Enabling TSO Follower Proxy")
 		}
+	}
 
-		if waitStr := query.Get("max-tso-batch-wait-interval"); waitStr != "" {
-			if waitDur, err := time.ParseDuration(waitStr); err == nil {
-				if err := client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur); err != nil {
-					logger.Warnf("Failed to set MaxTSOBatchWaitInterval: %v", err)
-				} else {
-					logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
-				}
+	if waitStr := query.Get("max-tso-batch-wait-interval"); waitStr != "" {
+		if waitDur, err := time.ParseDuration(waitStr); err == nil {
+			if err := client.KVStore.GetPDClient().UpdateOption(pd.MaxTSOBatchWaitInterval, waitDur); err != nil {
+				logger.Warnf("Failed to set MaxTSOBatchWaitInterval: %v", err)
 			} else {
-				logger.Warnf("Failed to parse max-tso-batch-wait-interval (%s): %v", waitStr, err)
+				logger.Infof("Set MaxTSOBatchWaitInterval to %s", waitDur)
 			}
+		} else {
+			logger.Warnf("Failed to parse max-tso-batch-wait-interval (%s): %v", waitStr, err)
 		}
 	}
 


### PR DESCRIPTION
#### Problem
In large-scale deployments with thousands of clients, the statRootFs method triggers high-concurrency access to two metadata counters:

```go
m.en.getCounter(usedSpace)
m.en.getCounter(totalInodes)
```

These counters are implemented as hot keys in TiKV. When each client frequently queries them, it results in:
- TiKV node QPS spiking to 50k–100k;
- TiKV nodes restarting due to overload;
- PD nodes being overwhelmed and becoming unstable.

This severely impacts the availability and performance of the metadata service.

#### Solution
This PR removes direct calls to getCounter(usedSpace) and getCounter(totalInodes). Instead, the values are now read only from in-memory atomic variables:

```go
used = atomic.LoadInt64(&m.usedSpace)
inodes = atomic.LoadInt64(&m.usedInodes)
```
These variables are already maintained in memory and provide sufficient accuracy for filesystem statistics.


####  Benefits
- Eliminates hot key access in TiKV.
- Greatly reduces metadata server and TiKV load under heavy client concurrency.
- Prevents PD and TiKV from being overwhelmed.
- Improves stability and scalability of statfs under load.