### PR TITLE
fix(gateway): add a null check for tagStr in CompleteMultipartUpload

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -1232,8 +1232,10 @@ func (n *jfsObjects) CompleteMultipartUpload(ctx context.Context, bucket, object
 			if eno != meta.ENOATTR {
 				logger.Errorf("get object tags error, path: %s, error: %s", n.upath(bucket, uploadID), eno)
 			}
-		} else if eno = n.fs.SetXattr(mctx, tmp, s3Tags, tagStr, 0); eno != 0 {
-			logger.Errorf("set object tags error, path: %s, tags: %s, error: %s", tmp, string(tagStr), eno)
+		} else if len(tagStr) > 0 {
+			if eno = n.fs.SetXattr(mctx, tmp, s3Tags, tagStr, 0); eno != 0 {
+				logger.Errorf("set object tags error, path: %s, tags: %s, error: %s", tmp, string(tagStr), eno)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What this PR does

This PR fixes [issue #6181](https://github.com/juicedata/juicefs/issues/6181) by adding a `nil` check for the `tagStr` field before calling `SetXattr` in the `CompleteMultipartUpload` method. This prevents unnecessary errors caused by inserting a `nil` value into the metadata store.

### Why we need it

When `ObjTag` is enabled and no tag value is provided, the JuiceFS Gateway may attempt to set an extended attribute (`xattr`) with a null value. This leads to a runtime error when the underlying metadata engine (e.g., PostgreSQL) enforces a NOT NULL constraint.

### How I tested

This change has been tested locally with the following steps:

1. Start JuiceFS in Gateway mode.
2. Use the S3 SDK to initiate a multipart upload via the Gateway endpoint.
3. Upload all parts using pre-signed URLs.
4. Call `CompleteMultipartUpload` without specifying tags.

After applying the fix, the multipart upload completed successfully without triggering the null value error.

### Related issue
[#6181](https://github.com/juicedata/juicefs/issues/6181)