### PR TITLE
object: wrong region of TOS

### DIFF
--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -287,7 +287,7 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	credentials.WithSecurityToken(token)
 	cli, err := tos.NewClientV2(
 		hostParts[1]+"."+hostParts[2],
-		tos.WithRegion(strings.TrimSuffix(hostParts[1], "tos-")),
+		tos.WithRegion(strings.TrimPrefix(hostParts[1], "tos-")),
 		tos.WithCredentials(credentials),
 		tos.WithEnableVerifySSL(httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify))
 	if err != nil {


### PR DESCRIPTION
tos endpoint: bucket.tos-cn-beijing.ivolces.com