### PR TITLE
meta: fix all-zero read response due to invalid `openFile.chunks` cache

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2118,6 +2118,7 @@ func (m *redisMeta) fillAttr(ctx Context, es []*Entry) error {
 		if re != nil {
 			if a, ok := re.(string); ok {
 				m.parseAttr([]byte(a), es[j].Attr)
+				m.of.Update(es[j].Inode, es[j].Attr)
 			}
 		}
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -26,7 +26,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"io"
 	"net/url"
 	"runtime"
@@ -39,6 +38,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"xorm.io/xorm"
 	"xorm.io/xorm/log"
 	"xorm.io/xorm/names"
@@ -2515,6 +2515,7 @@ func (m *dbMeta) doReaddir(ctx Context, inode Ino, plus uint8, entries *[]*Entry
 			}
 			if plus != 0 {
 				m.parseAttr(&n.node, entry.Attr)
+				m.of.Update(entry.Inode, entry.Attr)
 			} else {
 				entry.Attr.Typ = n.Type
 			}
@@ -4933,6 +4934,7 @@ func (m *dbMeta) getDirFetcher() dirFetcher {
 				}
 				if plus {
 					m.parseAttr(&n.node, entry.Attr)
+					m.of.Update(n.Inode, entry.Attr)
 				} else {
 					entry.Attr.Typ = n.Type
 				}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1838,6 +1838,8 @@ func (m *kvMeta) fillAttr(entries []*Entry) (err error) {
 	for j, re := range rs {
 		if re != nil {
 			m.parseAttr(re, entries[j].Attr)
+			// If `readdirplus` returns complete attributes, kernel may not invoke `GetAttr`. Therefore, we must also validate chunk cache here to prevent stale cache, which may lead to data corruption.
+			m.of.Update(entries[j].Inode, entries[j].Attr)
 		}
 	}
 	return err


### PR DESCRIPTION
When running TensorBoard on JuiceFS, we encountered a `ChecksumError`:
```
ReadRecordError(BadLengthCrc(ChecksumError { got: MaskedCrc(0x07980329), want: MaskedCrc(0x00000000) }))
```

TensorBoard's IO model can be simplified as: the TB library on one node continuously `open/append/close` an event file, while the TB server on another node keeps scanning a large directory. If it detects one event file has been updated, it reads a new record and performs a CRC check. This error occurs because TB server reads a record filled with all zeros.

After adding some debug logs, we found the empty record was caused by missing slices. It seems the `openFile.chunks` cache is not updated. Update of `openFile.chunks` is triggered by `GetAttr`. An accesslog we captured showed there was indeed no `GetAttr` request before the `Read` request that returned all zeros:
![img_v3_02n8_4a199e5e-96b8-4fda-b785-348fcba6400g](https://github.com/user-attachments/assets/09803344-4765-4b02-8aef-d4d737c46469)

One reasonable explanation is that when kernel has already obtained full attributes via `readdirplus`, it may not trigger a `GetAttr` request again within a certain `cache-timeout` period, which causes `openFile.chunks` to not expire. At this point,  TB server will find one file's length has increased and tries to read the next record, JuiceFS still considers its `openFile.chunks` valid, and returns all zeros since it cannot find corresponding slice in the chunk cache.

A simple fix is to also check the validity of `openFile.chunks` for attributes returned by readdirplus.

Additionally, since 2021, there have been [similar reports on TB's issue page](https://github.com/tensorflow/tensorboard/issues/5116) about encountering this issue on shared file systems. It's indeed true that cache invalidation is one of the hardest problems in computer science. 