### PR TITLE
vfs/metrics: histogram bucket range of FUSE latency should exceed range of object storage

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -196,7 +196,7 @@ func NewFileSystem(conf *vfs.Config, m meta.Meta, d chunk.ChunkStore, registry *
 		opsDurationsHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "sdk_ops_durations_histogram_seconds",
 			Help:    "Operations latency distributions.",
-			Buckets: prometheus.ExponentialBuckets(0.00001, 1.8, 30),
+			Buckets: prometheus.ExponentialBuckets(0.00001, 1.8, 29),
 		}),
 		registry: registry,
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -196,7 +196,7 @@ func NewFileSystem(conf *vfs.Config, m meta.Meta, d chunk.ChunkStore, registry *
 		opsDurationsHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "sdk_ops_durations_histogram_seconds",
 			Help:    "Operations latency distributions.",
-			Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(0.00001, 1.8, 30),
 		}),
 		registry: registry,
 	}

--- a/pkg/vfs/accesslog.go
+++ b/pkg/vfs/accesslog.go
@@ -18,11 +18,11 @@ package vfs
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
-	"strconv"
-	"strings"
 
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,7 +32,7 @@ var (
 	opsDurationsHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "fuse_ops_durations_histogram_seconds",
 		Help:    "Operations latency distributions.",
-		Buckets: prometheus.ExponentialBuckets(0.0001, 1.5, 30),
+		Buckets: prometheus.ExponentialBuckets(0.00001, 1.8, 30), // should cover range of `objectReqsHistogram`
 	})
 	opsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fuse_ops_total",

--- a/pkg/vfs/accesslog.go
+++ b/pkg/vfs/accesslog.go
@@ -32,7 +32,7 @@ var (
 	opsDurationsHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "fuse_ops_durations_histogram_seconds",
 		Help:    "Operations latency distributions.",
-		Buckets: prometheus.ExponentialBuckets(0.00001, 1.8, 30), // should cover range of `objectReqsHistogram`
+		Buckets: prometheus.ExponentialBuckets(0.00001, 1.8, 29), // should cover range of `objectReqsHistogram`
 	})
 	opsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fuse_ops_total",


### PR DESCRIPTION
Currently, the latency range for object storage is [0.01, 168]s, but range for FUSE latency is [0.0001, 12.7]s. The gap is too large that FUSE latency p99 being very insensitive when object storage latency increases, and sometimes the p99 is even much smaller than average:

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/36dc7fad-1d5c-4b92-88c3-f0f9375b1508" />

It is better to make FUSE latency range cover the range of object storage latency.