### PR TITLE
meta: fix leaking objects when quota is full

### DIFF
--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -203,16 +203,15 @@ func (c *chunkWriter) commitThread() {
 
 		f.Lock()
 		if err != 0 {
-			if err == syscall.ENOENT {
+			if err == syscall.ENOENT || err == syscall.ENOSPC || err == syscall.EDQUOT {
 				go func(id uint64, length int) {
 					_ = f.w.store.Remove(id, length)
 				}(s.id, int(s.length))
-			} else if err != syscall.ENOSPC && err != syscall.EDQUOT {
-				logger.Warnf("write inode:%d error: %s", f.inode, err)
+			} else {
 				err = syscall.EIO
 			}
 			f.err = err
-			logger.Errorf("write inode:%d indx:%d  %s", f.inode, c.indx, err)
+			logger.Errorf("write inode:%d indx:%d %s", f.inode, c.indx, err)
 		}
 		c.slices = c.slices[1:]
 	}


### PR DESCRIPTION
When quota/volume is full, no one will be tracking those pending slices, we should delete them as much as possible.