### PR TITLE
chunk: disable `writeback` flag in `cache-partial-only` mode

### DIFF
--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -105,7 +105,7 @@ func TestMetrics(t *testing.T) {
 		t.Fatalf("expect the stageBlockBytes is %d", len(content))
 	}
 	key := fmt.Sprintf("chunks/0/5/5000_2_%d", len(content))
-	stagingPath, err := m.stage(key, content, false)
+	stagingPath, err := m.stage(key, content)
 	if err != nil {
 		t.Fatalf("stage failed: %s", err)
 	}

--- a/pkg/chunk/mem_cache.go
+++ b/pkg/chunk/mem_cache.go
@@ -206,7 +206,7 @@ func (c *memcache) cleanupExpire() {
 	}
 }
 
-func (c *memcache) stage(key string, data []byte, keepCache bool) (string, error) {
+func (c *memcache) stage(key string, data []byte) (string, error) {
 	return "", errors.New("not supported")
 }
 func (c *memcache) uploaded(key string, size int)    {}


### PR DESCRIPTION
Two minor fixes:
1. `cache-partial-only` and `writeback` are two conflicting flags and cannot be enabled together. Stage files must always be linked to the cache directory; otherwise, even the local client won't be able to access those blocks before background upload is completed.
2. Stage metrics are inaccurate in some corner cases. For example, when two JuiceFS instances of the same volume are scheduled to the same node and both processes upload the stage directory simultaneously, the metrics will never return to zero.