### PR TITLE
object/tos: verify using the crc32 algorithm

### DIFF
--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -293,6 +293,10 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint: %v, error: %v", endpoint, err)
 	}
+	disableChecksum := strings.EqualFold(uri.Query().Get("disable-checksum"), "true")
+	if disableChecksum {
+		logger.Infof("default CRC checksum is disabled")
+	}
 	hostParts := strings.SplitN(uri.Host, ".", 3)
 	credentials := tos.NewStaticCredentials(accessKey, secretKey)
 	credentials.WithSecurityToken(token)
@@ -301,7 +305,7 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		tos.WithRegion(strings.TrimPrefix(hostParts[1], "tos-")),
 		tos.WithCredentials(credentials),
 		tos.WithEnableVerifySSL(httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify),
-		tos.WithEnableCRC(false))
+		tos.WithEnableCRC(!disableChecksum))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It is mainly to reduce CPU usage, the CPU consumption of using crc32c algorithm is lower than crc64. 
However, the drawback is that if data corruption occurs during transmission, the error will be discovered only when reading.