### PR TITLE
cmd/sync: clear the redundant delimiters in the files-from

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1467,7 +1467,12 @@ func produceFromList(tasks chan<- object.Object, src, dst object.ObjectStorage, 
 		if trimKey != key {
 			logger.Infof("found a prefix with a space character:%q", key)
 		}
-		prefixs <- path.Clean(trimKey)
+		isDir := strings.HasSuffix(trimKey, "/")
+		trimKey = path.Clean(trimKey)
+		if isDir {
+			trimKey += "/"
+		}
+		prefixs <- trimKey
 	}
 	close(prefixs)
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -26,7 +26,6 @@ import (
 	"math"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -1468,7 +1467,7 @@ func produceFromList(tasks chan<- object.Object, src, dst object.ObjectStorage, 
 		if trimKey != key {
 			logger.Infof("found a prefix with a space character:%q", key)
 		}
-		prefixs <- filepath.Clean(trimKey)
+		prefixs <- path.Clean(trimKey)
 	}
 	close(prefixs)
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -1467,7 +1468,7 @@ func produceFromList(tasks chan<- object.Object, src, dst object.ObjectStorage, 
 		if trimKey != key {
 			logger.Infof("found a prefix with a space character:%q", key)
 		}
-		prefixs <- trimKey
+		prefixs <- filepath.Clean(trimKey)
 	}
 	close(prefixs)
 


### PR DESCRIPTION
In order to be able to handle the format `a//b`