### PR TITLE
refactor: improve lock management in commitThread

### DIFF
--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -218,7 +218,7 @@ func (c *chunkWriter) commitThread() {
 		c.slices = c.slices[1:]
 	}
 	f.freeChunk(c)
-	defer f.Unlock()
+	f.Unlock()
 }
 
 type fileWriter struct {


### PR DESCRIPTION
When executing f.w.m.Write(meta.Background(), f.inode, c.indx, s.off, ss, s.lastMod), in some scenarios a panic may occur. When the defer method is executed, the lock has not been acquired, resulting in the error: fatal error: sync: unlock of unlocked mutex.

```
fatal error: sync: unlock of unlocked mutex
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x14b07d1]

goroutine 2010658 [running]:
sync.fatal({0x323aa8a?, 0xc000fa4ed0?})
        /usr/local/go/src/runtime/panic.go:1031 +0x1e
sync.(*Mutex).unlockSlow(0xc003031cc0, 0xffffffff)
        /usr/local/go/src/sync/mutex.go:229 +0x3c
sync.(*Mutex).Unlock(0x566ce20?)
        /usr/local/go/src/sync/mutex.go:223 +0x29
panic({0x2ce1be0, 0x5550ba0})
        /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/juicedata/juicefs/pkg/meta.(*dbMeta).upsertSlice(0xc0003ac500?, 0x3e66578?, 0xc000f3cc80?, 0x102000?, {0xc00481fe78, 0x18, 0x18}, 0xc001f218b3)
        /workspace/juicefs/pkg/meta/sql.go:1072 +0x331
github.com/juicedata/juicefs/pkg/meta.(*dbMeta).doWrite.func1(0xc00247c000)
        /workspace/juicefs/pkg/meta/sql.go:2302 +0x43d
github.com/juicedata/juicefs/pkg/meta.(*dbMeta).txn.func2(0xc00247c000?)
        /workspace/juicefs/pkg/meta/sql.go:806 +0x1d
xorm.io/xorm.(*Engine).Transaction(0x38335d0?, 0xc001f21b68, {0x0, 0x0, 0x38335d0?})
        /go/pkg/mod/gitea.com/davies/xorm@v1.0.8-0.20220528043536-552d84d1b34a/engine.go:1312 +0xc2
github.com/juicedata/juicefs/pkg/meta.(*dbMeta).txn(0xc000d12be0, 0xc001f21c60, {0xc002441750, 0x1, 0x1})
        /workspace/juicefs/pkg/meta/sql.go:805 +0x42f
github.com/juicedata/juicefs/pkg/meta.(*dbMeta).doWrite(0xc000d12be0, {0x3e66578?, 0xc000f3cc80?}, 0x1380a, 0x497445?, 0x0?, {0x49355c88, 0x101909, 0x0, 0x101909}, ...)
        /workspace/juicefs/pkg/meta/sql.go:2271 +0x145
github.com/juicedata/juicefs/pkg/meta.(*baseMeta).Write(0xc0003ac500, {0x3e66578, 0xc000f3cc80}, 0x1380a, 0x0, 0x0?, {0x49355c88, 0x101909, 0x0, 0x101909}, ...)
        /workspace/juicefs/pkg/meta/base.go:1475 +0x2d0
github.com/juicedata/juicefs/pkg/vfs.(*chunkWriter).commitThread(0xc003799290)
        /workspace/juicefs/pkg/vfs/writer.go:200 +0x223
created by github.com/juicedata/juicefs/pkg/vfs.(*fileWriter).writeChunk
        /workspace/juicefs/pkg/vfs/writer.go:270 +0x44a
```