### PR TITLE
fuse: add inode cache invalidation on file open

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -250,8 +250,9 @@ func (fs *fileSystem) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.Op
 		out.OpenFlags |= fuse.FOPEN_DIRECT_IO
 	} else if entry.Attr.KeepCache {
 		out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
+	} else {
+		fsserv.InodeNotify(uint64(in.NodeId), -1, 0)
 	}
-	fsserv.InodeNotify(uint64(in.NodeId), -1, 0)
 	return 0
 }
 

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -251,6 +251,7 @@ func (fs *fileSystem) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.Op
 	} else if entry.Attr.KeepCache {
 		out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
 	}
+	fsserv.InodeNotify(uint64(in.NodeId), -1, 0)
 	return 0
 }
 


### PR DESCRIPTION
Add InodeNotify call in Open method to force kernel cache invalidation when files are opened. This ensures that clients get fresh inode attribute information instead of relying on potentially stale cached data.

The change calls fsserv.InodeNotify() with the opened file's inode ID to notify the kernel to invalidate its cached attribute information. This improves consistency across multiple clients accessing the same files.

Resolves: #6323