### PR TITLE
sdk/python: raise exception when jfs_init returns 0

### DIFF
--- a/sdk/python/juicefs/juicefs/juicefs.py
+++ b/sdk/python/juicefs/juicefs/juicefs.py
@@ -35,7 +35,12 @@ XATTR_CREATE = 1
 XATTR_REPLACE = 2
 
 def check_error(r, fn, args):
-    if r < 0:
+    if fn.__name__ == "jfs_init" and r == 0:
+        name = args[0].decode()
+        e = OSError(f'JuiceFS initialized failed for {name}')
+        e.errno = 1
+        raise e
+    elif r < 0:
         formatted_args = []
         for arg in args[2:]:
             if isinstance(arg, (bytes, bytearray)) and len(arg) > 1024:


### PR DESCRIPTION
When `jfs_init` fails, it returns `0`, but Python SDK does not raise an exception because `check_error()` only checks `r < 0`. I modified `check_error()` to handle `jfs_init` failure case when it returns `0`.

This aligns with Java SDK behavior:
https://github.com/juicedata/juicefs/blob/f26ce2b1d5edbc7ca498fc79dd123fae860fe371/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java#L465-L468

Changes
- Added special case for `jfs_init` when `r == 0` in `check_error()`
- Error message follows Java SDK format for consistency

Tests
```python
import juicefs
try:
    client = juicefs.Client(name='test', meta='redis://invalid-host:6379')
except OSError as e:
    print(f"Exception raised: {e}")  # Now works correctly
```

Fixes #6331