### PR TITLE
mount: fix the max-fuse-io parameter was not taking effect

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -558,7 +558,7 @@ func genFuseOptExt(c *cli.Context, format *meta.Format) (fuseOpt string, mt int,
 	if format.EnableACL {
 		enableXattr = true
 	}
-	return genFuseOpt(c, format.Name), 1, !enableXattr, !format.EnableACL, int(utils.ParseBytes(c, "max-write", 'B'))
+	return genFuseOpt(c, format.Name), 1, !enableXattr, !format.EnableACL, int(utils.ParseBytes(c, "max-fuse-io", 'B'))
 }
 
 func shutdownGraceful(mp string) {


### PR DESCRIPTION
[In previous commits,](https://github.com/juicedata/juicefs/pull/6017) the max-write parameter was changed to max-fuse-io, but one instance of the code was left unchanged. This caused the max-fuse-io  parameter to not actually work.