### PR TITLE
vfs: Add support to skip trash if 's' attribute is set

### DIFF
--- a/docs/en/security/trash.md
+++ b/docs/en/security/trash.md
@@ -117,6 +117,12 @@ juicefs rmr .trash/2022-11-30-10/
 
 If you want to delete expired files more quickly, you can mount multiple mount points to exceed the deletion speed limit of a single client.
 
+## Selectively skipping trash {#skip}
+
+It is possible to skip the trash and permanently delete files directly. The 's' flag using `chattr` can be set on files or directories to enable this feature. When a file or directory has the 's' flag set, the file or directory will be permanently deleted when removed, bypassing the trash. New files or directories created under a directory with the 's' flag will also inherit this behavior. Existing JuiceFS files or directories moved into a directory with the 's' flag set will not inherit the flag.
+
+You will need to enable the mount option `--enable-ioctl` to allow adjusting file attributes using `chattr`.
+
 ## Trash and slices {#gc}
 
 Apart from user deleted files, there's another type of data which also resides in Trash, which isn't directly visible from the `.trash` directory, they are stale slices created by file edits and overwrites. Read more in [How JuiceFS stores files](../introduction/architecture.md#how-juicefs-store-files). To sum up, if applications constantly delete or overwrite files, object storage usage will exceed file system usage.

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -2240,6 +2240,9 @@ func testTrash(t *testing.T, m Meta) {
 		t.Fatalf("entries: %d", len(entries))
 	}
 	entries = entries[:0]
+	if st := m.Unlink(ctx, parent, "f3"); st != 0 {
+		t.Fatalf("unlink secrmd/f3: %s", st)
+	}
 	if st := m.Rmdir(ctx, 1, "secrmd"); st != 0 {
 		t.Fatalf("rmdir secrmd: %s", st)
 	}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -2188,6 +2188,62 @@ func testTrash(t *testing.T, m Meta) {
 		t.Fatalf("entries: %d", len(entries))
 	}
 
+	// Selectively skip trash based on FS_SECRM_FL
+	if st := m.Mkdir(ctx, 1, "secrmd", 0755, 022, 0, &parent, attr); st != 0 {
+		t.Fatalf("mkdir secrmd: %s", st)
+	}
+	if st := m.SetAttr(ctx, parent, SetAttrFlag, 0, &Attr{Flags: FlagSkipTrash}); st != 0 {
+		t.Fatalf("setattr secrmd secrm: %s", st)
+	}
+	if st := m.Create(ctx, parent, "f1", 0644, 022, 0, &inode, attr); st != 0 {
+		t.Fatalf("create secrmd/f1: %s", st)
+	}
+	if st := m.GetAttr(ctx, inode, attr); st != 0 || (attr.Flags&FlagSkipTrash) == 0 {
+		t.Fatalf("getattr secrmd/f1(%d): %s, attr %+v", inode, st, attr)
+	}
+	if st := m.Unlink(ctx, parent, "f1"); st != 0 {
+		t.Fatalf("unlink secrmd/f1: %s", st)
+	}
+	if st := m.Readdir(ctx, TrashInode+1, 0, &entries); st != 0 {
+		t.Fatalf("readdir: %s", st)
+	}
+	if len(entries) != 12 {
+		t.Fatalf("entries: %d", len(entries))
+	}
+	entries = entries[:0]
+	if st := m.Mkdir(ctx, parent, "d1", 0755, 022, 0, &inode, attr); st != 0 {
+		t.Fatalf("mkdir secrmd/d1: %s", st)
+	}
+	if st := m.Rmdir(ctx, parent, "d1"); st != 0 {
+		t.Fatalf("rmdir secrmd/d1: %s", st)
+	}
+	if st := m.Readdir(ctx, TrashInode+1, 0, &entries); st != 0 {
+		t.Fatalf("readdir: %s", st)
+	}
+	if len(entries) != 12 {
+		t.Fatalf("entries: %d", len(entries))
+	}
+	entries = entries[:0]
+	if st := m.Create(ctx, parent, "f2", 0644, 022, 0, &inode, attr); st != 0 {
+		t.Fatalf("create secrmd/f2: %s", st)
+	}
+	if st := m.Create(ctx, parent, "f3", 0644, 022, 0, &inode, attr); st != 0 {
+		t.Fatalf("create secrmd/f3: %s", st)
+	}
+	if st := m.Rename(ctx, parent, "f2", parent, "f3", 0, &inode, attr); st != 0 {
+		t.Fatalf("rename secrmd/f2 -> f3: %s", st)
+	}
+	if st := m.Readdir(ctx, TrashInode+1, 0, &entries); st != 0 {
+		t.Fatalf("readdir: %s", st)
+	}
+	if len(entries) != 12 {
+		t.Fatalf("entries: %d", len(entries))
+	}
+	entries = entries[:0]
+	if st := m.Rmdir(ctx, 1, "secrmd"); st != 0 {
+		t.Fatalf("rmdir secrmd: %s", st)
+	}
+
 	ctx2 := NewContext(1000, 1, []uint32{1})
 	if st := m.Unlink(ctx2, TrashInode+1, "d"); st != syscall.EPERM {
 		t.Fatalf("unlink d: %s", st)

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -99,6 +99,7 @@ const (
 	FlagWindowsHidden
 	FlagWindowsSystem
 	FlagWindowsArchive
+	FlagSkipTrash // skip moving to .trash - Mapped to 's' in chattr
 )
 
 const (

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1694,7 +1694,7 @@ func (m *dbMeta) doMknod(ctx Context, parent Ino, name string, _type uint8, mode
 		} else {
 			n.Mode = mode & ^cumask
 		}
-		if pn.Flags&FlagSkipTrash != 0 {
+		if (pn.Flags&FlagSkipTrash) != 0 {
 			n.Flags |= FlagSkipTrash
 		}
 
@@ -1833,7 +1833,7 @@ func (m *dbMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, skip
 			if (n.Flags&FlagAppend) != 0 || (n.Flags&FlagImmutable) != 0 {
 				return syscall.EPERM
 			}
-			if ((pn.Flags&FlagSkipTrash) != 0 || (n.Flags&FlagSkipTrash) != 0) {
+			if (n.Flags&FlagSkipTrash) != 0 {
 				trash = 0
 			}
 			if trash > 0 && n.Nlink > 1 {
@@ -1967,9 +1967,6 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, attr
 		if pn.Flags&FlagImmutable != 0 || pn.Flags&FlagAppend != 0 {
 			return syscall.EPERM
 		}
-		if pn.Flags&FlagSkipTrash != 0 {
-			trash = 0
-		}
 		var e = edge{Parent: parent, Name: []byte(name)}
 		ok, err = s.Get(&e)
 		if err != nil {
@@ -2007,7 +2004,7 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, attr
 		if exist {
 			return syscall.ENOTEMPTY
 		}
-		if n.Flags&FlagSkipTrash != 0 {
+		if (n.Flags&FlagSkipTrash) != 0 {
 			trash = 0
 		}
 		now := time.Now().UnixNano()
@@ -2218,10 +2215,7 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			if (dn.Flags&FlagAppend) != 0 || (dn.Flags&FlagImmutable) != 0 {
 				return syscall.EPERM
 			}
-			if spn.Flags&FlagSkipTrash != 0 {
-				trash = 0
-			} else if sn.Flags&FlagSkipTrash != 0 || dpn.Flags&FlagSkipTrash != 0 || dn.Flags&FlagSkipTrash != 0 {
-				dn.Flags |= FlagSkipTrash
+			if (dn.Flags&FlagSkipTrash) != 0 {
 				trash = 0
 			}
 			dn.setCtime(now)
@@ -2321,7 +2315,7 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			if _, err := s.Cols("inode", "type").Update(&se, &edge{Parent: parentDst, Name: de.Name}); err != nil {
 				return err
 			}
-			if _, err := s.Cols("flags", "ctime", "ctimensec", "parent").Update(dn, &node{Inode: dino}); err != nil {
+			if _, err := s.Cols("ctime", "ctimensec", "parent").Update(dn, &node{Inode: dino}); err != nil {
 				return err
 			}
 		} else {
@@ -2340,13 +2334,13 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 						return err
 					}
 				} else if de.Type != TypeDirectory && dn.Nlink > 0 {
-					if _, err := s.Cols("flags", "ctime", "ctimensec", "nlink", "parent").Update(dn, &node{Inode: dino}); err != nil {
+					if _, err := s.Cols("ctime", "ctimensec", "nlink", "parent").Update(dn, &node{Inode: dino}); err != nil {
 						return err
 					}
 				} else {
 					if de.Type == TypeFile {
 						if opened {
-							if _, err := s.Cols("flags","nlink", "ctime", "ctimensec").Update(&dn, &node{Inode: dino}); err != nil {
+							if _, err := s.Cols("nlink", "ctime", "ctimensec").Update(&dn, &node{Inode: dino}); err != nil {
 								return err
 							}
 							if err = mustInsert(s, sustained{Sid: m.sid, Inode: dino}); err != nil {


### PR DESCRIPTION
This change adds support for the FlagSkipTrash in the VFS and meta portions of the code and maps to `FS_SECRM_FL` / secure removal / 's' in chattr. Setting the attribute on a file will prevent the file from being sent to trash. New files and sub-directories will inherit the flag if the directory has the flag set.

Closes #5385