### PR TITLE
cmd/config: support toggling configuration for user group quota

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -140,6 +140,7 @@ func config(ctx *cli.Context) error {
 	}
 
 	originDirStats := format.DirStats
+	originUGQuota := format.UserGroupQuota
 	var quota, storage, trash, clientVer bool
 	var msg strings.Builder
 	encrypted := format.KeyEncrypted
@@ -230,6 +231,11 @@ func config(ctx *cli.Context) error {
 			if new := ctx.Bool(flag); new != format.DirStats {
 				msg.WriteString(fmt.Sprintf("%10s: %t -> %t\n", flag, format.DirStats, new))
 				format.DirStats = new
+			}
+		case "user-group-quota":
+			if new := ctx.Bool(flag); new != format.UserGroupQuota {
+				msg.WriteString(fmt.Sprintf("%10s: %t -> %t\n", flag, format.UserGroupQuota, new))
+				format.UserGroupQuota = new
 			}
 		case "min-client-version":
 			if new := ctx.String(flag); new != format.MinClientVersion {
@@ -357,5 +363,12 @@ func config(ctx *cli.Context) error {
 	if err = m.Init(format, false); err == nil {
 		fmt.Println(msg.String()[:msg.Len()-1])
 	}
+
+	if !originUGQuota && format.UserGroupQuota {
+		if err = m.ScanUserGroupUsage(meta.Background()); err != nil {
+			logger.Warnf("Scan user group usage: %s", err)
+		}
+	}
+
 	return err
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -482,6 +482,7 @@ func format(c *cli.Context) error {
 			Compression:      c.String("compress"),
 			TrashDays:        c.Int("trash-days"),
 			DirStats:         true,
+			UserGroupQuota:   false,
 			MetaVersion:      meta.MaxVersion,
 			MinClientVersion: "1.1.0-A",
 			EnableACL:        c.Bool("enable-acl"),

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -512,6 +512,8 @@ type Meta interface {
 	OnReload(func(new *Format))
 
 	HandleQuota(ctx Context, cmd uint8, dpath string, uid uint32, gid uint32, quotas map[string]*Quota, strict, repair bool, create bool) error
+	//Triggers a global user group quota scan
+	ScanUserGroupUsage(ctx Context) error
 
 	// Dump the tree under root, which may be modified by checkRoot
 	DumpMeta(w io.Writer, root Ino, threads int, keepSecret, fast, skipTrash bool) error

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -634,6 +634,13 @@ func (m *dbMeta) doInit(format *Format, force bool) error {
 				return errors.Wrap(err, "drop table dirStats")
 			}
 		}
+		if !old.UserGroupQuota && format.UserGroupQuota {
+			// remove user group quota as they are outdated
+			_, err = m.db.Where("TRUE").Delete(new(userGroupQuota))
+			if err != nil {
+				return errors.Wrap(err, "drop table userGroupQuota")
+			}
+		}
 		if err = format.update(&old, force); err != nil {
 			return errors.Wrap(err, "update format")
 		}


### PR DESCRIPTION
This commit introduces automatic scanning and initialization of user group quota
when the user-group-quota configuration is enabled. The changes include:

- Add ScanUserGroupUsage interface method for triggering quota scan
- Automatically trigger quota scan when enabling user-group-quota config
- Clean up outdated user group quota data when enabling the feature

The implementation ensures that when users enable user-group-quota through the
config command, the system automatically scans and initializes the quota usage
data.