### PR TITLE
cmd/quota: show "unchanged" instead of "unlimited"

### DIFF
--- a/cmd/quota.go
+++ b/cmd/quota.go
@@ -177,7 +177,7 @@ func quota(c *cli.Context) error {
 			size = humanize.IBytes(uint64(q.MaxSpace))
 			usedR = fmt.Sprintf("%d%%", q.UsedSpace*100/q.MaxSpace)
 		} else {
-			size = "no changed"
+			size = "unchanged"
 		}
 		iused := humanize.Comma(q.UsedInodes)
 		var itotal, iusedR string
@@ -185,7 +185,7 @@ func quota(c *cli.Context) error {
 			itotal = humanize.Comma(q.MaxInodes)
 			iusedR = fmt.Sprintf("%d%%", q.UsedInodes*100/q.MaxInodes)
 		} else {
-			itotal = "no changed"
+			itotal = "unchanged"
 		}
 		result = append(result, []string{p, size, used, usedR, itotal, iused, iusedR})
 	}


### PR DESCRIPTION
When only one of space and inodes is modified, the other should be left unchanged, and the previous printing can be confusing