### PR TITLE
cmd: add network-interfaces flag for IP discovery configuration

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -313,6 +313,10 @@ func metaFlags() []cli.Flag {
 			Value: false,
 			Usage: "Use local counters for statfs instead of querying metadata service",
 		},
+		&cli.StringFlag{
+			Name:  "network-interfaces",
+			Usage: "comma-separated list of network interfaces to use for IP discovery (e.g. eth0,en0), empty means all",
+		},
 	})
 }
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -340,6 +340,16 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 		atimeMode = meta.NoAtime
 	}
 	conf.AtimeMode = atimeMode
+
+	// Parse network interfaces
+	if ifaces := c.String("network-interfaces"); ifaces != "" {
+		conf.NetworkInterfaces = strings.Split(ifaces, ",")
+		// Trim whitespace from each interface name
+		for i := range conf.NetworkInterfaces {
+			conf.NetworkInterfaces[i] = strings.TrimSpace(conf.NetworkInterfaces[i])
+		}
+	}
+
 	return conf
 }
 

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -482,7 +482,7 @@ func (m *baseMeta) newSessionInfo() []byte {
 	if err != nil {
 		logger.Warnf("Failed to get hostname: %s", err)
 	}
-	ips, err := utils.FindLocalIPs()
+	ips, err := utils.FindLocalIPs(m.conf.NetworkInterfaces...)
 	if err != nil {
 		logger.Warnf("Failed to get local IP: %s", err)
 	}

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	Sid                uint64
 	SortDir            bool
 	FastStatfs         bool
+	NetworkInterfaces  []string // list of network interfaces to use for IP discovery (empty means all)
 }
 
 func DefaultConf() *Config {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -62,11 +62,19 @@ func GetLocalIp(address string) (string, error) {
 	return ip, nil
 }
 
-func FindLocalIPs() ([]net.IP, error) {
+func FindLocalIPs(allowedInterfaces ...string) ([]net.IP, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
 	}
+
+	// Build a set of allowed interface names for fast lookup
+	allowedSet := make(map[string]bool)
+	for _, name := range allowedInterfaces {
+		allowedSet[name] = true
+	}
+	checkAllowed := len(allowedSet) > 0
+
 	var ips []net.IP
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 {
@@ -74,6 +82,10 @@ func FindLocalIPs() ([]net.IP, error) {
 		}
 		if iface.Flags&net.FlagLoopback != 0 {
 			continue // loopback interface
+		}
+		// Filter by interface name if allowedInterfaces is specified
+		if checkAllowed && !allowedSet[iface.Name] {
+			continue
 		}
 		addrs, err := iface.Addrs()
 		if err != nil {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -71,6 +71,34 @@ func TestLocalIp(t *testing.T) {
 	}
 }
 
+func TestFindLocalIPs(t *testing.T) {
+	// Test without interface filter (should return all IPs)
+	ips, err := FindLocalIPs()
+	if err != nil {
+		t.Fatalf("FindLocalIPs failed: %s", err)
+	}
+	if len(ips) == 0 {
+		t.Logf("Warning: No network interfaces found (this might be expected in some environments)")
+	}
+
+	// Test with non-existent interface filter (should return no IPs)
+	ips, err = FindLocalIPs("nonexistent_interface_12345")
+	if err != nil {
+		t.Fatalf("FindLocalIPs with filter failed: %s", err)
+	}
+	if len(ips) != 0 {
+		t.Fatalf("Expected 0 IPs with non-existent interface, got %d", len(ips))
+	}
+
+	// Test with multiple interface filters
+	ips, err = FindLocalIPs("eth0", "en0", "lo0")
+	if err != nil {
+		t.Fatalf("FindLocalIPs with multiple filters failed: %s", err)
+	}
+	// We don't assert length here since it depends on the system
+	t.Logf("Found %d IPs with eth0/en0/lo0 filter", len(ips))
+}
+
 func TestTimeout(t *testing.T) {
 	err := WithTimeout(func(context.Context) error {
 		return nil


### PR DESCRIPTION
### Summary

When the system has a large number of network interfaces, the process of discovering all local IPs can sometimes timeout. To address this, a new option has been added to allow users to explicitly filter which interfaces are used during IP discovery.

### Changes Introduced

* **New CLI flag**: `--network-interfaces`
  Allows specifying a comma-separated list of network interfaces for IP discovery, reducing unnecessary scans.
* **Configuration update**:
  Added a new field `NetworkInterfaces` to the configuration structure to support the above flag.
* **Logic enhancement**:
  Modified the `FindLocalIPs` function to accept interface filters and updated `getMetaConf` accordingly.
* **Testing**:
  Added unit tests in `utils_test.go` to validate the new functionality and ensure backward compatibility.

### Motivation

This change improves reliability and performance in environments with many network interfaces by preventing timeouts during IP discovery.
