### PR TITLE
Fix another nil panic

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2582,8 +2582,8 @@ func (m *baseMeta) cleanupTrash(ctx Context) {
 		} else if ok {
 			if cCtx != nil {
 				cCtx.Cancel()
-				cCtx = WrapWithTimeout(ctx, 50*time.Minute)
 			}
+			cCtx = WrapWithTimeout(ctx, 50*time.Minute)
 			days := m.getFormat().TrashDays
 			go m.doCleanupTrash(cCtx, days, false)
 			go m.cleanupDelayedSlices(cCtx, days)


### PR DESCRIPTION
ref: #6382
cCtx in `cleanupTrash` is always nil.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x16c4997]

goroutine 142954 [running]:
github.com/juicedata/juicefs/pkg/meta.(*tikvClient).txn(0xc0016fc260, {0x0, 0x0}, 0xc0028191a0, 0x0)
        /workspace/pkg/meta/tkv_tikv.go:256 +0x57
github.com/juicedata/juicefs/pkg/meta.(*prefixClient).txn(0xc001199710, {0x0, 0x0}, 0xc00275f3e0, 0x0)
        /workspace/pkg/meta/tkv_prefix.go:90 +0x9a
github.com/juicedata/juicefs/pkg/meta.(*kvMeta).doCleanupDelayedSlices(0xc000a0c980, {0x0, 0x0}, 0x68f046ef)
        /workspace/pkg/meta/tkv.go:2407 +0x163
github.com/juicedata/juicefs/pkg/meta.(*baseMeta).cleanupDelayedSlices(0xc001bbc008, {0x0, 0x0}, 0x1)
        /workspace/pkg/meta/base.go:2803 +0x129
created by github.com/juicedata/juicefs/pkg/meta.(*baseMeta).cleanupTrash in goroutine 559
        /workspace/pkg/meta/base.go:2647 +0x3b8
```