### PR TITLE
cmd/sync: refactor some check

### DIFF
--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -225,12 +225,6 @@ func NewConfigFromCli(c *cli.Context) *Config {
 		logger.Warnf("threads should be larger than 0, reset it to 1")
 		cfg.Threads = 1
 	}
-	if len(cfg.FilesFrom) > 0 {
-		if !cfg.Dirs {
-			logger.Debugf("directories will be sync when files-from is set")
-			cfg.Dirs = true
-		}
-	}
 	for _, key := range envList() {
 		if os.Getenv(key) != "" {
 			cfg.Env[key] = os.Getenv(key)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1582,6 +1582,7 @@ func produceSingleObject(tasks chan<- object.Object, src, dst object.ObjectStora
 		return err
 	}
 	if obj.IsDir() {
+		// only `files-from` will hit this case
 		if !strings.HasSuffix(key, "/") {
 			return errDirSuffix
 		}


### PR DESCRIPTION
1. "obj.IsSymlink() && config.Links" not works
2. produceSingleObject should return nil when object is dir and config.Dirs == false (There are currently only two places that call it, so this return value doesn’t matter.)