### PR TITLE
vfs: fix input/output err when drop

### DIFF
--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -261,7 +261,6 @@ func (s *sliceReader) drop() {
 			s.state = INVALID // somebody still using it, so mark it for removal
 		}
 	}
-	s.cancel()
 }
 
 func (s *sliceReader) delete() {
@@ -688,6 +687,7 @@ func (f *fileReader) Close(ctx meta.Context) {
 	f.closing = true
 	f.visit(func(s *sliceReader) bool {
 		s.drop()
+		s.cancel()
 		return true
 	})
 	f.release()


### PR DESCRIPTION
fix input/output err in drop， cause by #6397

it's easy to reproduce by setting --max-readahead=0

mount cmd
```
sudo ./$bin mount $kv_ns $mount_point --cache-size 0   --log ./log/juicefs-cm.log --max-readahead 0
```

fio command
```
fio --name=big-write --directory=xx  --rw=read  --bs=4M --runtime 30s  --numjobs=1 --end_fsync=1 --group_reporting
big-write: (g=0): rw=read, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=psync, iodepth=1
fio-3.16
Starting 1 process
fio: io_u error on file /xx/big-write.0.0: Input/output error: read offset=131072, buflen=4063232
fio: first I/O failed. If /xx/big-write.0.0 is a zoned block device, consider --zonemode=zbd
fio: pid=191364, err=5/file:io_u.c:1787, func=io_u error, error=Input/output error

big-write: (groupid=0, jobs=1): err= 5 (file:io_u.c:1787, func=io_u error, error=Input/output error): pid=191364: Thu Nov 20 03:40:17 2025
  cpu          : usr=0.00%, sys=0.00%, ctx=7, majf=0, minf=54
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=33.3%, 4=66.7%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=2,0,0,0 short=1,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
```
juicefs  log
```
2025/11/20 03:39:57.058623 juicefs[191212] <INFO>: watching /home/yangwang/mnt/jfs-cm-4096, pid 191241 [watchdog@mount_unix.go:162]
2025/11/20 03:39:57.456176 juicefs[191212] <INFO>: OK, jfs-cm-4096 is ready at /home/yangwang/mnt/jfs-cm-4096 [checkMountpoint@mount_unix.go:235]
2025/11/20 03:40:03.569104 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:03.571276 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:03.873108 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:03.874511 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:04.176780 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:04.779011 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:05.680687 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:06.882362 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:08.383876 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:10.185724 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:12.287138 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:14.688937 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:17.390978 juicefs[191241] <WARNING>: fail to read sliceId 4099 (off:131072, size:131072, clen: 67108864, inode: 4): context canceled [readSlice@reader.go:831]
2025/11/20 03:40:17.391020 juicefs[191241] <ERROR>: read file 4: input/output error [done@reader.go:125]
2025/11/20 03:40:17.391061 juicefs[191241] <INFO>: slow operation: read (4,131072,131072,3): (0) - input/output error <13.826733> [logit@accesslog.go:92]
```