### PR TITLE
vfs/SetAttr:  async throttle setattr storms

### DIFF
--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -145,9 +145,7 @@ func onlyTime(set int) bool {
 	return (set &^ (meta.SetAttrAtime | meta.SetAttrAtimeNow | meta.SetAttrMtime | meta.SetAttrMtimeNow | meta.SetAttrCtime | meta.SetAttrCtimeNow)) == 0
 }
 
-// tryAsyncSetAttr attempts to submit an async SetAttr task (non-blocking with capacity control)
 func (v *VFS) tryAsyncSetAttr(ctx Context, ino Ino, set int, atime, mtime int64, atimensec, mtimensec uint32) bool {
-	// Build task (only time-related fields)
 	task := asyncSetAttrTask{
 		ctx:       ctx,
 		ino:       ino,
@@ -166,7 +164,6 @@ func (v *VFS) tryAsyncSetAttr(ctx Context, ino Ino, set int, atime, mtime int64,
 	}
 }
 
-// getAttrCache retrieves cached attributes (lock-free read)
 func (v *VFS) getAttrCache(ino Ino) (*attrCacheEntry, bool) {
 	if cached, ok := v.attrCache.Load(ino); ok {
 		entry := cached.(*attrCacheEntry)
@@ -174,7 +171,6 @@ func (v *VFS) getAttrCache(ino Ino) (*attrCacheEntry, bool) {
 	}
 	return nil, false
 }
-
 
 func (v *VFS) SetAttr(ctx Context, ino Ino, set int, fh uint64, mode, uid, gid uint32, atime, mtime int64, atimensec, mtimensec uint32, size uint64) (entry *meta.Entry, err syscall.Errno) {
 	str := setattrStr(set, mode, uid, gid, atime, mtime, size)
@@ -191,13 +187,9 @@ func (v *VFS) SetAttr(ctx Context, ino Ino, set int, fh uint64, mode, uid, gid u
 		return
 	}
 	var attr = &Attr{}
-	// Check if async processing is possible (only time-related, writeback enabled)
 	if onlyTime(set) && v.Conf.FuseOpts != nil && v.Conf.FuseOpts.EnableWriteback {
-		// Try to get cached attributes
 		if cachedEntry, ok := v.getAttrCache(ino); ok {
-			// Check if cache is still valid (5s TTL)
 			if time.Since(cachedEntry.timestamp) <= v.attrCacheTTL {
-				// Prepare attr for permission check
 				checkAttr := Attr{}
 				if set&meta.SetAttrAtime != 0 {
 					checkAttr.Atime = atime
@@ -215,7 +207,6 @@ func (v *VFS) SetAttr(ctx Context, ino Ino, set int, fh uint64, mode, uid, gid u
 					if set&meta.SetAttrMtimeNow != 0 {
 						v.writer.UpdateMtime(ino, time.Now())
 					}
-					// Async submission successful, return cached attributes immediately
 					v.UpdateLength(ino, &cachedEntry.attr)
 					entry = &meta.Entry{Inode: ino, Attr: &cachedEntry.attr}
 					if onlyTime(set) && v.Conf.FuseOpts != nil && v.Conf.FuseOpts.EnableWriteback {


### PR DESCRIPTION
**Background:**
When mounting with `-o writeback_cache` and running sequential writes, the kernel issues excessive `setattr` (time updates), which drags down throughput.

**Change:**
Add a short-lived attr cache plus an async `SetAttr` worker pool so pure time updates can be deduplicated, rate-limited, and handled without blocking the foreground path.

**Test Method and Script:**
Use 4K block sequential writing to create 4 files each of 512M size.
meta：sqlite
```
// seq_write.go
package main

import (
	"crypto/rand"
	"fmt"
	"os"
	"time"
)

const (
	blockSize = 4 * 1024          // 4KB
	fileSize  = 512 * 1024 * 1024 // 512MB
)

func main() {
	numIterations := 4

	// 记录总耗时
	totalDuration := time.Duration(0)

	for iteration := 1; iteration <= numIterations; iteration++ {
		// 计算文件中的块数
		numBlocks := fileSize / blockSize

		// 创建文件并预分配空间
		fileName := fmt.Sprintf("seq_write_%d.dat", iteration)
		file, err := os.Create(fileName)
		if err != nil {
			fmt.Printf("创建文件 %s 失败: %v\n", fileName, err)
			continue
		}

		fmt.Printf("\n开始写入文件 %s (迭代 %d/%d)\n", fileName, iteration, numIterations)

		// 预分配文件空间
		if err := file.Truncate(fileSize); err != nil {
			fmt.Printf("预分配文件空间失败: %v\n", err)
			file.Close()
			continue
		}

		// 生成随机数据块
		dataBlock := make([]byte, blockSize)
		if _, err := rand.Read(dataBlock); err != nil {
			fmt.Printf("生成随机数据失败: %v\n", err)
			file.Close()
			continue
		}

		// 记录开始时间
		startTime := time.Now()

		for writtenBlocks := 1; writtenBlocks <= numBlocks; writtenBlocks++ {
			offset := int64(writtenBlocks-1) * blockSize

			if _, err := file.WriteAt(dataBlock, offset); err != nil {
				fmt.Printf("写入文件失败: %v\n", err)
				break
			}

			if writtenBlocks%100 == 0 || writtenBlocks == numBlocks {
				progress := float64(writtenBlocks) / float64(numBlocks) * 100
				fmt.Printf("\r进度: %.2f%% (%d/%d)", progress, writtenBlocks, numBlocks)
			}
		}
		fmt.Println()

		// 关闭文件
		file.Close()

		// 计算并打印执行时间
		duration := time.Since(startTime)
		totalDuration += duration
		fmt.Printf("文件 %s 写入完成！耗时: %v\n", fileName, duration)
		fmt.Printf("写入速度: %.2f MB/s\n", float64(fileSize)/1024/1024/duration.Seconds())
	}

	// 打印总统计信息
	fmt.Printf("\n所有 %d 个文件写入完成！\n", numIterations)
	fmt.Printf("总耗时: %v\n", totalDuration)
	fmt.Printf("平均每个文件耗时: %v\n", totalDuration/time.Duration(numIterations))
	fmt.Printf("平均写入速度: %.2f MB/s\n", float64(fileSize*numIterations)/1024/1024/totalDuration.Seconds())
}

```

**Test Result:**
<img width="1340" height="540" alt="aa7e33aa99d00b93ff9f6656b317945d" src="https://github.com/user-attachments/assets/91c8a64f-fbad-4a19-9578-46846bf9f68f" />
<img width="769" height="254" alt="15ca005a5de07bc4387c3cf7788d5540" src="https://github.com/user-attachments/assets/6cd4827b-0177-4394-a01b-881790d43e45" />
<img width="693" height="375" alt="71be1778a841cee39f7ee81224165d13" src="https://github.com/user-attachments/assets/48ae72dc-dc52-4120-aa27-52016020e850" />
<img width="573" height="366" alt="c0f64b2defe2d3c06f9b7dea64339f96" src="https://github.com/user-attachments/assets/432d9c65-f707-4d0d-afe5-6c8916a7b86b" />
<img width="771" height="385" alt="a087586c499c024fcadaf7f16ac69634" src="https://github.com/user-attachments/assets/dc0d7422-9c4d-48a2-88f3-b40ba641af2b" />
