### PR TITLE
meta/format: fix format decrypt error

### DIFF
--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -125,7 +125,15 @@ func (f *Format) update(old *Format, force bool) error {
 			args = []interface{}{"meta version", old.MetaVersion, f.MetaVersion}
 		}
 		if args == nil {
-			f.UUID = old.UUID
+			if f.UUID != old.UUID {
+				if err := f.Decrypt(); err != nil {
+					return fmt.Errorf("decrypt format: %s", err)
+				}
+				f.UUID = old.UUID // UUID cannot be changed alone
+				if err := f.Encrypt(); err != nil {
+					return fmt.Errorf("encrypt format: %s", err)
+				}
+			}
 		} else {
 			return fmt.Errorf("cannot update volume %s from %v to %v", args...)
 		}


### PR DESCRIPTION
Occasionally, we encounter issues where newly created volumes fail to mount, with an error indicating that the `SecretKey` in tikv cannot be decrypted.

```
<FATAL>: object storage: format decrypt: open cipher: cipher: message authentication failed [main@main.go:31]
```

We have now identified the cause: for some unexpected reasons, user may trigger concurrent format operations at the same time, which the current JuiceFS cannot handle. Specifically, keys in format are encrypted using a new `UUID`, but the `update` method overwrites it with an old one, leading to subsequent decryption failures.

The root cause is - we should not update `UUID` along, other encrypted fields depending on it.