### PR TITLE
vfs: fix append write offset

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -848,6 +848,10 @@ func (v *VFS) Write(ctx Context, ino Ino, buf []byte, off, fh uint64) (err sysca
 	}
 	defer h.Wunlock()
 
+	// kernel might return a stale length from attr-cache before open as the offset.
+	if h.flags&uint32(os.O_APPEND) != 0 {
+		off = h.writer.GetLength()
+	}
 	err = h.writer.Write(ctx, off, buf)
 	if err == syscall.ENOENT || err == syscall.EPERM || err == syscall.EINVAL {
 		err = syscall.EBADF


### PR DESCRIPTION
When alternately appending writes, file1 and file2 are the same file on two different mount points, and data may be lost.
```shell
for ((i=1; i<=COUNT; i++)); do
    echo "$FILE1:$i" >> "$FILE1"    
    echo "$FILE2:$i" >> "$FILE2"
done
```