### PR TITLE
cache: speedup scanning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/baidubce/bce-sdk-go v0.9.221
 	github.com/bytedance/mockey v1.2.14
 	github.com/ceph/go-ceph v0.18.0
+	github.com/charlievieth/fastwalk v1.0.14
 	github.com/cloudsoda/go-smb2 v0.0.0-20250228001242-d4c70e6251cc
 	github.com/colinmarc/hdfs/v2 v2.4.0
 	github.com/davies/groupcache v0.0.0-20230821031435-e4e8362f58e1

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/ceph/go-ceph v0.18.0/go.mod h1:cflETVTBNAQM6jdr7hpNHHFHKYiJiWWcAeRDrR
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charlievieth/fastwalk v1.0.14 h1:3Eh5uaFGwHZd8EGwTjJnSpBkfwfsak9h6ICgnWlhAyg=
+github.com/charlievieth/fastwalk v1.0.14/go.mod h1:diVcUreiU1aQ4/Wu3NbxxH4/KYdKpLDojrQ1Bb2KgNY=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=


### PR DESCRIPTION
close #6501

test 1M files scan，time cost from 17.6s to 0.9s

A three-level directory structure: 5 subdirectories at the first level, 200 subdirectories at the second level, and 1,000 files at the third level, totaling 1 million files.

1. before
=== RUN   BenchmarkCachedScan/scan_cached
BenchmarkCachedScan/scan_cached
BenchmarkCachedScan/scan_cached-16 17576723554 ns/op 635703552 B/op 7033460 allocs/op

2. after
=== RUN   BenchmarkCachedScan/scan_cached
BenchmarkCachedScan/scan_cached
BenchmarkCachedScan/scan_cached-16 2 933730100 ns/op 648231736 B/op 8020471 allocs/op
