### PR TITLE
meta/redis: fix potential deadlock

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1852,6 +1852,11 @@ func (m *redisMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentD
 		// lock the parentDst
 		keys[0], keys[2] = keys[2], keys[0]
 	}
+	if !exchange {
+		if st := m.checkTrash(parentDst, &trash); st != 0 {
+			return st
+		}
+	}
 	err := m.txn(ctx, func(tx *redis.Tx) error {
 		opened = false
 		dino, dtyp = 0, 0


### PR DESCRIPTION
```
sync.(*Mutex).lockSlow(0xc001663460)
	/usr/local/go/src/sync/mutex.go:173 +0x15d
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:92
github.com/juicedata/juicefs/pkg/meta.(*baseMeta).txLock(...)
	/workspace/juicefs/pkg/meta/base.go:399
github.com/juicedata/juicefs/pkg/meta.(*redisMeta).txn(0xc000c29a40, {0x4b22718, 0xc002ae7ac0}, 0xc00093e3f0, {0xc0062e4220, 0x2, 0x2})
	/workspace/juicefs/pkg/meta/redis.go:1035 +0x297
github.com/juicedata/juicefs/pkg/meta.(*redisMeta).doMknod(0xc000c29a40, {0x4b22718, 0xc002ae7ac0}, 0x7fffffff10000000, {0xc0035ece40, 0xd}, 0x2, 0x16d, 0x0, {0x0, ...}, ...)
	/workspace/juicefs/pkg/meta/redis.go:1321 +0x29b
github.com/juicedata/juicefs/pkg/meta.(*baseMeta).checkTrash(0xc001662008, 0x0?, 0xc0035ecc58)
	/workspace/juicefs/pkg/meta/base.go:2478 +0x33b
github.com/juicedata/juicefs/pkg/meta.(*redisMeta).doRename.func1(0xc005990750)
	/workspace/juicefs/pkg/meta/redis.go:1786 +0xb25
github.com/juicedata/juicefs/pkg/meta.(*redisMeta).txn.replaceErrno.func2(0xc005990750?)
	/workspace/juicefs/pkg/meta/redis.go:1011 +0x17
github.com/redis/go-redis/v9.(*Client).Watch(0x0?, {0x7fdf4434a418, 0xc000dfa240}, 0xc000f5bb70, {0xc002ae78c0, 0x4, 0x4})
	/go/pkg/mod/github.com/redis/go-redis/v9@v9.7.3/tx.go:67 +0xda
github.com/juicedata/juicefs/pkg/meta.(*redisMeta).txn(0xc000c29a40, {0x4b22718, 0xc000dfa240}, 0xc0113fa780, {0xc002ae78c0, 0x4, 0x4})
	/workspace/juicefs/pkg/meta/redis.go:1047 +0x452
github.com/juicedata/juicefs/pkg/meta.(*redisMeta).doRename(0xc000c29a40, {0x4b22718, 0xc000dfa240}, 0x74c9, {0xc00495524e, 0x24}, 0x3581bba, {0xc00495521a, 0x24}, 0x0, ...)
	/workspace/juicefs/pkg/meta/redis.go:1738 +0x5a5
github.com/juicedata/juicefs/pkg/meta.(*baseMeta).Rename(0xc001662008, {0x4b22718, 0xc000dfa240}, 0x74c9, {0xc00495524e, 0x24}, 0x3581bba, {0xc00495521a, 0x24}, 0x0, ...)
	/workspace/juicefs/pkg/meta/base.go:1477 +0x94d
```