### PR TITLE
meta/tikv: enlarge AsyncCommit safe-window to 10s

### DIFF
--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -75,6 +75,10 @@ func newTikvClient(addr string) (tkvClient, error) {
 			query.Get("cert"),
 			query.Get("key"),
 			strings.Split(query.Get("verify-cn"), ","))
+		// We don't use the table model, let alone online DDL, so increasing the default
+		// SafeWindow can reduce the likelihood of asynchronously committed transactions
+		// falling back, thereby avoiding high tail latency.
+		conf.TiKVClient.AsyncCommit.SafeWindow = 10 * time.Second
 	})
 	interval := time.Hour * 3
 	if dur, err := time.ParseDuration(query.Get("gc-interval")); err == nil {


### PR DESCRIPTION
Currently, JuiceFS enables 1PC and AsyncCommit by default to significantly reduce transaction commit latency. However, when TiKV is under high load or experiences high scheduler latch contention, a transaction’s prewrite request may not be processed until two seconds after the client issues it. In such cases, TiKV rejects the prewrite due to the max_commit_ts constraint.

An example of the resulting warning message is:
```
[WARN] [prewrite.rs:469] ["commit_ts is too large, fallback to normal 2PC"]
```

The default SafeWindow is set to 2 seconds—a conservative safeguard primarily designed for TiDB’s online DDL operations. Since JuiceFS does not use the table model and does not perform online DDL at all, this threshold can be safely increased.

Test:  Sry, I don’t know how to test this—it’s based purely on theoretical reasoning.