### PR TITLE
cmd/object: fix "testing/" directory remains after formatting volume with shards

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -299,7 +299,7 @@ func config(ctx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if err = test(blob); err != nil {
+			if err = test(blob, format.Name); err != nil {
 				return err
 			}
 		}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -355,7 +355,7 @@ func doTesting(store object.ObjectStorage, key string, data []byte) error {
 	return nil
 }
 
-func test(store object.ObjectStorage) error {
+func test(store object.ObjectStorage, prefix string) error {
 	key := "testing/" + randSeq(10)
 	data := make([]byte, 100)
 	utils.RandRead(data)
@@ -370,7 +370,8 @@ func test(store object.ObjectStorage) error {
 		time.Sleep(time.Second * time.Duration(i*3+1))
 	}
 	if err == nil {
-		_ = store.Delete(ctx, "testing/")
+		ctxWithHint := object.WithShardHint(context.Background(), prefix+"/"+key)
+		_ = store.Delete(ctxWithHint, "testing/")
 	}
 	return err
 }
@@ -522,7 +523,7 @@ func format(c *cli.Context) error {
 	}
 	logger.Infof("Data use %s", blob)
 	if os.Getenv("JFS_NO_CHECK_OBJECT_STORAGE") == "" {
-		if err := test(blob); err != nil {
+		if err := test(blob, format.Name); err != nil {
 			logger.Fatalf("Storage %s is not configured correctly: %s", blob, err)
 		}
 		if create {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -617,7 +617,7 @@ func mount(c *cli.Context) error {
 			// test storage at startup to fail fast instead of throwing EIO in the middle of user's workload
 			if c.Bool("check-storage") {
 				start := time.Now()
-				if err = test(blob); err != nil {
+				if err = test(blob, format.Name); err != nil {
 					logger.Errorf("Object storage test failed: %s", err)
 					return err
 				} else {


### PR DESCRIPTION
related issue: https://github.com/juicedata/juicefs/issues/6576

**Summary:** This PR fixes a bug where test data is left behind in object storage when formatting a volume with sharding enabled.

**Technical Details**: Since sharded storage relies on FNV hashing of the key, a directory prefix like `testing/` and an object within it like` testing/abc` will likely land on different shards. By the time we try to clean up the prefix, the sharded implementation routes the request to the wrong bucket.

I implemented a ShardHint mechanism via context.Context. This allows the caller (in this case, the format command) to "hint" to the sharded storage which shard it should target, based on a previously used key. This approach is non-intrusive to the ObjectStorage interface and is a common pattern in Go for metadata propagatio.