### PR TITLE
meta/tkv: also support cancelling txn when request is interrupted

### DIFF
--- a/pkg/meta/tkv_bak.go
+++ b/pkg/meta/tkv_bak.go
@@ -18,7 +18,6 @@ package meta
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -297,7 +296,7 @@ func (m *kvMeta) dumpMix(ctx Context, opt *DumpOption, ch chan<- *dumpedResult) 
 		}
 		logger.Debugf("range: %v-%v", start, end)
 		eg.Go(func() error {
-			return m.txn(egCtx, func(tx *kvTxn) error {
+			return m.txn(WrapContext(egCtx), func(tx *kvTxn) error {
 				var ent *entry
 				tx.scan(start, end, false, func(k, v []byte) bool {
 					if egCtx.Err() != nil {
@@ -441,7 +440,7 @@ func (m *kvMeta) dumpDirStat(ctx Context, opt *DumpOption, ch chan<- *dumpedResu
 	})
 }
 
-func (m *kvMeta) insertKVs(ctx context.Context, pairs []*pair, threads int) error {
+func (m *kvMeta) insertKVs(ctx Context, pairs []*pair, threads int) error {
 	if len(pairs) == 0 {
 		return nil
 	}
@@ -464,7 +463,7 @@ func (m *kvMeta) insertKVs(ctx context.Context, pairs []*pair, threads int) erro
 			ePairs := pairs[last : i+1]
 			num, size, last = 0, 0, i+1
 			eg.Go(func() error {
-				return m.txn(egCtx, func(tx *kvTxn) error {
+				return m.txn(WrapContext(egCtx), func(tx *kvTxn) error {
 					for _, ep := range ePairs {
 						tx.set(ep.key, ep.value)
 					}

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -620,11 +620,20 @@ func relatimeNeedUpdate(attr *Attr, now time.Time) bool {
 
 type txMethodKey struct{}
 
+type txMethod string
+
+func (m *txMethod) name(ctx context.Context) string {
+	if *m == "" {
+		*m = txMethod(callerName(ctx)) // lazy evaluation
+	}
+	return string(*m)
+}
+
 func callerName(ctx context.Context) string {
 	if method, ok := ctx.Value(txMethodKey{}).(string); ok {
 		return method // Fast path, prefer explicitly provided method name
 	}
-	const minSkip = 2
+	const minSkip = 3
 	for i := minSkip; i < 20; i++ { // Slow path, find the real caller
 		pc, _, _, ok := runtime.Caller(i)
 		if !ok {

--- a/pkg/meta/utils_test.go
+++ b/pkg/meta/utils_test.go
@@ -91,13 +91,13 @@ func TestAtimeNeedsUpdate(t *testing.T) {
 
 func Test_getCallerName(t *testing.T) {
 	ctx := context.WithValue(context.Background(), txMethodKey{}, "test")
-	method := callerName(ctx)
-	if method != "test" {
+	var method txMethod
+	if method.name(ctx) != "test" {
 		t.Fatalf("expected %q, got %q", "test", method)
 	}
 	func() {
-		method := callerName(context.Background())
-		if method != "Test_getCallerName" {
+		var method txMethod
+		if method.name(context.Background()) != "Test_getCallerName" {
 			t.Fatalf("expected %q, got %q", "Test_getCallerName", method)
 		}
 	}()


### PR DESCRIPTION
In a busy mount point, fuse requests being canceled (interrupted) happens frequently. When a request is canceled, the corresponding inflight metadata and data requests should also support cancellation. In the current redis engine, txn already supports cancellation. This PR completes the cancellation capability for tkv.