### PR TITLE
Revert "vfs: fix append write offset"

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -848,10 +848,6 @@ func (v *VFS) Write(ctx Context, ino Ino, buf []byte, off, fh uint64) (err sysca
 	}
 	defer h.Wunlock()
 
-	// kernel might return a stale length from attr-cache before open as the offset.
-	if h.flags&uint32(os.O_APPEND) != 0 {
-		off = h.writer.GetLength()
-	}
 	err = h.writer.Write(ctx, off, buf)
 	if err == syscall.ENOENT || err == syscall.EPERM || err == syscall.EINVAL {
 		err = syscall.EBADF


### PR DESCRIPTION
Reverts juicedata/juicefs#6545
issue #6594
Under the [writeback_cache] mode, the kernel may first read pages and then complete the write before flushing them. In JuiceFS user-space this appears like an overwrite behavior, so using the file size directly as the offset (as in #6545) is incorrect.

The issue of concurrent appends potentially overwriting each other currently doesn’t have a good solution. It will be documented under the consistency exceptions section.