### PR TITLE
Windows: enhance user privilege handling and add printsid command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -86,6 +87,10 @@ func Main(args []string) error {
 			cmdSummary(),
 			cmdCompact(),
 		},
+	}
+
+	if runtime.GOOS == "windows" {
+		app.Commands = append(app.Commands, cmdPrintSID())
 	}
 
 	if calledViaMount(args) {

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -414,7 +415,11 @@ func (j *juiceFS) Shutdown() {
 }
 
 func newJFS(endpoint, accessKey, secretKey, token string) (object.ObjectStorage, error) {
-	pid, uid, gid = uint32(os.Getpid()), uint32(os.Getuid()), uint32(os.Getgid())
+	pid, uid, gid = uint32(os.Getpid()), uint32(utils.GetCurrentUID()), uint32(utils.GetCurrentGID())
+	if runtime.GOOS == "windows" && utils.IsWinAdminOrElevatedPrivilege() {
+		uid = 0
+		gid = 0
+	}
 	metaUrl := os.Getenv(endpoint)
 	if metaUrl == "" {
 		metaUrl = endpoint

--- a/cmd/printsid.go
+++ b/cmd/printsid.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/juicedata/juicefs/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func cmdPrintSID() *cli.Command {
+	return &cli.Command{
+		Name:     "printsid",
+		Category: "TOOL",
+		Action:   printSID,
+		Usage:    "Show SID info and the convected UID/GID for the current user.",
+		Hidden:   true,
+	}
+}
+
+func printSID(ctx *cli.Context) error {
+	if runtime.GOOS != "windows" {
+		return fmt.Errorf("printsid command is only supported on Windows")
+	}
+
+	userSid := utils.GetCurrentUserSIDStr()
+	groupSid := utils.GetCurrentUserGroupSIDStr()
+	fmt.Printf("Current User SID: %s, UID: %d\n", userSid, utils.GetCurrentUID())
+	fmt.Printf("Current Group SID: %s, GID: %d\n", groupSid, utils.GetCurrentGID())
+
+	return nil
+}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -43,6 +43,9 @@ $ juicefs restore redis://localhost/1 2023-05-10-01`,
 
 func restore(ctx *cli.Context) error {
 	setup0(ctx, 2, 0)
+	if runtime.GOOS == "windows" && !utils.IsWinAdminOrElevatedPrivilege() {
+		return fmt.Errorf("restore command requires Administrator or elevated privilege on Windows")
+	}
 	if os.Getuid() != 0 && runtime.GOOS != "windows" {
 		return fmt.Errorf("only root can restore files from trash")
 	}

--- a/cmd/rmr.go
+++ b/cmd/rmr.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -81,8 +82,10 @@ func rmr(ctx *cli.Context) error {
 		numThreads = 255
 	}
 	if ctx.Bool("skip-trash") {
-		if os.Getuid() != 0 {
+		if runtime.GOOS != "windows" && os.Getuid() != 0 {
 			logger.Fatalf("Only root can remove files directly")
+		} else if runtime.GOOS == "windows" && !utils.IsWinAdminOrElevatedPrivilege() {
+			logger.Fatalf("Removing files directly requires Administrator or elevated privilege on Windows")
 		}
 		flag = 1
 	}

--- a/pkg/fs/http.go
+++ b/pkg/fs/http.go
@@ -336,7 +336,7 @@ func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func StartHTTPServer(fs *FileSystem, config WebdavConfig) {
-	ctx := meta.NewContext(uint32(os.Getpid()), uint32(os.Getuid()), []uint32{uint32(os.Getgid())})
+	ctx := meta.NewContext(uint32(os.Getpid()), uint32(utils.GetCurrentUID()), []uint32{uint32(utils.GetCurrentGID())})
 	hfs := &webdavFS{ctx, fs, uint16(utils.GetUmask()), config}
 	srv := &webdav.Handler{
 		FileSystem: hfs,

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -71,7 +71,7 @@ type Config struct {
 }
 
 func NewJFSGateway(jfs *fs.FileSystem, conf *vfs.Config, gConf *Config) (minio.ObjectLayer, error) {
-	mctx = meta.NewContext(uint32(os.Getpid()), uint32(os.Getuid()), []uint32{uint32(os.Getgid())})
+	mctx = meta.NewContext(uint32(os.Getpid()), uint32(utils.GetCurrentUID()), []uint32{uint32(utils.GetCurrentGID())})
 	jfsObj := &jfsObjects{fs: jfs, conf: conf, listPool: minio.NewTreeWalkPool(time.Second * 10), gConf: gConf, nsMutex: minio.NewNSLock(false)}
 	go jfsObj.cleanup()
 	return jfsObj, nil

--- a/pkg/object/nfs.go
+++ b/pkg/object/nfs.go
@@ -465,7 +465,7 @@ func newNFSStore(addr, username, pass, token string) (ObjectStorage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to dial MOUNT service %s: %v", addr, err)
 	}
-	auth := rpc.NewAuthUnix(username, uint32(os.Getuid()), uint32(os.Getgid()))
+	auth := rpc.NewAuthUnix(username, uint32(utils.GetCurrentUID()), uint32(utils.GetCurrentGID()))
 	target, err := mount.Mount(path, auth.Auth())
 	target.Config.DirCount = 1 << 17
 	// Readdir returns up to 1M at a time, even if MaxCount is set larger

--- a/pkg/utils/utils_unix.go
+++ b/pkg/utils/utils_unix.go
@@ -29,6 +29,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func GetCurrentUID() int {
+	return os.Getuid()
+}
+
+func GetCurrentGID() int {
+	return os.Getgid()
+}
+
+func GetCurrentUserSIDStr() string {
+	return ""
+}
+
+func GetCurrentUserGroupSIDStr() string {
+	return ""
+}
+
+func IsWinAdminOrElevatedPrivilege() bool {
+	return false
+}
+
 func GetFileInode(path string) (uint64, error) {
 	fi, err := os.Stat(path)
 	if err != nil {

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -84,8 +83,8 @@ var internalNodes = []*internalNode{
 }
 
 func init() {
-	uid := uint32(os.Getuid())
-	gid := uint32(os.Getgid())
+	uid := uint32(utils.GetCurrentUID())
+	gid := uint32(utils.GetCurrentGID())
 	now := time.Now().Unix()
 	for _, v := range internalNodes {
 		if v.inode == trashInode {

--- a/pkg/win/sid.go
+++ b/pkg/win/sid.go
@@ -26,12 +26,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/juicedata/juicefs/pkg/utils"
-
 	"golang.org/x/sys/windows"
 )
-
-var logger = utils.GetLogger("juicefs")
 
 var (
 	modadvapi32                   = windows.NewLazySystemDLL("advapi32.dll")
@@ -332,13 +328,11 @@ func ConvertSidStrToUid(sidStr string) (int, error) {
 
 func convertSidToUid(sid *windows.SID) int {
 	if sid == nil || !sid.IsValid() {
-		logger.Trace("GetCurrentUID sid is invalid or nil")
 		return -1
 	}
 
 	subAuthCount := sid.SubAuthorityCount()
 	if subAuthCount == 0 {
-		logger.Trace("subAuthCount is 0")
 		return -1
 	}
 
@@ -349,8 +343,6 @@ func convertSidToUid(sid *windows.SID) int {
 	rid := sid.SubAuthority(uint32(subAuthCount - 1))
 	subAuth0 := sid.SubAuthority(0)
 	auth := sid.IdentifierAuthority()
-
-	logger.Tracef("GetCurrentUID: subAuthCount=%d, rid=%d, subAuth0=%d, auth=%v", subAuthCount, rid, subAuth0, auth)
 
 	ret := -1
 
@@ -395,8 +387,6 @@ func convertSidToUid(sid *windows.SID) int {
 	if ret == -1 {
 		ret = 65534 // fallback to unmapped SID
 	}
-
-	logger.Tracef("GetCurrentUID: returning %d for sid %s", ret, sid.String())
 
 	return ret
 }
@@ -453,7 +443,6 @@ func GetCurrentUID() int {
 
 	sid, err := GetCurrentUserSID()
 	if err != nil {
-		logger.Warnf("failed to get sid for current user, %s", err)
 		return -1
 	}
 
@@ -463,7 +452,6 @@ func GetCurrentUID() int {
 func GetCurrentGID() int {
 	sid, err := GetCurrentUserPrimaryGroupSID()
 	if err != nil {
-		logger.Warnf("failed to get primary group sid for current user, %s", err)
 		return -1
 	}
 
@@ -473,7 +461,6 @@ func GetCurrentGID() int {
 func GetCurrentGroupName() string {
 	sid, err := GetCurrentUserPrimaryGroupSID()
 	if err != nil {
-		logger.Warnf("failed to get sid for current user, %s", err)
 		return ""
 	}
 	return GetSidName(sid, false)
@@ -502,7 +489,6 @@ func GetSidName(sid *windows.SID, withDomain bool) string {
 		&sidType,
 	)
 	if err != nil {
-		logger.Warnf("LookupAccountSid failed: %s", err)
 		return sid.String()
 	}
 


### PR DESCRIPTION
This PR adjusts command execution on Windows so that Administrator or elevated users are treated as root (UID/GID 0), aligning behavior with the mount "--adminasroot" option. 

BTW, to break the crycle import, I removed the logger package use in win pkg