### PR TITLE
io/write: benchmark of comparing direct copy vs io.MultiReader for page merging

### DIFF
--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -407,3 +407,62 @@ func TestStoreRetry(t *testing.T) {
 	cs.(*cachedStore).load(context.TODO(), "non", p, false, false) // wont retry
 	require.Equal(t, int32(1), s.cnt)
 }
+
+// BenchmarkMultiPageMergeVariousSizes tests with different block/page configurations
+func BenchmarkMultiPageMergeVariousSizes(b *testing.B) {
+	configs := []struct {
+		name      string
+		pageSize  int
+		blockSize int
+	}{
+		{"Small_64KB_64pages", 64 << 10, 4 << 20},      // 64K pages, 4M block
+		{"Medium_64KB_16pages", 64 << 10, 1 << 20},     // 64K pages, 1M block
+		{"Large_1MB_64pages", 1 << 20, 64 << 20},       // 1M pages, 64M block
+		{"XLarge_1MB_256pages", 1 << 20, 256 << 20},    // 1M pages, 256M block
+		{"XXLarge_1MB_512pages", 1 << 20, 512 << 20},   // 1M pages, 512M block
+	}
+
+	for _, config := range configs {
+		// Test direct copy
+		// used in wSlice.upload() to merge multiple pages into a single block
+		b.Run(config.name+"/DirectCopy", func(b *testing.B) {
+			numPages := config.blockSize / config.pageSize
+			pages := make([][]byte, numPages)
+			for i := 0; i < numPages; i++ {
+				pages[i] = make([]byte, config.pageSize)
+			}
+			blockData := make([]byte, config.blockSize)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				off := 0
+				for _, p := range pages {
+					off += copy(blockData[off:], p)
+				}
+			}
+		})
+
+		// Test MultiReader approach
+		// using io.MultiReader to merge multiple pages into a single block
+		b.Run(config.name+"/MultiReader", func(b *testing.B) {
+			numPages := config.blockSize / config.pageSize
+			pages := make([][]byte, numPages)
+			for i := 0; i < numPages; i++ {
+				pages[i] = make([]byte, config.pageSize)
+			}
+			blockData := make([]byte, config.blockSize)
+			readers := make([]io.Reader, numPages)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for j, p := range pages {
+					readers[j] = bytes.NewReader(p)
+				}
+				mr := io.MultiReader(readers...)
+				io.ReadFull(mr, blockData)
+			}
+		})
+	}
+}


### PR DESCRIPTION


#### What type of PR is this?

* [x] benchmark

#### What this PR does / why we need it:

This PR presents a benchmark comparison between using direct slice copying (`copy()`) versus `io.MultiReader` for merging multiple pages into a single block. This is relevant to the optimization discussions in #6197.

The results demonstrate that **Direct Copy is the superior approach**, maintaining zero allocations and generally lower latency, whereas `io.MultiReader` introduces significant overhead due to interface method calls and heap allocations.

#### Benchmark Results

Running on: `Intel(R) Core(TM) Ultra 9 285H`

```text
BenchmarkMultiPageMergeVariousSizes/Small_64KB_64pages/DirectCopy-16         3213    381536 ns/op         0 B/op       0 allocs/op
BenchmarkMultiPageMergeVariousSizes/Small_64KB_64pages/MultiReader-16        3069    334822 ns/op      4248 B/op      66 allocs/op
BenchmarkMultiPageMergeVariousSizes/Medium_64KB_16pages/DirectCopy-16       33040     31959 ns/op         0 B/op       0 allocs/op
BenchmarkMultiPageMergeVariousSizes/Medium_64KB_16pages/MultiReader-16      33622     43694 ns/op      1048 B/op      18 allocs/op
BenchmarkMultiPageMergeVariousSizes/Large_1MB_64pages/DirectCopy-16           111  25669704 ns/op         0 B/op       0 allocs/op
BenchmarkMultiPageMergeVariousSizes/Large_1MB_64pages/MultiReader-16          100  25053181 ns/op      4248 B/op      66 allocs/op
BenchmarkMultiPageMergeVariousSizes/XLarge_1MB_256pages/DirectCopy-16          12 100549072 ns/op         0 B/op       0 allocs/op
BenchmarkMultiPageMergeVariousSizes/XLarge_1MB_256pages/MultiReader-16         25 105485582 ns/op     17176 B/op     258 allocs/op
BenchmarkMultiPageMergeVariousSizes/XXLarge_1MB_512pages/DirectCopy-16         12 200288523 ns/op         0 B/op       0 allocs/op
BenchmarkMultiPageMergeVariousSizes/XXLarge_1MB_512pages/MultiReader-16         9 217720419 ns/op     34072 B/op     514 allocs/op

```

#### Performance Analysis

`io.MultiReader` performs worse for three primary reasons:

**1. Excessive Function Call Chain**

* **Direct Copy:** Uses the built-in `copy()` function, which the compiler optimizes directly into a `memmove` instruction.
* **io.MultiReader:** Involves a deep call stack: `io.ReadFull` -> `MultiReader.Read` -> `bytes.Reader.Read` (interface) -> `EOF` checks -> `memmove`.

**2. Memory Allocations**

* **Direct Copy:** Operates on existing `[][]byte` slices with **0 allocations**.
* **io.MultiReader:** Requires allocating a slice of readers (`[]io.Reader`) and creating a new `bytes.Reader` struct (heap allocated) for every single page. As seen in the `XXLarge` benchmark, this results in over 500 allocations per operation.

**3. Inability to Inline (Dynamic Dispatch)**

* **Direct Copy:** The compiler knows the types are `[]byte` and can inline the logic.
* **io.MultiReader:** Relies on the `io.Reader` interface. This forces dynamic dispatch (runtime vtable lookup), preventing the compiler from inlining the read calls.

#### Which issue(s) this PR fixes:

Relates to #6197
