### PR TITLE
trash: Support real-time status monitoring of Trash

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1167,21 +1167,11 @@ func (m *baseMeta) GetTrashStats(ctx Context) (space int64, inodes int64) {
 
 func (m *baseMeta) syncTrashDirStat(ctx Context) error {
 	var totalSpace, totalInodes int64
-	var entries []*Entry
-	if st := m.en.doReaddir(ctx, TrashInode, 1, &entries, -1); st != 0 {
-		return errors.Wrap(st, "read trash")
-	}
-
-	for _, entry := range entries {
-		stat, st := m.GetDirStat(ctx, entry.Inode)
-		if st != 0 {
-			logger.Warnf("GetDirStat for subTrash %d: %s", entry.Inode, st)
-			continue
-		}
-		if stat != nil {
-			totalSpace += stat.space
-			totalInodes += stat.inodes
-		}
+	if err := m.scanTrashEntry(ctx, func(_ Ino, size uint64) {
+		totalSpace += align4K(size)
+		totalInodes++
+	}); err != nil {
+		return err
 	}
 
 	return m.en.doUpdateDirStat(ctx, map[Ino]dirStat{
@@ -2564,7 +2554,7 @@ func (m *baseMeta) Check(ctx Context, fpath string, opt *CheckOpt) error {
 	}
 	wg.Wait()
 	if fpath == "/" && opt.Repair && opt.Recursive && opt.SyncDirStat {
-		if err := m.syncVolumeStat(ctx); err != nil {
+		if err := m.en.doSyncVolumeStat(ctx); err != nil {
 			logger.Errorf("Sync used space: %s", err)
 			hasError = true
 		}
@@ -2901,7 +2891,6 @@ func (m *baseMeta) checkTrash(parent Ino, trash *Ino) syscall.Errno {
 		attr := Attr{Typ: TypeDirectory, Nlink: 2, Length: 4 << 10, Parent: TrashInode, Full: true}
 		st = m.en.doMknod(Background(), TrashInode, name, TypeDirectory, 0555, 0, "", trash, &attr)
 		m.en.updateStats(align4K(0), 1)
-		// Initialize dirstat for the new subTrash (empty directory)
 		m.updateDirStat(Background(), *trash, 0, 0, 0)
 	}
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -400,8 +400,6 @@ type Meta interface {
 	CleanupTrashBefore(ctx Context, edge time.Time, increProgress func(int), stats *CleanupTrashStats) syscall.Errno
 	// CleanupDetachedNodesBefore deletes all detached nodes before the given time.
 	CleanupDetachedNodesBefore(ctx Context, edge time.Time, increProgress func())
-	// SyncVolumeStat syncs the volume statistics from the database.
-	SyncVolumeStat(ctx Context) error
 
 	// StatFS returns summary statistics of a volume.
 	StatFS(ctx Context, ino Ino, totalspace, availspace, iused, iavail *uint64) syscall.Errno

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -191,6 +191,13 @@ func (m *baseMeta) updateDirStat(ctx Context, ino Ino, length, space, inodes int
 	m.dirStats[ino] = stat
 }
 
+func (m *baseMeta) updateTrashStats(ctx Context, trash Ino, space, inodes int64) {
+	m.updateDirStat(ctx, trash, 0, space, inodes)
+	if trash != TrashInode {
+		m.updateDirStat(ctx, TrashInode, 0, space, inodes)
+	}
+}
+
 func (m *baseMeta) updateParentStat(ctx Context, inode, parent Ino, length, space int64) {
 	if length == 0 && space == 0 {
 		return
@@ -267,14 +274,6 @@ func (m *baseMeta) doFlushStats() {
 	m.fsStatsLock.Lock()
 	m.en.doFlushStats()
 	m.fsStatsLock.Unlock()
-}
-
-func (m *baseMeta) syncVolumeStat(ctx Context) error {
-	return m.en.doSyncVolumeStat(ctx)
-}
-
-func (m *baseMeta) SyncVolumeStat(ctx Context) error {
-	return m.syncVolumeStat(ctx)
 }
 
 func (m *baseMeta) checkQuota(ctx Context, space, inodes int64, uid, gid uint32, parents ...Ino) syscall.Errno {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1730,12 +1730,10 @@ func (m *redisMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, s
 			m.fileDeleted(opened, parent.IsTrash(), inode, attr.Length)
 		}
 		if parent.IsTrash() {
-			m.updateDirStat(ctx, parent, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, parent, newSpace, newInode)
 			m.updateStats(newSpace, newInode)
 		} else if trash > 0 {
-			m.updateDirStat(ctx, trash, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, trash, newSpace, newInode)
 		} else {
 			m.updateStats(newSpace, newInode)
 		}
@@ -2123,8 +2121,7 @@ func (m *redisMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, len
 			m.updateStats(batchFsDeltaSpace, batchFsDeltaInodes)
 		}
 		if batchTrashDeltaSpace != 0 || batchTrashDeltaInodes != 0 {
-			m.updateDirStat(ctx, parent, 0, batchTrashDeltaSpace, batchTrashDeltaInodes)
-			m.updateDirStat(ctx, TrashInode, 0, batchTrashDeltaSpace, batchTrashDeltaInodes)
+			m.updateTrashStats(ctx, parent, batchTrashDeltaSpace, batchTrashDeltaInodes)
 		}
 
 		totalLength += batchLength
@@ -2255,12 +2252,10 @@ func (m *redisMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, o
 	}, m.inodeKey(parent), m.entryKey(parent))
 	if err == nil {
 		if parent.IsTrash() {
-			m.updateDirStat(ctx, parent, 0, -align4K(0), -1)
-			m.updateDirStat(ctx, TrashInode, 0, -align4K(0), -1)
+			m.updateTrashStats(ctx, parent, -align4K(0), -1)
 			m.updateStats(-align4K(0), -1)
 		} else if trash > 0 {
-			m.updateDirStat(ctx, trash, 0, align4K(0), 1)
-			m.updateDirStat(ctx, TrashInode, 0, align4K(0), 1)
+			m.updateTrashStats(ctx, trash, align4K(0), 1)
 		} else {
 			m.updateStats(-align4K(0), -1)
 		}
@@ -2597,16 +2592,14 @@ func (m *redisMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentD
 			} else {
 				m.updateStats(newSpace, newInode)
 			}
-			m.updateDirStat(ctx, parentSrc, 0, restoreSpace, restoreInodes)
-			m.updateDirStat(ctx, TrashInode, 0, restoreSpace, restoreInodes)
+			m.updateTrashStats(ctx, parentSrc, restoreSpace, restoreInodes)
 		} else if trash == 0 {
 			if dino > 0 && dtyp == TypeFile && tattr.Nlink == 0 {
 				m.fileDeleted(opened, false, dino, tattr.Length)
 			}
 			m.updateStats(newSpace, newInode)
 		} else {
-			m.updateDirStat(ctx, trash, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, trash, newSpace, newInode)
 		}
 	}
 	return errno(err)
@@ -3192,14 +3185,22 @@ func (m *redisMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno
 	if m.conf.ReadOnly {
 		return nil, syscall.EROFS
 	}
-	field := ino.String()
-	var stat *dirStat
-	var st syscall.Errno
 	if ino == TrashInode {
-		stat, st = m.calcTrashDirStat(ctx)
-	} else {
-		stat, st = m.calcDirStat(ctx, ino)
+		stat, st := m.calcTrashDirStat(ctx)
+		if st != 0 {
+			return nil, st
+		}
+		field := ino.String()
+		_, err := m.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.HSet(ctx, m.dirDataLengthKey(), field, stat.length)
+			pipe.HSet(ctx, m.dirUsedSpaceKey(), field, stat.space)
+			pipe.HSet(ctx, m.dirUsedInodesKey(), field, stat.inodes)
+			return nil
+		})
+		return stat, errno(err)
 	}
+	field := ino.String()
+	stat, st := m.calcDirStat(ctx, ino)
 	if st != 0 {
 		return nil, st
 	}
@@ -3220,27 +3221,6 @@ func (m *redisMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno
 		return err
 	}, m.inodeKey(ino))
 	return stat, errno(err)
-}
-
-func (m *redisMeta) calcTrashDirStat(ctx Context) (*dirStat, syscall.Errno) {
-	var totalSpace, totalInodes int64
-	var entries []*Entry
-	if st := m.en.doReaddir(ctx, TrashInode, 1, &entries, -1); st != 0 {
-		return nil, st
-	}
-
-	for _, entry := range entries {
-		stat, st := m.doGetDirStat(ctx, entry.Inode, false)
-		if st != 0 {
-			continue
-		}
-		if stat != nil {
-			totalSpace += stat.space
-			totalInodes += stat.inodes
-		}
-	}
-
-	return &dirStat{space: totalSpace, inodes: totalInodes}, 0
 }
 
 func (m *redisMeta) doUpdateDirStat(ctx Context, batch map[Ino]dirStat) error {
@@ -3323,6 +3303,17 @@ func (m *redisMeta) doGetDirStat(ctx Context, ino Ino, trySync bool) (*dirStat, 
 		return m.doSyncDirStat(ctx, ino)
 	}
 	return nil, 0
+}
+
+func (m *redisMeta) calcTrashDirStat(ctx Context) (*dirStat, syscall.Errno) {
+	var totalSpace, totalInodes int64
+	if err := m.scanTrashEntry(ctx, func(_ Ino, size uint64) {
+		totalSpace += align4K(size)
+		totalInodes++
+	}); err != nil {
+		return nil, errno(err)
+	}
+	return &dirStat{space: totalSpace, inodes: totalInodes}, 0
 }
 
 // For now only deleted files

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1967,12 +1967,10 @@ func (m *dbMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, skip
 			m.fileDeleted(opened, parent.IsTrash(), n.Inode, n.Length)
 		}
 		if parent.IsTrash() {
-			m.updateDirStat(ctx, parent, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, parent, newSpace, newInode)
 			m.updateStats(newSpace, newInode)
 		} else if trash > 0 {
-			m.updateDirStat(ctx, trash, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, trash, newSpace, newInode)
 		} else {
 			m.updateStats(newSpace, newInode)
 		}
@@ -2100,12 +2098,10 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, attr
 	})
 	if err == nil {
 		if parent.IsTrash() {
-			m.updateDirStat(ctx, parent, 0, -align4K(0), -1)
-			m.updateDirStat(ctx, TrashInode, 0, -align4K(0), -1)
+			m.updateTrashStats(ctx, parent, -align4K(0), -1)
 			m.updateStats(-align4K(0), -1)
 		} else if trash > 0 {
-			m.updateDirStat(ctx, trash, 0, align4K(0), 1)
-			m.updateDirStat(ctx, TrashInode, 0, align4K(0), 1)
+			m.updateTrashStats(ctx, trash, align4K(0), 1)
 		} else {
 			m.updateStats(-align4K(0), -1)
 		}
@@ -2514,16 +2510,14 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			} else {
 				m.updateStats(newSpace, newInode)
 			}
-			m.updateDirStat(ctx, parentSrc, 0, restoreSpace, restoreInodes)
-			m.updateDirStat(ctx, TrashInode, 0, restoreSpace, restoreInodes)
+			m.updateTrashStats(ctx, parentSrc, restoreSpace, restoreInodes)
 		} else if trash == 0 {
 			if dino > 0 && dn.Type == TypeFile && dn.Nlink == 0 {
 				m.fileDeleted(opened, false, dino, dn.Length)
 			}
 			m.updateStats(newSpace, newInode)
 		} else {
-			m.updateDirStat(ctx, trash, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, trash, newSpace, newInode)
 		}
 	}
 	return errno(err)
@@ -2988,8 +2982,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, length
 		m.updateStats(fsDeltaSpace, fsDeltaInodes)
 	}
 	if trashDeltaSpace != 0 || trashDeltaInodes != 0 {
-		m.updateDirStat(ctx, parent, 0, trashDeltaSpace, trashDeltaInodes)
-		m.updateDirStat(ctx, TrashInode, 0, trashDeltaSpace, trashDeltaInodes)
+		m.updateTrashStats(ctx, parent, trashDeltaSpace, trashDeltaInodes)
 	}
 	*length = totalLength
 	*space = totalSpace
@@ -3427,13 +3420,22 @@ func (m *dbMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno) {
 	if m.conf.ReadOnly {
 		return nil, syscall.EROFS
 	}
-	var stat *dirStat
-	var st syscall.Errno
 	if ino == TrashInode {
-		stat, st = m.calcTrashDirStat(ctx)
-	} else {
-		stat, st = m.calcDirStat(ctx, ino)
+		stat, st := m.calcTrashDirStat(ctx)
+		if st != 0 {
+			return nil, st
+		}
+		err := m.txn(func(s *xorm.Session) error {
+			record := &dirStats{ino, stat.length, stat.space, stat.inodes}
+			_, err := s.Insert(record)
+			if err != nil && isDuplicateEntryErr(err) {
+				_, err = s.Cols("data_length", "used_space", "used_inodes").Update(record, &dirStats{Inode: ino})
+			}
+			return err
+		})
+		return stat, errno(err)
 	}
+	stat, st := m.calcDirStat(ctx, ino)
 	if st != 0 {
 		return nil, st
 	}
@@ -3457,22 +3459,12 @@ func (m *dbMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno) {
 
 func (m *dbMeta) calcTrashDirStat(ctx Context) (*dirStat, syscall.Errno) {
 	var totalSpace, totalInodes int64
-	var entries []*Entry
-	if st := m.en.doReaddir(ctx, TrashInode, 1, &entries, -1); st != 0 {
-		return nil, st
+	if err := m.scanTrashEntry(ctx, func(_ Ino, size uint64) {
+		totalSpace += align4K(size)
+		totalInodes++
+	}); err != nil {
+		return nil, errno(err)
 	}
-
-	for _, entry := range entries {
-		stat, st := m.doGetDirStat(ctx, entry.Inode, false)
-		if st != 0 {
-			continue
-		}
-		if stat != nil {
-			totalSpace += stat.space
-			totalInodes += stat.inodes
-		}
-	}
-
 	return &dirStat{space: totalSpace, inodes: totalInodes}, 0
 }
 

--- a/pkg/meta/status.go
+++ b/pkg/meta/status.go
@@ -107,11 +107,6 @@ func Status(ctx context.Context, m Meta, trash bool, sections *Sections) error {
 		stat.PendingDeletedSliceCount, stat.PendingDeletedSliceSize = pendingDeletedSlicesSpinner.Current()
 		stat.TrashFileCount, stat.TrashFileSize = trashFileSpinner.Current()
 		stat.PendingDeletedFileCount, stat.PendingDeletedFileSize = pendingDeletedFileSpinner.Current()
-
-		// Sync trash stats to database
-		if err = m.SyncVolumeStat(WrapContext(ctx)); err != nil {
-			logger.Warnf("sync volume stat: %s", err)
-		}
 	}
 
 	if sections != nil {

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1437,12 +1437,10 @@ func (m *kvMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, skip
 			m.fileDeleted(opened, parent.IsTrash(), inode, attr.Length)
 		}
 		if parent.IsTrash() {
-			m.updateDirStat(ctx, parent, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, parent, newSpace, newInode)
 			m.updateStats(newSpace, newInode)
 		} else if trash > 0 {
-			m.updateDirStat(ctx, trash, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, trash, newSpace, newInode)
 		} else {
 			m.updateStats(newSpace, newInode)
 		}
@@ -1751,8 +1749,7 @@ func (m *kvMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, length
 			m.updateStats(batchFsDeltaSpace, batchFsDeltaInodes)
 		}
 		if batchTrashDeltaSpace != 0 || batchTrashDeltaInodes != 0 {
-			m.updateDirStat(ctx, parent, 0, batchTrashDeltaSpace, batchTrashDeltaInodes)
-			m.updateDirStat(ctx, TrashInode, 0, batchTrashDeltaSpace, batchTrashDeltaInodes)
+			m.updateTrashStats(ctx, parent, batchTrashDeltaSpace, batchTrashDeltaInodes)
 		}
 
 		totalLength += batchLength
@@ -1869,12 +1866,10 @@ func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, oldA
 	}, parent)
 	if err == nil {
 		if parent.IsTrash() {
-			m.updateDirStat(ctx, parent, 0, -align4K(0), -1)
-			m.updateDirStat(ctx, TrashInode, 0, -align4K(0), -1)
+			m.updateTrashStats(ctx, parent, -align4K(0), -1)
 			m.updateStats(-align4K(0), -1)
 		} else if trash > 0 {
-			m.updateDirStat(ctx, trash, 0, align4K(0), 1)
-			m.updateDirStat(ctx, TrashInode, 0, align4K(0), 1)
+			m.updateTrashStats(ctx, trash, align4K(0), 1)
 		} else {
 			m.updateStats(-align4K(0), -1)
 		}
@@ -2169,16 +2164,14 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			} else {
 				m.updateStats(newSpace, newInode)
 			}
-			m.updateDirStat(ctx, parentSrc, 0, restoreSpace, restoreInodes)
-			m.updateDirStat(ctx, TrashInode, 0, restoreSpace, restoreInodes)
+			m.updateTrashStats(ctx, parentSrc, restoreSpace, restoreInodes)
 		} else if trash == 0 {
 			if dino > 0 && dtyp == TypeFile && tattr.Nlink == 0 {
 				m.fileDeleted(opened, false, dino, tattr.Length)
 			}
 			m.updateStats(newSpace, newInode)
 		} else {
-			m.updateDirStat(ctx, trash, 0, newSpace, newInode)
-			m.updateDirStat(ctx, TrashInode, 0, newSpace, newInode)
+			m.updateTrashStats(ctx, trash, newSpace, newInode)
 		}
 	}
 	return errno(err)
@@ -2595,13 +2588,21 @@ func (m *kvMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno) {
 	if m.conf.ReadOnly {
 		return nil, syscall.EROFS
 	}
-	var stat *dirStat
-	var st syscall.Errno
 	if ino == TrashInode {
-		stat, st = m.calcTrashDirStat(ctx)
-	} else {
-		stat, st = m.calcDirStat(ctx, ino)
+		stat, st := m.calcTrashDirStat(ctx)
+		if st != 0 {
+			return nil, st
+		}
+		err := m.client.txn(ctx, func(tx *kvTxn) error {
+			tx.set(m.dirStatKey(ino), m.packDirStat(stat))
+			return nil
+		}, 0)
+		if err != nil && m.shouldRetry(err) {
+			err = nil
+		}
+		return stat, errno(err)
 	}
+	stat, st := m.calcDirStat(ctx, ino)
 	if st != 0 {
 		return nil, st
 	}
@@ -2617,27 +2618,6 @@ func (m *kvMeta) doSyncDirStat(ctx Context, ino Ino) (*dirStat, syscall.Errno) {
 		err = nil
 	}
 	return stat, errno(err)
-}
-
-func (m *kvMeta) calcTrashDirStat(ctx Context) (*dirStat, syscall.Errno) {
-	var totalSpace, totalInodes int64
-	var entries []*Entry
-	if st := m.en.doReaddir(ctx, TrashInode, 1, &entries, -1); st != 0 {
-		return nil, st
-	}
-
-	for _, entry := range entries {
-		stat, st := m.doGetDirStat(ctx, entry.Inode, false)
-		if st != 0 {
-			continue
-		}
-		if stat != nil {
-			totalSpace += stat.space
-			totalInodes += stat.inodes
-		}
-	}
-
-	return &dirStat{space: totalSpace, inodes: totalInodes}, 0
 }
 
 func (m *kvMeta) doUpdateDirStat(ctx Context, batch map[Ino]dirStat) error {
@@ -2691,6 +2671,17 @@ func (m *kvMeta) doGetDirStat(ctx Context, ino Ino, trySync bool) (*dirStat, sys
 		return m.doSyncDirStat(ctx, ino)
 	}
 	return nil, 0
+}
+
+func (m *kvMeta) calcTrashDirStat(ctx Context) (*dirStat, syscall.Errno) {
+	var totalSpace, totalInodes int64
+	if err := m.scanTrashEntry(ctx, func(_ Ino, size uint64) {
+		totalSpace += align4K(size)
+		totalInodes++
+	}); err != nil {
+		return nil, errno(err)
+	}
+	return &dirStat{space: totalSpace, inodes: totalInodes}, 0
 }
 
 func (m *kvMeta) doFindDeletedFiles(ts int64, limit int) (map[Ino]uint64, error) {


### PR DESCRIPTION
实现回收站的实时增量统计，目前支持统计回收站总空间和总inodes

主要修改点
1. 在元数据中添加trashSpace和trahsInodes，并支持监控指标
2. 在已有文件系统中，通过status --more命令来扫描更新
3. 在unlink、rmdir、batchUnlink、rename、restore等接口中实时修改后端统计


Implement real-time incremental statistics for the trash. Currently, it supports statistics on the total space and total inodes of the trash. 
Main modifications:
1. Add "trashSpace" and "trahsInodes" to the metadata and support monitoring indicators.
2. In the existing file system, scan for updates using the "status --more" command.
3. Real-time update the backend statistics in interfaces such as unlink, rmdir, batchUnlink, rename, and restore.