### PR TITLE
sdk/java: add max-downloads configuration option

### DIFF
--- a/docs/en/deployment/hadoop_java_sdk.md
+++ b/docs/en/deployment/hadoop_java_sdk.md
@@ -178,6 +178,7 @@ Please refer to the following table to set the relevant parameters of the JuiceF
 | Configuration            | Default Value | Description                                     |
 |--------------------------|---------------|-------------------------------------------------|
 | `juicefs.max-uploads`    | 20            | The max number of connections to upload         |
+| `juicefs.max-downloads`  | 200           | The max number of connections to download       |
 | `juicefs.max-deletes`    | 10            | The max number of connections to delete         |
 | `juicefs.get-timeout`    | 5             | The max number of seconds to download an object |
 | `juicefs.put-timeout`    | 60            | The max number of seconds to upload an object   |

--- a/docs/zh_cn/deployment/hadoop_java_sdk.md
+++ b/docs/zh_cn/deployment/hadoop_java_sdk.md
@@ -178,6 +178,7 @@ make win
 | 配置项                      | 默认值     | 描述                     |
 |--------------------------|---------|------------------------|
 | `juicefs.max-uploads`    | 20      | 上传数据的最大连接数             |
+| `juicefs.max-downloads`  | 200     | 下载连接的最大数量       |
 | `juicefs.max-deletes`    | 10      | 删除数据的最大连接数             |
 | `juicefs.get-timeout`    | 5       | 下载一个对象的超时时间，单位为秒。      |
 | `juicefs.put-timeout`    | 60      | 上传一个对象的超时时间，单位为秒。      |

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -366,6 +366,7 @@ type javaConf struct {
 	UploadLimit         string `json:"uploadLimit"`
 	DownloadLimit       string `json:"downloadLimit"`
 	MaxUploads          int    `json:"maxUploads"`
+	MaxDownloads        int    `json:"maxDownloads"`
 	MaxDeletes          int    `json:"maxDeletes"`
 	SkipDirNlink        int    `json:"skipDirNlink"`
 	SkipDirMtime        string `json:"skipDirMtime"`
@@ -681,6 +682,7 @@ func jfs_init(credentialPtr uintptr, count int32, cname, cjsonConf, cuser, group
 			CacheExpire:       utils.Duration(jConf.CacheExpire),
 			OSCache:           true,
 			MaxUpload:         jConf.MaxUploads,
+			MaxDownload:       jConf.MaxDownloads,
 			MaxRetries:        jConf.IORetries,
 			UploadLimit:       utils.ParseMbpsStr("upload-limit", jConf.UploadLimit) * 1e6 / 8,
 			DownloadLimit:     utils.ParseMbpsStr("download-limit", jConf.DownloadLimit) * 1e6 / 8,

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -485,6 +485,7 @@ public class JuiceFileSystemImpl extends FileSystem {
     obj.put("cacheExpire", getConf(conf, "cache-expire", "0"));
     obj.put("autoCreate", Boolean.valueOf(getConf(conf, "auto-create-cache-dir", "true")));
     obj.put("maxUploads", Integer.valueOf(getConf(conf, "max-uploads", "20")));
+    obj.put("maxDownloads", Integer.valueOf(getConf(conf, "max-downloads", "200")));
     obj.put("maxDeletes", Integer.valueOf(getConf(conf, "max-deletes", "10")));
     obj.put("skipDirNlink", Integer.valueOf(getConf(conf, "skip-dir-nlink", "20")));
     obj.put("skipDirMtime", getConf(conf, "skip-dir-mtime", "100ms"));


### PR DESCRIPTION
close #6676
Add `juicefs.max-downloads` configuration option to control  the maximum number of download connections.