### PR TITLE
object/oss: support oss private link endpoint

### DIFF
--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -398,6 +398,7 @@ func newOSS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 					return nil, fmt.Errorf("invalid private link endpoint: %q", domain)
 				}
 				regionID = parts[2]
+				useV4 = true
 			} else {
 				// oss-<region>.aliyuncs.com
 				// oss-<region>-internal.aliyuncs.com


### PR DESCRIPTION
As a supplement to #6202 - Alibaba OSS supports accessing via VPC [PrivateLink](https://help.aliyun.com/zh/oss/user-guide/access-oss-via-privatelink-network). However, JuiceFS currently does not support parsing such endpoints. The PR include two main changes:

1. Added support for parsing the region from PrivateLink endpoints.
2. PrivateLink endpoints only support path-style access, so the PR also forces path-style access when PrivateLink is detected.