### PR TITLE
fix 'unsupported version of the configuration' error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 run:
   timeout: 5m
   tests: false


### PR DESCRIPTION
'golangci-lint run' returns following error:
`error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/docs/product/migration-guide for migration instructions
The command is terminated due to an error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/docs/product/migration-guide for migration instructions`

add 'version' to fix this error
