### PR TITLE
vfs: add path protection feature with readonly and deny modes

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -297,6 +297,16 @@ func getVfsConf(c *cli.Context, metaConf *meta.Config, format *meta.Format, chun
 	if !skip_check && cfg.BackupMeta > 0 && cfg.BackupMeta < time.Minute*5 {
 		logger.Fatalf("backup-meta should not be less than 5 minutes: %s", cfg.BackupMeta)
 	}
+
+	// Parse path protection config
+	if c.IsSet("path-protection") {
+		var err error
+		cfg.PathProtection, err = vfs.ParsePathProtectionConfig(c.String("path-protection"))
+		if err != nil {
+			logger.Fatalf("invalid path-protection config: %s", err)
+		}
+	}
+
 	return cfg
 }
 

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -393,6 +393,10 @@ func mountFlags() []cli.Flag {
 			Name:  "hide-internal",
 			Usage: "hide all internal files (.accesslog, .stats, etc.)",
 		},
+		&cli.StringFlag{
+			Name:  "path-protection",
+			Usage: "path protection config in JSON format, use ^ to anchor patterns (e.g., {\"rules\":[{\"pattern\":\"^/mnt/jfs/logs/.*\",\"mode\":\"readonly\"},{\"pattern\":\"^/mnt/jfs/secrets/.*\",\"mode\":\"deny\"}]})",
+		},
 	}
 	if runtime.GOOS == "linux" {
 		selfFlags = append(selfFlags, &cli.BoolFlag{

--- a/docs/en/security/path_protection.md
+++ b/docs/en/security/path_protection.md
@@ -1,0 +1,111 @@
+---
+title: Path Protection
+description: Learn how to use path protection to restrict access to specific directories in JuiceFS.
+sidebar_position: 3
+---
+
+Path protection is a feature that allows you to restrict access to specific paths in JuiceFS using regular expression patterns. This is useful for protecting sensitive directories like `.git` from accidental modifications, or completely hiding secret directories.
+
+## Protection Modes
+
+Two protection modes are supported:
+
+| Mode | Write Operations | Read Operations |
+|------|------------------|-----------------|
+| `readonly` | Blocked | Allowed |
+| `deny` | Blocked | Blocked |
+
+## Usage
+
+Enable path protection using the `--path-protection` option when mounting:
+
+### Readonly Mode
+
+Protect `.git` directories from write operations while allowing reads:
+
+```shell
+juicefs mount \
+  --path-protection='{"rules":[{"pattern":"^/mnt/jfs/data/.*\\.git.*","mode":"readonly"}]}' \
+  redis://localhost /mnt/jfs
+```
+
+### Deny Mode
+
+Completely block access to secrets directory:
+
+```shell
+juicefs mount \
+  --path-protection='{"rules":[{"pattern":"^/mnt/jfs/secrets/.*","mode":"deny"}]}' \
+  redis://localhost /mnt/jfs
+```
+
+### Multiple Rules
+
+You can specify multiple protection rules:
+
+```shell
+juicefs mount \
+  --path-protection='{"rules":[{"pattern":"^/mnt/jfs/data/.*\\.git.*","mode":"readonly"},{"pattern":"^/mnt/jfs/secrets/.*","mode":"deny"}]}' \
+  redis://localhost /mnt/jfs
+```
+
+## Pattern Matching
+
+Patterns are regular expressions that match against the full path including the mountpoint. It is recommended to use `^` to anchor patterns to the beginning of the path to avoid unintended substring matches:
+
+- Pattern: `^/mnt/jfs/data/.*\.git.*` matches `/mnt/jfs/data/project/.git/config`
+- Pattern: `^/mnt/jfs/secrets/.*` matches `/mnt/jfs/secrets/api_key.txt`
+- Pattern without `^`: `/mnt/jfs/secrets/.*` would also match `/backup/mnt/jfs/secrets/foo` (unintended)
+
+## Affected Operations
+
+### Write Protection (readonly and deny modes)
+
+- Create file/directory
+- Write to file
+- Delete file/directory
+- Rename file/directory
+- Create symbolic/hard links
+- Modify attributes
+- Set/remove extended attributes
+
+### Read Protection (deny mode only)
+
+- Read file content
+- Lookup file/directory
+- List directory contents
+- Get file attributes
+- Get extended attributes
+
+## Error Codes
+
+| Error | Code | Description |
+|-------|------|-------------|
+| `EPERM` | 1 | Operation not permitted (write operations on protected paths) |
+| `EACCES` | 13 | Permission denied (read operations on deny-protected paths) |
+
+## Examples
+
+```shell
+# Test write protection (should fail)
+touch /mnt/jfs/data/project/.git/test.txt
+# Output: touch: cannot touch '...': Operation not permitted
+
+# Test read allowed in readonly mode (should succeed)
+cat /mnt/jfs/data/project/.git/config
+# Output: success
+
+# Test read blocked in deny mode (should fail)
+cat /mnt/jfs/secrets/api_key.txt
+# Output: cat: ...: Permission denied
+
+# Test lookup blocked in deny mode (should fail)
+ls /mnt/jfs/secrets/
+# Output: ls: cannot access ...: Permission denied
+```
+
+## Notes
+
+1. Path protection rules are evaluated in order. The first matching rule determines the protection mode.
+2. Patterns must match the full path including the mountpoint prefix. Use `^` to anchor patterns.
+3. Invalid regex patterns will cause the mount to fail with an error message.

--- a/docs/zh_cn/security/path_protection.md
+++ b/docs/zh_cn/security/path_protection.md
@@ -1,0 +1,111 @@
+---
+title: 路径保护
+description: 了解如何使用路径保护功能限制对 JuiceFS 中特定目录的访问。
+sidebar_position: 3
+---
+
+路径保护是一项允许您使用正则表达式模式限制对 JuiceFS 中特定路径访问的功能。这对于保护敏感目录（如 `.git`）免受意外修改，或完全隐藏机密目录非常有用。
+
+## 保护模式
+
+支持两种保护模式：
+
+| 模式 | 写操作 | 读操作 |
+|------|--------|--------|
+| `readonly` | 阻止 | 允许 |
+| `deny` | 阻止 | 阻止 |
+
+## 使用方法
+
+在挂载时使用 `--path-protection` 选项启用路径保护：
+
+### 只读模式
+
+保护 `.git` 目录免受写操作，同时允许读取：
+
+```shell
+juicefs mount \
+  --path-protection='{"rules":[{"pattern":"^/mnt/jfs/data/.*\\.git.*","mode":"readonly"}]}' \
+  redis://localhost /mnt/jfs
+```
+
+### 禁止模式
+
+完全禁止访问机密目录：
+
+```shell
+juicefs mount \
+  --path-protection='{"rules":[{"pattern":"^/mnt/jfs/secrets/.*","mode":"deny"}]}' \
+  redis://localhost /mnt/jfs
+```
+
+### 多条规则
+
+可以指定多条保护规则：
+
+```shell
+juicefs mount \
+  --path-protection='{"rules":[{"pattern":"^/mnt/jfs/data/.*\\.git.*","mode":"readonly"},{"pattern":"^/mnt/jfs/secrets/.*","mode":"deny"}]}' \
+  redis://localhost /mnt/jfs
+```
+
+## 模式匹配
+
+模式是匹配完整路径（包括挂载点）的正则表达式。建议使用 `^` 锚定模式到路径开头，以避免意外的子串匹配：
+
+- 模式：`^/mnt/jfs/data/.*\.git.*` 匹配 `/mnt/jfs/data/project/.git/config`
+- 模式：`^/mnt/jfs/secrets/.*` 匹配 `/mnt/jfs/secrets/api_key.txt`
+- 不带 `^` 的模式：`/mnt/jfs/secrets/.*` 也会匹配 `/backup/mnt/jfs/secrets/foo`（非预期）
+
+## 受影响的操作
+
+### 写保护（readonly 和 deny 模式）
+
+- 创建文件/目录
+- 写入文件
+- 删除文件/目录
+- 重命名文件/目录
+- 创建符号链接/硬链接
+- 修改属性
+- 设置/删除扩展属性
+
+### 读保护（仅 deny 模式）
+
+- 读取文件内容
+- 查找文件/目录
+- 列出目录内容
+- 获取文件属性
+- 获取扩展属性
+
+## 错误码
+
+| 错误 | 代码 | 描述 |
+|------|------|------|
+| `EPERM` | 1 | 操作不允许（受保护路径上的写操作） |
+| `EACCES` | 13 | 权限被拒绝（deny 保护路径上的读操作） |
+
+## 示例
+
+```shell
+# 测试写保护（应该失败）
+touch /mnt/jfs/data/project/.git/test.txt
+# 输出：touch: cannot touch '...': Operation not permitted
+
+# 测试只读模式下允许读取（应该成功）
+cat /mnt/jfs/data/project/.git/config
+# 输出：成功
+
+# 测试禁止模式下阻止读取（应该失败）
+cat /mnt/jfs/secrets/api_key.txt
+# 输出：cat: ...: Permission denied
+
+# 测试禁止模式下阻止查找（应该失败）
+ls /mnt/jfs/secrets/
+# 输出：ls: cannot access ...: Permission denied
+```
+
+## 注意事项
+
+1. 路径保护规则按顺序评估。第一个匹配的规则决定保护模式。
+2. 模式必须匹配包含挂载点前缀的完整路径。建议使用 `^` 锚定模式。
+3. 无效的正则表达式模式将导致挂载失败并显示错误消息。

--- a/pkg/vfs/path_protection.go
+++ b/pkg/vfs/path_protection.go
@@ -1,0 +1,203 @@
+/*
+ * JuiceFS, Copyright 2020 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vfs
+
+import (
+	"encoding/json"
+	"regexp"
+	"sync"
+	"syscall"
+)
+
+// ProtectionMode defines the type of protection for a path
+type ProtectionMode string
+
+const (
+	// ProtectionModeReadonly allows read operations but denies write operations
+	 ProtectionModeReadonly ProtectionMode = "readonly"
+	 // ProtectionModeDeny denies all operations (read and write)
+    ProtectionModeDeny ProtectionMode = "deny"
+)
+
+// PathProtectionRule defines a single protection rule
+type PathProtectionRule struct {
+    Pattern string         `json:"pattern"` // Regex pattern to match paths
+    Mode    ProtectionMode `json:"mode"`    // Protection mode: "readonly" or "deny"
+}
+
+// PathProtectionConfig holds all path protection configuration
+type PathProtectionConfig struct {
+    Enabled bool                  `json:"enabled"`
+    Rules   []PathProtectionRule  `json:"rules"`
+}
+
+// PathProtector handles path protection logic
+type PathProtector struct {
+    config     *PathProtectionConfig
+    rules     []*compiledRule
+    mountpoint string
+    mu         sync.RWMutex
+}
+
+type compiledRule struct {
+    pattern *regexp.Regexp
+    mode    ProtectionMode
+}
+
+// NewPathProtector creates a new PathProtector instance
+func NewPathProtector(config *PathProtectionConfig, mountpoint string) (*PathProtector, error) {
+    if config == nil {
+        config = &PathProtectionConfig{Enabled: false}
+    }
+
+    pp := &PathProtector{
+        config:     config,
+        mountpoint: mountpoint,
+        rules:      make([]*compiledRule, 0, len(config.Rules)),
+    }
+
+    // Compile all regex patterns
+    for _, rule := range config.Rules {
+        regex, err := regexp.Compile(rule.Pattern)
+        if err != nil {
+            return nil, err
+        }
+        pp.rules = append(pp.rules, &compiledRule{
+            pattern: regex,
+            mode:    rule.Mode,
+        })
+    }
+
+    return pp, nil
+}
+
+// ParsePathProtectionConfig parses path protection configuration from JSON string
+func ParsePathProtectionConfig(jsonStr string) (*PathProtectionConfig, error) {
+    if jsonStr == "" {
+        return &PathProtectionConfig{Enabled: false}, nil
+    }
+
+    var config PathProtectionConfig
+    if err := json.Unmarshal([]byte(jsonStr), &config); err != nil {
+        return nil, err
+    }
+
+    config.Enabled = len(config.Rules) > 0
+    return &config, nil
+}
+
+// CheckWrite checks if write operation is allowed for the given path
+// Returns syscall.Errno(0) if allowed, or appropriate error if blocked
+func (pp *PathProtector) CheckWrite(path string) syscall.Errno {
+    if pp == nil || !pp.config.Enabled {
+        return 0
+    }
+
+    pp.mu.RLock()
+    defer pp.mu.RUnlock()
+
+    for _, rule := range pp.rules {
+        if rule.pattern.MatchString(path) {
+            switch rule.mode {
+            case ProtectionModeReadonly, ProtectionModeDeny:
+                return syscall.EPERM // Operation not permitted
+            }
+        }
+    }
+    return 0
+}
+
+// CheckRead checks if read operation is allowed for the given path
+// Returns syscall.Errno(0) if allowed, or appropriate error if blocked
+func (pp *PathProtector) CheckRead(path string) syscall.Errno {
+    if pp == nil || !pp.config.Enabled {
+        return 0
+    }
+
+    pp.mu.RLock()
+    defer pp.mu.RUnlock()
+
+    for _, rule := range pp.rules {
+        if rule.pattern.MatchString(path) {
+            switch rule.mode {
+            case ProtectionModeDeny:
+                return syscall.EACCES // Permission denied
+            }
+        }
+    }
+    return 0
+}
+
+// IsProtected checks if the path matches any protection rule
+func (pp *PathProtector) IsProtected(path string) bool {
+    if pp == nil || !pp.config.Enabled {
+        return false
+    }
+
+    pp.mu.RLock()
+    defer pp.mu.RUnlock()
+
+    for _, rule := range pp.rules {
+        if rule.pattern.MatchString(path) {
+            return true
+        }
+    }
+    return false
+}
+
+// GetProtectionMode returns the protection mode for a path
+// Returns empty string if not protected
+func (pp *PathProtector) GetProtectionMode(path string) ProtectionMode {
+    if pp == nil || !pp.config.Enabled {
+        return ""
+    }
+
+    pp.mu.RLock()
+    defer pp.mu.RUnlock()
+
+    for _, rule := range pp.rules {
+        if rule.pattern.MatchString(path) {
+            return rule.mode
+        }
+    }
+    return ""
+}
+
+// GetStats returns statistics about the path protector
+func (pp *PathProtector) GetStats() map[string]interface{} {
+    if pp == nil {
+        return map[string]interface{}{"enabled": false}
+    }
+
+    pp.mu.RLock()
+    defer pp.mu.RUnlock()
+
+    rules := make([]map[string]string, 0, len(pp.rules))
+    for _, r := range pp.rules {
+        rules = append(rules, map[string]string{
+            "pattern": r.pattern.String(),
+            "mode":    string(r.mode),
+        })
+    }
+
+    return map[string]interface{}{
+        "enabled":    pp.config.Enabled,
+        "rules":      rules,
+        "mountpoint": pp.mountpoint,
+    }
+}
+

--- a/pkg/vfs/path_protection_test.go
+++ b/pkg/vfs/path_protection_test.go
@@ -1,0 +1,366 @@
+package vfs
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+)
+
+func TestPathProtectionBasic(t *testing.T) {
+	// Test parsing path protection config from JSON
+	// Pattern matches full path with ^ anchor
+	jsonStr := `{"rules":[{"pattern":"^/mnt/test/data/.*\\.git.*", "mode": "readonly"}]}`
+	config, err := ParsePathProtectionConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("Error parsing path protection config: %v", err)
+	}
+
+	if len(config.Rules) == 0 {
+		t.Fatalf("No rules provided")
+	}
+
+	if !config.Enabled {
+		t.Fatal("Config should be enabled when rules are present")
+	}
+
+	// Initialize path protector
+	pp, err := NewPathProtector(config, "/mnt/test")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+
+	// Test write protection on matched path
+	errno := pp.CheckWrite("/mnt/test/data/project/.git/config")
+	if errno != 1 { // syscall.EPERM = 1
+		t.Errorf("Expected write to be blocked for .git path, got errno=%d", errno)
+	}
+
+	// Test write allowed on non-protected path
+	errno = pp.CheckWrite("/mnt/test/data/project/src/main.go")
+	if errno != 0 {
+		t.Errorf("Expected write to be allowed for non-protected path, got errno=%d", errno)
+	}
+
+	// Test read allowed on readonly path (should succeed)
+	errno = pp.CheckRead("/mnt/test/data/project/.git/config")
+	if errno != 0 {
+		t.Errorf("Expected read to be allowed for readonly path, got errno=%d", errno)
+	}
+}
+
+func TestPathProtectionDenyMode(t *testing.T) {
+	jsonStr := `{"rules":[{"pattern":"^/mnt/test/data/config/.*", "mode": "deny"}]}`
+	config, err := ParsePathProtectionConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("Error parsing path protection config: %v", err)
+	}
+
+	pp, err := NewPathProtector(config, "/mnt/test")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+
+	// Test write blocked
+	errno := pp.CheckWrite("/mnt/test/data/config/settings.json")
+	if errno == 0 {
+		t.Error("Expected write to be blocked in deny mode")
+	}
+
+	// Test read blocked
+	errno = pp.CheckRead("/mnt/test/data/config/settings.json")
+	if errno == 0 {
+		t.Error("Expected read to be blocked in deny mode")
+	}
+}
+
+func TestPathProtectionEmpty(t *testing.T) {
+	// Test empty config
+	config, err := ParsePathProtectionConfig("")
+	if err != nil {
+		t.Fatalf("Error parsing empty config: %v", err)
+	}
+
+	if config.Enabled {
+		t.Error("Empty config should not be enabled")
+	}
+
+	pp, err := NewPathProtector(config, "/mnt/test")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+
+	// All operations should be allowed with empty config
+	if errno := pp.CheckWrite("/mnt/test/any/path"); errno != 0 {
+		t.Errorf("Expected write to be allowed with empty config, got errno=%d", errno)
+	}
+	if errno := pp.CheckRead("/mnt/test/any/path"); errno != 0 {
+		t.Errorf("Expected read to be allowed with empty config, got errno=%d", errno)
+	}
+}
+
+func TestPathProtectionNil(t *testing.T) {
+	// Test nil protector
+	var pp *PathProtector
+
+	if errno := pp.CheckWrite("/any/path"); errno != 0 {
+		t.Errorf("Nil protector should allow all writes, got errno=%d", errno)
+	}
+	if errno := pp.CheckRead("/any/path"); errno != 0 {
+		t.Errorf("Nil protector should allow all reads, got errno=%d", errno)
+	}
+	if pp.IsProtected("/any/path") {
+		t.Error("Nil protector should not report any path as protected")
+	}
+}
+
+func TestPathProtectionMultipleRules(t *testing.T) {
+	jsonStr := `{"rules":[
+		{"pattern":"^/mnt/data/.*\\.git.*", "mode": "readonly"},
+		{"pattern":"^/mnt/data/secrets/.*", "mode": "deny"},
+		{"pattern":"^/mnt/tmp/.*", "mode": "readonly"}
+	]}`
+	config, err := ParsePathProtectionConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("Error parsing config: %v", err)
+	}
+
+	pp, err := NewPathProtector(config, "/mnt")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+
+	// Test .git path (readonly)
+	if !pp.IsProtected("/mnt/data/project/.git") {
+		t.Error(".git path should be protected")
+	}
+	if errno := pp.CheckRead("/mnt/data/project/.git/config"); errno != 0 {
+		t.Error("readonly path should allow reads")
+	}
+
+	// Test secrets path (deny)
+	if errno := pp.CheckRead("/mnt/data/secrets/api_key.txt"); errno == 0 {
+		t.Error("deny path should block reads")
+	}
+
+	// Test tmp path (readonly)
+	if errno := pp.CheckWrite("/mnt/tmp/test.txt"); errno == 0 {
+		t.Error("readonly path should block writes")
+	}
+}
+
+func TestGetProtectionMode(t *testing.T) {
+	jsonStr := `{"rules":[{"pattern":"^/mnt/data/.*\\.git.*", "mode": "readonly"}]}`
+	config, _ := ParsePathProtectionConfig(jsonStr)
+
+	pp, _ := NewPathProtector(config, "/mnt")
+
+	mode := pp.GetProtectionMode("/mnt/data/project/.git")
+	if mode != ProtectionModeReadonly {
+		t.Errorf("Expected readonly mode, got %s", mode)
+	}
+
+	mode = pp.GetProtectionMode("/mnt/data/project/src")
+	if mode != "" {
+		t.Errorf("Expected empty mode for unprotected path, got %s", mode)
+	}
+}
+
+func TestGetStats(t *testing.T) {
+	jsonStr := `{"rules":[{"pattern":"^/mnt/test/data/.*\\.git.*", "mode": "readonly"}]}`
+	config, _ := ParsePathProtectionConfig(jsonStr)
+
+	pp, _ := NewPathProtector(config, "/mnt/test")
+	stats := pp.GetStats()
+
+	if !stats["enabled"].(bool) {
+		t.Error("Stats should show enabled=true")
+	}
+	if stats["mountpoint"].(string) != "/mnt/test" {
+		t.Errorf("Expected mountpoint /mnt/test, got %s", stats["mountpoint"])
+	}
+}
+
+// TestReadProtectionWithDenyMode tests that Read method properly blocks reads in deny mode
+func TestReadProtectionWithDenyMode(t *testing.T) {
+	// Create VFS without path protection initially
+	v, _ := createTestVFS(nil, "")
+	ctx := NewLogContext(meta.NewContext(10, 1, []uint32{2, 3}))
+
+	// First, create directory and file structure without protection
+	dataDir, errno := v.Mkdir(ctx, 1, "data", 0755, 0)
+	if errno != 0 {
+		t.Fatalf("Failed to create /data directory: %v", errno)
+	}
+
+	secretsDir, errno := v.Mkdir(ctx, dataDir.Inode, "secrets", 0755, 0)
+	if errno != 0 {
+		t.Fatalf("Failed to create /data/secrets directory: %v", errno)
+	}
+
+	// Create a file in the protected directory
+	fe, fh, errno := v.Create(ctx, secretsDir.Inode, "secret.txt", 0644, 0, syscall.O_RDWR)
+	if errno != 0 {
+		t.Fatalf("Failed to create file: %v", errno)
+	}
+
+	// Write some data to the file
+	data := []byte("secret data")
+	errno = v.Write(ctx, fe.Inode, data, 0, fh)
+	if errno != 0 {
+		t.Fatalf("Failed to write to file: %v", errno)
+	}
+
+	// Now enable path protection with deny mode
+	jsonStr := `{"rules":[{"pattern":"^/jfs/data/secrets/.*", "mode": "deny"}]}`
+	config, err := ParsePathProtectionConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("Error parsing config: %v", err)
+	}
+
+	pp, err := NewPathProtector(config, "/jfs")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+	v.PathProtector = pp
+
+	// Now try to read from the protected file - should be blocked
+	buf := make([]byte, 100)
+	_, errno = v.Read(ctx, fe.Inode, buf, 0, fh)
+	if errno != syscall.EACCES {
+		t.Errorf("Expected read to be blocked with EACCES, got errno=%d", errno)
+	}
+
+	// Create a file in unprotected path (before protection was enabled)
+	fe2, fh2, errno := v.Create(ctx, 1, "public.txt", 0644, 0, syscall.O_RDWR)
+	if errno != 0 {
+		t.Fatalf("Failed to create public file: %v", errno)
+	}
+
+	// Write some data
+	errno = v.Write(ctx, fe2.Inode, []byte("public data"), 0, fh2)
+	if errno != 0 {
+		t.Fatalf("Failed to write to public file: %v", errno)
+	}
+
+	// Read from unprotected file - should succeed
+	_, errno = v.Read(ctx, fe2.Inode, buf, 0, fh2)
+	if errno != 0 {
+		t.Errorf("Expected read to succeed for unprotected path, got errno=%d", errno)
+	}
+}
+
+// TestLookupProtectionWithDenyMode tests that Lookup method properly blocks lookups in deny mode
+func TestLookupProtectionWithDenyMode(t *testing.T) {
+	// Create VFS without path protection initially
+	v, _ := createTestVFS(nil, "")
+	ctx := NewLogContext(meta.NewContext(10, 1, []uint32{2, 3}))
+
+	// First, create directory and file structure without protection
+	dataDir, errno := v.Mkdir(ctx, 1, "data", 0755, 0)
+	if errno != 0 {
+		t.Fatalf("Failed to create /data directory: %v", errno)
+	}
+
+	secretsDir, errno := v.Mkdir(ctx, dataDir.Inode, "secrets", 0755, 0)
+	if errno != 0 {
+		t.Fatalf("Failed to create /data/secrets directory: %v", errno)
+	}
+
+	// Create a file in the protected directory
+	_, _, errno = v.Create(ctx, secretsDir.Inode, "secret.txt", 0644, 0, syscall.O_RDWR)
+	if errno != 0 {
+		t.Fatalf("Failed to create file: %v", errno)
+	}
+
+	// Now enable path protection with deny mode
+	jsonStr := `{"rules":[{"pattern":"^/jfs/data/secrets/.*", "mode": "deny"}]}`
+	config, err := ParsePathProtectionConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("Error parsing config: %v", err)
+	}
+
+	pp, err := NewPathProtector(config, "/jfs")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+	v.PathProtector = pp
+
+	// Try to lookup in the protected directory - should be blocked
+	_, errno = v.Lookup(ctx, secretsDir.Inode, "secret.txt")
+	if errno != syscall.EACCES {
+		t.Errorf("Expected lookup to be blocked with EACCES, got errno=%d", errno)
+	}
+
+	// Lookup in unprotected path should succeed
+	_, errno = v.Lookup(ctx, 1, "data")
+	if errno != 0 {
+		t.Errorf("Expected lookup to succeed for unprotected path, got errno=%d", errno)
+	}
+}
+
+// TestReadProtectionWithReadonlyMode tests that Read method allows reads in readonly mode
+func TestReadProtectionWithReadonlyMode(t *testing.T) {
+	// Create VFS without path protection initially
+	v, _ := createTestVFS(nil, "")
+	ctx := NewLogContext(meta.NewContext(10, 1, []uint32{2, 3}))
+
+	// First, create directory and file structure without protection
+	dataDir, errno := v.Mkdir(ctx, 1, "data", 0755, 0)
+	if errno != 0 {
+		t.Fatalf("Failed to create /data directory: %v", errno)
+	}
+
+	gitDir, errno := v.Mkdir(ctx, dataDir.Inode, ".git", 0755, 0)
+	if errno != 0 {
+		t.Fatalf("Failed to create /data/.git directory: %v", errno)
+	}
+
+	// Create a file in the protected directory
+	fe, fh, errno := v.Create(ctx, gitDir.Inode, "config", 0644, 0, syscall.O_RDWR)
+	if errno != 0 {
+		t.Fatalf("Failed to create file: %v", errno)
+	}
+
+	// Write some data to the file
+	data := []byte("[core]\nrepositoryformatversion = 0")
+	errno = v.Write(ctx, fe.Inode, data, 0, fh)
+	if errno != 0 {
+		t.Fatalf("Failed to write to file: %v", errno)
+	}
+
+	// Now enable path protection with readonly mode
+	jsonStr := `{"rules":[{"pattern":"^/jfs/data/.*\\.git.*", "mode": "readonly"}]}`
+	config, err := ParsePathProtectionConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("Error parsing config: %v", err)
+	}
+
+	pp, err := NewPathProtector(config, "/jfs")
+	if err != nil {
+		t.Fatalf("Error creating path protector: %v", err)
+	}
+	v.PathProtector = pp
+
+	// Read from readonly path - should succeed
+	buf := make([]byte, 100)
+	_, errno = v.Read(ctx, fe.Inode, buf, 0, fh)
+	if errno != 0 {
+		t.Errorf("Expected read to succeed for readonly path, got errno=%d", errno)
+	}
+}
+
+// TestParseInvalidConfig tests that invalid regex pattern returns error in NewPathProtector
+func TestParseInvalidConfig(t *testing.T) {
+	invalidJSON := `{"rules":[{"pattern":"[invalid(regex", "mode": "readonly"}]}`
+	config, err := ParsePathProtectionConfig(invalidJSON)
+	if err != nil {
+		t.Fatalf("ParsePathProtectionConfig should not validate regex, got error: %v", err)
+	}
+
+	// NewPathProtector should fail when compiling invalid regex
+	_, err = NewPathProtector(config, "/mnt")
+	if err == nil {
+		t.Error("Expected error for invalid regex pattern in NewPathProtector")
+	}
+}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -153,6 +153,9 @@ type Config struct {
 
 	// the mount point for current volume (to follow symlink)
 	Mountpoint string
+
+	// PathProtection enables path-based access control
+	PathProtection *PathProtectionConfig `json:",omitempty"`
 }
 
 type AnonymousAccount struct {
@@ -192,12 +195,22 @@ func (v *VFS) Lookup(ctx Context, parent Ino, name string) (entry *meta.Entry, e
 	defer func() {
 		logit(ctx, "lookup", err, "(%d,%s):%s", parent, name, (*Entry)(entry))
 	}()
+
+	// Check read protection for parent directory
+	if err = v.CheckPathReadProtection(ctx, parent); err != 0 {
+		return
+	}
+
 	if len(name) > maxName {
 		err = syscall.ENAMETOOLONG
 		return
 	}
 	err = v.Meta.Lookup(ctx, parent, name, &inode, attr, true)
 	if err == 0 {
+		// Check read protection for the lookup result
+		if err = v.CheckPathReadProtection(ctx, inode); err != 0 {
+			return
+		}
 		entry = &meta.Entry{Inode: inode, Attr: attr}
 	}
 	return
@@ -250,6 +263,10 @@ func (v *VFS) Mknod(ctx Context, parent Ino, name string, mode uint16, cumask ui
 		err = syscall.ENAMETOOLONG
 		return
 	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
+		return
+	}
 	_type := get_filetype(mode)
 	if _type == 0 {
 		err = syscall.EPERM
@@ -280,6 +297,10 @@ func (v *VFS) doUnlink(ctx Context, parent Ino, name string, skipTrash bool) (er
 		err = syscall.ENAMETOOLONG
 		return
 	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
+		return
+	}
 	err = v.Meta.Unlink(ctx, parent, name, skipTrash)
 	if err == 0 {
 		v.invalidateDirHandle(parent, name, 0, nil)
@@ -299,6 +320,10 @@ func (v *VFS) Mkdir(ctx Context, parent Ino, name string, mode uint16, cumask ui
 		err = syscall.ENAMETOOLONG
 		return
 	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
+		return
+	}
 
 	var inode Ino
 	var attr = &Attr{}
@@ -314,6 +339,10 @@ func (v *VFS) Rmdir(ctx Context, parent Ino, name string) (err syscall.Errno) {
 	defer func() { logit(ctx, "rmdir", err, "(%d,%s)", parent, name) }()
 	if len(name) > maxName {
 		err = syscall.ENAMETOOLONG
+		return
+	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
 		return
 	}
 	err = v.Meta.Rmdir(ctx, parent, name)
@@ -333,6 +362,10 @@ func (v *VFS) Symlink(ctx Context, path string, parent Ino, name string) (entry 
 	}
 	if len(name) > maxName || len(path) >= maxSymlink {
 		err = syscall.ENAMETOOLONG
+		return
+	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
 		return
 	}
 
@@ -368,6 +401,14 @@ func (v *VFS) Rename(ctx Context, parent Ino, name string, newparent Ino, newnam
 		err = syscall.ENAMETOOLONG
 		return
 	}
+	// Path protection check for source
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
+		return
+	}
+	// Path protection check for destination
+	if err = v.CheckPathWriteProtection(ctx, newparent, newname); err != 0 {
+		return
+	}
 
 	var inode Ino
 	var attr = &Attr{}
@@ -394,6 +435,10 @@ func (v *VFS) Link(ctx Context, ino Ino, newparent Ino, newname string) (entry *
 	}
 	if len(newname) > maxName {
 		err = syscall.ENAMETOOLONG
+		return
+	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, newparent, newname); err != 0 {
 		return
 	}
 
@@ -520,6 +565,10 @@ func (v *VFS) Create(ctx Context, parent Ino, name string, mode uint16, cumask u
 		err = syscall.ENAMETOOLONG
 		return
 	}
+	// Path protection check
+	if err = v.CheckPathWriteProtection(ctx, parent, name); err != 0 {
+		return
+	}
 
 	var inode Ino
 	var attr = &Attr{}
@@ -584,6 +633,17 @@ func (v *VFS) Open(ctx Context, ino Ino, flags uint32) (entry *meta.Entry, fh ui
 		return
 	}
 
+	// Path protection check for open with write flags
+	if (flags&O_ACCMODE) != syscall.O_RDONLY {
+		if err = v.CheckPathWriteProtectionByIno(ctx, ino); err != 0 {
+			return
+		}
+	} else {
+		if err = v.CheckPathReadProtection(ctx, ino); err != 0 {
+			return
+		}
+	}
+
 	err = v.Meta.Open(ctx, ino, flags, attr)
 	if err == 0 {
 		v.UpdateLength(ino, attr)
@@ -597,6 +657,10 @@ func (v *VFS) Truncate(ctx Context, ino Ino, size int64, fh uint64, attr *Attr) 
 	// defer func() { logit(ctx, "truncate (%d,%d): %s", ino, size, strerr(err)) }()
 	if IsSpecialNode(ino) {
 		err = syscall.EPERM
+		return
+	}
+	// Path protection check
+	if err = v.CheckPathWriteProtectionByIno(ctx, ino); err != 0 {
 		return
 	}
 	if size < 0 {
@@ -741,6 +805,11 @@ func (v *VFS) Read(ctx Context, ino Ino, buf []byte, off uint64, fh uint64) (n i
 		return
 	}
 
+	// Check read protection for non-special nodes
+	if err = v.CheckPathReadProtection(ctx, ino); err != 0 {
+		return
+	}
+
 	defer func() {
 		readSizeHistogram.Observe(float64(n))
 		logit(ctx, "read", err, "(%d,%d,%d,%d): (%d)", ino, size, off, fh, n)
@@ -834,6 +903,11 @@ func (v *VFS) Write(ctx Context, ino Ino, buf []byte, off, fh uint64) (err sysca
 			logger.Warnf("broken message: %d %d < %d", cmd, size, rb.Left())
 			h.data = append(h.data, uint8(syscall.EIO&0xff))
 		}
+		return
+	}
+
+	// Path protection check for non-control writes
+	if err = v.CheckPathWriteProtectionByIno(ctx, ino); err != 0 {
 		return
 	}
 
@@ -1230,6 +1304,7 @@ type VFS struct {
 	reader          DataReader
 	writer          DataWriter
 	cacheFiller     *CacheFiller
+	PathProtector   *PathProtector // Path protection handler
 
 	handles   map[Ino][]*handle
 	handleIno map[uint64]Ino
@@ -1246,18 +1321,31 @@ func NewVFS(conf *Config, m meta.Meta, store chunk.ChunkStore, registerer promet
 	reader := NewDataReader(conf, m, store)
 	writer := NewDataWriter(conf, m, store, reader)
 
+	// Initialize path protector if configured
+	var pathProtector *PathProtector
+	if conf.PathProtection != nil && conf.PathProtection.Enabled {
+		var err error
+		pathProtector, err = NewPathProtector(conf.PathProtection, conf.Meta.MountPoint)
+		if err != nil {
+			logger.Fatalf("Failed to initialize path protector: %s", err)
+		} else {
+			logger.Infof("Path protection enabled with %d rules", len(conf.PathProtection.Rules))
+		}
+	}
+
 	v := &VFS{
-		Conf:        conf,
-		Meta:        m,
-		Store:       store,
-		reader:      reader,
-		writer:      writer,
-		cacheFiller: NewCacheFiller(conf, m, store),
-		handles:     make(map[Ino][]*handle),
-		handleIno:   make(map[uint64]Ino),
-		modifiedAt:  make(map[meta.Ino]time.Time),
-		nextfh:      1,
-		registry:    registry,
+		Conf:          conf,
+		Meta:          m,
+		Store:         store,
+		reader:        reader,
+		writer:        writer,
+		cacheFiller:   NewCacheFiller(conf, m, store),
+		PathProtector: pathProtector,
+		handles:       make(map[Ino][]*handle),
+		handleIno:     make(map[uint64]Ino),
+		modifiedAt:    make(map[meta.Ino]time.Time),
+		nextfh:        1,
+		registry:      registry,
 	}
 
 	n := getInternalNode(ConfigInode)
@@ -1490,4 +1578,52 @@ func decodeACL(buff []byte) (*acl.Rule, syscall.Errno) {
 var aclTypes = map[string]uint8{
 	_SECURITY_ACL:         acl.TypeAccess,
 	_SECURITY_ACL_DEFAULT: acl.TypeDefault,
+}
+
+// CheckPathWriteProtection checks if write is allowed for the given path
+func (v *VFS) CheckPathWriteProtection(ctx Context, parent Ino, name string) syscall.Errno {
+	if v.PathProtector == nil {
+		return 0
+	}
+	// Get parent path and build full path
+	paths := v.Meta.GetPaths(ctx, parent)
+	var parentPath string
+	if len(paths) > 0 {
+		parentPath = paths[0]
+	} else {
+		parentPath = "/"
+	}
+	var fullPath string
+	if parentPath == "/" {
+		fullPath = v.Conf.Meta.MountPoint + "/" + name
+	} else {
+		fullPath = v.Conf.Meta.MountPoint + parentPath + "/" + name
+	}
+	return v.PathProtector.CheckWrite(fullPath)
+}
+
+// CheckPathReadProtection checks if read is allowed for the given path
+func (v *VFS) CheckPathReadProtection(ctx Context, ino Ino) syscall.Errno {
+	if v.PathProtector == nil {
+		return 0
+	}
+	paths := v.Meta.GetPaths(ctx, ino)
+	if len(paths) == 0 {
+		return 0
+	}
+	fullPath := v.Conf.Meta.MountPoint + paths[0]
+	return v.PathProtector.CheckRead(fullPath)
+}
+
+// CheckPathWriteProtectionByIno checks if write is allowed for the given inode
+func (v *VFS) CheckPathWriteProtectionByIno(ctx Context, ino Ino) syscall.Errno {
+	if v.PathProtector == nil {
+		return 0
+	}
+	paths := v.Meta.GetPaths(ctx, ino)
+	if len(paths) == 0 {
+		return 0
+	}
+	fullPath := v.Conf.Meta.MountPoint + paths[0]
+	return v.PathProtector.CheckWrite(fullPath)
 }


### PR DESCRIPTION
Add path-based access control to the VFS layer, allowing users to protect specific paths via regex patterns with --path-protection flag. Supports "readonly" (block writes, allow reads) and "deny" (block all) modes. Protection checks are enforced on Lookup, Open, Read, Write, Truncate, Create, Mknod, Unlink, Mkdir, Rmdir, Symlink, Rename, and Link operations. Invalid config causes mount to fail immediately rather than silently degrading. Regex patterns recommend ^ anchoring to avoid unintended substring matches.