### PR TITLE
cmd/config: fix bug where --bucket is treated as local path when --storage is not explicitly set

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -173,9 +173,11 @@ func config(ctx *cli.Context) error {
 		case "bucket":
 			// bucket will be accessed before storage, so it is necessary to determine if storage is a file
 			if new := ctx.String(flag); new != format.Bucket {
-				oldStorage := format.Storage
-				newStorage := ctx.String("storage")
-				if newStorage == "file" || (oldStorage == "file" && newStorage == "") {
+				effectiveStorage := format.Storage
+				if ctx.IsSet("storage") {
+					effectiveStorage = ctx.String("storage")
+				}
+				if effectiveStorage == "file" {
 					if p, err := filepath.Abs(new); err == nil {
 						new = p + "/"
 					} else {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -94,4 +94,17 @@ func TestConfig(t *testing.T) {
 	if format.Bucket != "http://localhost:9000/miniofs" || format.Storage != "minio" {
 		t.Fatalf("unexpect format: %+v", format)
 	}
+
+	if err = Main([]string{"", "config", testMeta, "--bucket", "http://localhost:9000/miniofs2", "--force"}); err != nil {
+		t.Fatalf("config: %s", err)
+	}
+	if data, err = getStdout([]string{"", "config", testMeta}); err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.Bucket != "http://localhost:9000/miniofs2" || format.Storage != "minio" {
+		t.Fatalf("unexpect format: %+v", format)
+	}
 }


### PR DESCRIPTION
When user wants to change an S3 endpoint, running `juicefs config $metaurl --bucket=http://xxx` may incorrectly rewrite `format.Bucket` into a local file path, causing an invalid bucket value to be set.

The root cause is that `storage` flag defaults to `file`, and current code reads storage by `ctx.String("storage")`, which returns this default value when `--storage` is not specified. As a result, `bucket` is changed silently.