### PR TITLE
logger: explose log level setting

### DIFF
--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -42,6 +42,14 @@ type logHandle struct {
 	colorful bool
 }
 
+func (l *logHandle) IsTrace() bool {
+	return l.IsLevelEnabled(logrus.TraceLevel)
+}
+
+func (l *logHandle) IsDebug() bool {
+	return l.IsLevelEnabled(logrus.DebugLevel)
+}
+
 func (l *logHandle) Format(e *logrus.Entry) ([]byte, error) {
 	lvl := e.Level
 	if l.lvl != nil {


### PR DESCRIPTION
Optimize Tracef/Debugf call in Lock or with function as argument

case 1
```
sync.Lock()
if logger.IsDebug() {
   logger.Debugf(xxxxxx)
}
sync.Unlock
```

case 2
```
if logger.IsDebug() {
   logger.Debugf(xxx, func1(arg), func2(arg), xxx)
}
```