### PR TITLE
meta/quota: fix create missing user/group quota records in doFlushQuotas

### DIFF
--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -327,10 +327,12 @@ func (m *baseMeta) syncQuotaMaps(existing map[uint64]*Quota, loaded map[uint64]*
 		}
 	}
 	// delete that are not in loaded
-	for key := range existing {
-		if _, ok := loaded[key]; !ok {
-			logger.Infof("Quota for %s %d is deleted", quotaType, key)
-			delete(existing, key)
+	if quotaType == "inode" {
+		for key := range existing {
+			if _, ok := loaded[key]; !ok {
+				logger.Infof("Quota for %s %d is deleted", quotaType, key)
+				delete(existing, key)
+			}
 		}
 	}
 }
@@ -834,7 +836,6 @@ func (m *baseMeta) scanGlobalUserGroupUsage(ctx Context) (map[uint64]*Summary, m
 
 		}
 	}
-
 	return userUsage, groupUsage, nil
 }
 

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -4268,9 +4268,10 @@ func (m *redisMeta) doFlushQuotas(ctx Context, quotas []*iQuota) error {
 				return err
 			}
 
-			field := strconv.FormatUint(q.qkey, 10)
-			pipe.HIncrBy(ctx, config.usedSpaceKey, field, q.quota.newSpace)
-			pipe.HIncrBy(ctx, config.usedInodesKey, field, q.quota.newInodes)
+			key := strconv.FormatUint(q.qkey, 10)
+			pipe.HSetNX(ctx, config.quotaKey, key, m.packQuota(-1, -1))
+			pipe.HIncrBy(ctx, config.usedSpaceKey, key, q.quota.newSpace)
+			pipe.HIncrBy(ctx, config.usedInodesKey, key, q.quota.newInodes)
 		}
 		return nil
 	})

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -4145,9 +4145,6 @@ func (m *dbMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota
 
 	// Load user and group quotas
 	for _, q := range userGroupQuotasList {
-		if q.MaxSpace < 0 && q.MaxInodes < 0 {
-			continue
-		}
 		quota := &Quota{
 			MaxSpace:   q.MaxSpace,
 			MaxInodes:  q.MaxInodes,
@@ -4171,17 +4168,33 @@ func (m *dbMeta) doFlushQuotas(ctx Context, quotas []*iQuota) error {
 	return m.txn(func(s *xorm.Session) error {
 		for _, q := range quotas {
 			if q.qtype == DirQuotaType {
-				logger.Infof("doFlushquot ino:%d, %+v", q.qkey, q.quota)
 				_, err := s.Exec(m.sqlConv("update dir_quota set used_space=used_space+?, used_inodes=used_inodes+? where inode=?"),
 					q.quota.newSpace, q.quota.newInodes, q.qkey)
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err := s.Exec(m.sqlConv("update user_group_quota set used_space=used_space+?, used_inodes=used_inodes+? where qtype=? and qkey=?"),
+				ret, err := s.Exec(m.sqlConv("update user_group_quota set used_space=used_space+?, used_inodes=used_inodes+? where qtype=? and qkey=?"),
 					q.quota.newSpace, q.quota.newInodes, q.qtype, q.qkey)
 				if err != nil {
 					return err
+				}
+				affected, err := ret.RowsAffected()
+				if err != nil {
+					return err
+				}
+				if affected == 0 {
+					quota := &userGroupQuota{
+						Qtype:      q.qtype,
+						Qkey:       q.qkey,
+						MaxSpace:   -1,
+						MaxInodes:  -1,
+						UsedSpace:  q.quota.newSpace,
+						UsedInodes: q.quota.newInodes,
+					}
+					if err := mustInsert(s, quota); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -3207,11 +3207,7 @@ func (m *kvMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota
 				} else {
 					id = binary.BigEndian.Uint64([]byte(k[2:])) // skip prefix
 				}
-				quota := m.parseQuota(v)
-				if quota.MaxSpace < 0 && quota.MaxInodes < 0 {
-					continue
-				}
-				quotas[id] = quota
+				quotas[id] =  m.parseQuota(v)
 			}
 		}
 		quotaMaps[i] = quotas
@@ -3276,17 +3272,26 @@ func (m *kvMeta) doSyncVolumeStat(ctx Context) error {
 func (m *kvMeta) doFlushQuotas(ctx Context, quotas []*iQuota) error {
 	return m.txn(ctx, func(tx *kvTxn) error {
 		keys := make([][]byte, 0, len(quotas))
-		qs := make([]*Quota, 0, len(quotas))
+		qs := make([]*iQuota, 0, len(quotas))
 		for _, q := range quotas {
 			key, err := m.getQuotaKey(q.qtype, q.qkey)
 			if err != nil {
 				return err
 			}
 			keys = append(keys, key)
-			qs = append(qs, q.quota)
+			qs = append(qs, q)
 		}
 		for i, v := range tx.gets(keys...) {
 			if len(v) == 0 {
+				if qs[i].qtype == UserQuotaType || qs[i].qtype == GroupQuotaType {
+					quota := &Quota{
+						MaxSpace:   -1,
+						MaxInodes:  -1,
+						UsedSpace:  qs[i].quota.newSpace,
+						UsedInodes: qs[i].quota.newInodes,
+					}
+					tx.set(keys[i], m.packQuota(quota))
+				}
 				continue
 			}
 			if len(v) != 32 {
@@ -3294,8 +3299,8 @@ func (m *kvMeta) doFlushQuotas(ctx Context, quotas []*iQuota) error {
 				continue
 			}
 			q := m.parseQuota(v)
-			q.UsedSpace += qs[i].newSpace
-			q.UsedInodes += qs[i].newInodes
+			q.UsedSpace += qs[i].quota.newSpace
+			q.UsedInodes += qs[i].quota.newInodes
 			tx.set(keys[i], m.packQuota(q))
 		}
 		return nil


### PR DESCRIPTION
Previously, the doFlushQuotas function only updated the existing user/group quotas. This could lead to inaccurate usage statistics. Now, it is necessary to support the creation of new quotas during the flush process.

rel ci test: https://github.com/juicedata/juicefs/pull/6724