### PR TITLE
chore: optimizations and performance improvements

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -168,7 +168,7 @@ func destroy(ctx *cli.Context) error {
 	var dirs []string
 	var mu sync.Mutex
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -192,7 +192,7 @@ func destroy(ctx *cli.Context) error {
 		}()
 	}
 	wg.Wait()
-	sort.Strings(dirs)
+	slices.Sort(dirs)
 	for i := len(dirs) - 1; i >= 0; i-- {
 		if err := blob.Delete(ctx.Context, dirs[i]); err == nil {
 			spin.Increment()

--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -225,7 +225,7 @@ func fsck(ctx *cli.Context) error {
 		for i, p := range brokens {
 			fileList = append(fileList, fmt.Sprintf("%13d: %s", i, p))
 		}
-		sort.Strings(fileList)
+		slices.Sort(fileList)
 		msg += strings.Join(fileList, "\n")
 		logger.Fatal(msg)
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -267,7 +267,7 @@ func gc(ctx *cli.Context) error {
 	skipped := progress.AddDoubleSpinnerTwo("Skipped objects", "Skipped data")
 
 	var leakedObj = make(chan string, 10240)
-	for i := 0; i < threads; i++ {
+	for range threads {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -23,7 +23,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 
 	"github.com/DataDog/zstd"
@@ -295,9 +296,7 @@ func showBakSummary(ctx *cli.Context, fp *os.File, withOffset bool) error {
 			data = append(data, []string{name, fmt.Sprintf("%d", info.Num)})
 		}
 	}
-	sort.Slice(data, func(i, j int) bool {
-		return data[i][0] < data[j][0]
-	})
+	slices.SortFunc(data, func(a, b []string) int { return cmp.Compare(a[0], b[0]) })
 
 	if withOffset {
 		fmt.Println(strings.Repeat("-", 34))

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -37,7 +37,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -708,7 +708,7 @@ func tellFstabOptions(c *cli.Context) string {
 			opts = append(opts, fmt.Sprintf("%s=%s", s, c.Generic(s)))
 		}
 	}
-	sort.Strings(opts)
+	slices.Sort(opts)
 	return strings.Join(opts, ",")
 }
 

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -27,7 +27,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -956,7 +956,7 @@ func functionalTesting(ctx context.Context, blob object.ObjectStorage, result *[
 				return fmt.Errorf("put object failed: %s", err.Error())
 			}
 		}
-		sort.Strings(sortedKeys)
+		slices.Sort(sortedKeys)
 		defer func() {
 			for i := 0; i < keyTotal; i++ {
 				_ = blob.Delete(ctx, fmt.Sprintf("hashKey%d", i))

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -25,7 +25,8 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -324,7 +325,7 @@ func (j *juiceFS) readDirSorted(dirname string, followLink bool) ([]*mEntry, sys
 			mEntries[i] = &mEntry{fi, string(e.Name), fi.IsSymlink()}
 		}
 	}
-	sort.Slice(mEntries, func(i, j int) bool { return mEntries[i].name < mEntries[j].name })
+	slices.SortFunc(mEntries, func(a, b *mEntry) int { return cmp.Compare(a.name, b.name) })
 	return mEntries, err
 }
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"cmp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -353,9 +354,7 @@ func (p *profiler) flusher() {
 			for k, s := range stats {
 				keyStats = append(keyStats, keyStat{k, s})
 			}
-			sort.Slice(keyStats, func(i, j int) bool { // reversed
-				return keyStats[i].sPtr.total > keyStats[j].sPtr.total
-			})
+			slices.SortFunc(keyStats, func(a, b keyStat) int { return cmp.Compare(b.sPtr.total, a.sPtr.total) })
 			p.flush(ts, keyStats, done)
 			if done {
 				os.Exit(0)
@@ -430,9 +429,7 @@ func profile(ctx *cli.Context) error {
 		for k, s := range stats {
 			keyStats = append(keyStats, keyStat{k, s})
 		}
-		sort.Slice(keyStats, func(i, j int) bool { // reversed
-			return keyStats[i].sPtr.total > keyStats[j].sPtr.total
-		})
+		slices.SortFunc(keyStats, func(a, b keyStat) int { return cmp.Compare(b.sPtr.total, a.sPtr.total) })
 		prof.replay = false
 		prof.interval = last.Sub(start)
 		prof.flush(last, keyStats, <-prof.done)

--- a/cmd/quota.go
+++ b/cmd/quota.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/dustin/go-humanize"
@@ -221,7 +221,7 @@ func quota(c *cli.Context) error {
 	for p := range qs {
 		paths = append(paths, p)
 	}
-	sort.Strings(paths)
+	slices.Sort(paths)
 	for _, p := range paths {
 		q := qs[p]
 		if q.UsedSpace < 0 {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -108,7 +108,7 @@ func doRestore(m meta.Meta, hour string, putBack bool, threads int) {
 	var mu sync.Mutex
 	restoredTo := make(map[meta.Ino]int)
 	var wg sync.WaitGroup
-	for i := 0; i < threads; i++ {
+	for range threads {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cmd/warmup.go
+++ b/cmd/warmup.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -318,7 +318,7 @@ func warmup(ctx *cli.Context) error {
 				for loc := range total.Locations {
 					locs = append(locs, loc)
 				}
-				sort.Strings(locs)
+				slices.Sort(locs)
 				for _, loc := range locs {
 					size := total.Locations[loc]
 					result = append(result, []string{loc, humanize.IBytes(size), fmt.Sprintf("%.1f%%", float64(size)*100/float64(bytes))})

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -29,7 +29,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1111,7 +1111,7 @@ func newCacheManager(config *Config, reg prometheus.Registerer, uploader func(ke
 		logger.Warnf("No cache dir existed, use memory cache instead, cache size: 100 MiB")
 		return newMemStore(config, metrics)
 	}
-	sort.Strings(dirs)
+	slices.Sort(dirs)
 	dirCacheSize := int64(config.CacheSize) / int64(len(dirs))
 	dirCacheItems := config.CacheItems / int64(len(dirs))
 	m := &cacheManager{

--- a/pkg/chunk/disk_cache_state.go
+++ b/pkg/chunk/disk_cache_state.go
@@ -140,10 +140,12 @@ func (dc *normalDC) init(cs *cacheStore) {
 func (dc *normalDC) tick() {
 	go func() {
 		for {
+			t := time.NewTimer(tickDurForNormal)
 			select {
 			case <-dc.stopCh:
+				t.Stop()
 				return
-			case <-time.After(tickDurForNormal):
+			case <-t.C:
 				atomic.StoreUint32(&dc.ioErrCnt, 0)
 			}
 		}

--- a/pkg/chunk/prefetch.go
+++ b/pkg/chunk/prefetch.go
@@ -33,7 +33,7 @@ func newPrefetcher(parallel int, fetch func(string)) *prefetcher {
 		busy:    make(map[string]bool),
 		op:      fetch,
 	}
-	for i := 0; i < parallel; i++ {
+	for range parallel {
 		go p.do()
 	}
 	return p

--- a/pkg/chunk/singleflight.go
+++ b/pkg/chunk/singleflight.go
@@ -52,7 +52,7 @@ func (con *Controller) Execute(key string, fn func() (*Page, error)) (*Page, err
 	c.val, c.err = fn()
 
 	con.Lock()
-	for i := 0; i < c.dups; i++ {
+	for range c.dups {
 		// Acquire for the pending Execute
 		c.val.Acquire()
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path"
 	"runtime/trace"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1466,9 +1466,7 @@ func (f *File) Readdir(ctx meta.Context, count int) (fi []os.FileInfo, err sysca
 			return
 		}
 		if f.fs.conf.Meta.SortDir {
-			sort.Slice(inodes[2:], func(i, j int) bool {
-				return string(inodes[i].Name) < string(inodes[j].Name)
-			})
+			slices.SortFunc(inodes[2:], func(a, b *meta.Entry) int { return bytes.Compare(a.Name, b.Name) })
 		}
 		// skip . and ..
 		for _, n := range inodes[2:] {
@@ -1509,9 +1507,7 @@ func (f *File) ReaddirPlus(ctx meta.Context, offset int) (entries []*meta.Entry,
 			}
 		}
 		if f.fs.conf.Meta.SortDir {
-			sort.Slice(f.entries, func(i, j int) bool {
-				return string(f.entries[i].Name) < string(f.entries[j].Name)
-			})
+			slices.SortFunc(f.entries, func(a, b *meta.Entry) int { return bytes.Compare(a.Name, b.Name) })
 		}
 	}
 	if offset >= len(f.entries) {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -26,7 +26,8 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"sort"
+	"cmp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -297,9 +298,7 @@ func (n *jfsObjects) ListBuckets(ctx context.Context) (buckets []minio.BucketInf
 	}
 
 	// Sort bucket infos by bucket name.
-	sort.Slice(buckets, func(i, j int) bool {
-		return buckets[i].Name < buckets[j].Name
-	})
+	slices.SortFunc(buckets, func(a, b minio.BucketInfo) int { return cmp.Compare(a.Name, b.Name) })
 	return buckets, nil
 }
 
@@ -1021,12 +1020,14 @@ func (n *jfsObjects) ListMultipartUploads(ctx context.Context, bucket string, pr
 	lmi.Delimiter = delimiter
 	commPrefixSet := make(map[string]struct{})
 	for _, p := range parents {
-		f, eno := n.fs.Open(mctx, n.tpath(bucket, "uploads", string(p.Name)), 0)
-		if eno != 0 {
-			return
-		}
-		defer f.Close(mctx)
-		entries, eno := f.ReaddirPlus(mctx, 0)
+		entries, eno := func() ([]*meta.Entry, syscall.Errno) {
+			f, eno := n.fs.Open(mctx, n.tpath(bucket, "uploads", string(p.Name)), 0)
+			if eno != 0 {
+				return nil, eno
+			}
+			defer f.Close(mctx)
+			return f.ReaddirPlus(mctx, 0)
+		}()
 		if eno != 0 {
 			err = jfsToObjectErr(ctx, eno, bucket)
 			return
@@ -1056,12 +1057,11 @@ func (n *jfsObjects) ListMultipartUploads(ctx context.Context, bucket string, pr
 		}
 	}
 
-	sort.Slice(lmi.Uploads, func(i, j int) bool {
-		if lmi.Uploads[i].Object == lmi.Uploads[j].Object {
-			return lmi.Uploads[i].UploadID < lmi.Uploads[j].UploadID
-		} else {
-			return lmi.Uploads[i].Object < lmi.Uploads[j].Object
+	slices.SortFunc(lmi.Uploads, func(a, b minio.MultipartInfo) int {
+		if c := cmp.Compare(a.Object, b.Object); c != 0 {
+			return c
 		}
+		return cmp.Compare(a.UploadID, b.UploadID)
 	})
 
 	if delimiter != "" {
@@ -1088,7 +1088,7 @@ func (n *jfsObjects) ListMultipartUploads(ctx context.Context, bucket string, pr
 		for prefix := range commPrefixSet {
 			lmi.CommonPrefixes = append(lmi.CommonPrefixes, prefix)
 		}
-		sort.Strings(lmi.CommonPrefixes)
+		slices.Sort(lmi.CommonPrefixes)
 	} else if len(lmi.Uploads) > maxUploads {
 		lmi.IsTruncated = true
 		lmi.Uploads = lmi.Uploads[:maxUploads]
@@ -1141,9 +1141,7 @@ func (n *jfsObjects) ListObjectParts(ctx context.Context, bucket, object, upload
 			})
 		}
 	}
-	sort.Slice(result.Parts, func(i, j int) bool {
-		return result.Parts[i].PartNumber < result.Parts[j].PartNumber
-	})
+	slices.SortFunc(result.Parts, func(a, b minio.ObjectPart) int { return cmp.Compare(a.PartNumber, b.PartNumber) })
 	if len(result.Parts) > maxParts {
 		result.IsTruncated = true
 		result.Parts = result.Parts[:maxParts]

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -28,7 +28,8 @@ import (
 	"path"
 	"reflect"
 	"runtime"
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -562,9 +563,6 @@ func (m *baseMeta) InitSharedMetrics(reg prometheus.Registerer) {
 
 	go func() {
 		for {
-			if m.sessCtx != nil && m.sessCtx.Canceled() {
-				return
-			}
 			var totalSpace, availSpace, iused, iavail uint64
 			err := m.StatFS(Background(), m.root, &totalSpace, &availSpace, &iused, &iavail)
 			if err == 0 {
@@ -574,17 +572,26 @@ func (m *baseMeta) InitSharedMetrics(reg prometheus.Registerer) {
 				m.totalInodesG.Set(float64(iused + iavail))
 			}
 			m.updateQuotaMetrics()
-			utils.SleepWithJitter(time.Second * 10)
+			t := time.NewTimer(utils.JitterIt(time.Second * 10))
+			select {
+			case <-m.sessCtx.Done():
+				t.Stop()
+				return
+			case <-t.C:
+			}
 		}
 	}()
 
 	go func() {
 		for {
-			if m.sessCtx != nil && m.sessCtx.Canceled() {
-				return
-			}
 			m.cleanupQuotaMetrics()
-			utils.SleepWithJitter(time.Hour)
+			t := time.NewTimer(utils.JitterIt(time.Hour))
+			select {
+			case <-m.sessCtx.Done():
+				t.Stop()
+				return
+			case <-t.C:
+			}
 		}
 	}()
 }
@@ -642,7 +649,7 @@ func (r *baseMeta) txBatchLock(inodes ...Ino) func() {
 		for i, ino := range inodes {
 			inodeSlots[i] = int(ino % nlocks)
 		}
-		sort.Ints(inodeSlots)
+		slices.Sort(inodeSlots)
 		uniqInodeSlots := inodeSlots[:0]
 		for i := 0; i < len(inodeSlots); i++ { // Go does not support recursive locks
 			if i == 0 || inodeSlots[i] != inodeSlots[i-1] {
@@ -961,10 +968,12 @@ func (m *baseMeta) Init(format *Format, force bool) error {
 func (m *baseMeta) cleanupDeletedFiles(ctx Context) {
 	defer m.sessWG.Done()
 	for {
+		t := time.NewTimer(utils.JitterIt(time.Hour))
 		select {
 		case <-ctx.Done():
+			t.Stop()
 			return
-		case <-time.After(utils.JitterIt(time.Hour)):
+		case <-t.C:
 		}
 		if ok, err := m.en.setIfSmall("lastCleanupFiles", time.Now().Unix(), int64(time.Hour.Seconds())*9/10); err != nil {
 			logger.Warnf("checking counter lastCleanupFiles: %s", err)
@@ -997,10 +1006,12 @@ func (m *baseMeta) cleanupDeletedFiles(ctx Context) {
 func (m *baseMeta) cleanupSlices(ctx Context) {
 	defer m.sessWG.Done()
 	for {
+		t := time.NewTimer(utils.JitterIt(time.Hour))
 		select {
 		case <-ctx.Done():
+			t.Stop()
 			return
-		case <-time.After(utils.JitterIt(time.Hour)):
+		case <-t.C:
 		}
 		if ok, err := m.en.setIfSmall("nextCleanupSlices", time.Now().Unix(), int64(time.Hour.Seconds())*9/10); err != nil {
 			logger.Warnf("checking counter nextCleanupSlices: %s", err)
@@ -2401,7 +2412,7 @@ func (m *baseMeta) Check(ctx Context, fpath string, opt *CheckOpt) error {
 		lock.Unlock()
 	}
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -2594,7 +2605,7 @@ func (m *baseMeta) GetFormat() Format {
 func (m *baseMeta) CompactAll(ctx Context, threads int, bar *utils.Bar) syscall.Errno {
 	var wg sync.WaitGroup
 	ch := make(chan cchunk, 1000000)
-	for i := 0; i < threads; i++ {
+	for range threads {
 		wg.Add(1)
 		go func() {
 			for c := range ch {
@@ -2727,7 +2738,7 @@ func (m *baseMeta) Compact(ctx Context, inode Ino, concurrency int, preFunc, pos
 	var wg sync.WaitGroup
 	// compact
 	chunkChan := make(chan cchunk, 10000)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -2874,10 +2885,12 @@ func (m *baseMeta) trashEntry(parent, inode Ino, name string) string {
 func (m *baseMeta) cleanupTrash(ctx Context) {
 	defer m.sessWG.Done()
 	for {
+		t := time.NewTimer(utils.JitterIt(time.Hour))
 		select {
 		case <-ctx.Done():
+			t.Stop()
 			return
-		case <-time.After(utils.JitterIt(time.Hour)):
+		case <-t.C:
 		}
 		if st := m.en.doGetAttr(ctx, TrashInode, nil); st != 0 {
 			if st != syscall.ENOENT {
@@ -2950,7 +2963,7 @@ func (m *baseMeta) CleanupTrashBefore(ctx Context, edge time.Time, increProgress
 		logger.Warnf("readdir trash %d: %s", TrashInode, st)
 		return st
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Inode < entries[j].Inode })
+	slices.SortFunc(entries, func(a, b *Entry) int { return cmp.Compare(a.Inode, b.Inode) })
 	var count uint64
 	done := make(chan struct{})
 	defer func() {
@@ -3124,7 +3137,7 @@ func (m *baseMeta) ScanDeletedObject(ctx Context, tss trashSliceScan, pss pendin
 			}, concurrency)
 			var wg sync.WaitGroup
 
-			for i := 0; i < concurrency; i++ {
+			for range concurrency {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
@@ -3888,7 +3901,7 @@ func (m *baseMeta) LoadMetaV2(ctx Context, r io.Reader, opt *LoadOption) error {
 		}
 	}
 
-	for i := 0; i < opt.Threads; i++ {
+	for range opt.Threads {
 		wg.Add(1)
 		go workerFunc(ctx, taskCh)
 	}

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -18,7 +18,7 @@ package meta
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -123,9 +123,7 @@ func (m *baseMeta) groupBatch(batch map[Ino]dirStat, size int) [][]Ino {
 	for ino := range batch {
 		inos = append(inos, ino)
 	}
-	sort.Slice(inos, func(i, j int) bool {
-		return inos[i] < inos[j]
-	})
+	slices.Sort(inos)
 	var batches [][]Ino
 	for i := 0; i < len(inos); i += size {
 		end := i + size

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -36,7 +36,9 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
-	"sort"
+	"bytes"
+	"cmp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -4386,7 +4388,7 @@ func (m *redisMeta) dumpEntries(es ...*DumpedEntry) error {
 				for k, v := range keys {
 					xattrs = append(xattrs, &DumpedXattr{k, v})
 				}
-				sort.Slice(xattrs, func(i, j int) bool { return xattrs[i].Name < xattrs[j].Name })
+				slices.SortFunc(xattrs, func(a, b *DumpedXattr) int { return cmp.Compare(a.Name, b.Name) })
 				e.Xattrs = xattrs
 			}
 
@@ -4523,7 +4525,7 @@ func (m *redisMeta) dumpDir(inode Ino, tree *DumpedEntry, bw *bufio.Writer, dept
 	for _, e := range tree.Entries {
 		entries = append(entries, e)
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	slices.SortFunc(entries, func(a, b *DumpedEntry) int { return cmp.Compare(a.Name, b.Name) })
 	if showProgress != nil {
 		showProgress(int64(len(entries)), 0)
 	}
@@ -4930,9 +4932,7 @@ func (m *redisMeta) LoadMeta(r io.Reader) (err error) {
 			binary.BigEndian.PutUint32(a[47:51], uint32(len(ps))) // nlink
 			binary.BigEndian.PutUint64(a[63:71], 0)
 			p.Set(ctx, m.inodeKey(i), a, 0)
-			for k := range st {
-				delete(st, k)
-			}
+			clear(st)
 			for _, p := range ps {
 				st[p] = st[p] + 1
 			}
@@ -5539,9 +5539,7 @@ func (s *redisDirHandler) List(ctx Context, offset int) ([]*Entry, syscall.Errno
 		}
 
 		if s.en.conf.SortDir {
-			sort.Slice(entries, func(i, j int) bool {
-				return string(entries[i].Name) < string(entries[j].Name)
-			})
+			slices.SortFunc(entries, func(a, b *Entry) int { return bytes.Compare(a.Name, b.Name) })
 		}
 		if s.plus {
 			nEntries := len(entries)

--- a/pkg/meta/redis_bak.go
+++ b/pkg/meta/redis_bak.go
@@ -774,9 +774,7 @@ func (m *redisMeta) loadSymlinks(ctx Context, msg proto.Message) error {
 			if err := m.rdb.MSet(ctx, syms).Err(); err != nil {
 				return err
 			}
-			for k := range syms {
-				delete(syms, k)
-			}
+			clear(syms)
 		}
 	}
 	if len(syms) == 0 {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -30,8 +30,8 @@ import (
 	"net/url"
 	"runtime"
 	"runtime/debug"
+	"cmp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -270,6 +270,7 @@ type dbMeta struct {
 	snap  *dbSnap
 
 	noReadOnlyTxn bool
+	driverName    string
 	statement     map[string]string
 	tablePrefix   string
 }
@@ -535,9 +536,14 @@ func newSQLMeta(driver, addr string, conf *Config) (Meta, error) {
 	engine.DB().SetMaxIdleConns(vIdleConns)
 	engine.DB().SetConnMaxIdleTime(time.Second * time.Duration(vIdleTime))
 	engine.SetTableMapper(prefixMapper{mapper: engine.GetTableMapper(), prefix: tablePrefix})
+	dname := engine.DriverName()
+	if dname == "pgx" {
+		dname = "postgres"
+	}
 	m := &dbMeta{
 		baseMeta:    newBaseMeta(addr, conf),
 		db:          engine,
+		driverName:  dname,
 		statement:   make(map[string]string),
 		tablePrefix: tablePrefix,
 	}
@@ -560,11 +566,7 @@ func (m *dbMeta) Shutdown() error {
 }
 
 func (m *dbMeta) Name() string {
-	name := m.db.DriverName()
-	if name == "pgx" {
-		name = "postgres"
-	}
-	return name
+	return m.driverName
 }
 
 func (m *dbMeta) doDeleteSlice(id uint64, size uint32) error {
@@ -1072,7 +1074,7 @@ func (m *dbMeta) txn(f func(s *xorm.Session) error, inodes ...Ino) error {
 			m.txRestart.WithLabelValues(method.name(context.TODO())).Add(1)
 			logger.Debugf("Transaction failed, restart it (tried %d): %s", i+1, err)
 			lastErr = err
-			time.Sleep(time.Millisecond * time.Duration(i*i))
+			time.Sleep(time.Millisecond * time.Duration(min(i*i, 1000)))
 			continue
 		} else if err == nil && i > 1 {
 			logger.Warnf("Transaction succeeded after %d tries (%s), inodes: %v, method: %s, last error: %s", i+1, time.Since(start), inodes, method.name(context.TODO()), lastErr)
@@ -1121,7 +1123,7 @@ func (m *dbMeta) roTxn(ctx context.Context, f func(s *xorm.Session) error) error
 		if err != nil {
 			logger.Debugf("Start transaction failed, try again (tried %d): %s", i+1, err)
 			lastErr = err
-			time.Sleep(time.Millisecond * time.Duration(i*i))
+			time.Sleep(time.Millisecond * time.Duration(min(i*i, 1000)))
 			continue
 		}
 		err = f(s)
@@ -1133,7 +1135,7 @@ func (m *dbMeta) roTxn(ctx context.Context, f func(s *xorm.Session) error) error
 			m.txRestart.WithLabelValues(method.name(ctx)).Add(1)
 			logger.Debugf("Read transaction failed, restart it (tried %d): %s", i+1, err)
 			lastErr = err
-			time.Sleep(time.Millisecond * time.Duration(i*i))
+			time.Sleep(time.Millisecond * time.Duration(min(i*i, 1000)))
 			continue
 		} else if err == nil && i > 1 {
 			logger.Warnf("Read transaction succeeded after %d tries (%s), method: %s, last error: %s", i+1, time.Since(start), method.name(ctx), lastErr)
@@ -1169,7 +1171,7 @@ func (m *dbMeta) simpleTxn(ctx context.Context, f func(s *xorm.Session) error) e
 			m.txRestart.WithLabelValues(method.name(ctx)).Add(1)
 			logger.Debugf("Read transaction failed, restart it (tried %d): %s", i+1, err)
 			lastErr = err
-			time.Sleep(time.Millisecond * time.Duration(i*i))
+			time.Sleep(time.Millisecond * time.Duration(min(i*i, 1000)))
 			continue
 		} else if err == nil && i > 1 {
 			logger.Warnf("Simple transaction succeeded after %d tries (%s), method: %s, last error: %s", i+1, time.Since(start), method.name(ctx), lastErr)
@@ -1236,9 +1238,14 @@ func (m *dbMeta) doSyncVolumeStat(ctx Context) error {
 	var used, inode int64
 	if err := m.simpleTxn(ctx, func(s *xorm.Session) error {
 		total, err := s.SumsInt(&dirStats{}, "used_space", "used_inodes")
-		used += total[0]
-		inode += total[1]
-		return err
+		if err != nil {
+			return err
+		}
+		if len(total) >= 2 {
+			used += total[0]
+			inode += total[1]
+		}
+		return nil
 	}); err != nil {
 		return err
 	}
@@ -2085,7 +2092,7 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, attr
 
 func (m *dbMeta) getNodesForUpdate(s *xorm.Session, nodes ...*node) error {
 	// sort them to avoid deadlock
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Inode < nodes[j].Inode })
+	slices.SortFunc(nodes, func(a, b *node) int { return cmp.Compare(a.Inode, b.Inode) })
 	for i := range nodes {
 		ok, err := s.ForUpdate().Get(nodes[i])
 		if err != nil {
@@ -4179,7 +4186,7 @@ func (m *dbMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota
 }
 
 func (m *dbMeta) doFlushQuotas(ctx Context, quotas []*iQuota) error {
-	sort.Slice(quotas, func(i, j int) bool { return quotas[i].qkey < quotas[j].qkey })
+	slices.SortFunc(quotas, func(a, b *iQuota) int { return cmp.Compare(a.qkey, b.qkey) })
 	return m.txn(func(s *xorm.Session) error {
 		for _, q := range quotas {
 			if q.qtype == DirQuotaType {
@@ -4244,7 +4251,7 @@ func (m *dbMeta) dumpEntry(s *xorm.Session, inode Ino, typ uint8, e *DumpedEntry
 		for _, x := range rows {
 			xattrs = append(xattrs, &DumpedXattr{x.Name, string(x.Value)})
 		}
-		sort.Slice(xattrs, func(i, j int) bool { return xattrs[i].Name < xattrs[j].Name })
+		slices.SortFunc(xattrs, func(a, b *DumpedXattr) int { return cmp.Compare(a.Name, b.Name) })
 		e.Xattrs = xattrs
 	}
 
@@ -4338,7 +4345,7 @@ func (m *dbMeta) dumpEntryFast(inode Ino, typ uint8) *DumpedEntry {
 		for _, x := range rows {
 			xattrs = append(xattrs, &DumpedXattr{x.Name, string(x.Value)})
 		}
-		sort.Slice(xattrs, func(i, j int) bool { return xattrs[i].Name < xattrs[j].Name })
+		slices.SortFunc(xattrs, func(a, b *DumpedXattr) int { return cmp.Compare(a.Name, b.Name) })
 		e.Xattrs = xattrs
 	}
 
@@ -4406,7 +4413,7 @@ func (m *dbMeta) dumpDir(s *xorm.Session, inode Ino, tree *DumpedEntry, bw *bufi
 	for _, e := range tree.Entries {
 		entries = append(entries, e)
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	slices.SortFunc(entries, func(a, b *DumpedEntry) int { return cmp.Compare(a.Name, b.Name) })
 	_ = tree.writeJsonWithOutEntry(bw, depth)
 
 	ms := make([]sync.Mutex, threads)
@@ -4478,7 +4485,7 @@ func (m *dbMeta) dumpDirFast(inode Ino, tree *DumpedEntry, bw *bufio.Writer, dep
 	}
 	edges := m.snap.edges[inode]
 	_ = tree.writeJsonWithOutEntry(bw, depth)
-	sort.Slice(edges, func(i, j int) bool { return bytes.Compare(edges[i].Name, edges[j].Name) == -1 })
+	slices.SortFunc(edges, func(a, b *edge) int { return bytes.Compare(a.Name, b.Name) })
 
 	for i, e := range edges {
 		entry := m.dumpEntryFast(e.Inode, e.Type)

--- a/pkg/meta/sql_bak.go
+++ b/pkg/meta/sql_bak.go
@@ -266,9 +266,7 @@ func (m *dbMeta) dumpEdges(ctx Context, opt *DumpOption, ch chan<- *dumpedResult
 	st := make(map[uint64]int64)
 	for inode, ps := range dumpParents {
 		if len(ps) > 1 {
-			for k := range st {
-				delete(st, k)
-			}
+			clear(st)
 			for _, p := range ps {
 				st[p] = st[p] + 1
 			}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -27,8 +27,9 @@ import (
 	"math"
 	"math/rand"
 	"runtime"
+	"cmp"
 	"runtime/debug"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -3340,7 +3341,7 @@ func (m *kvMeta) dumpEntry(inode Ino, e *DumpedEntry, showProgress func(totalInc
 			return true
 		})
 		if len(xattrs) > 0 {
-			sort.Slice(xattrs, func(i, j int) bool { return xattrs[i].Name < xattrs[j].Name })
+			slices.SortFunc(xattrs, func(a, b *DumpedXattr) int { return cmp.Compare(a.Name, b.Name) })
 			e.Xattrs = xattrs
 		}
 
@@ -3439,7 +3440,7 @@ func (m *kvMeta) dumpDir(ctx Context, inode Ino, tree *DumpedEntry, bw *bufio.Wr
 	for _, e := range tree.Entries {
 		entries = append(entries, e)
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	slices.SortFunc(entries, func(a, b *DumpedEntry) int { return cmp.Compare(a.Name, b.Name) })
 	_ = tree.writeJsonWithOutEntry(bw, depth)
 
 	ms := make([]sync.Mutex, threads)
@@ -3515,7 +3516,7 @@ func (m *kvMeta) dumpDirFast(inode Ino, tree *DumpedEntry, bw *bufio.Writer, dep
 		}
 		names = append(names, n)
 	}
-	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	slices.Sort(names)
 	_ = tree.writeJsonWithOutEntry(bw, depth)
 	for i, name := range names {
 		e := entries[name]
@@ -3966,9 +3967,7 @@ func (m *kvMeta) LoadMeta(r io.Reader) error {
 				binary.BigEndian.PutUint32(a[47:51], uint32(len(ps))) // nlink
 				binary.BigEndian.PutUint64(a[63:71], 0)
 				tx.set(m.inodeKey(i), a)
-				for k := range st {
-					delete(st, k)
-				}
+				clear(st)
 				for _, p := range ps {
 					st[p] = st[p] + 1
 				}

--- a/pkg/meta/tkv_bak.go
+++ b/pkg/meta/tkv_bak.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -445,9 +445,7 @@ func (m *kvMeta) insertKVs(ctx Context, pairs []*pair, threads int) error {
 		return nil
 	}
 
-	sort.Slice(pairs, func(i, j int) bool {
-		return bytes.Compare(pairs[i].key, pairs[j].key) < 0
-	})
+	slices.SortFunc(pairs, func(a, b *pair) int { return bytes.Compare(a.key, b.key) })
 
 	maxSize, maxNum := 5<<20, m.maxTxnBatchNum()
 	n := len(pairs)

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -23,8 +23,9 @@ import (
 	"net/url"
 	"path"
 	"runtime"
+	"cmp"
 	"runtime/debug"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -139,7 +140,7 @@ func errno(err error) syscall.Errno {
 	if err == nil {
 		return 0
 	}
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return syscall.EINTR
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
@@ -272,7 +273,7 @@ func updateLocks(ls []plockRecord, nl plockRecord) []plockRecord {
 	if nl.Start <= nl.End {
 		ls = append(ls, nl)
 	}
-	sort.Slice(ls, func(i, j int) bool { return ls[i].Start < ls[j].Start })
+	slices.SortFunc(ls, func(a, b plockRecord) int { return cmp.Compare(a.Start, b.Start) })
 	for i := 0; i < len(ls); {
 		if ls[i].Type == F_UNLCK || ls[i].Start > ls[i].End {
 			// remove empty one
@@ -588,9 +589,7 @@ func (m *baseMeta) getTreeSummary(ctx Context, tree *TreeSummary, depth, topN ui
 		tree.Files += c.Files
 		tree.Size += c.Size
 	}
-	sort.Slice(tree.Children, func(i, j int) bool {
-		return tree.Children[i].Size > tree.Children[j].Size
-	})
+	slices.SortFunc(tree.Children, func(a, b *TreeSummary) int { return cmp.Compare(b.Size, a.Size) })
 	if len(tree.Children) > int(topN) {
 		omitChild := &TreeSummary{
 			Path: path.Join(tree.Path, "..."),

--- a/pkg/object/bos.go
+++ b/pkg/object/bos.go
@@ -27,8 +27,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -193,7 +194,7 @@ func (q *bosclient) List(ctx context.Context, prefix, start, token, delimiter st
 		for _, p := range out.CommonPrefixes {
 			objs = append(objs, &obj{p.Prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, out.IsTruncated, out.NextMarker, nil
 }

--- a/pkg/object/ceph.go
+++ b/pkg/object/ceph.go
@@ -28,7 +28,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -234,7 +234,7 @@ func (c *ceph) ListAll(_ context.Context, prefix, marker string, followLink bool
 		keys = append(keys, key)
 	}
 	// the keys are not ordered, sort them first
-	sort.Strings(keys)
+	slices.Sort(keys)
 	c.release(ctx)
 
 	var objs = make(chan Object, 1000)

--- a/pkg/object/cifs.go
+++ b/pkg/object/cifs.go
@@ -26,9 +26,10 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"cmp"
 	"os"
 	"path"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -430,7 +431,7 @@ func (c *cifsStore) List(ctx context.Context, prefix, marker, token, delimiter s
 	}
 
 	// Sort entries by name
-	sort.Slice(mEntries, func(i, j int) bool { return mEntries[i].Name() < mEntries[j].Name() })
+	slices.SortFunc(mEntries, func(a, b *mEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 
 	// Generate object list
 	for _, e := range mEntries {

--- a/pkg/object/cos.go
+++ b/pkg/object/cos.go
@@ -26,8 +26,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -108,6 +109,7 @@ func (c *COS) Get(ctx context.Context, key string, off, limit int64, getters ...
 		return nil, err
 	}
 	if err = checkGetStatus(resp.StatusCode, params.Range != ""); err != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		return nil, err
 	}
@@ -198,7 +200,7 @@ func (c *COS) List(ctx context.Context, prefix, start, token, delimiter string, 
 			}
 			objs = append(objs, &obj{key, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, resp.IsTruncated, resp.NextMarker, nil
 }

--- a/pkg/object/dragonfly.go
+++ b/pkg/object/dragonfly.go
@@ -29,8 +29,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"cmp"
 	"path"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -504,7 +505,7 @@ func (d *dragonfly) List(ctx context.Context, prefix, marker, token, delimiter s
 		for _, o := range objectMetadatas.CommonPrefixes {
 			objs = append(objs, &obj{o, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return generateListResult(objs, limit)
 }

--- a/pkg/object/encrypt.go
+++ b/pkg/object/encrypt.go
@@ -52,7 +52,7 @@ func ExportRsaPrivateKeyToPem(key *rsa.PrivateKey, passphrase string) string {
 	if passphrase != "" {
 		var err error
 		// nolint:staticcheck
-		block, _ = x509.EncryptPEMBlock(rand.Reader, block.Type, buf, []byte(passphrase), x509.PEMCipherAES256)
+		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, buf, []byte(passphrase), x509.PEMCipherAES256)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/object/file.go
+++ b/pkg/object/file.go
@@ -25,8 +25,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"cmp"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -272,7 +273,7 @@ func readDirSorted(dir string, followLink bool) ([]*mEntry, error) {
 			mEntries[i] = &mEntry{e, e.Name(), nil, isSymlink}
 		}
 	}
-	sort.Slice(mEntries, func(i, j int) bool { return mEntries[i].Name() < mEntries[j].Name() })
+	slices.SortFunc(mEntries, func(a, b *mEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 	return mEntries, err
 }
 

--- a/pkg/object/gluster.go
+++ b/pkg/object/gluster.go
@@ -28,8 +28,9 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"cmp"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -196,7 +197,7 @@ func (g *gluster) readDirSorted(dirname string, followLink bool) ([]*mEntry, err
 			mEntries = append(mEntries, &mEntry{nil, name, e, isSymlink})
 		}
 	}
-	sort.Slice(mEntries, func(i, j int) bool { return mEntries[i].Name() < mEntries[j].Name() })
+	slices.SortFunc(mEntries, func(a, b os.FileInfo) int { return cmp.Compare(a.Name(), b.Name()) })
 	return mEntries, err
 }
 

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -24,8 +24,9 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -183,7 +184,7 @@ func (g *gs) List(ctx context.Context, prefix, start, token, delimiter string, l
 		}
 	}
 	if delimiter != "" {
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, nextPageToken != "", nextPageToken, nil
 }

--- a/pkg/object/hdfs.go
+++ b/pkg/object/hdfs.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -187,12 +187,6 @@ func (h *hdfsclient) Put(ctx context.Context, key string, in io.Reader, getters 
 	return err
 }
 
-func min(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 func IsErrReplicating(err error) bool {
 	pe, ok := err.(*os.PathError)
@@ -256,7 +250,7 @@ func (h *hdfsclient) List(ctx context.Context, prefix, marker, token, delimiter 
 		}
 		entryMap[names[i]] = info
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 
 	for _, name := range names {
 		p := dir + name

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -26,8 +26,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -207,7 +208,7 @@ func (s *ibmcos) List(ctx context.Context, prefix, start, token, delimiter strin
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, *resp.IsTruncated, *resp.NextMarker, nil
 }

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -26,8 +26,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -213,7 +214,7 @@ func (s *ks3) List(ctx context.Context, prefix, start, token, delimiter string, 
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	var nextMarker string
 	if resp.NextMarker != nil {

--- a/pkg/object/mem.go
+++ b/pkg/object/mem.go
@@ -21,9 +21,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"cmp"
 	"io"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -181,9 +182,7 @@ func (m *memStore) List(ctx context.Context, prefix, marker, token, delimiter st
 			objs = append(objs, f)
 		}
 	}
-	sort.Slice(objs, func(i, j int) bool {
-		return objs[i].Key() < objs[j].Key()
-	})
+	slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	if int64(len(objs)) > limit {
 		objs = objs[:limit]
 	}

--- a/pkg/object/nfs.go
+++ b/pkg/object/nfs.go
@@ -26,8 +26,9 @@ import (
 	"io"
 	"os"
 	"os/user"
+	"cmp"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -297,7 +298,7 @@ func (n *nfsStore) readDirSorted(ctx context.Context, dir string, followLink boo
 			nfsEntries[i] = &nfsEntry{e, e.Name(), nil, e.Attr.Attr.Type == nfs.NF3Lnk}
 		}
 	}
-	sort.Slice(nfsEntries, func(i, j int) bool { return nfsEntries[i].Name() < nfsEntries[j].Name() })
+	slices.SortFunc(nfsEntries, func(a, b *nfsEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 	return nfsEntries, err
 }
 

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -28,8 +28,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -125,6 +126,7 @@ func (s *obsClient) Get(ctx context.Context, key string, off, limit int64, gette
 		return nil, err
 	}
 	if err = checkGetStatus(resp.StatusCode, rangeStr != ""); err != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		return nil, err
 	}
@@ -231,7 +233,7 @@ func (s *obsClient) List(ctx context.Context, prefix, start, token, delimiter st
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, resp.IsTruncated, resp.NextMarker, nil
 }

--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -27,8 +27,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -212,7 +213,7 @@ func (o *ossClient) List(ctx context.Context, prefix, start, token, delimiter st
 		for _, o := range result.CommonPrefixes {
 			objs = append(objs, &obj{oss.ToString(o.Prefix), 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, result.IsTruncated, oss.ToString(result.NextContinuationToken), nil
 }

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -26,8 +26,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -100,6 +101,7 @@ func (q *qingstor) Get(ctx context.Context, key string, off, limit int64, getter
 		return nil, err
 	}
 	if err = checkGetStatus(*output.StatusCode, rangeStr != ""); err != nil {
+		_, _ = io.Copy(io.Discard, output.Body)
 		_ = output.Body.Close()
 		return nil, err
 	}
@@ -229,7 +231,7 @@ func (q *qingstor) List(ctx context.Context, prefix, start, token, delimiter str
 		for _, p := range out.CommonPrefixes {
 			objs = append(objs, &obj{*p, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, *out.HasMore, *out.NextMarker, nil
 }

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -25,8 +25,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -171,7 +172,7 @@ func (q *qiniu) List(ctx context.Context, prefix, startAfter, token, delimiter s
 			}
 			objs = append(objs, &obj{p, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	if len(objs) == 0 {
 		hasNext = false

--- a/pkg/object/redis.go
+++ b/pkg/object/redis.go
@@ -27,7 +27,7 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -112,7 +112,7 @@ func (t *redisStore) ListAll(ctx context.Context, prefix, marker string, followL
 			cursor = c
 		}
 	}
-	sort.Strings(keyList)
+	slices.Sort(keyList)
 
 	go func() {
 		defer close(objs)

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -233,6 +233,7 @@ func (s *RestfulStorage) request(ctx context.Context, method, key string, body i
 
 func parseError(resp *http.Response) error {
 	data, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
 	if err != nil {
 		return fmt.Errorf("request failed: %s", err)
 	}
@@ -301,6 +302,7 @@ func (s *RestfulStorage) Get(ctx context.Context, key string, off, limit int64, 
 		return nil, parseError(resp)
 	}
 	if err = checkGetStatus(resp.StatusCode, len(headers) > 0); err != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		return nil, err
 	}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -25,9 +25,10 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"cmp"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -272,7 +273,7 @@ func (s *s3client) List(ctx context.Context, prefix, start, token, delimiter str
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	var isTruncated bool
 	if resp.IsTruncated != nil {
@@ -451,6 +452,12 @@ func defaultPathStyle() bool {
 var oracleCompileRegexp = `.*\.compat.objectstorage\.(.*)\.oraclecloud\.com`
 var OVHCompileRegexp = `^s3\.(\w*)(\.\w*)?\.cloud\.ovh\.net$`
 
+var (
+	vpcEndpointRe  = regexp.MustCompile(`^.*\.(.*)\.vpce\.amazonaws\.com`)
+	oracleRegionRe = regexp.MustCompile(oracleCompileRegexp)
+	ovhRegionRe    = regexp.MustCompile(OVHCompileRegexp)
+)
+
 func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) {
 	if !strings.Contains(endpoint, "://") {
 		if len(strings.Split(endpoint, ".")) > 1 && !strings.HasSuffix(endpoint, ".amazonaws.com") {
@@ -497,12 +504,11 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 		} else {
 			// get region or endpoint
 			if strings.Contains(uri.Host, ".amazonaws.com") {
-				vpcCompile := regexp.MustCompile(`^.*\.(.*)\.vpce\.amazonaws\.com`)
 				// vpc link
-				if vpcCompile.MatchString(uri.Host) {
+				if vpcEndpointRe.MatchString(uri.Host) {
 					bucketName = hostParts[0]
 					ep = hostParts[1]
-					if submatch := vpcCompile.FindStringSubmatch(uri.Host); len(submatch) == 2 {
+					if submatch := vpcEndpointRe.FindStringSubmatch(uri.Host); len(submatch) == 2 {
 						region = submatch[1]
 					}
 				} else {
@@ -519,13 +525,10 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 				bucketName = hostParts[0]
 				ep = hostParts[1]
 
-				for _, compileRegexp := range []string{oracleCompileRegexp, OVHCompileRegexp} {
-					compile := regexp.MustCompile(compileRegexp)
-					if compile.MatchString(ep) {
-						if submatch := compile.FindStringSubmatch(ep); len(submatch) >= 2 {
-							region = submatch[1]
-							break
-						}
+				for _, re := range []*regexp.Regexp{oracleRegionRe, ovhRegionRe} {
+					if submatch := re.FindStringSubmatch(ep); len(submatch) >= 2 {
+						region = submatch[1]
+						break
 					}
 				}
 			}

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -17,8 +17,9 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"cmp"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -361,7 +362,7 @@ func (f *sftpStore) sortByName(c *sftp.Client, path string, fis []os.FileInfo, f
 			mEntries[i] = &mEntry{e, e.Name(), nil, isSymlink}
 		}
 	}
-	sort.Slice(mEntries, func(i, j int) bool { return mEntries[i].Name() < mEntries[j].Name() })
+	slices.SortFunc(mEntries, func(a, b *mEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 	return mEntries
 }
 

--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -25,8 +25,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -176,7 +177,7 @@ func (t *tosClient) List(ctx context.Context, prefix, start, token, delimiter st
 		for _, p := range resp.CommonPrefixes {
 			objs = append(objs, &obj{p.Prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	return objs, resp.IsTruncated, resp.NextContinuationToken, nil
 }

--- a/pkg/object/ufile.go
+++ b/pkg/object/ufile.go
@@ -31,8 +31,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"cmp"
 	"net/url"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -253,7 +254,7 @@ func (u *ufile) List(ctx context.Context, prefix, start, token, delimiter string
 		for _, item := range out.CommonPrefixes {
 			objs = append(objs, &obj{item.Prefix, 0, time.Unix(0, 0), true, ""})
 		}
-		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
+		slices.SortFunc(objs, func(a, b Object) int { return cmp.Compare(a.Key(), b.Key()) })
 	}
 	// This is a bug in ufile, NextMarker is not the last one after sorting.
 	var lastKey string

--- a/pkg/object/webdav.go
+++ b/pkg/object/webdav.go
@@ -25,9 +25,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"cmp"
 	"os"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/studio-b12/gowebdav"
@@ -151,9 +152,7 @@ func (w *webdav) List(ctx context.Context, prefix, marker, token, delimiter stri
 			sortedInfos[idx] = o
 		}
 	}
-	sort.Slice(sortedInfos, func(i, j int) bool {
-		return sortedInfos[i].Name() < sortedInfos[j].Name()
-	})
+	slices.SortFunc(sortedInfos, func(a, b os.FileInfo) int { return cmp.Compare(a.Name(), b.Name()) })
 	for _, info := range sortedInfos {
 		key := root[1:] + info.Name()
 		if !strings.HasPrefix(key, prefix) || (marker != "" && key <= marker) {

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -91,6 +91,8 @@ func httpRequest(url string, body []byte) (ans []byte, err error) {
 	return io.ReadAll(resp.Body)
 }
 
+var workerLogRe = regexp.MustCompile(`^.*<([A-Z]+)>: (.*)`)
+
 var sendStatMu sync.Mutex
 
 func sendStats(addr string) {
@@ -322,7 +324,6 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 			}
 			logger.Infof("launch a worker on %s", host)
 			var finished = make(chan struct{})
-			var logRe = regexp.MustCompile(`^.*<([A-Z]+)>: (.*)`)
 			go func() {
 				r := bufio.NewReader(stderr)
 				for {
@@ -334,7 +335,7 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 					line = strings.TrimSuffix(line, "\n")
 
 					var level, content string
-					if matches := logRe.FindStringSubmatch(line); len(matches) >= 3 {
+					if matches := workerLogRe.FindStringSubmatch(line); len(matches) >= 3 {
 						level = matches[1]
 						content = matches[2]
 					} else {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -112,6 +112,12 @@ func (l *globalLimit) request(ask int64) (int64, int64, error) {
 		return 0, 0, err
 	}
 	result, err := http.Post(l.address, "application/json", bytes.NewReader(data))
+	if result != nil {
+		defer func() {
+			_, _ = io.Copy(io.Discard, result.Body)
+			_ = result.Body.Close()
+		}()
+	}
 	if err != nil || result.StatusCode != http.StatusOK {
 		var status string
 		if result != nil {
@@ -120,7 +126,6 @@ func (l *globalLimit) request(ask int64) (int64, int64, error) {
 		logger.Errorf("request traffic control %s failed: %s, http status: %s", l.address, err, status)
 		return 0, 0, err
 	}
-	defer result.Body.Close()
 	content, err := io.ReadAll(result.Body)
 	if err != nil {
 		return 0, 0, err

--- a/pkg/vfs/backup.go
+++ b/pkg/vfs/backup.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -191,7 +191,7 @@ func rotate(objs []string, now time.Time) []string {
 	}
 
 	var toDel, within []string
-	sort.Strings(objs)
+	slices.Sort(objs)
 	for i := len(objs) - 1; i >= 0; i-- {
 		if len(objs[i]) != 30 { // len("dump-2006-01-02-150405.json.gz")
 			logger.Warnf("bad object for metadata backup %s: length %d", objs[i], len(objs[i]))

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -153,6 +153,9 @@ func (s *sliceReader) done(err syscall.Errno, delay time.Duration) {
 }
 
 func retry_time(trycnt uint32) time.Duration {
+	if trycnt == 0 {
+		return time.Millisecond
+	}
 	if trycnt < 30 {
 		return time.Millisecond * time.Duration((trycnt-1)*300+1)
 	}
@@ -519,9 +522,7 @@ func (f *fileReader) splitRange(block *frange) []uint64 {
 		}
 		return true
 	})
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i] < ranges[j]
-	})
+	slices.Sort(ranges)
 	return ranges
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"cmp"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 	"syscall"
 	"time"
@@ -96,7 +97,7 @@ func (o FuseOptions) StripOptions() FuseOptions {
 		o.Options = append(o.Options, opt)
 	}
 
-	sort.Strings(o.Options)
+	slices.Sort(o.Options)
 
 	// ignore these options because they won't be send to kernel
 	o.IgnoreSecurityLabels,
@@ -608,7 +609,7 @@ func (v *VFS) Truncate(ctx Context, ino Ino, size int64, fh uint64, attr *Attr) 
 		return
 	}
 	hs := v.findAllHandles(ino)
-	sort.Slice(hs, func(i, j int) bool { return hs[i].fh < hs[j].fh })
+	slices.SortFunc(hs, func(a, b *handle) int { return cmp.Compare(a.fh, b.fh) })
 	for _, h := range hs {
 		if !h.Wlock(ctx) {
 			err = syscall.EINTR

--- a/sdk/java/libjfs/bridge.go
+++ b/sdk/java/libjfs/bridge.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -288,7 +288,7 @@ func writeLabels(buf *bufio.Writer, m model.Metric, numLabels int) error {
 			labelStrings = append(labelStrings, labelString)
 		}
 	}
-	sort.Strings(labelStrings)
+	slices.Sort(labelStrings)
 	for _, s := range labelStrings {
 		if err := buf.WriteByte('.'); err != nil {
 			return err


### PR DESCRIPTION
Optimizations:
- [Faster sorting with Go generics](https://eli.thegreenplace.net/2022/faster-sorting-with-go-generics/)
- HTTP response body leaks
- parseError never closes body
- Drain body before close for HTTP keep-alive
- Compile regexps once at package level
- Proper context-based cancellation for metrics goroutines