### PR TITLE
cmd: use %q for CLI-derived strings in logs

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -118,13 +118,13 @@ func (bc *benchCase) writeFiles(index int) {
 		fname := filepath.Join(bc.bm.tmpdir, fmt.Sprintf("%s.%d.%d", bc.name, index, i))
 		fp, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
-			logger.Fatalf("Failed to open file %s: %s", fname, err)
+			logger.Fatalf("Failed to open file %q: %s", fname, err)
 		}
 		buf := make([]byte, bc.bsize)
 		utils.RandRead(buf)
 		for j := 0; j < bc.bcount; j++ {
 			if _, err = fp.Write(buf); err != nil {
-				logger.Fatalf("Failed to write file %s: %s", fname, err)
+				logger.Fatalf("Failed to write file %q: %s", fname, err)
 			}
 			bc.wbar.Increment()
 		}
@@ -137,12 +137,12 @@ func (bc *benchCase) readFiles(index int) {
 		fname := filepath.Join(bc.bm.tmpdir, fmt.Sprintf("%s.%d.%d", bc.name, index, i))
 		fp, err := os.Open(fname)
 		if err != nil {
-			logger.Fatalf("Failed to open file %s: %s", fname, err)
+			logger.Fatalf("Failed to open file %q: %s", fname, err)
 		}
 		buf := make([]byte, bc.bsize)
 		for j := 0; j < bc.bcount; j++ {
 			if n, err := fp.Read(buf); err != nil || n != bc.bsize {
-				logger.Fatalf("Failed to read file %s: %d %s", fname, n, err)
+				logger.Fatalf("Failed to read file %q: %d %s", fname, n, err)
 			}
 			bc.rbar.Increment()
 		}
@@ -154,7 +154,7 @@ func (bc *benchCase) statFiles(index int) {
 	for i := 0; i < bc.fcount; i++ {
 		fname := filepath.Join(bc.bm.tmpdir, fmt.Sprintf("%s.%d.%d", bc.name, index, i))
 		if _, err := os.Stat(fname); err != nil {
-			logger.Fatalf("Failed to stat file %s: %s", fname, err)
+			logger.Fatalf("Failed to stat file %q: %s", fname, err)
 		}
 		bc.sbar.Increment()
 	}
@@ -314,7 +314,7 @@ func bench(ctx *cli.Context) error {
 	}
 	tmpdir, err := filepath.Abs(ctx.Args().First())
 	if err != nil {
-		logger.Fatalf("Failed to get absolute path of %s: %s", ctx.Args().First(), err)
+		logger.Fatalf("Failed to get absolute path of %q: %s", ctx.Args().First(), err)
 	}
 	bigSize := utils.ParseBytes(ctx, "big-file-size", 'M')
 	smallSize := utils.ParseBytes(ctx, "small-file-size", 'K')
@@ -342,7 +342,7 @@ func bench(ctx *cli.Context) error {
 	/* --- Prepare --- */
 	if _, err := os.Stat(bm.tmpdir); os.IsNotExist(err) {
 		if err = os.MkdirAll(bm.tmpdir, 0777); err != nil {
-			logger.Fatalf("Failed to create %s: %s", bm.tmpdir, err)
+			logger.Fatalf("Failed to create %q: %s", bm.tmpdir, err)
 		}
 	}
 	mp, _ := findMountpoint(bm.tmpdir)
@@ -430,11 +430,11 @@ func bench(ctx *cli.Context) error {
 	/* --- Clean-up --- */
 	if runtime.GOOS == "windows" {
 		if err := exec.Command("cmd", "/C", "rd", "/s", "/q", bm.tmpdir).Run(); err != nil {
-			logger.Warnf("Failed to cleanup %s: %s", bm.tmpdir, err)
+			logger.Warnf("Failed to cleanup %q: %s", bm.tmpdir, err)
 		}
 	} else {
 		if err := exec.Command("rm", "-rf", bm.tmpdir).Run(); err != nil {
-			logger.Warnf("Failed to cleanup %s: %s", bm.tmpdir, err)
+			logger.Warnf("Failed to cleanup %q: %s", bm.tmpdir, err)
 		}
 	}
 

--- a/cmd/compact.go
+++ b/cmd/compact.go
@@ -66,12 +66,12 @@ func compact(ctx *cli.Context) error {
 	for i := 0; i < len(paths); i++ {
 		path, err := filepath.Abs(paths[i])
 		if err != nil {
-			logger.Fatalf("get absolute path of %s error: %v", paths[i], err)
+			logger.Fatalf("get absolute path of %q error: %v", paths[i], err)
 		}
 
 		inodeNo, err := utils.GetFileInode(path)
 		if err != nil {
-			logger.Errorf("lookup inode for %s error: %v", path, err)
+			logger.Errorf("lookup inode for %q error: %v", path, err)
 			continue
 		}
 		inode := meta.Ino(inodeNo)
@@ -123,6 +123,6 @@ func doCompact(inode meta.Ino, path string, coCnt uint16) error {
 		return fmt.Errorf("compact [%d:%s] error: %s", inode, path, errno)
 	}
 
-	logger.Infof("compact [%d:%s] success.", inode, path)
+	logger.Infof("compact [%d:%q] success.", inode, path)
 	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -204,7 +204,7 @@ func config(ctx *cli.Context) error {
 					if p, err := filepath.Abs(new); err == nil {
 						new = p + "/"
 					} else {
-						logger.Fatalf("Failed to get absolute path of %s: %s", new, err)
+						logger.Fatalf("Failed to get absolute path of %q: %s", new, err)
 					}
 				}
 				msg.WriteString(fmt.Sprintf("%10s: %s -> %s\n", flag, format.Bucket, new))

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -427,7 +427,7 @@ func collectLog(ctx *cli.Context, cmd string, requireRootPrivileges bool, currDi
 		}
 
 		copyArgs := []string{"powershell", "-Command", fmt.Sprintf("Get-Content -Tail %d %s > %s", limit, logPath, retLogPath)}
-		logger.Infof("The last %d lines of %s will be collected", limit, logPath)
+		logger.Infof("The last %d lines of %q will be collected", limit, logPath)
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		return exec.CommandContext(timeoutCtx, copyArgs[0], copyArgs[1:]...).Run()
@@ -437,7 +437,7 @@ func collectLog(ctx *cli.Context, cmd string, requireRootPrivileges bool, currDi
 			copyArgs = append(copyArgs, "sudo")
 		}
 		copyArgs = append(copyArgs, "/bin/sh", "-c", fmt.Sprintf("tail -n %d %s > %s", limit, logPath, retLogPath))
-		logger.Infof("The last %d lines of %s will be collected", limit, logPath)
+		logger.Infof("The last %d lines of %q will be collected", limit, logPath)
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		return exec.CommandContext(timeoutCtx, copyArgs[0], copyArgs[1:]...).Run()
@@ -541,7 +541,7 @@ func debug(ctx *cli.Context) error {
 	}
 
 	uid, pid, cmd, err := getCmdMount(amp)
-	logger.Infof("mount point:%s pid:%s uid:%s", amp, pid, uid)
+	logger.Infof("mount point:%q pid:%s uid:%s", amp, pid, uid)
 	if err != nil {
 		return fmt.Errorf("failed to get mount command: %v", err)
 	}
@@ -568,6 +568,6 @@ func debug(ctx *cli.Context) error {
 
 	wg.Wait()
 	abs, _ := filepath.Abs(currDir)
-	logger.Infof("All files are collected to %s", abs)
+	logger.Infof("All files are collected to %q", abs)
 	return geneZipFile(currDir, filepath.Join(outDir, fmt.Sprintf("%s-%s.zip", prefix, timestamp)))
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -122,7 +122,7 @@ func destroy(ctx *cli.Context) error {
 		logger.Fatalf("load setting: %s", err)
 	}
 	if uuid := ctx.Args().Get(1); uuid != format.UUID {
-		logger.Fatalf("UUID %s != expected %s", uuid, format.UUID)
+		logger.Fatalf("UUID %q != expected %q", uuid, format.UUID)
 	}
 	blob, err := createStorage(*format)
 	if err != nil {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -168,7 +168,7 @@ func dump(ctx *cli.Context) error {
 		if dst == "" {
 			dst = "STDOUT"
 		}
-		logger.Infof("Dump metadata into %s succeed", dst)
+		logger.Infof("Dump metadata into %q succeed", dst)
 	}
 	return err
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -388,7 +388,7 @@ func loadEncrypt(keyPath string) string {
 	}
 	pem, err := os.ReadFile(keyPath)
 	if err != nil {
-		logger.Fatalf("load RSA key from %s: %s", keyPath, err)
+		logger.Fatalf("load RSA key from %q: %s", keyPath, err)
 	}
 	return string(pem)
 }
@@ -399,7 +399,7 @@ func readKerbConf(file string) string {
 	}
 	data, err := os.ReadFile(file)
 	if err != nil {
-		logger.Fatalf("load Kerberos config from %s: %s", file, err)
+		logger.Fatalf("load Kerberos config from %q: %s", file, err)
 	}
 	return string(data)
 }
@@ -411,10 +411,10 @@ func format(c *cli.Context) error {
 	name := c.Args().Get(1)
 	validName := regexp.MustCompile(`^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$`)
 	if !validName.MatchString(name) {
-		logger.Fatalf("invalid name: %s, only alphabet, number and - are allowed, and the length should be 3 to 63 characters.", name)
+		logger.Fatalf("invalid name: %q, only alphabet, number and - are allowed, and the length should be 3 to 63 characters.", name)
 	}
 	if v := c.String("compress"); compress.NewCompressor(v) == nil {
-		logger.Fatalf("Unsupported compress algorithm: %s", v)
+		logger.Fatalf("Unsupported compress algorithm: %q", v)
 	}
 	if v := c.Int("trash-days"); v < 0 {
 		logger.Fatalf("Invalid trash days: %d", v)
@@ -465,7 +465,7 @@ func format(c *cli.Context) error {
 			case "storage":
 				format.Storage = c.String(flag)
 			case "encrypt-rsa-key", "encrypt-algo":
-				logger.Warnf("Flag %s is ignored since it cannot be updated", flag)
+				logger.Warnf("Flag %q is ignored since it cannot be updated", flag)
 			case "ranger-rest-url":
 				format.RangerRestUrl = c.String(flag)
 			case "ranger-service":
@@ -533,7 +533,7 @@ func format(c *cli.Context) error {
 		if err == nil {
 			format.Bucket = p
 		} else {
-			logger.Fatalf("Failed to get absolute path of %s: %s", format.Bucket, err)
+			logger.Fatalf("Failed to get absolute path of %q: %s", format.Bucket, err)
 		}
 		if format.Storage == "file" {
 			format.Bucket += "/"

--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -94,11 +94,11 @@ func fsck(ctx *cli.Context) error {
 	path := ctx.String("path")
 	repairDirMode, err := strconv.ParseUint(ctx.String("repair-dir-mode"), 8, 16) // base 8 (octal), 16-bit result
 	if err != nil {
-		logger.Fatalf("invalid repair-dir-mode: %s", err)
+		logger.Fatalf("invalid repair-dir-mode %q: %s", ctx.String("repair-dir-mode"), err)
 	}
 	if path != "" {
 		if !strings.HasPrefix(path, "/") {
-			logger.Fatalf("File path should be the absolute path within JuiceFS")
+			logger.Fatalf("file path %q should be the absolute path within JuiceFS", path)
 		}
 		err := m.Check(c, path, &meta.CheckOpt{
 			Repair:        ctx.Bool("repair"),

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -165,7 +165,7 @@ func gateway(c *cli.Context) error {
 
 	umask, err := strconv.ParseUint(c.String("umask"), 8, 16)
 	if err != nil {
-		logger.Fatalf("invalid umask %s: %s", c.String("umask"), err)
+		logger.Fatalf("invalid umask %q: %s", c.String("umask"), err)
 	}
 	bucket := c.String("bucket-name")
 	if bucket == "" {
@@ -258,7 +258,7 @@ func initForSvc(c *cli.Context, mp string, svcType, metaUrl, listenAddr string) 
 		logger.Fatalf("load setting: %s", err)
 	}
 	if st := metaCli.Chroot(meta.Background(), metaConf.Subdir); st != 0 {
-		logger.Fatalf("Chroot to %s: %s", metaConf.Subdir, st)
+		logger.Fatalf("Chroot to %q: %s", metaConf.Subdir, st)
 	}
 	registerer, registry := wrapRegister(c, svcType, format.Name)
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -97,12 +97,12 @@ func info(ctx *cli.Context) error {
 		} else {
 			d, err = filepath.Abs(path)
 			if err != nil {
-				logger.Fatalf("abs of %s: %s", path, err)
+				logger.Fatalf("abs of %q: %s", path, err)
 			}
 			inode, err = utils.GetFileInode(d)
 		}
 		if err != nil {
-			logger.Errorf("lookup inode for %s: %s", path, err)
+			logger.Errorf("lookup inode for %q: %s", path, err)
 			continue
 		}
 		if inode < uint64(meta.RootInode) {
@@ -110,7 +110,7 @@ func info(ctx *cli.Context) error {
 		}
 		f, err := openController(d)
 		if err != nil {
-			logger.Errorf("Open control file for %s: %s", d, err)
+			logger.Errorf("Open control file for %q: %s", d, err)
 			continue
 		}
 
@@ -251,7 +251,7 @@ func ltypeToString(t uint32) string {
 func legacyInfo(d, path string, inode uint64, recursive, raw uint8) {
 	f, err := openController(d)
 	if err != nil {
-		logger.Errorf("Open control file for %s: %s", d, err)
+		logger.Errorf("Open control file for %q: %s", d, err)
 		return
 	}
 	defer f.Close()

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -163,7 +163,7 @@ func convert(path string, key, algo string) (string, error) {
 
 	nPath := path[:strings.LastIndex(path, ".")]
 	if utils.Exists(nPath) {
-		logger.Infof("plain backup %s already exists, skip conversion", nPath)
+		logger.Infof("plain backup %q already exists, skip conversion", nPath)
 		return nPath, nil
 	}
 
@@ -182,7 +182,7 @@ func convert(path string, key, algo string) (string, error) {
 	if _, err = io.Copy(w, r); err != nil {
 		return "", fmt.Errorf("failed to convert %s to %s: %w", path, nPath, err)
 	}
-	logger.Infof("converted backup %s to %s", path, nPath)
+	logger.Infof("converted backup %q to %q", path, nPath)
 	return nPath, nil
 }
 
@@ -252,12 +252,12 @@ func load(ctx *cli.Context) error {
 	} else {
 		return err
 	}
-	logger.Infof("load metadata from %s succeed", src)
+	logger.Infof("load metadata from %q succeed", src)
 	return nil
 }
 
 func statBak(ctx *cli.Context, path string) error {
-	logger.Infof("load backup from %s", path)
+	logger.Infof("load backup from %q", path)
 	fp, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", path, err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -222,7 +222,7 @@ func reorderOptions(app *cli.App, args []string) []string {
 			if hasValue {
 				i++
 				if i >= len(args) {
-					logger.Fatalf("option %s requires value", option)
+					logger.Fatalf("option %q requires value", option)
 				}
 				newArgs = append(newArgs, args[i])
 			}
@@ -261,7 +261,7 @@ func reorderOptions(app *cli.App, args []string) []string {
 			}
 		} else {
 			if strings.HasPrefix(option, "-") && !utils.StringContains(args, "--generate-bash-completion") {
-				logger.Fatalf("unknown option: %s", option)
+				logger.Fatalf("unknown option: %q", option)
 			}
 			others = append(others, option)
 		}

--- a/cmd/mdtest.go
+++ b/cmd/mdtest.go
@@ -122,11 +122,11 @@ func runTest(jfs *fs.FileSystem, rootDir string, np, width, depth, files, bytes 
 
 	start := time.Now()
 	if err := jfs.Mkdir(ctx, rootDir, 0777, umask); err != 0 {
-		logger.Errorf("mkdir %s: %s", rootDir, err)
+		logger.Errorf("mkdir %q: %s", rootDir, err)
 	}
 	root := path.Join(rootDir, "test-dir.0-0")
 	if err := jfs.Mkdir(ctx, root, 0777, umask); err != 0 {
-		logger.Fatalf("Mkdir %s: %s", root, err)
+		logger.Fatalf("Mkdir %q: %s", root, err)
 	}
 	root = path.Join(root, "mdtest_tree.0")
 	if err := createDir(jfs, root, depth, width); err != nil {
@@ -205,7 +205,7 @@ func initForMdtest(c *cli.Context, mp string, metaUrl string) *fs.FileSystem {
 		logger.Fatalf("load setting: %s", err)
 	}
 	if st := m.Chroot(meta.Background(), metaConf.Subdir); st != 0 {
-		logger.Fatalf("Chroot to %s: %s", metaConf.Subdir, st)
+		logger.Fatalf("Chroot to %q: %s", metaConf.Subdir, st)
 	}
 	registerer, registry := wrapRegister(c, mp, format.Name)
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -86,7 +86,7 @@ func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *p
 	// default set
 	ip, port, err := net.SplitHostPort(c.String("metrics"))
 	if err != nil {
-		logger.Fatalf("metrics format error: %v", err)
+		logger.Fatalf("metrics format error %q: %v", c.String("metrics"), err)
 	}
 	go metric.UpdateMetrics(registerer)
 	http.Handle("/metrics", promhttp.HandlerFor(
@@ -114,7 +114,7 @@ func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *p
 	if err != nil {
 		// Don't try other ports on metrics set but listen failed
 		if c.IsSet("metrics") {
-			logger.Errorf("listen on %s:%s failed: %v", ip, port, err)
+			logger.Errorf("listen on %q:%q failed: %v", ip, port, err)
 			return ""
 		}
 		// Listen port on 0 will auto listen on a free port
@@ -132,7 +132,7 @@ func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *p
 	}()
 
 	metricsAddr := ln.Addr().String()
-	logger.Infof("Prometheus metrics listening on %s", metricsAddr)
+	logger.Infof("Prometheus metrics listening on %q", metricsAddr)
 	return metricsAddr
 }
 
@@ -147,10 +147,10 @@ func wrapRegister(c *cli.Context, mp, name string) (prometheus.Registerer, *prom
 		for _, kv := range strings.Split(c.String("custom-labels"), ";") {
 			splited := strings.Split(kv, ":")
 			if len(splited) != 2 {
-				logger.Fatalf("invalid label format: %s", kv)
+				logger.Fatalf("invalid label format: %q", kv)
 			}
 			if utils.StringContains([]string{"mp", "vol_name", "instance"}, splited[0]) {
-				logger.Warnf("overriding reserved label: %s", splited[0])
+				logger.Warnf("overriding reserved label: %q", splited[0])
 			}
 			commonLabels[splited[0]] = splited[1]
 		}
@@ -192,13 +192,13 @@ func relPathToAbs(ss []string) []string {
 			if h, err := os.UserHomeDir(); err == nil {
 				ss[i] = filepath.Join(h, d[1:])
 			} else {
-				logger.Fatalf("Expand user home dir of %s: %s", d, err)
+				logger.Fatalf("Expand user home dir of %q: %s", d, err)
 			}
 		} else {
 			if ad, err := filepath.Abs(d); err == nil {
 				ss[i] = ad
 			} else {
-				logger.Fatalf("Find absolute path of %s: %s", d, err)
+				logger.Fatalf("Find absolute path of %q: %s", d, err)
 			}
 		}
 	}
@@ -288,7 +288,7 @@ func getVfsConf(c *cli.Context, metaConf *meta.Config, format *meta.Format, chun
 	if c.IsSet("umask") {
 		umask, err := strconv.ParseUint(c.String("umask"), 8, 16)
 		if err != nil {
-			logger.Fatalf("invalid umask %s: %s", c.String("umask"), err)
+			logger.Fatalf("invalid umask %q: %s", c.String("umask"), err)
 		}
 		cfg.UMask = uint16(umask)
 	}
@@ -336,7 +336,7 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 
 	atimeMode := c.String("atime-mode")
 	if atimeMode != meta.RelAtime && atimeMode != meta.StrictAtime && atimeMode != meta.NoAtime {
-		logger.Warnf("unknown atime-mode \"%s\", changed to %s", atimeMode, meta.NoAtime)
+		logger.Warnf("unknown atime-mode %q, changed to %q", atimeMode, meta.NoAtime)
 		atimeMode = meta.NoAtime
 	}
 	conf.AtimeMode = atimeMode
@@ -356,7 +356,7 @@ func getMetaConf(c *cli.Context, mp string, readOnly bool) *meta.Config {
 func getChunkConf(c *cli.Context, format *meta.Format) *chunk.Config {
 	cm, err := strconv.ParseUint(c.String("cache-mode"), 8, 32)
 	if err != nil {
-		logger.Warnf("Invalid cache-mode %s, using default value 0600", c.String("cache-mode"))
+		logger.Warnf("Invalid cache-mode %q, using default value 0600", c.String("cache-mode"))
 		cm = 0600
 	}
 	chunkConf := &chunk.Config{
@@ -462,7 +462,7 @@ func NewReloadableStorage(format *meta.Format, cli meta.Meta, patch func(*meta.F
 		}
 		old := &holder.fmt
 		if new.Storage != old.Storage || new.Bucket != old.Bucket || new.AccessKey != old.AccessKey || new.SecretKey != old.SecretKey || new.SessionToken != old.SessionToken || new.StorageClass != old.StorageClass {
-			logger.Infof("found new configuration: storage=%s bucket=%s ak=%s storageClass=%s", new.Storage, new.Bucket, new.AccessKey, new.StorageClass)
+			logger.Infof("found new configuration: storage=%q bucket=%q ak=%q storageClass=%q", new.Storage, new.Bucket, new.AccessKey, new.StorageClass)
 
 			newBlob, err := createStorage(*new)
 			if err != nil {
@@ -552,7 +552,7 @@ func mount(c *cli.Context) error {
 			return err
 		}, time.Second*3)
 		if err != nil {
-			logger.Fatalf("abs %s: %s", mp, err)
+			logger.Fatalf("abs %q: %s", mp, err)
 		}
 		if mp == "/" {
 			logger.Fatalf("should not mount on the root directory")
@@ -570,7 +570,7 @@ func mount(c *cli.Context) error {
 					logger.Warnf("failed to update fstab: %s", e2)
 				}
 				if e1 == nil && e2 == nil {
-					logger.Infof("Successfully updated fstab, now you can mount with `mount %s`", mp)
+					logger.Infof("Successfully updated fstab, now you can mount with `mount %q`", mp)
 				}
 			}
 		}
@@ -680,6 +680,6 @@ func mount(c *cli.Context) error {
 	}
 	err = metaCli.CloseSession()
 	object.Shutdown(blob)
-	logger.Infof("The juicefs mount process exit successfully, mountpoint: %s", metaConf.MountPoint)
+	logger.Infof("The juicefs mount process exit successfully, mountpoint: %q", metaConf.MountPoint)
 	return err
 }

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -159,7 +159,7 @@ func watchdog(ctx context.Context, mp string) {
 				if pid == 0 {
 					_, conf, err := loadConfig(mp)
 					if err == nil {
-						logger.Infof("watching %s, pid %d", mp, conf.Pid)
+						logger.Infof("watching %q, pid %d", mp, conf.Pid)
 						pid = conf.Pid
 						agentAddr = conf.Port.DebugAgent
 					} else {
@@ -179,7 +179,7 @@ func watchdog(ctx context.Context, mp string) {
 			time.Sleep(time.Second * 30)
 			// double check
 			if atomic.LoadInt64(&lastActive)+60 < time.Now().Unix() && ctx.Err() == nil {
-				logger.Infof("mount point %s is not active for %s", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
+				logger.Infof("mount point %q is not active for %s", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
 				showThreadStack(agentAddr)
 				killMountProcess(pid, dev, &lastActive)
 				atomic.StoreInt64(&lastActive, time.Now().Unix())
@@ -207,7 +207,7 @@ func parseFuseFd(mountPoint string) (fd int) {
 
 func checkMountpoint(name, mp, logPath string, background bool) {
 	if parseFuseFd(mp) > 0 {
-		logger.Infof("\033[92mOK\033[0m, %s with special mount point %s", name, mp)
+		logger.Infof("\033[92mOK\033[0m, %s with special mount point %q", name, mp)
 		return
 	}
 	_, oldConf, _ := loadConfig(mp)
@@ -232,7 +232,7 @@ func checkMountpoint(name, mp, logPath string, background bool) {
 						continue
 					}
 				}
-				logger.Infof("\033[92mOK\033[0m, %s is ready at %s", name, mp)
+				logger.Infof("\033[92mOK\033[0m, %s is ready at %q", name, mp)
 				return
 			}
 		}
@@ -246,7 +246,7 @@ func checkMountpoint(name, mp, logPath string, background bool) {
 		_ = syscall.Kill(mountPid, syscall.SIGABRT) // Kill and show stack trace
 	}
 	if background {
-		logger.Fatalf("The mount point is not ready in %d seconds (%s), please check the log (%s) or re-mount in foreground", mountTimeOut, mountDesc, logPath)
+		logger.Fatalf("The mount point is not ready in %d seconds (%s), please check the log (%q) or re-mount in foreground", mountTimeOut, mountDesc, logPath)
 	} else {
 		logger.Fatalf("The mount point is not ready in %d seconds (%s), exit it", mountTimeOut, mountDesc)
 	}
@@ -260,7 +260,7 @@ func checkSvcPort(address string) {
 		conn, err := net.DialTimeout("tcp", address, 500*time.Millisecond)
 		if err == nil {
 			_ = conn.Close()
-			logger.Infof("\033[92mOK\033[0m, service is ready on %s", address)
+			logger.Infof("\033[92mOK\033[0m, service is ready on %q", address)
 			return
 		}
 		_, _ = os.Stdout.WriteString(".")
@@ -287,15 +287,15 @@ func makeDaemonForSvc(c *cli.Context, m meta.Meta, metaUrl, listenAddr string) e
 		var err error
 		attrs.Stdout, err = os.OpenFile(logfile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			logger.Errorf("open log file %s: %s", logfile, err)
+			logger.Errorf("open log file %q: %s", logfile, err)
 		} else {
-			logger.Infof("open log file %s", logfile)
+			logger.Infof("open log file %q", logfile)
 		}
 
 		conn, err := net.DialTimeout("tcp", listenAddr, 500*time.Millisecond)
 		if err == nil {
 			_ = conn.Close()
-			logger.Fatalf("unable to start the server: %s is already in use", listenAddr)
+			logger.Fatalf("unable to start the server: %q is already in use", listenAddr)
 		}
 	}
 	if godaemon.Stage() <= 1 {
@@ -512,17 +512,17 @@ func prepareMp(mp string) {
 		if err2 != nil {
 			if os.IsExist(err2) || strings.Contains(err2.Error(), "timeout after 3s") {
 				// a broken mount point, umount it
-				logger.Infof("mountpoint %s is broken: %s, umount it", mp, err)
+				logger.Infof("mountpoint %q is broken: %s, umount it", mp, err)
 				_ = doUmount(mp, true)
 			} else {
-				logger.Fatalf("create %s: %s", mp, err2)
+				logger.Fatalf("create %q: %s", mp, err2)
 			}
 		}
 	} else if err == nil {
 		ino, _ = utils.GetFileInode(mp)
 		if ino <= uint64(meta.RootInode) && fi.Size() == 0 {
 			// a broken mount point, umount it
-			logger.Infof("mountpoint %s is broken (ino=%d, size=%d), umount it", mp, ino, fi.Size())
+			logger.Infof("mountpoint %q is broken (ino=%d, size=%d), umount it", mp, ino, fi.Size())
 			_ = doUmount(mp, true)
 		}
 	}
@@ -538,14 +538,14 @@ func prepareMp(mp string) {
 		if fi, err := os.Stat(mp); err == nil {
 			if st, ok := fi.Sys().(*syscall.Stat_t); ok {
 				if st.Uid != uint32(os.Getuid()) {
-					logger.Fatalf("current user should own %s", mp)
+					logger.Fatalf("current user should own %q", mp)
 				}
 			}
 		}
 	case "linux":
 		f, err := os.CreateTemp(mp, ".test")
 		if err != nil && (os.IsPermission(err) || errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EROFS)) {
-			logger.Fatalf("Do not have write permission on %s", mp)
+			logger.Fatalf("Do not have write permission on %q", mp)
 		} else if f != nil {
 			_ = f.Close()
 			_ = os.Remove(f.Name())
@@ -564,7 +564,7 @@ func genFuseOptExt(c *cli.Context, format *meta.Format) (fuseOpt string, mt int,
 func shutdownGraceful(mp string) {
 	_, conf, err := loadConfig(mp)
 	if err != nil {
-		logger.Warnf("load config from %s: %s", mp, err)
+		logger.Warnf("load config from %q: %s", mp, err)
 		return
 	}
 	fuseFd, fuseSetting = getFuseFd(conf.CommPath)
@@ -584,7 +584,7 @@ func shutdownGraceful(mp string) {
 		}
 		time.Sleep(time.Millisecond * 100)
 	}
-	logger.Infof("mount point %s is busy, stop upgrade, mount on top of it", mp)
+	logger.Infof("mount point %q is busy, stop upgrade, mount on top of it", mp)
 	err = sendFuseFd(conf.CommPath, fuseSetting, fuseFd)
 	if err != nil {
 		logger.Warnf("send FUSE fd: %s", err)
@@ -605,7 +605,7 @@ func canShutdownGracefully(mp string, newConf *vfs.Config) bool {
 		return err
 	}, time.Second*3)
 	if err != nil {
-		logger.Warnf("get inode of %s: %s", mp, err)
+		logger.Warnf("get inode of %q: %s", mp, err)
 		_ = doUmount(mp, true)
 		return false
 	} else if ino != 1 {
@@ -619,7 +619,7 @@ func canShutdownGracefully(mp string, newConf *vfs.Config) bool {
 		return false
 	}
 	if oldConf.Pid == 0 || oldConf.CommPath == "" {
-		logger.Infof("mount point %s is not ready for upgrade, mount on top of it", mp)
+		logger.Infof("mount point %q is not ready for upgrade, mount on top of it", mp)
 		return false
 	}
 	if oldConf.Format.Name != newConf.Format.Name {
@@ -649,12 +649,12 @@ func absPath(d string) string {
 		if h, err := os.UserHomeDir(); err == nil {
 			return filepath.Join(h, d[1:])
 		} else {
-			logger.Fatalf("Expand user home dir of %s: %s", d, err)
+			logger.Fatalf("Expand user home dir of %q: %s", d, err)
 		}
 	}
 	d, err := filepath.Abs(d)
 	if err != nil {
-		logger.Fatalf("Expand %s: %s", d, err)
+		logger.Fatalf("Expand %q: %s", d, err)
 	}
 	return d
 }
@@ -816,7 +816,7 @@ func makeDaemon(c *cli.Context, conf *vfs.Config) error {
 		_ = os.MkdirAll(filepath.Dir(logfile), 0755)
 		attrs.Stdout, err = os.OpenFile(logfile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			logger.Errorf("open log file %s: %s", logfile, err)
+			logger.Errorf("open log file %q: %s", logfile, err)
 		}
 	}
 	_, _, err := godaemon.MakeDaemon(&attrs)
@@ -996,7 +996,7 @@ func parseUIDGID(input string, defaultUid uint32, defaultGid uint32) (uint32, ui
 	if ss[0] != "" {
 		u, err := strconv.ParseUint(ss[0], 10, 32)
 		if err != nil {
-			logger.Fatalf("invalid uid: %s", ss[0])
+			logger.Fatalf("invalid uid: %q", ss[0])
 		}
 		uid = uint32(u)
 		if uid == 0 {
@@ -1007,7 +1007,7 @@ func parseUIDGID(input string, defaultUid uint32, defaultGid uint32) (uint32, ui
 	if len(ss) == 2 && ss[1] != "" {
 		g, err := strconv.ParseUint(ss[1], 10, 32)
 		if err != nil {
-			logger.Fatalf("invalid gid: %s", ss[1])
+			logger.Fatalf("invalid gid: %q", ss[1])
 		}
 		gid = uint32(g)
 		if gid == 0 {
@@ -1060,10 +1060,9 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 			logger.Infof("Map root uid/gid 0 to %d/%d by setting root-squash", uid, gid)
 		}
 	}
-	logger.Infof("Mounting volume %s at %s ...", conf.Format.Name, conf.Meta.MountPoint)
+	logger.Infof("Mounting volume %s at %q ...", conf.Format.Name, conf.Meta.MountPoint)
 	err := fuse.Serve(v, c.String("o"), c.Bool("enable-xattr"), c.Bool("enable-ioctl"))
 	if err != nil {
 		logger.Fatalf("fuse: %s", err)
 	}
 }
-

--- a/cmd/objbench.go
+++ b/cmd/objbench.go
@@ -166,7 +166,7 @@ func objbench(ctx *cli.Context) error {
 		}
 		var err error
 		if endpoint, err = filepath.Abs(endpoint); err != nil {
-			logger.Fatalf("invalid path: %s", err)
+			logger.Fatalf("invalid path %q: %s", endpoint, err)
 		}
 	}
 	var blobOrigin object.ObjectStorage
@@ -186,7 +186,7 @@ func objbench(ctx *cli.Context) error {
 	storageClass := ctx.String("storage-class")
 	if os, ok := blob.(object.SupportStorageClass); ok && storageClass != "" {
 		if err := os.SetStorageClass(storageClass); err != nil {
-			logger.Fatalf("set storageClass %s failed: %v", storageClass, err)
+			logger.Fatalf("set storageClass %q failed: %v", storageClass, err)
 		}
 	}
 	defer func() {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -373,16 +373,16 @@ func profile(ctx *cli.Context) error {
 	logPath := ctx.Args().First()
 	st, err := os.Stat(logPath)
 	if err != nil {
-		logger.Fatalf("Failed to stat path %s: %s", logPath, err)
+		logger.Fatalf("Failed to stat path %q: %s", logPath, err)
 	}
 	var replay bool
 	if st.IsDir() { // mount point
 		inode, err := utils.GetFileInode(logPath)
 		if err != nil {
-			logger.Fatalf("Failed to lookup inode for %s: %s", logPath, err)
+			logger.Fatalf("Failed to lookup inode for %q: %s", logPath, err)
 		}
 		if inode != uint64(meta.RootInode) {
-			logger.Fatalf("Path %s is not a mount point!", logPath)
+			logger.Fatalf("Path %q is not a mount point!", logPath)
 		}
 		if p := filepath.Join(logPath, ".jfs.accesslog"); utils.Exists(p) {
 			logPath = p
@@ -398,7 +398,7 @@ func profile(ctx *cli.Context) error {
 	}
 	file, err := os.Open(logPath)
 	if err != nil {
-		logger.Fatalf("Failed to open log file %s: %s", logPath, err)
+		logger.Fatalf("Failed to open log file %q: %s", logPath, err)
 	}
 	defer file.Close()
 

--- a/cmd/quota.go
+++ b/cmd/quota.go
@@ -134,7 +134,7 @@ func quota(c *cli.Context) error {
 	case "check":
 		cmd = meta.QuotaCheck
 	default:
-		logger.Fatalf("Invalid quota command: %s", c.Command.Name)
+		logger.Fatalf("Invalid quota command: %q", c.Command.Name)
 	}
 
 	var uid, gid uint32
@@ -143,10 +143,10 @@ func quota(c *cli.Context) error {
 	validateID := func(name string) uint32 {
 		id := c.Uint64(name)
 		if id == 0 {
-			logger.Fatalf("Invalid --%s: 0 is not allowed", name)
+			logger.Fatalf("Invalid --%q: 0 is not allowed", name)
 		}
 		if id > math.MaxUint32 {
-			logger.Fatalf("Invalid --%s: %d exceeds maximum value %d", name, id, math.MaxUint32)
+			logger.Fatalf("Invalid --%q: %d exceeds maximum value %d", name, id, math.MaxUint32)
 		}
 		return uint32(id)
 	}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -70,19 +70,19 @@ func doRestore(m meta.Meta, hour string, putBack bool, threads int) {
 			_ = m.CloseSession()
 		}()
 	}
-	logger.Infof("restore files in %s ...", hour)
+	logger.Infof("restore files in %q ...", hour)
 	ctx := meta.Background()
 	var parent meta.Ino
 	var attr meta.Attr
 	err := m.Lookup(ctx, meta.TrashInode, hour, &parent, &attr, false)
 	if err != 0 {
-		logger.Errorf("lookup %s: %s", hour, err)
+		logger.Errorf("lookup %q: %s", hour, err)
 		return
 	}
 	var entries []*meta.Entry
 	err = m.Readdir(meta.Background(), parent, 0, &entries)
 	if err != 0 {
-		logger.Errorf("list %s: %s", hour, err)
+		logger.Errorf("list %q: %s", hour, err)
 		return
 	}
 	entries = entries[2:]
@@ -142,7 +142,7 @@ func doRestore(m meta.Meta, hour string, putBack bool, threads int) {
 	skipped.Done()
 	restored.Done()
 	p.Done()
-	logger.Infof("restored %d files in %s", restored.Current(), hour)
+	logger.Infof("restored %d files in %q", restored.Current(), hour)
 	for dst, count := range restoredTo {
 		logger.Infof("restored %d files to %q", count, strings.Join(m.GetPaths(ctx, dst), ", "))
 	}

--- a/cmd/rmr.go
+++ b/cmd/rmr.go
@@ -95,7 +95,7 @@ func rmr(ctx *cli.Context) error {
 		path := ctx.Args().Get(i)
 		p, err := filepath.Abs(path)
 		if err != nil {
-			logger.Errorf("abs of %s: %s", path, err)
+			logger.Errorf("abs of %q: %s", path, err)
 			continue
 		}
 		d := filepath.Dir(p)
@@ -106,7 +106,7 @@ func rmr(ctx *cli.Context) error {
 		}
 		f, err := openController(d)
 		if err != nil {
-			logger.Errorf("Open control file for %s: %s", d, err)
+			logger.Errorf("Open control file for %q: %s", d, err)
 			continue
 		}
 		wb := utils.NewBuffer(8 + 8 + 1 + uint32(len(name)) + 1 + 1)
@@ -124,7 +124,7 @@ func rmr(ctx *cli.Context) error {
 		if _, errno := readProgress(f, func(count, bytes uint64) {
 			spin.SetCurrent(int64(count))
 		}); errno != 0 {
-			logger.Fatalf("RMR %s: %s", path, errno)
+			logger.Fatalf("RMR %q: %s", path, errno)
 		}
 		_ = f.Close()
 	}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -369,13 +369,13 @@ func readStats(mp string) map[string]float64 {
 		f, err = os.Open(filepath.Join(mp, ".stats"))
 	}
 	if err != nil {
-		logger.Warnf("open stats file under mount point %s: %s", mp, err)
+		logger.Warnf("open stats file under mount point %q: %s", mp, err)
 		return nil
 	}
 	defer f.Close()
 	d, err := io.ReadAll(f)
 	if err != nil {
-		logger.Warnf("read stats file under mount point %s: %s", mp, err)
+		logger.Warnf("read stats file under mount point %q: %s", mp, err)
 		return nil
 	}
 	stats := make(map[string]float64)
@@ -398,10 +398,10 @@ func stats(ctx *cli.Context) error {
 	mp := ctx.Args().First()
 	inode, err := utils.GetFileInode(mp)
 	if err != nil {
-		logger.Fatalf("lookup inode for %s: %s", mp, err)
+		logger.Fatalf("lookup inode for %q: %s", mp, err)
 	}
 	if inode != 1 {
-		logger.Fatalf("path %s is not a mount point", mp)
+		logger.Fatalf("path %q is not a mount point", mp)
 	}
 
 	watcher := &statsWatcher{

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -103,11 +103,11 @@ func summary(ctx *cli.Context) error {
 	dspin := progress.AddDoubleSpinner(path)
 	dpath, err := filepath.Abs(path)
 	if err != nil {
-		logger.Fatalf("abs of %s: %s", path, err)
+		logger.Fatalf("abs of %q: %s", path, err)
 	}
 	inode, err := utils.GetFileInode(dpath)
 	if err != nil {
-		logger.Fatalf("lookup inode for %s: %s", path, err)
+		logger.Fatalf("lookup inode for %q: %s", path, err)
 	}
 	if inode < uint64(meta.RootInode) {
 		logger.Fatalf("inode number shouldn't be less than %d", meta.RootInode)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -341,7 +341,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 		if isFilePath(uri) {
 			absPath, err := filepath.Abs(uri)
 			if err != nil {
-				logger.Fatalf("invalid path: %s", err.Error())
+				logger.Fatalf("invalid path %q: %s", uri, err.Error())
 			}
 			if !strings.HasPrefix(absPath, "/") { // Windows path
 				absPath = "/" + strings.ReplaceAll(absPath, "\\", "/")
@@ -371,7 +371,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 	uri, token := extractToken(uri)
 	u, err := url.Parse(uri)
 	if err != nil {
-		logger.Fatalf("Can't parse %s: %s", uri, err.Error())
+		logger.Fatalf("Can't parse %q: %s", uri, err.Error())
 	}
 	user := u.User
 	var accessKey, secretKey string
@@ -425,14 +425,14 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 
 	if conf.Links {
 		if _, ok := store.(object.SupportSymlink); !ok {
-			logger.Warnf("storage %s does not support symlink, ignore it", uri)
+			logger.Warnf("storage %q does not support symlink, ignore it", uri)
 			conf.Links = false
 		}
 	}
 
 	if conf.Perms {
 		if _, ok := store.(object.FileSystem); !ok {
-			logger.Warnf("%s is not a file system, can not preserve permissions", store)
+			logger.Warnf("%q is not a file system, can not preserve permissions", store)
 			conf.Perms = false
 		}
 	}
@@ -505,7 +505,7 @@ func doSync(c *cli.Context) error {
 		if os, ok := dst.(object.SupportStorageClass); ok {
 			err := os.SetStorageClass(config.StorageClass)
 			if err != nil {
-				logger.Errorf("set storage class %s: %s", config.StorageClass, err)
+				logger.Errorf("set storage class %q: %s", config.StorageClass, err)
 			}
 		}
 	}

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -141,10 +141,10 @@ func setTier(ctx *cli.Context) error {
 	}
 	oldTier := format.Tiers[attr.Tier]
 	if attr.Tier == uint8(id) {
-		logger.Infof("storage class of %s is already %d(%s), no change needed", path, id, oldTier.GetHumanSc())
+		logger.Infof("storage class of %q is already %d(%s), no change needed", path, id, oldTier.GetHumanSc())
 		return nil
 	}
-	logger.Infof("set storage tier of %s from %d(%s) to %d(%s)", path, attr.Tier, oldTier.GetHumanSc(), id, newTier.GetHumanSc())
+	logger.Infof("set storage tier of %q from %d(%s) to %d(%s)", path, attr.Tier, oldTier.GetHumanSc(), id, newTier.GetHumanSc())
 
 	blob, err := createStorage(*format)
 	if err != nil {
@@ -177,7 +177,7 @@ func setTier(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	logger.Infof("storage tier of %s is set to %d(%s)", path, id, newTier.GetHumanSc())
+	logger.Infof("storage tier of %q is set to %d(%s)", path, id, newTier.GetHumanSc())
 	return nil
 }
 

--- a/cmd/warmup.go
+++ b/cmd/warmup.go
@@ -210,13 +210,13 @@ func warmup(ctx *cli.Context) error {
 		if abs, err := filepath.Abs(p); err == nil {
 			paths = append(paths, abs)
 		} else {
-			logger.Fatalf("Failed to get absolute path of %s: %s", p, err)
+			logger.Fatalf("Failed to get absolute path of %q: %s", p, err)
 		}
 	}
 	if fname := ctx.String("file"); fname != "" {
 		fd, err := os.Open(fname)
 		if err != nil {
-			logger.Fatalf("Failed to open file %s: %s", fname, err)
+			logger.Fatalf("Failed to open file %q: %s", fname, err)
 		}
 		defer fd.Close()
 		scanner := bufio.NewScanner(fd)
@@ -225,12 +225,12 @@ func warmup(ctx *cli.Context) error {
 				if abs, e := filepath.Abs(p); e == nil {
 					paths = append(paths, abs)
 				} else {
-					logger.Warnf("Skipped path %s because it fails to get absolute path: %s", p, e)
+					logger.Warnf("Skipped path %q because it fails to get absolute path: %s", p, e)
 				}
 			}
 		}
 		if err = scanner.Err(); err != nil {
-			logger.Fatalf("Reading file %s failed with error: %s", fname, err)
+			logger.Fatalf("Reading file %q failed with error: %s", fname, err)
 		}
 	}
 	if len(paths) == 0 {
@@ -250,7 +250,7 @@ func warmup(ctx *cli.Context) error {
 	for ; mp != "/"; mp = filepath.Dir(mp) {
 		inode, err := utils.GetFileInode(mp)
 		if err != nil {
-			logger.Fatalf("lookup inode for %s: %s", mp, err)
+			logger.Fatalf("lookup inode for %q: %s", mp, err)
 		}
 		if inode == uint64(meta.RootInode) {
 			break
@@ -280,14 +280,14 @@ func warmup(ctx *cli.Context) error {
 		if mp == "/" {
 			inode, err := utils.GetFileInode(path)
 			if err != nil {
-				logger.Errorf("lookup inode for %s: %s", mp, err)
+				logger.Errorf("lookup inode for %q: %s", mp, err)
 				continue
 			}
 			batch = append(batch, fmt.Sprintf("inode:%d", inode))
 		} else if strings.HasPrefix(path, mp) {
 			batch = append(batch, path[start:])
 		} else {
-			logger.Errorf("Path %s is not under mount point %s", path, mp)
+			logger.Errorf("Path %q is not under mount point %q", path, mp)
 			continue
 		}
 		if len(batch) >= batchMax {

--- a/pkg/sync/checkpoint.go
+++ b/pkg/sync/checkpoint.go
@@ -253,7 +253,7 @@ func (m *CheckpointManager) ValidateConfig(current *Config) bool {
 
 	// Must match fields
 	if old.Start != current.Start || old.End != current.End {
-		logger.Warnf("Checkpoint config mismatch: start/end, old: %v/%v, current: %v/%v", old.Start, old.End, current.Start, current.End)
+		logger.Warnf("Checkpoint config mismatch: start/end, old: %q/%q, current: %q/%q", old.Start, old.End, current.Start, current.End)
 		return false
 	}
 
@@ -291,7 +291,7 @@ func (m *CheckpointManager) ValidateConfig(current *Config) bool {
 	}
 
 	if old.FilesFrom != current.FilesFrom {
-		logger.Warnf("Checkpoint config mismatch: files-from, old: %v, current: %v", old.FilesFrom, current.FilesFrom)
+		logger.Warnf("Checkpoint config mismatch: files-from, old: %q, current: %q", old.FilesFrom, current.FilesFrom)
 		return false
 	}
 

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -294,15 +294,15 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 			rpath := filepath.Join("/tmp", filepath.Base(path))
 			cmd := exec.Command("rsync", "-a", "-e", "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no", path, host+":"+rpath)
 			output, err := cmd.CombinedOutput()
-			logger.Debugf("exec: %s,err: %s", cmd.String(), string(output))
+			logger.Debugf("exec: %q,err: %s", cmd.String(), string(output))
 			if err != nil {
 				// fallback to scp
 				cmd = exec.Command("scp", "-o", "StrictHostKeyChecking=no", "-o", "PasswordAuthentication=no", path, host+":"+rpath)
 				output, err = cmd.CombinedOutput()
-				logger.Debugf("exec: %s,err: %s", cmd.String(), string(output))
+				logger.Debugf("exec: %q,err: %s", cmd.String(), string(output))
 			}
 			if err != nil {
-				logger.Errorf("copy itself to %s: %s", host, err)
+				logger.Errorf("copy itself to %q: %s", host, err)
 				return
 			}
 			// launch itself
@@ -332,7 +332,7 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 			for i, s := range printEnv {
 				argsBk[i+1] = s
 			}
-			logger.Debugf("launch worker command args: [ssh, %s]", strings.Join(shellescape.EscapeArgs(argsBk), ", "))
+			logger.Debugf("launch worker command args: [ssh, %q]", strings.Join(shellescape.EscapeArgs(argsBk), ", "))
 			cmd = exec.Command("ssh", shellescape.EscapeArgs(args)...)
 			cmd.Stdin = os.Stdin
 			stderr, err := cmd.StderrPipe()
@@ -341,10 +341,10 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 			}
 			err = cmd.Start()
 			if err != nil {
-				logger.Errorf("start itself at %s: %s", host, err)
+				logger.Errorf("start itself at %q: %s", host, err)
 				return
 			}
-			logger.Infof("launch a worker on %s", host)
+			logger.Infof("launch a worker on %q", host)
 			var finished = make(chan struct{})
 			var logRe = regexp.MustCompile(`^.*<([A-Z]+)>: (.*)`)
 			go func() {
@@ -368,20 +368,20 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 
 					switch level {
 					case "ERROR":
-						logger.Errorf("[%s] %s", host, content)
+						logger.Errorf("[%q] %s", host, content)
 					case "WARNING":
-						logger.Warnf("[%s] %s", host, content)
+						logger.Warnf("[%q] %s", host, content)
 					case "DEBUG":
-						logger.Debugf("[%s] %s", host, content)
+						logger.Debugf("[%q] %s", host, content)
 					default:
-						logger.Infof("[%s] %s", host, content)
+						logger.Infof("[%q] %s", host, content)
 					}
 				}
 			}()
 			err = cmd.Wait()
 			<-finished
 			if err != nil {
-				logger.Errorf("%s: %s", host, err)
+				logger.Errorf("%q: %s", host, err)
 			}
 		}(host)
 	}

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -165,13 +165,13 @@ func NewConfigFromCli(c *cli.Context) *Config {
 	if c.IsSet("start-time") {
 		startTime, err = cast.ToTimeInDefaultLocationE(c.String("start-time"), time.Local)
 		if err != nil {
-			logger.Fatalf("failed to parse start time: %v", err)
+			logger.Fatalf("failed to parse start time %q: %v", c.String("start-time"), err)
 		}
 	}
 	if c.IsSet("end-time") {
 		endTime, err = cast.ToTimeInDefaultLocationE(c.String("end-time"), time.Local)
 		if err != nil {
-			logger.Fatalf("failed to parse end time: %v", err)
+			logger.Fatalf("failed to parse end time %q: %v", c.String("end-time"), err)
 		}
 	}
 	cfg := &Config{

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1417,14 +1417,14 @@ func parseIncludeRules(args []string) (rules []rule) {
 		}
 		if l-1 > i && (a == "-include" || a == "-exclude") {
 			if _, err := path.Match(args[i+1], "xxxx"); err != nil {
-				logger.Warnf("ignore invalid pattern: %s %s", a, args[i+1])
+				logger.Warnf("ignore invalid pattern: %q %q", a, args[i+1])
 				continue
 			}
 			rules = append(rules, parseRule(a, args[i+1]))
 		} else if strings.HasPrefix(a, "-include=") || strings.HasPrefix(a, "-exclude=") {
 			if s := strings.Split(a, "="); len(s) == 2 && s[1] != "" {
 				if _, err := path.Match(s[1], "xxxx"); err != nil {
-					logger.Warnf("ignore invalid pattern: %s", a)
+					logger.Warnf("ignore invalid pattern: %q", a)
 					continue
 				}
 				rules = append(rules, parseRule(s[0], s[1]))
@@ -2168,7 +2168,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 			}
 			launchWorker(addr, config, &wg)
 		}
-		logger.Infof("Syncing from %s to %s", src, dst)
+		logger.Infof("Syncing from %q to %q", src, dst)
 		if config.Start != "" {
 			logger.Infof("first key: %q", config.Start)
 		}


### PR DESCRIPTION
## What changed

This updates command and sync logging to use `%q` for strings derived from CLI input where invisible characters matter, including paths, URIs, flag values, mountpoints, worker args, and related user-supplied values.

## Why

Some logs were formatting CLI-derived strings with `%s`, which can hide trailing spaces, embedded escapes, or other non-obvious input issues. Using `%q` makes those values explicit in logs and makes debugging CLI input problems easier.

## Impact

Log output now shows quoted and escaped forms for affected CLI-derived strings. Runtime behavior is otherwise unchanged.

## Root cause

The codebase had multiple command and sync log sites that printed user-provided CLI strings with `%s`, so invisible characters were not visible in diagnostics.

## Validation

- `gofmt -w` on all touched files
- `go test ./cmd -run '^$'`
- `go test ./pkg/sync/...`
- `go test ./cmd/... ./pkg/sync/...` fails in this environment because Redis on `127.0.0.1:6379` is unavailable
