### PR TITLE
pkg/chunk: use non-blocking send in scanDelayedStaging

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -1135,7 +1135,11 @@ func (store *cachedStore) scanDelayedStaging() {
 	for _, item := range store.pendingKeys {
 		store.pendingMutex.Unlock()
 		if item.ts.Before(cutoff) && item.uploading.CompareAndSwap(false, true) {
-			store.pendingCh <- item
+			select {
+			case store.pendingCh <- item:
+			default:
+				item.uploading.Store(false) // channel full; next scan will retry
+			}
 		}
 		store.pendingMutex.Lock()
 	}


### PR DESCRIPTION
The blocking send on `pendingCh` would stall `scanDelayedStaging` indefinitely when all upload workers are occupied (e.g. object store temporarily unreachable). During the stall the item's uploading flag stays true, preventing any other path from re-queuing it, and future scans are blocked behind the goroutine.

`addDelayedStaging` already guards this with select/default; apply the same pattern here: reset uploading to false on a full channel so the next scan iteration retries.