### PR TITLE
pkg/fuse: invalidate kernel inode cache on write-close

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -534,6 +534,14 @@ func Serve(v *vfs.VFS, options string, xattrs, ioctl bool) error {
 		v.InvalidateEntry = func(parent Ino, name string) syscall.Errno {
 			return syscall.Errno(fssrv.EntryNotify(uint64(parent), name))
 		}
+		v.InvalidateInode = func(ino Ino) syscall.Errno {
+			return syscall.Errno(fssrv.InodeNotify(uint64(ino), -1, 0))
+		}
+	} else if runtime.GOOS == "darwin" {
+		v.InvalidateInode = func(ino Ino) syscall.Errno {
+			go fssrv.InodeNotify(uint64(ino), -1, 0)
+			return 0
+		}
 	}
 
 	fsserv = fssrv

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -673,6 +673,9 @@ func (v *VFS) Release(ctx Context, ino Ino, fh uint64) {
 			if f.writer != nil {
 				_ = f.writer.Flush(ctx)
 				v.invalidateAttr(ino)
+				if v.InvalidateInode != nil {
+					_ = v.InvalidateInode(ino)
+				}
 			}
 			if locks&1 != 0 {
 				_ = v.Meta.Flock(ctx, ino, fowner^fh, F_UNLCK, false)
@@ -1226,6 +1229,7 @@ type VFS struct {
 	Meta            meta.Meta
 	Store           chunk.ChunkStore
 	InvalidateEntry func(parent meta.Ino, name string) syscall.Errno
+	InvalidateInode func(ino meta.Ino) syscall.Errno
 	UpdateFormat    func(*meta.Format)
 	reader          DataReader
 	writer          DataWriter

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -1161,3 +1161,34 @@ func testReaddir(t *testing.T, metaUri string, dirNum int, offset int) {
 	entriesTwo := readAll(ctx, parent, fh, offset)
 	require.True(t, reflect.DeepEqual(entriesOne, entriesTwo))
 }
+
+func TestInvalidateInodeOnWriteRelease(t *testing.T) {
+	v, _ := createTestVFS(nil, "")
+	ctx := NewLogContext(meta.Background())
+
+	var invalidated []Ino
+	v.InvalidateInode = func(ino Ino) syscall.Errno {
+		invalidated = append(invalidated, ino)
+		return 0
+	}
+
+	// Create and write a file, then release the write handle.
+	fe, fh, e := v.Create(ctx, 1, "f", 0644, 0, syscall.O_RDWR)
+	require.Equal(t, syscall.Errno(0), e)
+	ino := fe.Inode
+
+	require.Equal(t, syscall.Errno(0), v.Write(ctx, ino, []byte("hello"), 0, fh))
+	require.Empty(t, invalidated, "InvalidateInode must not fire before Release")
+
+	v.Release(ctx, ino, fh)
+	require.Equal(t, []Ino{ino}, invalidated,
+		"InvalidateInode must fire exactly once after releasing a write handle")
+
+	// Releasing a read-only handle must not trigger InvalidateInode.
+	_, fhRO, e := v.Open(ctx, ino, syscall.O_RDONLY)
+	require.Equal(t, syscall.Errno(0), e)
+	before := len(invalidated)
+	v.Release(ctx, ino, fhRO)
+	require.Equal(t, before, len(invalidated),
+		"InvalidateInode must not fire when releasing a read-only handle")
+}


### PR DESCRIPTION
JuiceFS correctly invalidated its own internal attribute state after a write-close (`invalidateAttr`), but never sent `FUSE_NOTIFY_INVAL_INODE` to the kernel. Within the `--attr-cache`/`--entry-cache` timeout window, the kernel could serve stale page-cache data to any reader making the write invisible.

This adds an `InvalidateInode` callback to VFS, symmetric to the existing `InvalidateEntry`, wired in fuse.go's `Serve()` to `fssrv.InodeNotify`. It is called from `Release()` when the handle was opened for writing, forcing the kernel to drop its cached pages and attributes for that inode immediately on close.

The result is that write visibility on FUSE mounts is now consistent: after a writable file handle is closed, any subsequent reader on the same mount is guaranteed to go through JuiceFS and see current data, regardless of cache timeout settings.