### PR TITLE
meta: fix GetDirStat returning stale inodes count before flush

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -292,7 +292,7 @@ type baseMeta struct {
 	dSliceMu sync.Mutex
 	dSliceWG sync.WaitGroup
 
-	dirStatsLock sync.Mutex
+	dirStatsLock sync.RWMutex
 	dirStats     map[Ino]dirStat
 
 	fsStatsLock sync.Mutex

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -167,14 +167,10 @@ func (m *baseMeta) GetDirStat(ctx Context, inode Ino) (stat *dirStat, st syscall
 	}
 	if stat == nil {
 		stat, st = m.calcDirStat(ctx, inode)
-	}
-	if st == 0 && stat != nil {
-		// Merge any pending in-memory deltas that have not yet been flushed
-		// to the store. Without this, callers see a stale snapshot whenever
-		// updateDirStat has been called but the flush ticker hasn't fired yet.
-		m.dirStatsLock.Lock()
+	} else {
+		m.dirStatsLock.RLock()
 		pending := m.dirStats[inode]
-		m.dirStatsLock.Unlock()
+		m.dirStatsLock.RUnlock()
 		stat.length += pending.length
 		stat.space += pending.space
 		stat.inodes += pending.inodes

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -168,6 +168,17 @@ func (m *baseMeta) GetDirStat(ctx Context, inode Ino) (stat *dirStat, st syscall
 	if stat == nil {
 		stat, st = m.calcDirStat(ctx, inode)
 	}
+	if st == 0 && stat != nil {
+		// Merge any pending in-memory deltas that have not yet been flushed
+		// to the store. Without this, callers see a stale snapshot whenever
+		// updateDirStat has been called but the flush ticker hasn't fired yet.
+		m.dirStatsLock.Lock()
+		pending := m.dirStats[inode]
+		m.dirStatsLock.Unlock()
+		stat.length += pending.length
+		stat.space += pending.space
+		stat.inodes += pending.inodes
+	}
 	return
 }
 


### PR DESCRIPTION
`GetDirStat` reads directory statistics directly from the store but was unaware of pending in-memory deltas queued by `updateDirStat`. Those deltas are flushed asynchronously on a ticker (default 100 ms), so any caller that reads `GetDirStat` in the window between a mutation and the next flush receives a stale snapshot.

This manifested as a flaky `testRenameDirStat` failure on MySQL (Test 4): a cross-directory rename with overwrite calls `updateDirStat` to decrement the source directory's inode count, but the subsequent `GetDirStat` assertion ran before the flush ticker fired, seeing the pre-rename value.

Fix: after fetching the persisted value from the store, `GetDirStat` now merges any pending in-memory delta for the same inode under `dirStatsLock`. Since `doFlushDirStat` replaces the map with a fresh one after each flush, there is no risk of double-counting once deltas are persisted.