### PR TITLE
meta: fix empty holes exposed by out-of-order buffered write commits

### DIFF
--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -50,19 +50,20 @@ type DataWriter interface {
 }
 
 type sliceWriter struct {
-	id      uint64
-	chunk   *chunkWriter
-	off     uint32
-	length  uint32
-	soff    uint32
-	slen    uint32
-	writer  chunk.Writer
-	freezed bool
-	done    bool
-	err     syscall.Errno
-	notify  *utils.Cond
-	started time.Time
-	lastMod time.Time
+	id         uint64
+	chunk      *chunkWriter
+	off        uint32
+	length     uint32
+	soff       uint32
+	slen       uint32
+	writer     chunk.Writer
+	growLength bool // true if this slice will extend file length visible in metadata
+	freezed    bool
+	done       bool
+	err        syscall.Errno
+	notify     *utils.Cond
+	started    time.Time
+	lastMod    time.Time
 }
 
 func (s *sliceWriter) prepareID(ctx meta.Context, retry bool) {
@@ -197,8 +198,8 @@ func (c *chunkWriter) commitThread() {
 		// Only commits that extend the file need ordering - they could expose a
 		// "hole" (zeros) if an earlier chunk's data hasn't been committed yet.
 		// Overwrites within the committed length are safe to proceed concurrently.
-		for f.hasLowerPendingChunk(c.indx) {
-			f.commitcond.WaitWithTimeout(time.Millisecond * 100)
+		if s.growLength {
+			f.waitCommit(s)
 		}
 
 		err := s.err
@@ -226,11 +227,10 @@ func (c *chunkWriter) commitThread() {
 			}
 			f.err = err
 			logger.Errorf("write inode:%d indx:%d %s", f.inode, c.indx, err)
-		} else {
-			if end := c.sliceEnd(s); end > f.committedTo {
-				f.committedTo = end
-			}
+		} else if end := c.sliceEnd(s); end > f.committedTo {
+			f.committedTo = end
 		}
+		f.finishCommit(s)
 		c.slices = c.slices[1:]
 	}
 	f.freeChunk(c)
@@ -243,17 +243,18 @@ type fileWriter struct {
 
 	inode        Ino
 	length       uint64
-	committedTo  uint64
 	tierID       uint8
 	err          syscall.Errno
 	flushwaiting uint16
 	writewaiting uint16
 	refs         uint16
 	chunks       map[uint32]*chunkWriter
+	committedTo  uint64 // highest file length already committed to metadata
+	commitQueue  []*sliceWriter
 
 	flushcond  *utils.Cond // wait for chunks==nil (flush)
 	writecond  *utils.Cond // wait for flushwaiting==0 (write)
-	commitcond *utils.Cond // wait for lower-index chunks to finish committing
+	commitcond *utils.Cond // wait for grow-length slices to commit in queue order
 }
 
 // protected by file
@@ -269,8 +270,6 @@ func (f *fileWriter) findChunk(i uint32) *chunkWriter {
 // protected by file
 func (f *fileWriter) freeChunk(c *chunkWriter) {
 	delete(f.chunks, c.indx)
-	// Wake higher-index commitThreads that wait for this chunk to finish
-	f.commitcond.Broadcast()
 	if len(f.chunks) == 0 && f.flushwaiting > 0 {
 		f.flushcond.Broadcast()
 	}
@@ -280,24 +279,40 @@ func (c *chunkWriter) sliceEnd(s *sliceWriter) uint64 {
 	return uint64(c.indx)*meta.ChunkSize + uint64(s.off) + uint64(s.slen)
 }
 
-func (c *chunkWriter) hasPendingBeyond(length uint64) bool {
-	for _, s := range c.slices {
-		if c.sliceEnd(s) > length {
-			return true
-		}
+func (f *fileWriter) waitCommit(s *sliceWriter) {
+	for len(f.commitQueue) > 0 && f.commitQueue[0] != s {
+		f.commitcond.WaitWithTimeout(time.Millisecond * 100)
 	}
-	return false
 }
 
-// hasLowerPendingChunk reports whether any lower-index chunk still has a
-// pending slice that may still push committedTo forward.
-func (f *fileWriter) hasLowerPendingChunk(indx uint32) bool {
-	for i, c := range f.chunks {
-		if i < indx && c.hasPendingBeyond(f.committedTo) {
-			return true
+func (f *fileWriter) enqueueCommit(s *sliceWriter) {
+	if s.growLength || s.chunk.sliceEnd(s) <= f.committedTo {
+		return
+	}
+	s.growLength = true
+	f.commitQueue = append(f.commitQueue, s)
+}
+
+func (f *fileWriter) finishCommit(s *sliceWriter) {
+	if !s.growLength {
+		return
+	}
+	// Queue head should always match `s` after waitCommit returns
+	if len(f.commitQueue) > 0 && f.commitQueue[0] == s {
+		f.commitQueue = f.commitQueue[1:]
+		f.commitcond.Broadcast()
+		return
+	}
+	// Fallback path to avoid wedging future commits if that invariant is broken
+	for i, queued := range f.commitQueue {
+		if queued == s {
+			logger.Warnf("write inode:%d grow-length queue out of order, should not happen", f.inode)
+			copy(f.commitQueue[i:], f.commitQueue[i+1:])
+			f.commitQueue = f.commitQueue[:len(f.commitQueue)-1]
+			f.commitcond.Broadcast()
+			return
 		}
 	}
-	return false
 }
 
 // protected by file
@@ -321,7 +336,11 @@ func (f *fileWriter) writeChunk(ctx meta.Context, indx uint32, off uint32, data 
 			go c.commitThread()
 		}
 	}
-	return s.write(ctx, off-s.off, data)
+	if st := s.write(ctx, off-s.off, data); st != 0 {
+		return st
+	}
+	f.enqueueCommit(s)
+	return 0
 }
 
 func (f *fileWriter) totalSlices() int {

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -152,10 +152,11 @@ func (s *sliceWriter) write(ctx meta.Context, off uint32, data []uint8) syscall.
 }
 
 type chunkWriter struct {
-	indx   uint32
-	file   *fileWriter
-	slices []*sliceWriter
-	queued bool
+	indx        uint32
+	file        *fileWriter
+	slices      []*sliceWriter
+	queued      bool
+	maxSliceEnd uint64
 }
 
 // protected by file
@@ -229,8 +230,8 @@ func (c *chunkWriter) commitThread() {
 			f.committedTo = end
 		}
 		c.slices = c.slices[1:]
-		if c.queued && !c.hasSliceBeyond(f.committedTo) { // recheck after dequeuing one committed slice
-			f.dequeueCommit(c)
+		if c.queued && f.committedTo >= c.maxSliceEnd {
+			f.dequeueCommit(c) // dequeue once committed caught up to pending
 		}
 	}
 	f.freeChunk(c)
@@ -280,19 +281,16 @@ func (c *chunkWriter) sliceEnd(s *sliceWriter) uint64 {
 }
 
 // protected by file
-func (c *chunkWriter) hasSliceBeyond(length uint64) bool {
-	for _, s := range c.slices {
-		if c.sliceEnd(s) > length {
-			return true
-		}
-	}
-	return false
-}
-
-// protected by file
 func (f *fileWriter) tryEnqueueCommit(s *sliceWriter) {
 	c := s.chunk
-	if c.queued || c.sliceEnd(s) <= f.committedTo {
+	end := c.sliceEnd(s)
+	if end <= f.committedTo {
+		return
+	}
+	if end > c.maxSliceEnd {
+		c.maxSliceEnd = end
+	}
+	if c.queued {
 		return
 	}
 	c.queued = true
@@ -314,6 +312,7 @@ func (f *fileWriter) dequeueCommit(c *chunkWriter) {
 	}
 	f.commitQueue = f.commitQueue[1:]
 	c.queued = false
+	c.maxSliceEnd = 0
 	f.commitcond.Broadcast()
 }
 
@@ -486,6 +485,7 @@ func (f *fileWriter) Truncate(length uint64) {
 	// TODO: truncate write buffer if length < f.length
 	f.length = length
 	f.committedTo = length
+	// Truncate doesn't drop slices from c.slices, so leave maxSliceEnd as is
 }
 
 type dataWriter struct {

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -51,20 +51,19 @@ type DataWriter interface {
 }
 
 type sliceWriter struct {
-	id         uint64
-	chunk      *chunkWriter
-	off        uint32
-	length     uint32
-	soff       uint32
-	slen       uint32
-	writer     chunk.Writer
-	growLength bool // true if this slice will extend file length visible in metadata
-	freezed    bool
-	done       bool
-	err        syscall.Errno
-	notify     *utils.Cond
-	started    time.Time
-	lastMod    time.Time
+	id      uint64
+	chunk   *chunkWriter
+	off     uint32
+	length  uint32
+	soff    uint32
+	slen    uint32
+	writer  chunk.Writer
+	freezed bool
+	done    bool
+	err     syscall.Errno
+	notify  *utils.Cond
+	started time.Time
+	lastMod time.Time
 }
 
 func (s *sliceWriter) prepareID(ctx meta.Context, retry bool) {
@@ -156,6 +155,7 @@ type chunkWriter struct {
 	indx   uint32
 	file   *fileWriter
 	slices []*sliceWriter
+	queued bool
 }
 
 // protected by file
@@ -196,11 +196,12 @@ func (c *chunkWriter) commitThread() {
 			}
 		}
 
-		// Only commits that extend the file need ordering - they could expose a
+		// Only commits that extend file size need ordering - they could expose a
 		// "hole" (zeros) if an earlier chunk's data hasn't been committed yet.
 		// Overwrites within the committed length are safe to proceed concurrently.
-		if s.growLength {
-			f.waitCommit(s)
+		// Slice order within a chunk is handled by c.slices FIFO above.
+		if c.queued {
+			f.waitCommit(c)
 		}
 
 		err := s.err
@@ -227,8 +228,10 @@ func (c *chunkWriter) commitThread() {
 		} else if end := c.sliceEnd(s); end > f.committedTo {
 			f.committedTo = end
 		}
-		f.finishCommit(s)
 		c.slices = c.slices[1:]
+		if c.queued && !c.hasSliceBeyond(f.committedTo) { // recheck after dequeuing one committed slice
+			f.dequeueCommit(c)
+		}
 	}
 	f.freeChunk(c)
 	f.Unlock()
@@ -247,11 +250,11 @@ type fileWriter struct {
 	refs         uint16
 	chunks       map[uint32]*chunkWriter
 	committedTo  uint64 // highest file length already committed to metadata
-	commitQueue  []*sliceWriter
+	commitQueue  []*chunkWriter
 
 	flushcond  *utils.Cond // wait for chunks==nil (flush)
 	writecond  *utils.Cond // wait for flushwaiting==0 (write)
-	commitcond *utils.Cond // wait for grow-length slices to commit in queue order
+	commitcond *utils.Cond // wait for grow-length chunks to commit in queue order
 }
 
 // protected by file
@@ -276,28 +279,41 @@ func (c *chunkWriter) sliceEnd(s *sliceWriter) uint64 {
 	return uint64(c.indx)*meta.ChunkSize + uint64(s.off) + uint64(s.slen)
 }
 
-func (f *fileWriter) enqueueCommit(s *sliceWriter) {
-	if s.growLength || s.chunk.sliceEnd(s) <= f.committedTo {
-		return
+// protected by file
+func (c *chunkWriter) hasSliceBeyond(length uint64) bool {
+	for _, s := range c.slices {
+		if c.sliceEnd(s) > length {
+			return true
+		}
 	}
-	s.growLength = true
-	f.commitQueue = append(f.commitQueue, s)
+	return false
 }
 
-func (f *fileWriter) waitCommit(s *sliceWriter) {
-	for len(f.commitQueue) > 0 && f.commitQueue[0] != s { // not my turn
+// protected by file
+func (f *fileWriter) tryEnqueueCommit(s *sliceWriter) {
+	c := s.chunk
+	if c.queued || c.sliceEnd(s) <= f.committedTo {
+		return
+	}
+	c.queued = true
+	f.commitQueue = append(f.commitQueue, c)
+	f.commitcond.Broadcast()
+}
+
+// protected by file
+func (f *fileWriter) waitCommit(c *chunkWriter) {
+	for len(f.commitQueue) > 0 && f.commitQueue[0] != c { // not my turn
 		f.commitcond.WaitWithTimeout(time.Millisecond * 100)
 	}
 }
 
-func (f *fileWriter) finishCommit(s *sliceWriter) {
-	if !s.growLength {
-		return
-	}
-	if len(f.commitQueue) == 0 || f.commitQueue[0] != s { // data race happened after waitCommit?
+// protected by file
+func (f *fileWriter) dequeueCommit(c *chunkWriter) {
+	if len(f.commitQueue) == 0 || f.commitQueue[0] != c { // data race happened after waitCommit?
 		panic(fmt.Sprintf("write inode:%d commit queue out of order", f.inode))
 	}
 	f.commitQueue = f.commitQueue[1:]
+	c.queued = false
 	f.commitcond.Broadcast()
 }
 
@@ -325,7 +341,7 @@ func (f *fileWriter) writeChunk(ctx meta.Context, indx uint32, off uint32, data 
 	if st := s.write(ctx, off-s.off, data); st != 0 {
 		return st
 	}
-	f.enqueueCommit(s)
+	f.tryEnqueueCommit(s)
 	return 0
 }
 

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -204,10 +204,6 @@ func (c *chunkWriter) commitThread() {
 		}
 
 		err := s.err
-		skipped := err == 0 && f.err != 0
-		if skipped {
-			err = f.err
-		}
 		f.Unlock()
 
 		if err == 0 {
@@ -218,7 +214,7 @@ func (c *chunkWriter) commitThread() {
 
 		f.Lock()
 		if err != 0 {
-			if skipped || err == syscall.ENOENT || err == syscall.ENOSPC || err == syscall.EDQUOT {
+			if err == syscall.ENOENT || err == syscall.ENOSPC || err == syscall.EDQUOT {
 				go func(id uint64, length int) {
 					_ = f.w.store.Remove(id, length)
 				}(s.id, int(s.length))

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -17,6 +17,7 @@
 package vfs
 
 import (
+	"fmt"
 	"math/rand"
 	"runtime"
 	"sync"
@@ -279,12 +280,6 @@ func (c *chunkWriter) sliceEnd(s *sliceWriter) uint64 {
 	return uint64(c.indx)*meta.ChunkSize + uint64(s.off) + uint64(s.slen)
 }
 
-func (f *fileWriter) waitCommit(s *sliceWriter) {
-	for len(f.commitQueue) > 0 && f.commitQueue[0] != s {
-		f.commitcond.WaitWithTimeout(time.Millisecond * 100)
-	}
-}
-
 func (f *fileWriter) enqueueCommit(s *sliceWriter) {
 	if s.growLength || s.chunk.sliceEnd(s) <= f.committedTo {
 		return
@@ -293,26 +288,21 @@ func (f *fileWriter) enqueueCommit(s *sliceWriter) {
 	f.commitQueue = append(f.commitQueue, s)
 }
 
+func (f *fileWriter) waitCommit(s *sliceWriter) {
+	for len(f.commitQueue) > 0 && f.commitQueue[0] != s { // not my turn
+		f.commitcond.WaitWithTimeout(time.Millisecond * 100)
+	}
+}
+
 func (f *fileWriter) finishCommit(s *sliceWriter) {
 	if !s.growLength {
 		return
 	}
-	// Queue head should always match `s` after waitCommit returns
-	if len(f.commitQueue) > 0 && f.commitQueue[0] == s {
-		f.commitQueue = f.commitQueue[1:]
-		f.commitcond.Broadcast()
-		return
+	if len(f.commitQueue) == 0 || f.commitQueue[0] != s { // data race happened after waitCommit?
+		panic(fmt.Sprintf("write inode:%d commit queue out of order", f.inode))
 	}
-	// Fallback path to avoid wedging future commits if that invariant is broken
-	for i, queued := range f.commitQueue {
-		if queued == s {
-			logger.Warnf("write inode:%d grow-length queue out of order, should not happen", f.inode)
-			copy(f.commitQueue[i:], f.commitQueue[i+1:])
-			f.commitQueue = f.commitQueue[:len(f.commitQueue)-1]
-			f.commitcond.Broadcast()
-			return
-		}
-	}
+	f.commitQueue = f.commitQueue[1:]
+	f.commitcond.Broadcast()
 }
 
 // protected by file

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -202,6 +202,10 @@ func (c *chunkWriter) commitThread() {
 		}
 
 		err := s.err
+		skipped := err == 0 && f.err != 0
+		if skipped {
+			err = f.err
+		}
 		f.Unlock()
 
 		if err == 0 {
@@ -212,7 +216,7 @@ func (c *chunkWriter) commitThread() {
 
 		f.Lock()
 		if err != 0 {
-			if err == syscall.ENOENT || err == syscall.ENOSPC || err == syscall.EDQUOT {
+			if skipped || err == syscall.ENOENT || err == syscall.ENOSPC || err == syscall.EDQUOT {
 				go func(id uint64, length int) {
 					_ = f.w.store.Remove(id, length)
 				}(s.id, int(s.length))

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -193,6 +193,14 @@ func (c *chunkWriter) commitThread() {
 				go s.flushData()
 			}
 		}
+
+		// Only commits that extend the file need ordering - they could expose a
+		// "hole" (zeros) if an earlier chunk's data hasn't been committed yet.
+		// Overwrites within the committed length are safe to proceed concurrently.
+		for f.hasLowerPendingChunk(c.indx) {
+			f.commitcond.WaitWithTimeout(time.Millisecond * 100)
+		}
+
 		err := s.err
 		f.Unlock()
 
@@ -214,6 +222,10 @@ func (c *chunkWriter) commitThread() {
 			}
 			f.err = err
 			logger.Errorf("write inode:%d indx:%d %s", f.inode, c.indx, err)
+		} else {
+			if end := c.sliceEnd(s); end > f.committedTo {
+				f.committedTo = end
+			}
 		}
 		c.slices = c.slices[1:]
 	}
@@ -227,6 +239,7 @@ type fileWriter struct {
 
 	inode        Ino
 	length       uint64
+	committedTo  uint64
 	tierID       uint8
 	err          syscall.Errno
 	flushwaiting uint16
@@ -234,8 +247,9 @@ type fileWriter struct {
 	refs         uint16
 	chunks       map[uint32]*chunkWriter
 
-	flushcond *utils.Cond // wait for chunks==nil (flush)
-	writecond *utils.Cond // wait for flushwaiting==0 (write)
+	flushcond  *utils.Cond // wait for chunks==nil (flush)
+	writecond  *utils.Cond // wait for flushwaiting==0 (write)
+	commitcond *utils.Cond // wait for lower-index chunks to finish committing
 }
 
 // protected by file
@@ -251,9 +265,35 @@ func (f *fileWriter) findChunk(i uint32) *chunkWriter {
 // protected by file
 func (f *fileWriter) freeChunk(c *chunkWriter) {
 	delete(f.chunks, c.indx)
+	// Wake higher-index commitThreads that wait for this chunk to finish
+	f.commitcond.Broadcast()
 	if len(f.chunks) == 0 && f.flushwaiting > 0 {
 		f.flushcond.Broadcast()
 	}
+}
+
+func (c *chunkWriter) sliceEnd(s *sliceWriter) uint64 {
+	return uint64(c.indx)*meta.ChunkSize + uint64(s.off) + uint64(s.slen)
+}
+
+func (c *chunkWriter) hasPendingBeyond(length uint64) bool {
+	for _, s := range c.slices {
+		if c.sliceEnd(s) > length {
+			return true
+		}
+	}
+	return false
+}
+
+// hasLowerPendingChunk reports whether any lower-index chunk still has a
+// pending slice that may still push committedTo forward.
+func (f *fileWriter) hasLowerPendingChunk(indx uint32) bool {
+	for i, c := range f.chunks {
+		if i < indx && c.hasPendingBeyond(f.committedTo) {
+			return true
+		}
+	}
+	return false
 }
 
 // protected by file
@@ -420,6 +460,7 @@ func (f *fileWriter) Truncate(length uint64) {
 	defer f.Unlock()
 	// TODO: truncate write buffer if length < f.length
 	f.length = length
+	f.committedTo = length
 }
 
 type dataWriter struct {
@@ -485,14 +526,16 @@ func (w *dataWriter) Open(inode Ino, len uint64, tierID uint8) FileWriter {
 	f, ok := w.files[inode]
 	if !ok {
 		f = &fileWriter{
-			w:      w,
-			inode:  inode,
-			length: len,
-			tierID: tierID,
-			chunks: make(map[uint32]*chunkWriter),
+			w:           w,
+			inode:       inode,
+			length:      len,
+			committedTo: len,
+			tierID:      tierID,
+			chunks:      make(map[uint32]*chunkWriter),
 		}
 		f.flushcond = utils.NewCond(f)
 		f.writecond = utils.NewCond(f)
+		f.commitcond = utils.NewCond(f)
 		w.files[inode] = f
 	}
 	f.refs++


### PR DESCRIPTION
Fixes #5038.

Technically speaking, this is not a bug, but given the append-only log-writing scenario, it’s not an uncommon use case. I think it’s better to fix it rather than exposing holes to readers.

## Description

Buffered writes are committed asynchronously per chunk. A later chunk can finish first and update metadata before an earlier chunk that is still pending. When that out-of-order commit extends the visible file size, concurrent readers may observe empty holes in the gap, and the hole can remain if the earlier commit later fails.

## Fix

- commits that extend the file wait until lower-index chunks no longer have pending slices beyond `committedTo`
- overwrites within the already committed range still proceed concurrently
- donot publish later chunks after commit failure

## Cost

Data uploads still run in parallel across all chunks — only the lightweight metadata commits are serialized in chunk index order, so there should be only a very small performance regression.
