### PR TITLE
object: add User-Agent to all storage backends

### DIFF
--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	blob2 "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -251,7 +252,7 @@ func autoWasbEndpoint(containerName, accountName, scheme string, credential *azb
 			logger.Debugf("Attempt to resolve domain name %s failed: %s", baseURL, err)
 			continue
 		}
-		client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL), credential, nil)
+		client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL), credential, azblobOptions())
 		if err != nil {
 			return "", err
 		}
@@ -277,7 +278,7 @@ func autoWasbEndpointWithToken(containerName, accountName, scheme string, creden
 			logger.Debugf("Attempt to resolve domain name %s failed: %s", baseURL, err)
 			continue
 		}
-		client, err := azblob.NewClient(fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL), credential, nil)
+		client, err := azblob.NewClient(fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL), credential, azblobOptions())
 		if err != nil {
 			return "", err
 		}
@@ -293,6 +294,16 @@ func autoWasbEndpointWithToken(containerName, accountName, scheme string, creden
 		return "", fmt.Errorf("fail to get endpoint for container %s", containerName)
 	}
 	return endpoint, nil
+}
+
+func azblobOptions() *azblob.ClientOptions {
+	return &azblob.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: UserAgent,
+			},
+		},
+	}
 }
 
 func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, error) {
@@ -311,7 +322,7 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 	if connString := os.Getenv("AZURE_STORAGE_CONNECTION_STRING"); connString != "" {
 		logger.Debugf("Using Azure connection string authentication")
 		var client *azblob.Client
-		if client, err = azblob.NewClientFromConnectionString(connString, nil); err != nil {
+		if client, err = azblob.NewClientFromConnectionString(connString, azblobOptions()); err != nil {
 			return nil, err
 		}
 		return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName, useTokenAuth: false}, nil
@@ -336,7 +347,7 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 		}
 
 		serviceURL := fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain)
-		client, err := azblob.NewClient(serviceURL, tokenCred, nil)
+		client, err := azblob.NewClient(serviceURL, tokenCred, azblobOptions())
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create Azure blob client with token credential: %v", err)
 		}
@@ -361,7 +372,7 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 		return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
 	}
 
-	client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain), credential, nil)
+	client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain), credential, azblobOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/object/b2.go
+++ b/pkg/object/b2.go
@@ -164,6 +164,7 @@ func newB2(endpoint, keyID, applicationKey, token string) (ObjectStorage, error)
 	}
 	hostParts := strings.Split(uri.Host, ".")
 	name := hostParts[0]
+	// TODO: set UserAgent once kothar/go-backblaze supports http.Client injection
 	client, err := backblaze.NewB2(backblaze.Credentials{
 		KeyID:          keyID,
 		ApplicationKey: applicationKey,

--- a/pkg/object/gs.go
+++ b/pkg/object/gs.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 type gs struct {
@@ -224,7 +225,7 @@ func newGS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 	}
 	clis := make([]*storage.Client, size)
 	for i := 0; i < size; i++ {
-		client, err := storage.NewClient(ctx)
+		client, err := storage.NewClient(ctx, option.WithUserAgent(UserAgent))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -330,6 +330,7 @@ func newIBMCOS(endpoint, apiKey, serviceInstanceID, token string) (ObjectStorage
 			authEndpoint, apiKey, serviceInstanceID)).
 		WithS3ForcePathStyle(defaultPathStyle())
 	sess := session.Must(session.NewSession())
+	sess.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler(UserAgent))
 	client := s3.New(sess, conf)
 	return &ibmcos{bucket: bucket, s3: client}, nil
 }

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -414,7 +414,8 @@ func newOBS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	// Empty proxy url string has no effect
 	// there is a bug in the retry of PUT (did not call Seek(0,0) before retry), so disable the retry here
 	c, err := obs.New(accessKey, secretKey, endpoint, obs.WithSecurityToken(token),
-		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithHttpTransport(httpClient.Transport.(*http.Transport)))
+		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithUserAgent(UserAgent),
+		obs.WithHttpTransport(httpClient.Transport.(*http.Transport)))
 	if err != nil {
 		return nil, fmt.Errorf("fail to initialize OBS: %q", err)
 	}

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -214,9 +215,12 @@ func newQiniu(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		options.EndpointOptions.DisableHTTPS = uri.Scheme == "http"
 		options.UsePathStyle = true
 		options.HTTPClient = httpClient
-		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
-			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
-		})
+		options.APIOptions = append(options.APIOptions,
+			func(stack *smithymiddleware.Stack) error {
+				return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+			},
+			middleware.AddUserAgentKey(UserAgent),
+		)
 		options.RetryMaxAttempts = 1
 	})
 	s3c := s3client{bucket: bucket, s3: client, region: region}

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -222,6 +222,7 @@ func (s *RestfulStorage) request(ctx context.Context, method, key string, body i
 			req.ContentLength = st.Size()
 		}
 	}
+	req.Header.Set("User-Agent", UserAgent)
 	now := time.Now().UTC().Format(http.TimeFormat)
 	req.Header.Add("Date", now)
 	for key := range headers {

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -561,9 +561,12 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 	optFns = append(optFns, func(options *s3.Options) {
 		options.EndpointOptions.DisableHTTPS = !ssl
 		options.Region = region
-		options.APIOptions = append(options.APIOptions, func(stack *smithymiddleware.Stack) error {
-			return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
-		})
+		options.APIOptions = append(options.APIOptions,
+			func(stack *smithymiddleware.Stack) error {
+				return v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware(stack)
+			},
+			middleware.AddUserAgentKey(UserAgent),
+		)
 		options.RetryMaxAttempts = 1
 	})
 

--- a/pkg/object/swift.go
+++ b/pkg/object/swift.go
@@ -151,6 +151,7 @@ func newSwiftOSS(endpoint, username, apiKey, token string) (ObjectStorage, error
 		ApiKey:    apiKey,
 		AuthToken: token,
 		AuthUrl:   authURL,
+		UserAgent: UserAgent,
 		Transport: httpClient.Transport.(*http.Transport),
 	}
 	err = conn.Authenticate(context.Background())

--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -321,6 +321,7 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		hostParts[1]+"."+hostParts[2],
 		tos.WithRegion(strings.TrimPrefix(hostParts[1], "tos-")),
 		tos.WithCredentials(credentials),
+		tos.WithUserAgentProductName(UserAgent),
 		tos.WithEnableVerifySSL(httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify),
 		tos.WithEnableCRC(!disableChecksum))
 	if err != nil {

--- a/pkg/object/ufile.go
+++ b/pkg/object/ufile.go
@@ -116,6 +116,7 @@ func (u *ufile) Create(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("User-Agent", UserAgent)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err

--- a/pkg/object/webdav.go
+++ b/pkg/object/webdav.go
@@ -188,6 +188,7 @@ func newWebDAV(endpoint, user, passwd, token string) (ObjectStorage, error) {
 	}
 	c := gowebdav.NewClient(uri.String(), user, passwd)
 	c.SetTransport(httpClient.Transport)
+	c.SetHeader("User-Agent", UserAgent)
 	return &webdav{endpoint: uri, c: c}, nil
 }
 


### PR DESCRIPTION
## Summary

- Wire the existing `UserAgent` variable into all storage backends that were missing it: **S3**, **Qiniu**, **WebDAV**, **UFile**, **TOS** (Volcengine), **IBM COS**, **Google Cloud Storage**, and **Azure Blob Storage**
- Uses each SDK's idiomatic mechanism: aws-sdk-go-v2 middleware, Azure telemetry options, GCS client options, TOS product name option, and direct `User-Agent` header setting for HTTP-based backends
- The native B2 backend cannot be covered yet because [kothar/go-backblaze](https://github.com/kothar/go-backblaze) does not expose `http.Client` injection — a TODO comment is added, and an [upstream PR](https://github.com/kothar/go-backblaze/pull/46) has been submitted to unblock this

## Motivation

Several backends (BOS, COS, OSS, Storj) already set `UserAgent`, but the majority — including the S3 backend that covers Backblaze B2's S3-compatible endpoint — did not. This means cloud storage providers cannot identify JuiceFS traffic in access logs.

Setting a User-Agent follows conventions established by rclone, minio-go, and aws-sdk-go, and aligns with [Backblaze's integration checklist](https://www.backblaze.com/docs/cloud-storage-integration-checklist) guidance for integrators. It gives operators version visibility for support and issue triage.

## Test plan

- [ ] Build with `make juicefs`
- [ ] For S3-compatible backends: format and mount a JuiceFS volume against MinIO (`docker run -p 9000:9000 minio/minio server /data`), perform reads/writes, and verify `JuiceFS-<version>` appears in `mc admin trace` output's User-Agent field
- [ ] For other backends: run existing integration tests in `pkg/object/*_test.go`
- [ ] Verify no regressions in backends that already set UserAgent (BOS, COS, OSS, Storj)

🤖 Generated with [Claude Code](https://claude.com/claude-code)