### PR TITLE
feat(wasb): support sas token authentication via --session-token

### DIFF
--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -333,12 +333,13 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 			if domain == "" {
 				domain = "blob.core.windows.net"
 			}
-			sasURL := fmt.Sprintf("%s://%s.%s?%s", uri.Scheme, accountName, domain, token)
+			normalizedToken := strings.TrimPrefix(strings.TrimSpace(token), "?")
+			sasURL := fmt.Sprintf("%s://%s.%s?%s", uri.Scheme, accountName, domain, normalizedToken)
 			client, err := azblob.NewClientWithNoCredential(sasURL, nil)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to create Azure blob client with SAS token: %v", err)
 			}
-			return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName}, nil
+			return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName, useTokenAuth: true}, nil
 		}
 
 		// Managed identity / token-based authentication

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -310,8 +310,9 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 	if accountKey == "" {
 		domain := domainFromHost(hostParts)
 
-		if token != "" {
-			normalized := normalizeSASToken(token)
+		normalized := normalizeSASToken(token)
+
+		if normalized != "" {
 			if domain == "" {
 				var err error
 				if domain, err = autoWasbEndpoint(accountName, uri.Scheme, func(serviceURL string) (*azblob.Client, error) {

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -246,26 +246,30 @@ func createAzureCredential() (azcore.TokenCredential, error) {
 func autoWasbEndpoint(containerName, accountName, scheme string, makeClient func(serviceURL string) (*azblob.Client, error)) (string, error) {
 	baseURLs := []string{"blob.core.windows.net", "blob.core.chinacloudapi.cn"}
 	endpoint := ""
+	var lastErr error
 	for _, baseURL := range baseURLs {
 		if _, err := net.LookupIP(fmt.Sprintf("%s.%s", accountName, baseURL)); err != nil {
 			logger.Debugf("Attempt to resolve domain name %s failed: %s", baseURL, err)
+			lastErr = err
 			continue
 		}
 		serviceURL := fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL)
 		client, err := makeClient(serviceURL)
 		if err != nil {
 			logger.Debugf("Try to create client at %s failed: %s", baseURL, err)
+			lastErr = err
 			continue
 		}
 		if _, err = client.ServiceClient().GetProperties(ctx, nil); err != nil {
 			logger.Debugf("Try to get service properties at %s failed: %s", baseURL, err)
+			lastErr = err
 			continue
 		}
 		endpoint = baseURL
 		break
 	}
 	if endpoint == "" {
-		return "", fmt.Errorf("fail to get endpoint for container %s", containerName)
+		return "", fmt.Errorf("fail to get endpoint for container %s: %w", containerName, lastErr)
 	}
 	return endpoint, nil
 }

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -317,22 +317,40 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 		return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName, useTokenAuth: false}, nil
 	}
 
-	// Priority 2: Try managed identity / token-based authentication if no account key provided
+	// Priority 2: No account key — use SAS token or managed identity
 	if accountKey == "" {
-		logger.Debugf("No account key provided, attempting token-based authentication (managed identity, Azure CLI, etc.)")
-		tokenCred, err := createAzureCredential()
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create Azure credential (managed identity/Azure CLI): %v", err)
-		}
-
 		var domain string
 		if len(hostParts) > 1 {
 			domain = hostParts[1]
 			if !strings.HasPrefix(hostParts[1], "blob") {
 				domain = fmt.Sprintf("blob.%s", hostParts[1])
 			}
-		} else if domain, err = autoWasbEndpointWithToken(containerName, accountName, uri.Scheme, tokenCred); err != nil {
-			return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
+		}
+
+		if token != "" {
+			// SAS token authentication via --session-token
+			logger.Debugf("Using SAS token authentication")
+			if domain == "" {
+				domain = "blob.core.windows.net"
+			}
+			sasURL := fmt.Sprintf("%s://%s.%s?%s", uri.Scheme, accountName, domain, token)
+			client, err := azblob.NewClientWithNoCredential(sasURL, nil)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to create Azure blob client with SAS token: %v", err)
+			}
+			return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName}, nil
+		}
+
+		// Managed identity / token-based authentication
+		logger.Debugf("No account key provided, attempting token-based authentication (managed identity, Azure CLI, etc.)")
+		tokenCred, err := createAzureCredential()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create Azure credential (managed identity/Azure CLI): %v", err)
+		}
+		if domain == "" {
+			if domain, err = autoWasbEndpointWithToken(containerName, accountName, uri.Scheme, tokenCred); err != nil {
+				return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
+			}
 		}
 
 		serviceURL := fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain)

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -260,8 +260,8 @@ func autoWasbEndpoint(containerName, accountName, scheme string, makeClient func
 			lastErr = err
 			continue
 		}
-		if _, err = client.ServiceClient().NewContainerClient(containerName).GetProperties(ctx, nil); err != nil {
-			logger.Debugf("Try to get container properties at %s failed: %s", baseURL, err)
+		if _, err = client.ServiceClient().GetProperties(ctx, nil); err != nil {
+			logger.Debugf("Try to get service properties at %s failed: %s", baseURL, err)
 			lastErr = err
 			continue
 		}

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -243,7 +243,7 @@ func createAzureCredential() (azcore.TokenCredential, error) {
 	return cred, nil
 }
 
-func autoWasbEndpoint(containerName, accountName, scheme string, credential *azblob.SharedKeyCredential) (string, error) {
+func autoWasbEndpoint(containerName, accountName, scheme string, makeClient func(serviceURL string) (*azblob.Client, error)) (string, error) {
 	baseURLs := []string{"blob.core.windows.net", "blob.core.chinacloudapi.cn"}
 	endpoint := ""
 	for _, baseURL := range baseURLs {
@@ -251,35 +251,11 @@ func autoWasbEndpoint(containerName, accountName, scheme string, credential *azb
 			logger.Debugf("Attempt to resolve domain name %s failed: %s", baseURL, err)
 			continue
 		}
-		client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL), credential, nil)
+		serviceURL := fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL)
+		client, err := makeClient(serviceURL)
 		if err != nil {
-			return "", err
-		}
-		if _, err = client.ServiceClient().GetProperties(ctx, nil); err != nil {
-			logger.Debugf("Try to get containers properties at %s failed: %s", baseURL, err)
+			logger.Debugf("Try to create client at %s failed: %s", baseURL, err)
 			continue
-		}
-		endpoint = baseURL
-		break
-	}
-
-	if endpoint == "" {
-		return "", fmt.Errorf("fail to get endpoint for container %s", containerName)
-	}
-	return endpoint, nil
-}
-
-func autoWasbEndpointWithToken(containerName, accountName, scheme string, credential azcore.TokenCredential) (string, error) {
-	baseURLs := []string{"blob.core.windows.net", "blob.core.chinacloudapi.cn"}
-	endpoint := ""
-	for _, baseURL := range baseURLs {
-		if _, err := net.LookupIP(fmt.Sprintf("%s.%s", accountName, baseURL)); err != nil {
-			logger.Debugf("Attempt to resolve domain name %s failed: %s", baseURL, err)
-			continue
-		}
-		client, err := azblob.NewClient(fmt.Sprintf("%s://%s.%s", scheme, accountName, baseURL), credential, nil)
-		if err != nil {
-			return "", err
 		}
 		if _, err = client.ServiceClient().GetProperties(ctx, nil); err != nil {
 			logger.Debugf("Try to get service properties at %s failed: %s", baseURL, err)
@@ -288,11 +264,30 @@ func autoWasbEndpointWithToken(containerName, accountName, scheme string, creden
 		endpoint = baseURL
 		break
 	}
-
 	if endpoint == "" {
 		return "", fmt.Errorf("fail to get endpoint for container %s", containerName)
 	}
 	return endpoint, nil
+}
+
+func autoWasbEndpointWithSharedKey(containerName, accountName, scheme string, credential *azblob.SharedKeyCredential) (string, error) {
+	return autoWasbEndpoint(containerName, accountName, scheme, func(serviceURL string) (*azblob.Client, error) {
+		return azblob.NewClientWithSharedKeyCredential(serviceURL, credential, nil)
+	})
+}
+
+func autoWasbEndpointWithToken(containerName, accountName, scheme string, credential azcore.TokenCredential) (string, error) {
+	return autoWasbEndpoint(containerName, accountName, scheme, func(serviceURL string) (*azblob.Client, error) {
+		return azblob.NewClient(serviceURL, credential, nil)
+	})
+}
+
+func autoWasbEndpointWithSASToken(containerName, accountName, scheme, token string) (string, error) {
+	normalizedToken := strings.TrimPrefix(strings.TrimSpace(token), "?")
+	return autoWasbEndpoint(containerName, accountName, scheme, func(serviceURL string) (*azblob.Client, error) {
+		sasURL := serviceURL + "?" + normalizedToken
+		return azblob.NewClientWithNoCredential(sasURL, nil)
+	})
 }
 
 func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, error) {
@@ -331,7 +326,10 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 			// SAS token authentication via --session-token
 			logger.Debugf("Using SAS token authentication")
 			if domain == "" {
-				domain = "blob.core.windows.net"
+				var err error
+				if domain, err = autoWasbEndpointWithSASToken(containerName, accountName, uri.Scheme, token); err != nil {
+					return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
+				}
 			}
 			normalizedToken := strings.TrimPrefix(strings.TrimSpace(token), "?")
 			sasURL := fmt.Sprintf("%s://%s.%s?%s", uri.Scheme, accountName, domain, normalizedToken)
@@ -376,7 +374,7 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 		if !strings.HasPrefix(hostParts[1], "blob") {
 			domain = fmt.Sprintf("blob.%s", hostParts[1])
 		}
-	} else if domain, err = autoWasbEndpoint(containerName, accountName, uri.Scheme, credential); err != nil {
+	} else if domain, err = autoWasbEndpointWithSharedKey(containerName, accountName, uri.Scheme, credential); err != nil {
 		return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
 	}
 

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -358,7 +358,7 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 		if domain, err = autoWasbEndpoint(accountName, uri.Scheme, func(serviceURL string) (*azblob.Client, error) {
 			return azblob.NewClientWithSharedKeyCredential(serviceURL, credential, nil)
 		}); err != nil {
-			return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
+			return nil, fmt.Errorf("Unable to get endpoint of container %s: %w", containerName, err)
 		}
 	}
 	client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain), credential, nil)

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -260,8 +260,8 @@ func autoWasbEndpoint(containerName, accountName, scheme string, makeClient func
 			lastErr = err
 			continue
 		}
-		if _, err = client.ServiceClient().GetProperties(ctx, nil); err != nil {
-			logger.Debugf("Try to get service properties at %s failed: %s", baseURL, err)
+		if _, err = client.ServiceClient().NewContainerClient(containerName).GetProperties(ctx, nil); err != nil {
+			logger.Debugf("Try to get container properties at %s failed: %s", baseURL, err)
 			lastErr = err
 			continue
 		}

--- a/pkg/object/azure.go
+++ b/pkg/object/azure.go
@@ -243,9 +243,23 @@ func createAzureCredential() (azcore.TokenCredential, error) {
 	return cred, nil
 }
 
-func autoWasbEndpoint(containerName, accountName, scheme string, makeClient func(serviceURL string) (*azblob.Client, error)) (string, error) {
+func normalizeSASToken(token string) string {
+	return strings.TrimPrefix(strings.TrimSpace(token), "?")
+}
+
+func domainFromHost(hostParts []string) string {
+	if len(hostParts) <= 1 {
+		return ""
+	}
+	domain := hostParts[1]
+	if !strings.HasPrefix(domain, "blob") {
+		return fmt.Sprintf("blob.%s", domain)
+	}
+	return domain
+}
+
+func autoWasbEndpoint(accountName, scheme string, makeClient func(serviceURL string) (*azblob.Client, error)) (string, error) {
 	baseURLs := []string{"blob.core.windows.net", "blob.core.chinacloudapi.cn"}
-	endpoint := ""
 	var lastErr error
 	for _, baseURL := range baseURLs {
 		if _, err := net.LookupIP(fmt.Sprintf("%s.%s", accountName, baseURL)); err != nil {
@@ -265,33 +279,9 @@ func autoWasbEndpoint(containerName, accountName, scheme string, makeClient func
 			lastErr = err
 			continue
 		}
-		endpoint = baseURL
-		break
+		return baseURL, nil
 	}
-	if endpoint == "" {
-		return "", fmt.Errorf("fail to get endpoint for container %s: %w", containerName, lastErr)
-	}
-	return endpoint, nil
-}
-
-func autoWasbEndpointWithSharedKey(containerName, accountName, scheme string, credential *azblob.SharedKeyCredential) (string, error) {
-	return autoWasbEndpoint(containerName, accountName, scheme, func(serviceURL string) (*azblob.Client, error) {
-		return azblob.NewClientWithSharedKeyCredential(serviceURL, credential, nil)
-	})
-}
-
-func autoWasbEndpointWithToken(containerName, accountName, scheme string, credential azcore.TokenCredential) (string, error) {
-	return autoWasbEndpoint(containerName, accountName, scheme, func(serviceURL string) (*azblob.Client, error) {
-		return azblob.NewClient(serviceURL, credential, nil)
-	})
-}
-
-func autoWasbEndpointWithSASToken(containerName, accountName, scheme, token string) (string, error) {
-	normalizedToken := strings.TrimPrefix(strings.TrimSpace(token), "?")
-	return autoWasbEndpoint(containerName, accountName, scheme, func(serviceURL string) (*azblob.Client, error) {
-		sasURL := serviceURL + "?" + normalizedToken
-		return azblob.NewClientWithNoCredential(sasURL, nil)
-	})
+	return "", fmt.Errorf("fail to auto-detect endpoint: %w", lastErr)
 }
 
 func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, error) {
@@ -318,25 +308,19 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 
 	// Priority 2: No account key — use SAS token or managed identity
 	if accountKey == "" {
-		var domain string
-		if len(hostParts) > 1 {
-			domain = hostParts[1]
-			if !strings.HasPrefix(hostParts[1], "blob") {
-				domain = fmt.Sprintf("blob.%s", hostParts[1])
-			}
-		}
+		domain := domainFromHost(hostParts)
 
 		if token != "" {
-			// SAS token authentication via --session-token
-			logger.Debugf("Using SAS token authentication")
+			normalized := normalizeSASToken(token)
 			if domain == "" {
 				var err error
-				if domain, err = autoWasbEndpointWithSASToken(containerName, accountName, uri.Scheme, token); err != nil {
+				if domain, err = autoWasbEndpoint(accountName, uri.Scheme, func(serviceURL string) (*azblob.Client, error) {
+					return azblob.NewClientWithNoCredential(serviceURL+"?"+normalized, nil)
+				}); err != nil {
 					return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
 				}
 			}
-			normalizedToken := strings.TrimPrefix(strings.TrimSpace(token), "?")
-			sasURL := fmt.Sprintf("%s://%s.%s?%s", uri.Scheme, accountName, domain, normalizedToken)
+			sasURL := fmt.Sprintf("%s://%s.%s?%s", uri.Scheme, accountName, domain, normalized)
 			client, err := azblob.NewClientWithNoCredential(sasURL, nil)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to create Azure blob client with SAS token: %v", err)
@@ -344,49 +328,43 @@ func newWasb(endpoint, accountName, accountKey, token string) (ObjectStorage, er
 			return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName, useTokenAuth: true}, nil
 		}
 
-		// Managed identity / token-based authentication
-		logger.Debugf("No account key provided, attempting token-based authentication (managed identity, Azure CLI, etc.)")
 		tokenCred, err := createAzureCredential()
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create Azure credential (managed identity/Azure CLI): %v", err)
 		}
 		if domain == "" {
-			if domain, err = autoWasbEndpointWithToken(containerName, accountName, uri.Scheme, tokenCred); err != nil {
+			if domain, err = autoWasbEndpoint(accountName, uri.Scheme, func(serviceURL string) (*azblob.Client, error) {
+				return azblob.NewClient(serviceURL, tokenCred, nil)
+			}); err != nil {
 				return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
 			}
 		}
-
 		serviceURL := fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain)
 		client, err := azblob.NewClient(serviceURL, tokenCred, nil)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create Azure blob client with token credential: %v", err)
 		}
-		logger.Debugf("Successfully authenticated using token-based credential")
 		return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName, useTokenAuth: true}, nil
 	}
 
-	// Priority 3: Shared key authentication (existing behavior)
-	logger.Debugf("Using Azure shared key authentication")
+	// Priority 3: Shared key authentication
 	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
 		return nil, err
 	}
-
-	var domain string
-	if len(hostParts) > 1 {
-		domain = hostParts[1]
-		if !strings.HasPrefix(hostParts[1], "blob") {
-			domain = fmt.Sprintf("blob.%s", hostParts[1])
+	domain := domainFromHost(hostParts)
+	if domain == "" {
+		if domain, err = autoWasbEndpoint(accountName, uri.Scheme, func(serviceURL string) (*azblob.Client, error) {
+			return azblob.NewClientWithSharedKeyCredential(serviceURL, credential, nil)
+		}); err != nil {
+			return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
 		}
-	} else if domain, err = autoWasbEndpointWithSharedKey(containerName, accountName, uri.Scheme, credential); err != nil {
-		return nil, fmt.Errorf("Unable to get endpoint of container %s: %s", containerName, err)
 	}
-
 	client, err := azblob.NewClientWithSharedKeyCredential(fmt.Sprintf("%s://%s.%s", uri.Scheme, accountName, domain), credential, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName, useTokenAuth: false}, nil
+	return &wasb{container: client.ServiceClient().NewContainerClient(containerName), azblobCli: client, cName: containerName}, nil
 }
 
 func init() {

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -781,7 +781,7 @@ func TestAzure(t *testing.T) { //skip mutate
 	}
 	//https://containersName.core.windows.net
 	abs, _ := newWasb(os.Getenv("AZURE_ENDPOINT"),
-		os.Getenv("AZURE_STORAGE_ACCOUNT"), os.Getenv("AZURE_STORAGE_KEY"), "")
+		os.Getenv("AZURE_STORAGE_ACCOUNT"), os.Getenv("AZURE_STORAGE_KEY"), os.Getenv("AZURE_SAS_TOKEN"))
 	testStorage(t, abs)
 }
 


### PR DESCRIPTION
## Context
The WASB driver supports connection string, managed identity, and shared key authentication, but not SAS tokens. The `--session-token` flag exists and works for S3/OSS backends but is silently ignored for WASB. The only workaround is embedding the SAS in `AZURE_STORAGE_CONNECTION_STRING`, which decouples the auth from being handled by the metadata store, this is inconsistent with other blob stores implementation.

## Behavior
### Before
```bash
# SAS only works via environment variable — cannot be stored in metadata DB
export AZURE_STORAGE_CONNECTION_STRING="BlobEndpoint=https://account.blob.core.windows.net;SharedAccessSignature=sv=2026-02-06&sr=d&sig=..."
juicefs mount sqlite3://meta.db /mnt
```

Setting --session-token with --storage wasb has no effect. The token is stored in the metadata DB but silently ignored at mount time.

### After
```bash
# SAS token stored in metadata DB via --session-token, no env var needed
juicefs format --storage wasb \
  --bucket https://mycontainer \
  --access-key mystorageaccount \
  --session-token 'sv=2026-02-06&sr=d&sdd=1&sp=rwdl&sig=...' \
  sqlite3://meta.db myvolume

juicefs mount sqlite3://meta.db /mnt
```

The SAS token is persisted in the metadata DB and read at mount time. No environment variables required.

## Changes

•  Add SAS token authentication as a sub-case of the existing "no account key" branch in `newWasb()` (`pkg/object/azure.go`)
•  When `--session-token` is set and `--secret-key` is empty, create the Azure client using `NewClientWithNoCredential` with the SAS query string appended to the service URL