### PR TITLE
meta: fix group check when setting the setgid bit

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1494,14 +1494,7 @@ func (m *baseMeta) inheritMode(ctx Context, _type uint8, parentGid uint32, paren
 		if _type == TypeDirectory {
 			childMode |= 02000
 		} else if childMode&02010 == 02010 && ctx.Uid() != 0 {
-			found := false
-			for _, g := range ctx.Gids() {
-				if g == parentGid {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !containsGid(ctx, parentGid) {
 				childMode &= ^uint16(02000)
 			}
 		}
@@ -3514,7 +3507,7 @@ func (m *baseMeta) mergeAttr(ctx Context, inode Ino, set uint16, cur, attr *Attr
 	}
 	if set&SetAttrMode != 0 {
 		if ctx.Uid() != 0 && (attr.Mode&02000) != 0 {
-			if ctx.Gid() != cur.Gid {
+			if !containsGid(ctx, cur.Gid) {
 				attr.Mode &= 05777
 			}
 		}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -639,6 +639,26 @@ func testMetaClient(t *testing.T, m Meta) {
 			t.Fatalf("sgid should be cleared")
 		}
 
+		var p2 Ino
+		ctx4 := NewContext(3, 3, []uint32{3, 1})
+		if st := m.Mkdir(ctx4, 1, "d3", 0775, 0, 0, &p2, attr); st != 0 {
+			t.Fatalf("mkdir d3: %s", st)
+		}
+		if st := m.SetAttr(ctx4, p2, SetAttrGID, 0, &Attr{Gid: 1}); st != 0 {
+			t.Fatalf("chgrp d3: %s", st)
+		}
+		if st := m.SetAttr(ctx4, p2, SetAttrMode, 0, &Attr{Mode: 02775}); st != 0 {
+			t.Fatalf("chmod g+s d3: %s", st)
+		}
+		if st := m.GetAttr(ctx4, p2, attr); st != 0 {
+			t.Fatalf("getattr d3: %s", st)
+		} else if attr.Mode&02000 == 0 {
+			t.Fatalf("sgid should be kept when gid is in supplementary groups")
+		}
+		if st := m.Rmdir(ctx4, 1, "d3"); st != 0 {
+			t.Fatalf("rmdir d3: %s", st)
+		}
+
 	}
 	if st := m.Resolve(ctx2, 1, "/d1/d2", nil, nil, false); st != 0 && st != syscall.ENOTSUP {
 		t.Fatalf("resolve /d1/d2: %s", st)

--- a/pkg/meta/random_test.go
+++ b/pkg/meta/random_test.go
@@ -238,13 +238,7 @@ func (m *fsMachine) create(_type uint8, parent Ino, name string, mode, umask uin
 		if _type == TypeDirectory {
 			p.mode |= 02000
 		} else if n.mode&02010 == 02010 && m.ctx.Uid() != 0 {
-			var found bool
-			for _, gid := range m.ctx.Gids() {
-				if gid == p.gid {
-					found = true
-				}
-			}
-			if !found {
+			if !containsGid(m.ctx, p.gid) {
 				n.mode &= ^uint16(02000)
 			}
 		}
@@ -397,13 +391,7 @@ func (m *fsMachine) symlink(parent Ino, name string, inode Ino, target string) s
 		if _type == TypeDirectory {
 			p.mode |= 02000
 		} else if n.mode&02010 == 02010 && m.ctx.Uid() != 0 {
-			var found bool
-			for _, gid := range m.ctx.Gids() {
-				if gid == p.gid {
-					found = true
-				}
-			}
-			if !found {
+			if !containsGid(m.ctx, p.gid) {
 				n.mode &= ^uint16(02000)
 			}
 		}


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/6940

chmod clears the set-group-ID bit of a regular file if the file's group ID does not match the user's effective group ID or one of the user's supplementary  group  IDs