### PR TITLE
meta/redis: close standalone client after cluster mode detection

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -2604,9 +2604,6 @@ func testConcurrentDir(t *testing.T, m Meta) {
 		}(i)
 	}
 	g.Wait()
-	if err != nil {
-		t.Fatalf("concurrent dir: %s", err)
-	}
 	for i := 0; i < 100; i++ {
 		g.Add(1)
 		go func(i int) {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -235,6 +235,7 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 			info, err := c.ClusterInfo(Background()).Result()
 			if err != nil && strings.Contains(err.Error(), "cluster mode") || err == nil && strings.Contains(info, "cluster_state:") {
 				logger.Infof("redis %s is in cluster mode", hosts)
+				c.Close()
 			} else {
 				rdb = c
 			}


### PR DESCRIPTION
  Also remove an unreachable error check in testConcurrentDir that was
  always false.