### PR TITLE
fix(java-sdk): move null check before dereference in getFileBlockLocations

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -987,6 +987,9 @@ public class JuiceFileSystemImpl extends FileSystem {
 
   @Override
   public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len) throws IOException {
+    if (file == null) {
+      return null;
+    }
     if (needCheckPermission() && !checkPathAccess(file.getPath(), FsAction.READ, "getFileBlockLocations")) {
       return superGroupFileSystem.getFileBlockLocations(file, start, len);
     }
@@ -999,10 +1002,6 @@ public class JuiceFileSystemImpl extends FileSystem {
         }
       }
       return bls;
-    }
-
-    if (file == null) {
-      return null;
     }
 
     if (start < 0 || len < 0) {


### PR DESCRIPTION
Current behavior: In JuiceFileSystemImpl.getFileBlockLocations(), the null check for the 'file' parameter is placed after file.getPath() is already called in the permission check branch (line 990). This means when 'file' is null, a NullPointerException is thrown at file.getPath() before the null check on line 1004 is ever reached, making the null check dead code.