### PR TITLE
fix(java-sdk): fix getAncestor to properly walk up the directory tree

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/permission/RangerPermissionChecker.java
+++ b/sdk/java/src/main/java/io/juicefs/permission/RangerPermissionChecker.java
@@ -267,16 +267,15 @@ public class RangerPermissionChecker {
   }
 
   public FileStatus getAncestor(Path path) throws IOException {
-    if (path.getParent() != null) {
-      return getIfExist(path.getParent());
+    Path parent = path.getParent();
+    while (parent != null) {
+      FileStatus status = getIfExist(parent);
+      if (status != null) {
+        return status;
+      }
+      parent = parent.getParent();
     }
-    path = path.getParent();
-    FileStatus tmp = null;
-    while (path != null && tmp == null) {
-      tmp = getIfExist(path);
-      path = path.getParent();
-    }
-    return tmp;
+    return null;
   }
 
   public static class PathObj {


### PR DESCRIPTION
Current behavior: `RangerPermissionChecker.getAncestor() `has two code paths:

When `path.getParent() != null`: `returns getIfExist(path.getParent())`, which only goes one level up to the immediate parent.
When `path.getParent() == null (root path): sets path = null,` then enters a while loop that never executes because path is already null, resulting in dead code and always returning null.
Problem:

The method name 'getAncestor' implies finding the nearest existing ancestor in the directory tree, but the original implementation only checks the immediate parent directory, not the full ancestor chain.
The second branch contains dead code (while loop never executes).
For paths where the immediate parent does not exist but a higher ancestor does, the method incorrectly returns null instead of finding the actual existing ancestor.