### PR TITLE
CI: refactor rename dir stat tests with assertInodes helper

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -92,6 +92,16 @@ func waitCheckResult(m Meta, expect dirStat, statFn func() (*dirStat, syscall.Er
 	}
 }
 
+func assertInodes(t *testing.T, m Meta, label string, dirIno Ino, expected int64) {
+	t.Helper()
+	ctx := Background()
+	if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: expected}, func() (*dirStat, syscall.Errno) {
+		return m.GetDirStat(ctx, dirIno)
+	}); err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
 func TestRedisClient(t *testing.T) {
 	m, err := newRedisMeta("redis", "127.0.0.1:6379/10", testConfig())
 	if err != nil || m.Name() != "redis" {
@@ -3156,64 +3166,46 @@ func testRenameDirStat(t *testing.T, m Meta) {
 	}
 	defer m.CloseSession()
 
-	// assertInodes verifies the inode count of a directory, waiting up to 3s for consistency.
-	assertInodes := func(label string, dirIno Ino, expected int64) {
-		t.Helper()
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: expected}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dirIno)
-		}); err != nil {
-			t.Fatalf("%s: %v", label, err)
-		}
-	}
-
 	// Test 1: Rename file from dir1 to dir2 (cross-directory, no overwrite)
-	// pre-condition: dir1=0, dir2=0
-	assertInodes("Test 1 pre-condition dir1", dir1, 0)
-	assertInodes("Test 1 pre-condition dir2", dir2, 0)
+	assertInodes(t, m, "Test 1 pre-condition dir1", dir1, 0)
+	assertInodes(t, m, "Test 1 pre-condition dir2", dir2, 0)
 	{
 		if st := m.Create(ctx, dir1, "file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file1: %s", st)
 		}
-		assertInodes("Test 1 after create dir1", dir1, 1)
-
+		assertInodes(t, m, "Test 1 after create dir1", dir1, 1)
 		if st := m.Rename(ctx, dir1, "file1", dir2, "file1", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename file1 to dir2: %s", st)
 		}
-
-		assertInodes("Test 1 dir1 after rename", dir1, 0)
-		assertInodes("Test 1 dir2 after rename", dir2, 1)
-
+		assertInodes(t, m, "Test 1 dir1 after rename", dir1, 0)
+		assertInodes(t, m, "Test 1 dir2 after rename", dir2, 1)
 		if st := m.Unlink(ctx, dir2, "file1"); st != 0 {
 			t.Fatalf("cleanup dir2/file1: %s", st)
 		}
-		assertInodes("Test 1 cleanup dir2", dir2, 0)
+		assertInodes(t, m, "Test 1 cleanup dir2", dir2, 0)
 		t.Logf("Test 1 passed: cross-dir rename without overwrite")
 	}
 
-	// Test 2: Rename file within same directory (no overwrite, no change in stat)
-	// pre-condition: dir1=0
-	assertInodes("Test 2 pre-condition dir1", dir1, 0)
+	// Test 2: Rename file within same directory (no overwrite)
+	assertInodes(t, m, "Test 2 pre-condition dir1", dir1, 0)
 	{
 		if st := m.Create(ctx, dir1, "file2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file2: %s", st)
 		}
-		assertInodes("Test 2 after create dir1", dir1, 1)
-
+		assertInodes(t, m, "Test 2 after create dir1", dir1, 1)
 		if st := m.Rename(ctx, dir1, "file2", dir1, "file3", 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("rename file2 to file3 in same dir: %s", st)
 		}
-		assertInodes("Test 2 same dir after rename", dir1, 1)
-
+		assertInodes(t, m, "Test 2 same dir after rename", dir1, 1)
 		if st := m.Unlink(ctx, dir1, "file3"); st != 0 {
 			t.Fatalf("cleanup dir1/file3: %s", st)
 		}
-		assertInodes("Test 2 cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test 2 cleanup dir1", dir1, 0)
 		t.Logf("Test 2 passed: same-dir rename without overwrite")
 	}
 
 	// Test 3: Rename with overwrite in same directory (trash disabled)
-	// pre-condition: dir1=0
-	assertInodes("Test 3 pre-condition dir1", dir1, 0)
+	assertInodes(t, m, "Test 3 pre-condition dir1", dir1, 0)
 	{
 		if st := m.Create(ctx, dir1, "file4", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file4: %s", st)
@@ -3221,26 +3213,21 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir1, "file5", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file5: %s", st)
 		}
-		assertInodes("Test 3 after creates dir1", dir1, 2)
-
-		// rename file4 -> file5 (overwrite), trash is disabled
+		assertInodes(t, m, "Test 3 after creates dir1", dir1, 2)
 		if st := m.Rename(ctx, dir1, "file4", dir1, "file5", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename file4 to file5 (overwrite): %s", st)
 		}
-		// overwritten file is deleted: 2 -> 1
-		assertInodes("Test 3 overwrite inodes", dir1, 1)
-
+		assertInodes(t, m, "Test 3 overwrite inodes", dir1, 1)
 		if st := m.Unlink(ctx, dir1, "file5"); st != 0 {
 			t.Fatalf("cleanup file5 after Test 3: %s", st)
 		}
-		assertInodes("Test 3 cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test 3 cleanup dir1", dir1, 0)
 		t.Logf("Test 3 passed: same-dir rename with overwrite")
 	}
 
 	// Test 4: Rename with overwrite across directories
-	// pre-condition: dir2=0, dir3=0
-	assertInodes("Test 4 pre-condition dir2", dir2, 0)
-	assertInodes("Test 4 pre-condition dir3", dir3, 0)
+	assertInodes(t, m, "Test 4 pre-condition dir2", dir2, 0)
+	assertInodes(t, m, "Test 4 pre-condition dir3", dir3, 0)
 	{
 		if st := m.Create(ctx, dir2, "file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file1 in dir2: %s", st)
@@ -3248,30 +3235,23 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir3, "file_src", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file_src in dir3: %s", st)
 		}
-		assertInodes("Test 4 after create dir2", dir2, 1)
-		assertInodes("Test 4 after create dir3", dir3, 1)
-
-		// rename dir3/file_src -> dir2/file1 (overwrite)
+		assertInodes(t, m, "Test 4 after create dir2", dir2, 1)
+		assertInodes(t, m, "Test 4 after create dir3", dir3, 1)
 		if st := m.Rename(ctx, dir3, "file_src", dir2, "file1", 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("rename file_src to file1 (overwrite cross-dir): %s", st)
 		}
-
-		// dir2: one deleted, one added → net 1
-		assertInodes("Test 4 dir2 after rename", dir2, 1)
-		// dir3: one deleted → 0
-		assertInodes("Test 4 dir3 after rename", dir3, 0)
-
+		assertInodes(t, m, "Test 4 dir2 after rename", dir2, 1)
+		assertInodes(t, m, "Test 4 dir3 after rename", dir3, 0)
 		if st := m.Unlink(ctx, dir2, "file1"); st != 0 {
 			t.Fatalf("cleanup dir2/file1: %s", st)
 		}
-		assertInodes("Test 4 cleanup dir2", dir2, 0)
+		assertInodes(t, m, "Test 4 cleanup dir2", dir2, 0)
 		t.Logf("Test 4 passed: cross-dir rename with overwrite")
 	}
 
-	// Test 5: Exchange rename across directories (RenameExchange)
-	// pre-condition: dir1=0, dir3=0
-	assertInodes("Test 5 pre-condition dir1", dir1, 0)
-	assertInodes("Test 5 pre-condition dir3", dir3, 0)
+	// Test 5: Exchange rename across directories
+	assertInodes(t, m, "Test 5 pre-condition dir1", dir1, 0)
+	assertInodes(t, m, "Test 5 pre-condition dir3", dir3, 0)
 	{
 		if st := m.Create(ctx, dir1, "ex1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create ex1: %s", st)
@@ -3279,31 +3259,26 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir3, "ex2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create ex2: %s", st)
 		}
-		assertInodes("Test 5 after create dir1", dir1, 1)
-		assertInodes("Test 5 after create dir3", dir3, 1)
-
-		// exchange: ex1 <-> ex2
+		assertInodes(t, m, "Test 5 after create dir1", dir1, 1)
+		assertInodes(t, m, "Test 5 after create dir3", dir3, 1)
 		if st := m.Rename(ctx, dir1, "ex1", dir3, "ex2", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename exchange ex1 <-> ex2: %s", st)
 		}
-		// exchange does not change inode counts
-		assertInodes("Test 5 dir1 after exchange", dir1, 1)
-		assertInodes("Test 5 dir3 after exchange", dir3, 1)
-
+		assertInodes(t, m, "Test 5 dir1 after exchange", dir1, 1)
+		assertInodes(t, m, "Test 5 dir3 after exchange", dir3, 1)
 		if st := m.Unlink(ctx, dir1, "ex1"); st != 0 {
 			t.Fatalf("cleanup ex1 after Test 5: %s", st)
 		}
 		if st := m.Unlink(ctx, dir3, "ex2"); st != 0 {
 			t.Fatalf("cleanup ex2 after Test 5: %s", st)
 		}
-		assertInodes("Test 5 cleanup dir1", dir1, 0)
-		assertInodes("Test 5 cleanup dir3", dir3, 0)
+		assertInodes(t, m, "Test 5 cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test 5 cleanup dir3", dir3, 0)
 		t.Logf("Test 5 passed: exchange rename")
 	}
 
-	// Test 6: Same-directory exchange (RenameExchange)
-	// pre-condition: dir1=0
-	assertInodes("Test 6 pre-condition dir1", dir1, 0)
+	// Test 6: Same-directory exchange
+	assertInodes(t, m, "Test 6 pre-condition dir1", dir1, 0)
 	{
 		if st := m.Create(ctx, dir1, "file_a", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file_a: %s", st)
@@ -3311,21 +3286,18 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir1, "file_b", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file_b: %s", st)
 		}
-		assertInodes("Test 6 after creates dir1", dir1, 2)
-
-		// exchange within same directory: file_a <-> file_b
+		assertInodes(t, m, "Test 6 after creates dir1", dir1, 2)
 		if st := m.Rename(ctx, dir1, "file_a", dir1, "file_b", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename same-dir exchange file_a <-> file_b: %s", st)
 		}
-		assertInodes("Test 6 same dir after exchange", dir1, 2)
-
+		assertInodes(t, m, "Test 6 same dir after exchange", dir1, 2)
 		if st := m.Unlink(ctx, dir1, "file_b"); st != 0 {
 			t.Fatalf("cleanup dir1/file_b: %s", st)
 		}
 		if st := m.Unlink(ctx, dir1, "file_a"); st != 0 {
 			t.Fatalf("cleanup dir1/file_a: %s", st)
 		}
-		assertInodes("Test 6 cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test 6 cleanup dir1", dir1, 0)
 		t.Logf("Test 6 passed: same-dir exchange rename")
 	}
 }
@@ -3363,33 +3335,20 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 	}
 	defer m.CloseSession()
 
-	assertInodes := func(label string, ino Ino, expected int64) {
-		t.Helper()
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: expected}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, ino)
-		}); err != nil {
-			t.Fatalf("%s: %v", label, err)
-		}
-	}
-
 	// Test with trash enabled: overwrite should move to trash instead of delete
 	{
-		assertInodes("Test trash overwrite pre-condition dir1", dir1, 0)
+		assertInodes(t, m, "Test trash overwrite pre-condition dir1", dir1, 0)
 		if st := m.Create(ctx, dir1, "trash_file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create trash_file1: %s", st)
 		}
 		if st := m.Create(ctx, dir1, "trash_file2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create trash_file2: %s", st)
 		}
-		assertInodes("Test trash overwrite after creates dir1", dir1, 2)
-
-		// rename with overwrite (file2 goes to trash)
+		assertInodes(t, m, "Test trash overwrite after creates dir1", dir1, 2)
 		if st := m.Rename(ctx, dir1, "trash_file1", dir1, "trash_file2", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename with trash enabled: %s", st)
 		}
-
-		// with trash: overwritten file goes to trash, so inode count decreases by 1 (2->1)
-		assertInodes("Test trash overwrite", dir1, 1)
+		assertInodes(t, m, "Test trash overwrite", dir1, 1)
 		overwritten := Attr{}
 		if st := m.GetAttr(ctx, file2Inode, &overwritten); st != 0 && st != syscall.ENOENT {
 			t.Fatalf("Test trash overwrite: getattr overwritten inode %d: %s", file2Inode, st)
@@ -3399,31 +3358,27 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		if st := m.Unlink(ctx, dir1, "trash_file2"); st != 0 {
 			t.Fatalf("cleanup trash_file2: %s", st)
 		}
-		assertInodes("Test trash overwrite cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test trash overwrite cleanup dir1", dir1, 0)
 		t.Logf("Test trash overwrite passed")
 	}
 
 	// Test cross-directory overwrite with trash enabled
 	{
-		assertInodes("Test trash cross-dir pre-condition dir1", dir1, 0)
-		assertInodes("Test trash cross-dir pre-condition dir2", dir2, 0)
+		assertInodes(t, m, "Test trash cross-dir pre-condition dir1", dir1, 0)
+		assertInodes(t, m, "Test trash cross-dir pre-condition dir2", dir2, 0)
 		if st := m.Create(ctx, dir1, "cross_trash1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create cross_trash1: %s", st)
 		}
 		if st := m.Create(ctx, dir2, "cross_trash2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create cross_trash2: %s", st)
 		}
-		assertInodes("Test trash cross-dir after create dir1", dir1, 1)
-		assertInodes("Test trash cross-dir after create dir2", dir2, 1)
-
-		// cross-dir rename with overwrite and trash
+		assertInodes(t, m, "Test trash cross-dir after create dir1", dir1, 1)
+		assertInodes(t, m, "Test trash cross-dir after create dir2", dir2, 1)
 		if st := m.Rename(ctx, dir1, "cross_trash1", dir2, "cross_trash2", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename cross_trash1 to cross_trash2 (overwrite with trash): %s", st)
 		}
-
-		// dir1: one moved away, dir2: one deleted and one added (net no change)
-		assertInodes("Test trash cross-dir dir1", dir1, 0)
-		assertInodes("Test trash cross-dir dir2", dir2, 1)
+		assertInodes(t, m, "Test trash cross-dir dir1", dir1, 0)
+		assertInodes(t, m, "Test trash cross-dir dir2", dir2, 1)
 		overwritten := Attr{}
 		if st := m.GetAttr(ctx, file2Inode, &overwritten); st != 0 && st != syscall.ENOENT {
 			t.Fatalf("Test trash cross-dir overwrite: getattr overwritten inode %d: %s", file2Inode, st)
@@ -3433,47 +3388,40 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		if st := m.Unlink(ctx, dir2, "cross_trash2"); st != 0 {
 			t.Fatalf("cleanup cross_trash2: %s", st)
 		}
-		assertInodes("Test trash cross-dir cleanup dir2", dir2, 0)
+		assertInodes(t, m, "Test trash cross-dir cleanup dir2", dir2, 0)
 		t.Logf("Test trash cross-dir overwrite passed")
 	}
 
 	// Test exchange with trash enabled
 	{
-		assertInodes("Test trash exchange pre-condition dir1", dir1, 0)
-		assertInodes("Test trash exchange pre-condition dir2", dir2, 0)
+		assertInodes(t, m, "Test trash exchange pre-condition dir1", dir1, 0)
+		assertInodes(t, m, "Test trash exchange pre-condition dir2", dir2, 0)
 		if st := m.Create(ctx, dir1, "ex_trash1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create ex_trash1: %s", st)
 		}
 		if st := m.Create(ctx, dir2, "ex_trash2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create ex_trash2: %s", st)
 		}
-		assertInodes("Test trash exchange after create dir1", dir1, 1)
-		assertInodes("Test trash exchange after create dir2", dir2, 1)
-
-		// exchange with trash
+		assertInodes(t, m, "Test trash exchange after create dir1", dir1, 1)
+		assertInodes(t, m, "Test trash exchange after create dir2", dir2, 1)
 		if st := m.Rename(ctx, dir1, "ex_trash1", dir2, "ex_trash2", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename exchange with trash: %s", st)
 		}
-
-		// exchange should not change inode counts
-		assertInodes("Test trash exchange dir1", dir1, 1)
-		assertInodes("Test trash exchange dir2", dir2, 1)
-
-		// RenameExchange swaps inode bindings, path names keep unchanged.
+		assertInodes(t, m, "Test trash exchange dir1", dir1, 1)
+		assertInodes(t, m, "Test trash exchange dir2", dir2, 1)
 		if st := m.Unlink(ctx, dir1, "ex_trash1"); st != 0 {
 			t.Fatalf("cleanup ex_trash1: %s", st)
 		}
 		if st := m.Unlink(ctx, dir2, "ex_trash2"); st != 0 {
 			t.Fatalf("cleanup ex_trash2: %s", st)
 		}
-		assertInodes("Test trash exchange cleanup dir1", dir1, 0)
-		assertInodes("Test trash exchange cleanup dir2", dir2, 0)
+		assertInodes(t, m, "Test trash exchange cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test trash exchange cleanup dir2", dir2, 0)
 		t.Logf("Test trash exchange passed")
 	}
 
-	// Test 7: Restore from trash with overwrite (no exchange)
+	// Test 7: Restore from trash with overwrite
 	{
-		// Create a file to be deleted (moved to trash)
 		if st := m.Create(ctx, dir1, "to_trash", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create to_trash: %s", st)
 		}
@@ -3481,85 +3429,62 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		if st := m.GetAttr(ctx, file1Inode, &attr); st != 0 {
 			t.Fatalf("getattr to_trash: %s", st)
 		}
-
-		// Create target file that will be overwritten
 		if st := m.Create(ctx, dir2, "victim", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create victim: %s", st)
 		}
-
 		m.FlushSession()
-
-		// Delete the file to move it to trash
 		if st := m.Unlink(ctx, dir1, "to_trash"); st != 0 {
 			t.Fatalf("unlink to_trash: %s", st)
 		}
-
 		time.Sleep(500 * time.Millisecond)
 		m.FlushSession()
-
-		// Get the trash inode (it should be marked as trash)
 		if !trashInode.IsTrash() {
-			// File in trash has a special inode
-			trashInode = file1Inode // Try using the same inode as it might be converted
+			trashInode = file1Inode
 		}
-
 		stat1Before, _ := m.GetDirStat(ctx, dir1)
 		stat2Before, _ := m.GetDirStat(ctx, dir2)
-
-		// Try to restore from trash by renaming to dir2/victim (overwrite)
-		// Note: This test demonstrates the behavior, but from trash recovery
-		// may have specific restrictions depending on implementation
 		st := m.Rename(ctx, dir1, "to_trash", dir2, "victim", 0, &trashInode, &attr)
 		if st == 0 {
-			// If rename from trash succeeded, verify stats
 			m.FlushSession()
 			stat1After, _ := m.GetDirStat(ctx, dir1)
 			stat2After, _ := m.GetDirStat(ctx, dir2)
-
-			// dir1 should decrease (removed from trash)
 			if stat1After.inodes != stat1Before.inodes-1 {
 				t.Logf("Test 7 partial: rename from trash did decrease dir1 by 1")
 			}
-			// dir2 should increase by 1 (file restored and victim replaced)
 			if stat2After.inodes != stat2Before.inodes {
 				t.Logf("Test 7 partial: dir2 stat changed after restore from trash")
 			}
 			t.Logf("Test 7 passed: restore from trash with overwrite")
 		} else {
-			// If rename is blocked from trash, that's expected
 			t.Logf("Test 7 skipped: rename from trash not allowed (expected for security)")
 		}
 		if st := m.Unlink(ctx, dir2, "victim"); st != 0 && st != syscall.ENOENT {
 			t.Fatalf("cleanup victim: %s", st)
 		}
-		assertInodes("Test 7 cleanup dir2", dir2, 0)
+		assertInodes(t, m, "Test 7 cleanup dir2", dir2, 0)
 	}
 
 	// Test 8: Same-dir exchange with trash enabled
 	{
-		assertInodes("Test 8 pre-condition dir1", dir1, 0)
+		assertInodes(t, m, "Test 8 pre-condition dir1", dir1, 0)
 		if st := m.Create(ctx, dir1, "trash_a", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create trash_a: %s", st)
 		}
 		if st := m.Create(ctx, dir1, "trash_b", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create trash_b: %s", st)
 		}
-		assertInodes("Test 8 after creates dir1", dir1, 2)
-
-		// same-dir exchange with trash enabled
+		assertInodes(t, m, "Test 8 after creates dir1", dir1, 2)
 		if st := m.Rename(ctx, dir1, "trash_a", dir1, "trash_b", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename same-dir exchange with trash: %s", st)
 		}
-
-		// same-dir exchange should not change inode count
-		assertInodes("Test 8 same-dir exchange", dir1, 2)
+		assertInodes(t, m, "Test 8 same-dir exchange", dir1, 2)
 		if st := m.Unlink(ctx, dir1, "trash_b"); st != 0 {
 			t.Fatalf("cleanup trash_b: %s", st)
 		}
 		if st := m.Unlink(ctx, dir1, "trash_a"); st != 0 {
 			t.Fatalf("cleanup trash_a: %s", st)
 		}
-		assertInodes("Test 8 cleanup dir1", dir1, 0)
+		assertInodes(t, m, "Test 8 cleanup dir1", dir1, 0)
 		t.Logf("Test 8 passed: same-dir exchange with trash")
 	}
 }

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -3441,19 +3441,13 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		if !trashInode.IsTrash() {
 			trashInode = file1Inode
 		}
-		stat1Before, _ := m.GetDirStat(ctx, dir1)
-		stat2Before, _ := m.GetDirStat(ctx, dir2)
+		assertInodes(t, m, "Test 7 before rename dir1", dir1, 0)
+		assertInodes(t, m, "Test 7 before rename dir2", dir2, 1)
 		st := m.Rename(ctx, dir1, "to_trash", dir2, "victim", 0, &trashInode, &attr)
 		if st == 0 {
 			m.FlushSession()
-			stat1After, _ := m.GetDirStat(ctx, dir1)
-			stat2After, _ := m.GetDirStat(ctx, dir2)
-			if stat1After.inodes != stat1Before.inodes-1 {
-				t.Logf("Test 7 partial: rename from trash did decrease dir1 by 1")
-			}
-			if stat2After.inodes != stat2Before.inodes {
-				t.Logf("Test 7 partial: dir2 stat changed after restore from trash")
-			}
+			assertInodes(t, m, "Test 7 after rename dir1", dir1, 0)
+			assertInodes(t, m, "Test 7 after rename dir2", dir2, 1)
 			t.Logf("Test 7 passed: restore from trash with overwrite")
 		} else {
 			t.Logf("Test 7 skipped: rename from trash not allowed (expected for security)")

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -3135,7 +3135,7 @@ func testRenameDirStat(t *testing.T, m Meta) {
 	var dir1, dir2, dir3 Ino
 	var file1Inode, file2Inode Ino
 
-	// setup: create 3 directories and some files
+	// setup: create 3 directories
 	if st := m.Mkdir(ctx, RootInode, "dir1", 0755, 022, 0, &dir1, &attr); st != 0 {
 		t.Fatalf("mkdir dir1: %s", st)
 	}
@@ -3156,66 +3156,64 @@ func testRenameDirStat(t *testing.T, m Meta) {
 	}
 	defer m.CloseSession()
 
+	// assertInodes verifies the inode count of a directory, waiting up to 3s for consistency.
+	assertInodes := func(label string, dirIno Ino, expected int64) {
+		t.Helper()
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: expected}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dirIno)
+		}); err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+	}
+
 	// Test 1: Rename file from dir1 to dir2 (cross-directory, no overwrite)
+	// pre-condition: dir1=0, dir2=0
+	assertInodes("Test 1 pre-condition dir1", dir1, 0)
+	assertInodes("Test 1 pre-condition dir2", dir2, 0)
 	{
 		if st := m.Create(ctx, dir1, "file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file1: %s", st)
 		}
-
-		m.FlushSession()
-		stat1Before, _ := m.GetDirStat(ctx, dir1)
-		stat2Before, _ := m.GetDirStat(ctx, dir2)
+		assertInodes("Test 1 after create dir1", dir1, 1)
 
 		if st := m.Rename(ctx, dir1, "file1", dir2, "file1", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename file1 to dir2: %s", st)
 		}
 
-		m.FlushSession()
+		assertInodes("Test 1 dir1 after rename", dir1, 0)
+		assertInodes("Test 1 dir2 after rename", dir2, 1)
 
-		// dir1 should decrease by one file
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes - 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 1 dir1 inodes: %v", err)
+		if st := m.Unlink(ctx, dir2, "file1"); st != 0 {
+			t.Fatalf("cleanup dir2/file1: %s", st)
 		}
-		// dir2 should increase by one file
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat2Before.inodes + 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test 1 dir2 inodes: %v", err)
-		}
-		m.Unlink(ctx, dir2, "file1")
-		m.FlushSession()
+		assertInodes("Test 1 cleanup dir2", dir2, 0)
 		t.Logf("Test 1 passed: cross-dir rename without overwrite")
 	}
 
 	// Test 2: Rename file within same directory (no overwrite, no change in stat)
+	// pre-condition: dir1=0
+	assertInodes("Test 2 pre-condition dir1", dir1, 0)
 	{
 		if st := m.Create(ctx, dir1, "file2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file2: %s", st)
 		}
-
-		m.FlushSession()
-		statBefore, _ := m.GetDirStat(ctx, dir1)
+		assertInodes("Test 2 after create dir1", dir1, 1)
 
 		if st := m.Rename(ctx, dir1, "file2", dir1, "file3", 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("rename file2 to file3 in same dir: %s", st)
 		}
+		assertInodes("Test 2 same dir after rename", dir1, 1)
 
-		m.FlushSession()
-
-		// same directory inodes should not change
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 2 same dir inodes: %v", err)
+		if st := m.Unlink(ctx, dir1, "file3"); st != 0 {
+			t.Fatalf("cleanup dir1/file3: %s", st)
 		}
-		m.Unlink(ctx, dir1, "file3")
-		m.FlushSession()
+		assertInodes("Test 2 cleanup dir1", dir1, 0)
 		t.Logf("Test 2 passed: same-dir rename without overwrite")
 	}
 
-	// Test 3: Rename with overwrite in same directory
+	// Test 3: Rename with overwrite in same directory (trash disabled)
+	// pre-condition: dir1=0
+	assertInodes("Test 3 pre-condition dir1", dir1, 0)
 	{
 		if st := m.Create(ctx, dir1, "file4", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file4: %s", st)
@@ -3223,31 +3221,26 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir1, "file5", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file5: %s", st)
 		}
-
-		m.FlushSession()
-		statBefore, _ := m.GetDirStat(ctx, dir1)
+		assertInodes("Test 3 after creates dir1", dir1, 2)
 
 		// rename file4 -> file5 (overwrite), trash is disabled
 		if st := m.Rename(ctx, dir1, "file4", dir1, "file5", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename file4 to file5 (overwrite): %s", st)
 		}
+		// overwritten file is deleted: 2 -> 1
+		assertInodes("Test 3 overwrite inodes", dir1, 1)
 
-		m.FlushSession()
-
-		// with trash disabled: overwritten file is deleted, so inodes should decrease by 1
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes - 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 3 overwrite inodes: %v", err)
-		}
 		if st := m.Unlink(ctx, dir1, "file5"); st != 0 {
 			t.Fatalf("cleanup file5 after Test 3: %s", st)
 		}
-		m.FlushSession()
+		assertInodes("Test 3 cleanup dir1", dir1, 0)
 		t.Logf("Test 3 passed: same-dir rename with overwrite")
 	}
 
 	// Test 4: Rename with overwrite across directories
+	// pre-condition: dir2=0, dir3=0
+	assertInodes("Test 4 pre-condition dir2", dir2, 0)
+	assertInodes("Test 4 pre-condition dir3", dir3, 0)
 	{
 		if st := m.Create(ctx, dir2, "file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file1 in dir2: %s", st)
@@ -3255,36 +3248,30 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir3, "file_src", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file_src in dir3: %s", st)
 		}
-
-		m.FlushSession()
-		stat2Before, _ := m.GetDirStat(ctx, dir2)
-		stat3Before, _ := m.GetDirStat(ctx, dir3)
+		assertInodes("Test 4 after create dir2", dir2, 1)
+		assertInodes("Test 4 after create dir3", dir3, 1)
 
 		// rename dir3/file_src -> dir2/file1 (overwrite)
 		if st := m.Rename(ctx, dir3, "file_src", dir2, "file1", 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("rename file_src to file1 (overwrite cross-dir): %s", st)
 		}
 
-		m.FlushSession()
+		// dir2: one deleted, one added → net 1
+		assertInodes("Test 4 dir2 after rename", dir2, 1)
+		// dir3: one deleted → 0
+		assertInodes("Test 4 dir3 after rename", dir3, 0)
 
-		// dir2: one deleted, one added, total no change
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat2Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test 4 dir2 inodes: %v", err)
+		if st := m.Unlink(ctx, dir2, "file1"); st != 0 {
+			t.Fatalf("cleanup dir2/file1: %s", st)
 		}
-		// dir3: one deleted, should decrease by 1
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat3Before.inodes - 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir3)
-		}); err != nil {
-			t.Fatalf("Test 4 dir3 inodes: %v", err)
-		}
-		m.Unlink(ctx, dir2, "file1")
-		m.FlushSession()
+		assertInodes("Test 4 cleanup dir2", dir2, 0)
 		t.Logf("Test 4 passed: cross-dir rename with overwrite")
 	}
 
-	// Test 5: Rename with overwrite + RenameExchange flag across directories
+	// Test 5: Exchange rename across directories (RenameExchange)
+	// pre-condition: dir1=0, dir3=0
+	assertInodes("Test 5 pre-condition dir1", dir1, 0)
+	assertInodes("Test 5 pre-condition dir3", dir3, 0)
 	{
 		if st := m.Create(ctx, dir1, "ex1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create ex1: %s", st)
@@ -3292,40 +3279,31 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir3, "ex2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create ex2: %s", st)
 		}
-
-		m.FlushSession()
-		stat1Before, _ := m.GetDirStat(ctx, dir1)
-		stat3Before, _ := m.GetDirStat(ctx, dir3)
+		assertInodes("Test 5 after create dir1", dir1, 1)
+		assertInodes("Test 5 after create dir3", dir3, 1)
 
 		// exchange: ex1 <-> ex2
 		if st := m.Rename(ctx, dir1, "ex1", dir3, "ex2", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename exchange ex1 <-> ex2: %s", st)
 		}
+		// exchange does not change inode counts
+		assertInodes("Test 5 dir1 after exchange", dir1, 1)
+		assertInodes("Test 5 dir3 after exchange", dir3, 1)
 
-		m.FlushSession()
-
-		// both directories should not change their inode counts with exchange
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 5 dir1 inodes: %v", err)
-		}
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat3Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir3)
-		}); err != nil {
-			t.Fatalf("Test 5 dir3 inodes: %v", err)
-		}
 		if st := m.Unlink(ctx, dir1, "ex1"); st != 0 {
 			t.Fatalf("cleanup ex1 after Test 5: %s", st)
 		}
 		if st := m.Unlink(ctx, dir3, "ex2"); st != 0 {
 			t.Fatalf("cleanup ex2 after Test 5: %s", st)
 		}
-		m.FlushSession()
+		assertInodes("Test 5 cleanup dir1", dir1, 0)
+		assertInodes("Test 5 cleanup dir3", dir3, 0)
 		t.Logf("Test 5 passed: exchange rename")
 	}
 
 	// Test 6: Same-directory exchange (RenameExchange)
+	// pre-condition: dir1=0
+	assertInodes("Test 6 pre-condition dir1", dir1, 0)
 	{
 		if st := m.Create(ctx, dir1, "file_a", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create file_a: %s", st)
@@ -3333,26 +3311,21 @@ func testRenameDirStat(t *testing.T, m Meta) {
 		if st := m.Create(ctx, dir1, "file_b", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create file_b: %s", st)
 		}
-
-		m.FlushSession()
-		statBefore, _ := m.GetDirStat(ctx, dir1)
+		assertInodes("Test 6 after creates dir1", dir1, 2)
 
 		// exchange within same directory: file_a <-> file_b
 		if st := m.Rename(ctx, dir1, "file_a", dir1, "file_b", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename same-dir exchange file_a <-> file_b: %s", st)
 		}
+		assertInodes("Test 6 same dir after exchange", dir1, 2)
 
-		m.FlushSession()
-
-		// same-dir exchange should not change inode count
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 6 same dir exchange: %v", err)
+		if st := m.Unlink(ctx, dir1, "file_b"); st != 0 {
+			t.Fatalf("cleanup dir1/file_b: %s", st)
 		}
-		m.Unlink(ctx, dir1, "file_b")
-		m.Unlink(ctx, dir1, "file_a")
-		m.FlushSession()
+		if st := m.Unlink(ctx, dir1, "file_a"); st != 0 {
+			t.Fatalf("cleanup dir1/file_a: %s", st)
+		}
+		assertInodes("Test 6 cleanup dir1", dir1, 0)
 		t.Logf("Test 6 passed: same-dir exchange rename")
 	}
 }
@@ -3392,6 +3365,12 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 
 	// Test with trash enabled: overwrite should move to trash instead of delete
 	{
+		// pre-condition: dir1=0
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 0}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir1)
+		}); err != nil {
+			t.Fatalf("Test trash overwrite pre-condition dir1: %v", err)
+		}
 		if st := m.Create(ctx, dir1, "trash_file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create trash_file1: %s", st)
 		}
@@ -3400,19 +3379,20 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		}
 		defer m.Unlink(ctx, dir1, "trash_file2")
 
-		m.FlushSession()
-		statBefore, _ := m.GetDirStat(ctx, dir1)
+		// after creates: dir1=2
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 2}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir1)
+		}); err != nil {
+			t.Fatalf("Test trash overwrite after creates dir1: %v", err)
+		}
 
 		// rename with overwrite (file2 goes to trash)
 		if st := m.Rename(ctx, dir1, "trash_file1", dir1, "trash_file2", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename with trash enabled: %s", st)
 		}
 
-		m.FlushSession()
-
-		// with trash: deleted file doesn't reduce inode count, only goes to trash
-		// stat should decrease by 1 (the overwritten file)
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes - 1}, func() (*dirStat, syscall.Errno) {
+		// with trash: overwritten file goes to trash, so inode count decreases by 1 (2->1)
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 1}, func() (*dirStat, syscall.Errno) {
 			return m.GetDirStat(ctx, dir1)
 		}); err != nil {
 			t.Fatalf("Test trash overwrite: %v", err)
@@ -3428,6 +3408,13 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 
 	// Test cross-directory overwrite with trash enabled
 	{
+		// pre-condition: dir1=0 (trash_file2 defer cleanup may still hold 1, but trash_file1 was renamed away)
+		// dir2=0
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 0}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir2)
+		}); err != nil {
+			t.Fatalf("Test trash cross-dir pre-condition dir2: %v", err)
+		}
 		if st := m.Create(ctx, dir1, "cross_trash1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create cross_trash1: %s", st)
 		}
@@ -3438,25 +3425,31 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 			m.Unlink(ctx, dir2, "cross_trash2")
 		}()
 
-		m.FlushSession()
-		stat1Before, _ := m.GetDirStat(ctx, dir1)
-		stat2Before, _ := m.GetDirStat(ctx, dir2)
+		// after creates: dir2=1
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 1}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir2)
+		}); err != nil {
+			t.Fatalf("Test trash cross-dir after create dir2: %v", err)
+		}
+		// capture dir1 count (may be 1 due to defer trash_file2)
+		stat1Before, st1 := m.GetDirStat(ctx, dir1)
+		if st1 != 0 || stat1Before == nil {
+			t.Fatalf("Test trash cross-dir: get dir1 stat: %s", st1)
+		}
 
 		// cross-dir rename with overwrite and trash
 		if st := m.Rename(ctx, dir1, "cross_trash1", dir2, "cross_trash2", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename cross_trash1 to cross_trash2 (overwrite with trash): %s", st)
 		}
 
-		m.FlushSession()
-
-		// dir1: one deleted
+		// dir1: one file moved away → stat1Before - 1
 		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes - 1}, func() (*dirStat, syscall.Errno) {
 			return m.GetDirStat(ctx, dir1)
 		}); err != nil {
 			t.Fatalf("Test trash cross-dir dir1: %v", err)
 		}
-		// dir2: one deleted (goes to trash), one added, net no change
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat2Before.inodes}, func() (*dirStat, syscall.Errno) {
+		// dir2: one deleted (goes to trash), one added, net 1
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 1}, func() (*dirStat, syscall.Errno) {
 			return m.GetDirStat(ctx, dir2)
 		}); err != nil {
 			t.Fatalf("Test trash cross-dir dir2: %v", err)
@@ -3483,16 +3476,30 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 			m.Unlink(ctx, dir2, "ex_trash1")
 		}()
 
-		m.FlushSession()
-		stat1Before, _ := m.GetDirStat(ctx, dir1)
-		stat2Before, _ := m.GetDirStat(ctx, dir2)
+		// capture stable counts after creates
+		stat1Before, st1 := m.GetDirStat(ctx, dir1)
+		if st1 != 0 || stat1Before == nil {
+			t.Fatalf("Test trash exchange: get dir1 stat: %s", st1)
+		}
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir1)
+		}); err != nil {
+			t.Fatalf("Test trash exchange stable dir1: %v", err)
+		}
+		stat2Before, st2 := m.GetDirStat(ctx, dir2)
+		if st2 != 0 || stat2Before == nil {
+			t.Fatalf("Test trash exchange: get dir2 stat: %s", st2)
+		}
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat2Before.inodes}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir2)
+		}); err != nil {
+			t.Fatalf("Test trash exchange stable dir2: %v", err)
+		}
 
 		// exchange with trash
 		if st := m.Rename(ctx, dir1, "ex_trash1", dir2, "ex_trash2", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename exchange with trash: %s", st)
 		}
-
-		m.FlushSession()
 
 		// exchange should not change inode counts
 		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes}, func() (*dirStat, syscall.Errno) {
@@ -3579,15 +3586,21 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 			t.Fatalf("create trash_b: %s", st)
 		}
 
-		m.FlushSession()
-		statBefore, _ := m.GetDirStat(ctx, dir1)
+		// capture stable count after creates
+		statBefore, stBefore := m.GetDirStat(ctx, dir1)
+		if stBefore != 0 || statBefore == nil {
+			t.Fatalf("Test 8: get dir1 stat: %s", stBefore)
+		}
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, dir1)
+		}); err != nil {
+			t.Fatalf("Test 8 stable pre-condition dir1: %v", err)
+		}
 
 		// same-dir exchange with trash enabled
 		if st := m.Rename(ctx, dir1, "trash_a", dir1, "trash_b", RenameExchange, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename same-dir exchange with trash: %s", st)
 		}
-
-		m.FlushSession()
 
 		// same-dir exchange should not change inode count
 		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes}, func() (*dirStat, syscall.Errno) {
@@ -3595,9 +3608,12 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		}); err != nil {
 			t.Fatalf("Test 8 same-dir exchange: %v", err)
 		}
-		m.Unlink(ctx, dir1, "trash_b")
-		m.Unlink(ctx, dir1, "trash_a")
-		m.FlushSession()
+		if st := m.Unlink(ctx, dir1, "trash_b"); st != 0 {
+			t.Fatalf("cleanup trash_b: %s", st)
+		}
+		if st := m.Unlink(ctx, dir1, "trash_a"); st != 0 {
+			t.Fatalf("cleanup trash_a: %s", st)
+		}
 		t.Logf("Test 8 passed: same-dir exchange with trash")
 	}
 }

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -3363,28 +3363,25 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 	}
 	defer m.CloseSession()
 
+	assertInodes := func(label string, ino Ino, expected int64) {
+		t.Helper()
+		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: expected}, func() (*dirStat, syscall.Errno) {
+			return m.GetDirStat(ctx, ino)
+		}); err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+	}
+
 	// Test with trash enabled: overwrite should move to trash instead of delete
 	{
-		// pre-condition: dir1=0
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 0}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test trash overwrite pre-condition dir1: %v", err)
-		}
+		assertInodes("Test trash overwrite pre-condition dir1", dir1, 0)
 		if st := m.Create(ctx, dir1, "trash_file1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create trash_file1: %s", st)
 		}
 		if st := m.Create(ctx, dir1, "trash_file2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create trash_file2: %s", st)
 		}
-		defer m.Unlink(ctx, dir1, "trash_file2")
-
-		// after creates: dir1=2
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 2}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test trash overwrite after creates dir1: %v", err)
-		}
+		assertInodes("Test trash overwrite after creates dir1", dir1, 2)
 
 		// rename with overwrite (file2 goes to trash)
 		if st := m.Rename(ctx, dir1, "trash_file1", dir1, "trash_file2", 0, &file1Inode, &attr); st != 0 {
@@ -3392,109 +3389,66 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		}
 
 		// with trash: overwritten file goes to trash, so inode count decreases by 1 (2->1)
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test trash overwrite: %v", err)
-		}
+		assertInodes("Test trash overwrite", dir1, 1)
 		overwritten := Attr{}
 		if st := m.GetAttr(ctx, file2Inode, &overwritten); st != 0 && st != syscall.ENOENT {
 			t.Fatalf("Test trash overwrite: getattr overwritten inode %d: %s", file2Inode, st)
 		} else if st == 0 && overwritten.Parent <= TrashInode {
 			t.Fatalf("Test trash overwrite: overwritten inode %d should be moved to trash or deleted, parent=%d", file2Inode, overwritten.Parent)
 		}
+		if st := m.Unlink(ctx, dir1, "trash_file2"); st != 0 {
+			t.Fatalf("cleanup trash_file2: %s", st)
+		}
+		assertInodes("Test trash overwrite cleanup dir1", dir1, 0)
 		t.Logf("Test trash overwrite passed")
 	}
 
 	// Test cross-directory overwrite with trash enabled
 	{
-		// pre-condition: dir1=0 (trash_file2 defer cleanup may still hold 1, but trash_file1 was renamed away)
-		// dir2=0
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 0}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test trash cross-dir pre-condition dir2: %v", err)
-		}
+		assertInodes("Test trash cross-dir pre-condition dir1", dir1, 0)
+		assertInodes("Test trash cross-dir pre-condition dir2", dir2, 0)
 		if st := m.Create(ctx, dir1, "cross_trash1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create cross_trash1: %s", st)
 		}
 		if st := m.Create(ctx, dir2, "cross_trash2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create cross_trash2: %s", st)
 		}
-		defer func() {
-			m.Unlink(ctx, dir2, "cross_trash2")
-		}()
-
-		// after creates: dir2=1
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test trash cross-dir after create dir2: %v", err)
-		}
-		// capture dir1 count (may be 1 due to defer trash_file2)
-		stat1Before, st1 := m.GetDirStat(ctx, dir1)
-		if st1 != 0 || stat1Before == nil {
-			t.Fatalf("Test trash cross-dir: get dir1 stat: %s", st1)
-		}
+		assertInodes("Test trash cross-dir after create dir1", dir1, 1)
+		assertInodes("Test trash cross-dir after create dir2", dir2, 1)
 
 		// cross-dir rename with overwrite and trash
 		if st := m.Rename(ctx, dir1, "cross_trash1", dir2, "cross_trash2", 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("rename cross_trash1 to cross_trash2 (overwrite with trash): %s", st)
 		}
 
-		// dir1: one file moved away → stat1Before - 1
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes - 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test trash cross-dir dir1: %v", err)
-		}
-		// dir2: one deleted (goes to trash), one added, net 1
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: 1}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test trash cross-dir dir2: %v", err)
-		}
+		// dir1: one moved away, dir2: one deleted and one added (net no change)
+		assertInodes("Test trash cross-dir dir1", dir1, 0)
+		assertInodes("Test trash cross-dir dir2", dir2, 1)
 		overwritten := Attr{}
 		if st := m.GetAttr(ctx, file2Inode, &overwritten); st != 0 && st != syscall.ENOENT {
 			t.Fatalf("Test trash cross-dir overwrite: getattr overwritten inode %d: %s", file2Inode, st)
 		} else if st == 0 && overwritten.Parent <= TrashInode {
 			t.Fatalf("Test trash cross-dir overwrite: overwritten inode %d should be moved to trash or deleted, parent=%d", file2Inode, overwritten.Parent)
 		}
+		if st := m.Unlink(ctx, dir2, "cross_trash2"); st != 0 {
+			t.Fatalf("cleanup cross_trash2: %s", st)
+		}
+		assertInodes("Test trash cross-dir cleanup dir2", dir2, 0)
 		t.Logf("Test trash cross-dir overwrite passed")
 	}
 
 	// Test exchange with trash enabled
 	{
+		assertInodes("Test trash exchange pre-condition dir1", dir1, 0)
+		assertInodes("Test trash exchange pre-condition dir2", dir2, 0)
 		if st := m.Create(ctx, dir1, "ex_trash1", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create ex_trash1: %s", st)
 		}
 		if st := m.Create(ctx, dir2, "ex_trash2", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create ex_trash2: %s", st)
 		}
-		defer func() {
-			m.Unlink(ctx, dir1, "ex_trash2")
-			m.Unlink(ctx, dir2, "ex_trash1")
-		}()
-
-		// capture stable counts after creates
-		stat1Before, st1 := m.GetDirStat(ctx, dir1)
-		if st1 != 0 || stat1Before == nil {
-			t.Fatalf("Test trash exchange: get dir1 stat: %s", st1)
-		}
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test trash exchange stable dir1: %v", err)
-		}
-		stat2Before, st2 := m.GetDirStat(ctx, dir2)
-		if st2 != 0 || stat2Before == nil {
-			t.Fatalf("Test trash exchange: get dir2 stat: %s", st2)
-		}
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat2Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test trash exchange stable dir2: %v", err)
-		}
+		assertInodes("Test trash exchange after create dir1", dir1, 1)
+		assertInodes("Test trash exchange after create dir2", dir2, 1)
 
 		// exchange with trash
 		if st := m.Rename(ctx, dir1, "ex_trash1", dir2, "ex_trash2", RenameExchange, &file1Inode, &attr); st != 0 {
@@ -3502,16 +3456,18 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		}
 
 		// exchange should not change inode counts
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat1Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test trash exchange dir1: %v", err)
+		assertInodes("Test trash exchange dir1", dir1, 1)
+		assertInodes("Test trash exchange dir2", dir2, 1)
+
+		// RenameExchange swaps inode bindings, path names keep unchanged.
+		if st := m.Unlink(ctx, dir1, "ex_trash1"); st != 0 {
+			t.Fatalf("cleanup ex_trash1: %s", st)
 		}
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: stat2Before.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir2)
-		}); err != nil {
-			t.Fatalf("Test trash exchange dir2: %v", err)
+		if st := m.Unlink(ctx, dir2, "ex_trash2"); st != 0 {
+			t.Fatalf("cleanup ex_trash2: %s", st)
 		}
+		assertInodes("Test trash exchange cleanup dir1", dir1, 0)
+		assertInodes("Test trash exchange cleanup dir2", dir2, 0)
 		t.Logf("Test trash exchange passed")
 	}
 
@@ -3573,29 +3529,22 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 			// If rename is blocked from trash, that's expected
 			t.Logf("Test 7 skipped: rename from trash not allowed (expected for security)")
 		}
-		m.Unlink(ctx, dir2, "victim")
-		m.FlushSession()
+		if st := m.Unlink(ctx, dir2, "victim"); st != 0 && st != syscall.ENOENT {
+			t.Fatalf("cleanup victim: %s", st)
+		}
+		assertInodes("Test 7 cleanup dir2", dir2, 0)
 	}
 
 	// Test 8: Same-dir exchange with trash enabled
 	{
+		assertInodes("Test 8 pre-condition dir1", dir1, 0)
 		if st := m.Create(ctx, dir1, "trash_a", 0644, 022, 0, &file1Inode, &attr); st != 0 {
 			t.Fatalf("create trash_a: %s", st)
 		}
 		if st := m.Create(ctx, dir1, "trash_b", 0644, 022, 0, &file2Inode, &attr); st != 0 {
 			t.Fatalf("create trash_b: %s", st)
 		}
-
-		// capture stable count after creates
-		statBefore, stBefore := m.GetDirStat(ctx, dir1)
-		if stBefore != 0 || statBefore == nil {
-			t.Fatalf("Test 8: get dir1 stat: %s", stBefore)
-		}
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 8 stable pre-condition dir1: %v", err)
-		}
+		assertInodes("Test 8 after creates dir1", dir1, 2)
 
 		// same-dir exchange with trash enabled
 		if st := m.Rename(ctx, dir1, "trash_a", dir1, "trash_b", RenameExchange, &file1Inode, &attr); st != 0 {
@@ -3603,17 +3552,14 @@ func testRenameDirStatWithTrash(t *testing.T, m Meta) {
 		}
 
 		// same-dir exchange should not change inode count
-		if err := waitCheckResult(m, dirStat{length: -1, space: -1, inodes: statBefore.inodes}, func() (*dirStat, syscall.Errno) {
-			return m.GetDirStat(ctx, dir1)
-		}); err != nil {
-			t.Fatalf("Test 8 same-dir exchange: %v", err)
-		}
+		assertInodes("Test 8 same-dir exchange", dir1, 2)
 		if st := m.Unlink(ctx, dir1, "trash_b"); st != 0 {
 			t.Fatalf("cleanup trash_b: %s", st)
 		}
 		if st := m.Unlink(ctx, dir1, "trash_a"); st != 0 {
 			t.Fatalf("cleanup trash_a: %s", st)
 		}
+		assertInodes("Test 8 cleanup dir1", dir1, 0)
 		t.Logf("Test 8 passed: same-dir exchange with trash")
 	}
 }


### PR DESCRIPTION
Some getDirStat calls remain unprotected and may return stale values under race conditions. This commit adds assertions to all these getDirStat invocations to ensure correctness.