### PR TITLE
fix(sdk/python): load platform-specific libjfs extension

### DIFF
--- a/.github/workflows/fsspec.yml
+++ b/.github/workflows/fsspec.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build and install SDK
         timeout-minutes: 5
         run: |
-          make -C sdk/python/ libjfs.so
+          make -C sdk/python/ libjfs
           sudo python3 sdk/python/juicefs/setup.py install
 
       - name: Build and install juicefs spec

--- a/.github/workflows/pysdk.yml
+++ b/.github/workflows/pysdk.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Build and install SDK
         timeout-minutes: 5
         run: |
-          make -C sdk/python/ libjfs.so
+          make -C sdk/python/ libjfs
           sudo python3 sdk/python/juicefs/setup.py install
           df -h
 

--- a/docs/en/deployment/python_sdk.md
+++ b/docs/en/deployment/python_sdk.md
@@ -18,15 +18,15 @@ cd juicefs/sdk/python
 
 ### Direct Compilation
 
-Direct compilation requires `go1.20+` and `python3` environments.
+Direct compilation requires `go1.20+`, `make`, and `python3` environments.
 
-#### Step 1: Compile libjfs.so
+#### Step 1: Compile libjfs
 
 ```bash
-go build -buildmode c-shared -ldflags="-s -w" -o juicefs/juicefs/libjfs.so ../java/libjfs
+make libjfs
 ```
 
-The compiled `libjfs.so` and `libjfs.h` files will be in the `sdk/python/juicefs/juicefs` directory.
+The compiled native library (`libjfs.so` on Linux, `libjfs.dylib` on macOS, or `libjfs.dll` on Windows) and `libjfs.h` file will be in the `sdk/python/juicefs/juicefs` directory.
 
 #### Step 2: Compile Python SDK
 

--- a/docs/zh_cn/deployment/python_sdk.md
+++ b/docs/zh_cn/deployment/python_sdk.md
@@ -31,15 +31,15 @@ cd juicefs/sdk/python
 
 ### 直接编译
 
-直接编译需要 `go1.20+` 和 `python3` 环境。
+直接编译需要 `go1.20+`、`make` 和 `python3` 环境。
 
-#### 第一步：编译 libjfs.so
+#### 第一步：编译 libjfs
 
 ```bash
-go build -buildmode c-shared -ldflags="-s -w" -o juicefs/juicefs/libjfs.so ../java/libjfs
+make libjfs
 ```
 
-编译产生的 `libjfs.so` 和 `libjfs.h` 文件在 `sdk/python/juicefs/juicefs` 目录下。
+编译产生的原生库（Linux 上为 `libjfs.so`，macOS 上为 `libjfs.dylib`，Windows 上为 `libjfs.dll`）和 `libjfs.h` 文件在 `sdk/python/juicefs/juicefs` 目录下。
 
 #### 第二步：编译 Python SDK
 

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -3,3 +3,5 @@ build
 *.egg-info 
 *.h
 *.so
+*.dylib
+*.dll

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,6 +1,19 @@
 LDFLAGS = -s -w
 
-.PHONY: libjfs.so juicefs
+ifeq ($(OS),Windows_NT)
+	LIBJFS_EXT = dll
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		LIBJFS_EXT = dylib
+	else
+		LIBJFS_EXT = so
+	endif
+endif
+
+LIBJFS := juicefs/juicefs/libjfs.$(LIBJFS_EXT)
+
+.PHONY: libjfs libjfs.so juicefs
 
 # SET GOPROXY if WITH_PROXY is set
 CN_GOPROXY ?= 0
@@ -27,8 +40,10 @@ ifneq ($(strip $(REVISION)),) # Use git clone
 endif
 
 # libjfs is located in the sdk/java/libjfs
-libjfs.so:
-	go build -buildmode c-shared -ldflags="$(LDFLAGS)" -o juicefs/juicefs/libjfs.so ../java/libjfs
+libjfs:
+	go build -buildmode c-shared -ldflags="$(LDFLAGS)" -o $(LIBJFS) ../java/libjfs
+
+libjfs.so: libjfs
 
 builder: Dockerfile.builder
 	docker build -t sdkbuilder -f Dockerfile.builder .

--- a/sdk/python/examples/ffrecord/readme.md
+++ b/sdk/python/examples/ffrecord/readme.md
@@ -13,7 +13,7 @@ python3 sdk/python/examples/ffrecord/main.py read
 python3 sdk/python/examples/ffrecord/main.py
 
 # Prepare python-sdk
-make -C sdk/python libjfs.so
+make -C sdk/python libjfs
 # Read dataset with Juicefs-pythonsdk-dataloader: (takes 10.02s)
 python3 sdk/python/examples/ffrecord/dataloader.py
 ```

--- a/sdk/python/juicefs/juicefs/juicefs.py
+++ b/sdk/python/juicefs/juicefs/juicefs.py
@@ -21,6 +21,7 @@ import json
 import locale
 import os
 import pwd
+import sys
 import six
 import struct
 import threading
@@ -80,7 +81,13 @@ def unpack(fmt, buf):
 
 class JuiceFSLib(object):
     def __init__(self):
-        self.lib = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), "libjfs.so"))
+        if sys.platform == "win32":
+            _ext = "dll"
+        elif sys.platform == "darwin":
+            _ext = "dylib"
+        else:
+            _ext = "so"
+        self.lib = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), f"libjfs.{_ext}"))
 
     def __getattr__(self, n):
         fn = getattr(self.lib, n)

--- a/sdk/python/juicefs/setup.py
+++ b/sdk/python/juicefs/setup.py
@@ -9,7 +9,7 @@ setup(
     name='juicefs',
     version=VERSION,
     description=BUILD_INFO,
-    package_data={'juicefs': ['*.so']},
+    package_data={'juicefs': ['*.so', '*.dylib', '*.dll']},
     packages=find_packages(where="."),
     include_package_data=True,
     install_requires=['six'],


### PR DESCRIPTION
## Context

When using the Python SDK, the SDK looks for `libjfs.so`, however when building juicefs on different architecture you might end up with a `libjfs.dylib` or `libjfs.dll`

this is handled in the [Java SDK](https://github.com/juicedata/juicefs/blob/ec1beda7cbb457d849761e4303fd07ce622f7d85/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java#L806-L811) 
```java
    if (os.toLowerCase().contains("windows")) {
      osId = "dll";
      dir = new File(System.getProperty("java.io.tmpdir"));
    } else if (os.toLowerCase().contains("mac")) {
      osId = "dylib";
    }
```

but not in the Python SDK, this PR fixes this

## Changes
- checks for system in JuiceFS Python SDK
- load appropriate lib based on host architecture