### PR TITLE
docs: add valkey as metadata engine with some keydb improvements

### DIFF
--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -25,7 +25,7 @@ When the average file is larger (over 64MB), or the file is frequently modified 
 
 When you need to migrate between two types of metadata engines, you can use this method to estimate the required storage space. For example, if you want to migrate the metadata engine from a relational database (MySQL) to a key-value database (Redis), and the current usage of MySQL is 30GB, then the target Redis needs to prepare at least 15GB or more of memory. The reverse is also true.
 
-## Redis Compatible Database
+## Redis compatible database
 
 ### Redis
 
@@ -182,7 +182,7 @@ The Active Replication feature is asynchronous and may cause consistency issues,
 
 When being used as the metadata storage engine for JuiceFS, KeyDB functions the same way as Redis. Please refer to KeyDB's [documentation](https://docs.keydb.dev/docs) for installation and other aspects, as well as the [Redis](#redis) section for usage.
 
-## Key-Value Database
+## Key-value database
 
 ### BadgerDB
 
@@ -219,7 +219,7 @@ BadgerDB only allows single-process access. If you need to perform operations li
 By using the official tool TiUP, you can easily build a local playground for testing (refer [here](https://tikv.org/docs/latest/concepts/tikv-in-5-minutes) for details). Production environment generally requires at least three hosts to store three data replicas (refer to the [official document](https://tikv.org/docs/latest/deploy/install/install) for all deployment steps).
 
 :::note
-It's recommended to use dedicated TiKV 5.0+ cluster as the metadata engine for JuiceFS.
+It is recommended to use dedicated TiKV 5.0+ cluster as the metadata engine for JuiceFS.
 :::
 
 #### Create a file system
@@ -477,7 +477,7 @@ juicefs.fdb mount -d \
     /mnt/jfs
 ```
 
-## SQL Database
+## SQL database
 
 Each database can only be used by one JuiceFS file system by default. If you want multiple file systems to share a database, you can achieve this by adding a `table_prefix` <VersionAdd>1.3</VersionAdd> query parameter in the META-URL to add different table prefixes for different file systems.
 For example: `mysql://user:mypassword@(192.168.1.6:3306)/juicefs?table_prefix=volume1`
@@ -513,8 +513,8 @@ mysql://<username>[:<password>]@unix(<socket-file-path>)/<database-name>
 
 :::note
 
-1. Don't leave out the `()` brackets on either side of the URL.
-2. Special characters in passwords do not require URL encoding
+1. Don not leave out the `()` brackets on either side of the URL.
+2. Special characters in passwords do not require URL encoding.
 
 :::
 

--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -168,16 +168,16 @@ In the above example, `/etc/certs` is just a directory name. Replace it with you
 
 ### Valkey
 
-[Valkey](https://valkey.io) is an open-source fork of Redis, created to preserve the project's community-driven governance while remaining fully compatible with the Redis ecosystem. Valkey focuses on maintaining stability, improved performance, and continued innovation under a neutral approach, ensuring long-term availability for users who rely on Redis-compatible workloads.
+[Valkey](https://valkey.io) is an open-source fork of Redis, created to preserve the project's community-driven governance while remaining highly compatible with the Redis ecosystem. Valkey focuses on maintaining stability, improving performance, and continuing innovation under a neutral approach, ensuring long-term availability for users who rely on Redis-compatible workloads.
 
 When being used as the metadata storage engine for JuiceFS, Valkey functions the same way as Redis. Please refer to Valkey's [documentation](https://valkey.io/topics/installation) for installation and other aspects, as well as the [Redis](#redis) section for usage.
 
 ### KeyDB
 
-[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active).
+[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active). KeyDB is [not actively maintained](https://github.com/Snapchat/KeyDB/issues/895) at the moment, and it is considered to be compatible with Redis version 6.
 
 :::note
-Similar to Redis, Active Replication is asynchronous and may cause consistency issues, so use with caution! Also note that Active-Active replication is only available in [Redis Cloud](https://redis.io/cloud) or [Redis Software](https://redis.io/software) (Redis' enterprise offering).
+The Active Replication feature is asynchronous and may cause consistency issues, so use with caution!
 :::
 
 When being used as the metadata storage engine for JuiceFS, KeyDB functions the same way as Redis. Please refer to KeyDB's [documentation](https://docs.keydb.dev/docs) for installation and other aspects, as well as the [Redis](#redis) section for usage.

--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -25,7 +25,7 @@ When the average file is larger (over 64MB), or the file is frequently modified 
 
 When you need to migrate between two types of metadata engines, you can use this method to estimate the required storage space. For example, if you want to migrate the metadata engine from a relational database (MySQL) to a key-value database (Redis), and the current usage of MySQL is 30GB, then the target Redis needs to prepare at least 15GB or more of memory. The reverse is also true.
 
-## Redis compatible database
+## Redis-compatible database
 
 ### Redis
 

--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -174,7 +174,7 @@ When being used as the metadata storage engine for JuiceFS, Valkey functions the
 
 ### KeyDB
 
-[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active). KeyDB is [not actively maintained](https://github.com/Snapchat/KeyDB/issues/895) at the moment, and it is considered compatible with Redis version 6.
+[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active). KeyDB is considered compatible with Redis version 6, but it is [not actively maintained by its community](https://github.com/Snapchat/KeyDB/issues/895) at the moment.
 
 :::note
 The Active Replication feature is asynchronous and may cause consistency issues, so use with caution!

--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -166,15 +166,21 @@ When specifying options in a URL, start with the `?` symbol and use the `&` symb
 
 In the above example, `/etc/certs` is just a directory name. Replace it with your actual certificate directory when using it, which can be a relative or absolute path.
 
+### Valkey
+
+[Valkey](https://valkey.io) is an open-source fork of Redis, created to preserve the project's community-driven governance while remaining fully compatible with the Redis ecosystem. Valkey focuses on maintaining stability, improved performance, and continued innovation under a neutral approach, ensuring long-term availability for users who rely on Redis-compatible workloads.
+
+When being used as the metadata storage engine for JuiceFS, Valkey functions the same way as Redis. Please refer to Valkey's [documentation](https://valkey.io/topics/installation) for installation and other aspects, as well as the [Redis](#redis) section for usage.
+
 ### KeyDB
 
-[KeyDB](https://keydb.dev) is an open source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis, and also supports [Active Replication](https://github.com/JohnSully/KeyDB/wiki/Active-Replication), i.e., the Active Active feature.
+[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active).
 
 :::note
-Same as Redis, the Active Replication is asynchronous, which may cause consistency issues. So use with caution!
+Similar to Redis, Active Replication is asynchronous and may cause consistency issues, so use with caution! Also note that Active-Active replication is only available in [Redis Cloud](https://redis.io/cloud) or [Redis Software](https://redis.io/software) (Redis' enterprise offering).
 :::
 
-When being used as metadata storage engine for Juice, KeyDB is used exactly in the same way as Redis. So please refer to the [Redis](#redis) section for usage.
+When being used as the metadata storage engine for JuiceFS, KeyDB functions the same way as Redis. Please refer to KeyDB's [documentation](https://docs.keydb.dev/docs) for installation and other aspects, as well as the [Redis](#redis) section for usage.
 
 ## Key-Value Database
 

--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -174,7 +174,7 @@ When being used as the metadata storage engine for JuiceFS, Valkey functions the
 
 ### KeyDB
 
-[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active). KeyDB is [not actively maintained](https://github.com/Snapchat/KeyDB/issues/895) at the moment, and it is considered to be compatible with Redis version 6.
+[KeyDB](https://keydb.dev) is an open-source fork of Redis, developed to stay aligned with the Redis community. KeyDB implements multi-threading support, better memory utilization, and greater throughput on top of Redis and also supports [Active Replication](https://docs.keydb.dev/docs/active-rep) (also known as Active-Active). KeyDB is [not actively maintained](https://github.com/Snapchat/KeyDB/issues/895) at the moment, and it is considered compatible with Redis version 6.
 
 :::note
 The Active Replication feature is asynchronous and may cause consistency issues, so use with caution!
@@ -514,7 +514,7 @@ mysql://<username>[:<password>]@unix(<socket-file-path>)/<database-name>
 :::note
 
 1. Don't leave out the `()` brackets on either side of the URL.
-2. Special characters in passwords do not require url encoding
+2. Special characters in passwords do not require URL encoding
 
 :::
 
@@ -656,7 +656,7 @@ juicefs format \
 1. JuiceFS uses public [schema](https://www.postgresql.org/docs/current/ddl-schemas.html) by default, if you want to use a `non-public schema`,  you need to specify `search_path` in the connection string parameter. e.g `postgres://user:mypassword@192.168.1.6:5432/juicefs?search_path=pguser1`
 2. If the `public schema` is not the first hit in the `search_path` configured on the PostgreSQL server, the `search_path` parameter must be explicitly set in the connection string.
 3. The `search_path` connection parameter can be set to multiple schemas natively, but currently JuiceFS only supports setting one. `postgres://user:mypassword@192.168.1.6:5432/juicefs?search_path=pguser1,public` will be considered illegal.
-4. Special characters in the password need to be replaced by url encoding. For example, `|` needs to be replaced with `%7C`.
+4. Special characters in the password need to be replaced by URL encoding. For example, `|` needs to be replaced with `%7C`.
 
 :::
 

--- a/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
@@ -153,15 +153,23 @@ juicefs format --storage s3 \
 
 上例中的 `/etc/certs` 只是一个目录，实际使用时请替换为你的证书目录，可以使用相对路径或绝对路径。
 
+### Valkey
+
+[Valkey](https://valkey.io) 是 Redis 的一个开源分支，旨在保留该项目由社区驱动的治理模式，同时保持与 Redis 生态系统的高度兼容。Valkey 专注于在中立的方式下维护稳定性、提升性能并持续创新，从而为依赖 Redis 兼容工作负载的用户确保长期可用性。
+
+在用于 JuiceFS 的元数据存储引擎时，Valkey 的功能与 Redis 完全相同。请参考 Valkey 的[文档](https://valkey.io/topics/installation)进行安装以及了解其他相关内容，同时参考 [Redis](#redis) 章节了解使用方法。
+
 ### KeyDB
 
 [KeyDB](https://keydb.dev) 是 Redis 的开源分支，在开发上保持与 Redis 主线对齐。KeyDB 在 Redis 的基础上实现了多线程支持、更好的内存利用率和更大的吞吐量，另外还支持 [Active Replication](https://github.com/JohnSully/KeyDB/wiki/Active-Replication)，即 Active Active（双活）功能。
 
+[KeyDB](https://keydb.dev) 是 Redis 的一个开源分支，其开发目的是与 Redis 社区保持一致。KeyDB 在 Redis 的基础上实现了多线程支持、更优的内存利用率以及更高的吞吐量，同时还支持 Active Replication（也称为 Active-Active）。KeyDB [目前不再积极维护](https://github.com/Snapchat/KeyDB/issues/895)，并且被认为与 Redis 6 版本兼容。
+
 :::note 注意
-KeyDB 的数据复制是异步的，使用 Active Active（双活）功能可能导致数据一致性问题，请务必充分验证、谨慎使用！
+KeyDB 的 Active Replication 功能是异步复制的，可能会导致一致性问题，请务必充分验证、谨慎使用！
 :::
 
-在用于 JuiceFS 元数据存储时，KeyDB 与 Redis 的用法完全一致，这里不再赘述，请参考 [Redis](#redis) 部分使用。
+在用于 JuiceFS 的元数据存储引擎时，KeyDB 的功能与 Redis 完全相同。请参考 KeyDB 的[文档](https://docs.keydb.dev/docs)进行安装以及了解其他相关内容，同时参考 [Redis](#redis) 章节了解使用方法。
 
 ## 键值数据库
 

--- a/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
@@ -161,7 +161,7 @@ juicefs format --storage s3 \
 
 ### KeyDB
 
-[KeyDB](https://keydb.dev) 是 Redis 的一个开源分支，其开发目的是与 Redis 社区保持一致。KeyDB 在 Redis 的基础上实现了多线程支持、更优的内存利用率以及更高的吞吐量，同时还支持 [Active Replication](https://github.com/JohnSully/KeyDB/wiki/Active-Replication)，即 Active-Active（双活）功能。KeyDB [目前不再积极维护](https://github.com/Snapchat/KeyDB/issues/895)，并且被认为与 Redis 6 版本兼容。
+[KeyDB](https://keydb.dev) 是 Redis 的一个开源分支，其开发目的是与 Redis 社区保持一致。KeyDB 在 Redis 的基础上实现了多线程支持、更优的内存利用率以及更高的吞吐量，同时还支持 [Active Replication](https://docs.keydb.dev/docs/active-rep)，即 Active-Active（双活）功能。KeyDB 被认为与 Redis 6 版本兼容，但目前[不再被其社区积极维护](https://github.com/Snapchat/KeyDB/issues/895)。
 
 :::note 注意
 KeyDB 的 Active Replication 功能是异步复制的，可能会导致一致性问题，请务必充分验证、谨慎使用！

--- a/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
@@ -157,19 +157,17 @@ juicefs format --storage s3 \
 
 [Valkey](https://valkey.io) 是 Redis 的一个开源分支，旨在保留该项目由社区驱动的治理模式，同时保持与 Redis 生态系统的高度兼容。Valkey 专注于在中立的方式下维护稳定性、提升性能并持续创新，从而为依赖 Redis 兼容工作负载的用户确保长期可用性。
 
-在用于 JuiceFS 的元数据存储引擎时，Valkey 的功能与 Redis 完全相同。请参考 Valkey 的[文档](https://valkey.io/topics/installation)进行安装以及了解其他相关内容，同时参考 [Redis](#redis) 章节了解使用方法。
+在用于 JuiceFS 的元数据存储引擎时，Valkey 的功能与 Redis 完全相同。请参考 Valkey 的[文档](https://valkey.io/topics/installation)进行安装以及了解其他相关内容，同时参考本文档 [Redis](#redis) 章节了解使用方法。
 
 ### KeyDB
 
-[KeyDB](https://keydb.dev) 是 Redis 的开源分支，在开发上保持与 Redis 主线对齐。KeyDB 在 Redis 的基础上实现了多线程支持、更好的内存利用率和更大的吞吐量，另外还支持 [Active Replication](https://github.com/JohnSully/KeyDB/wiki/Active-Replication)，即 Active Active（双活）功能。
-
-[KeyDB](https://keydb.dev) 是 Redis 的一个开源分支，其开发目的是与 Redis 社区保持一致。KeyDB 在 Redis 的基础上实现了多线程支持、更优的内存利用率以及更高的吞吐量，同时还支持 Active Replication（也称为 Active-Active）。KeyDB [目前不再积极维护](https://github.com/Snapchat/KeyDB/issues/895)，并且被认为与 Redis 6 版本兼容。
+[KeyDB](https://keydb.dev) 是 Redis 的一个开源分支，其开发目的是与 Redis 社区保持一致。KeyDB 在 Redis 的基础上实现了多线程支持、更优的内存利用率以及更高的吞吐量，同时还支持 [Active Replication](https://github.com/JohnSully/KeyDB/wiki/Active-Replication)，即 Active-Active（双活）功能。KeyDB [目前不再积极维护](https://github.com/Snapchat/KeyDB/issues/895)，并且被认为与 Redis 6 版本兼容。
 
 :::note 注意
 KeyDB 的 Active Replication 功能是异步复制的，可能会导致一致性问题，请务必充分验证、谨慎使用！
 :::
 
-在用于 JuiceFS 的元数据存储引擎时，KeyDB 的功能与 Redis 完全相同。请参考 KeyDB 的[文档](https://docs.keydb.dev/docs)进行安装以及了解其他相关内容，同时参考 [Redis](#redis) 章节了解使用方法。
+在用于 JuiceFS 的元数据存储引擎时，KeyDB 的功能与 Redis 完全相同。请参考 KeyDB 的[文档](https://docs.keydb.dev/docs)进行安装以及了解其他相关内容，同时参考本文档 [Redis](#redis) 章节了解使用方法。
 
 ## 键值数据库
 

--- a/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
@@ -129,7 +129,7 @@ juicefs mount -d "redis://192.168.1.6:6379/1" /mnt/jfs
 
 JuiceFS 同时支持 Redis 的 TLS 单向加密认证和 mTLS 双向加密认证连接。通过 TLS 或 mTLS 连接到 Redis 时均使用 `rediss://` 协议头，但是在使用 TLS 单向加密认证时，不需要指定客户端证书和私钥。
 
-:::note
+:::note 注意
 对 Redis mTLS 功能的支持需要使用 1.1.0 及以上版本的 JuiceFS
 :::
 
@@ -497,7 +497,7 @@ mysql://<username>[:<password>]@unix(<socket-file-path>)/<database-name>
 :::note 注意
 
 1. 不要漏掉 URL 两边的 `()` 括号
-2. 密码中的特殊字符不需要进行 url 编码
+2. 密码中的特殊字符不需要进行 URL 编码
 
 :::
 
@@ -621,12 +621,12 @@ juicefs format \
     pics
 ```
 
-:::note 说明
+:::note 注意
 
 1. JuiceFS 默认使用的 public [schema](https://www.postgresql.org/docs/current/ddl-schemas.html) ，如果要使用非 `public schema`，需要在连接字符串中指定 `search_path` 参数，例如 `postgres://user:mypassword@192.168.1.6:5432/juicefs?search_path=pguser1`
 2. 如果 `public schema` 并非是 PostgreSQL 服务端配置的 `search_path` 中第一个命中的，则必须在连接字符串中明确设置 `search_path` 参数
 3. `search_path` 连接参数原生可以设置为多个 schema，但是目前 JuiceFS 仅支持设置一个。`postgres://user:mypassword@192.168.1.6:5432/juicefs?search_path=pguser1,public` 将被认为不合法
-4. 密码中的特殊字符需要进行 url 编码，例如 `|` 需要编码为`%7C`。
+4. 密码中的特殊字符需要进行 URL 编码，例如 `|` 需要编码为`%7C`。
 
 :::
 


### PR DESCRIPTION
- Tested Valkey as the metadata engine.
- It had no issue with `juicefs format/mount/bench`.