### PR TITLE
cmd/mount: improve handing when process hung

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -57,6 +57,8 @@ import (
 
 var mountPid int
 
+const fuseConnectionsPath = "/sys/fs/fuse/connections"
+
 func showThreadStack(agentAddr string) {
 	if agentAddr == "" {
 		return
@@ -95,25 +97,29 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 			return
 		}
 	}
-	if runtime.GOOS == "linux" && dev > 0 {
-		tids, _ := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
-		for _, tid := range tids {
-			stack, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/stack", pid, tid))
-			if err == nil && bytes.Contains(stack, []byte("fuse_simple_request")) {
-				logger.Errorf("find deadlock in mount process, abort it: %s", string(stack))
-				if fuseFd > 0 {
-					_ = syscall.Close(fuseFd)
-					fuseFd = 0
-				}
-				f, err := os.OpenFile(fmt.Sprintf("/sys/fs/fuse/connections/%d/abort", devMinor(dev)), os.O_WRONLY, 0777)
-				if err != nil {
-					logger.Warn(err)
-				} else {
-					_, _ = f.WriteString("1")
-					_ = f.Close()
-				}
-				break
+	if runtime.GOOS != "linux" || dev == 0 {
+		return
+	}
+	conn := devMinor(dev)
+	data, err := os.ReadFile(filepath.Join(fuseConnectionsPath, strconv.FormatUint(uint64(conn), 10), "waiting"))
+	if err == nil {
+		waiting, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err == nil && waiting > 0 {
+			if fuseFd > 0 {
+				_ = syscall.Close(fuseFd)
+				fuseFd = 0
 			}
+			f, err := os.OpenFile(filepath.Join(fuseConnectionsPath, strconv.FormatUint(uint64(conn), 10), "abort"), os.O_WRONLY, 0)
+			if err != nil {
+				logger.Warn(err)
+				return
+			}
+			defer func() { _ = f.Close() }()
+			if _, err = f.WriteString("1"); err != nil {
+				logger.Warn(err)
+			}
+		} else if err != nil {
+			logger.Warnf("watchdog: read waiting FUSE requests for connection %d: %v; aborting anyway", conn, err)
 		}
 	}
 }

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -105,10 +105,12 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if err == nil {
 		waiting, err := strconv.Atoi(strings.TrimSpace(string(data)))
 		if err == nil && waiting > 0 {
+			fuseMu.Lock()
 			if fuseFd > 0 {
 				_ = syscall.Close(fuseFd)
 				fuseFd = 0
 			}
+			fuseMu.Unlock()
 			f, err := os.OpenFile(filepath.Join(fuseConnectionsPath, strconv.FormatUint(uint64(conn), 10), "abort"), os.O_WRONLY, 0)
 			if err != nil {
 				logger.Warn(err)
@@ -119,7 +121,7 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 				logger.Warn(err)
 			}
 		} else if err != nil {
-			logger.Warnf("watchdog: read waiting FUSE requests for connection %d: %v; aborting anyway", conn, err)
+			logger.Warnf("watchdog: failed to parse waiting FUSE requests for connection %d: %v; abort not triggered", conn, err)
 		}
 	}
 }

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -83,7 +83,6 @@ func devMinor(dev uint64) uint32 {
 	return uint32(minor)
 }
 
-
 func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if pid > 0 {
 		logger.Infof("watchdog: kill %d", pid)
@@ -139,9 +138,9 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 				logger.Warn(err)
 				return
 			}
-			logger.Warnf("watchdog: FUSE abort triggered for connection %d", conn)
+			logger.Warnf("watchdog: FUSE abort triggered for connection %d, pid %d", conn, pid)
 		} else if err != nil {
-			logger.Warnf("watchdog: failed to parse waiting FUSE requests for connection %d: %v; abort not triggered", conn, err)
+			logger.Warnf("watchdog: failed to parse waiting FUSE requests for connection %d, pid %d: %v; abort not triggered", conn, pid, err)
 		}
 	}
 }

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -83,6 +83,7 @@ func devMinor(dev uint64) uint32 {
 	return uint32(minor)
 }
 
+
 func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if pid > 0 {
 		logger.Infof("watchdog: kill %d", pid)
@@ -105,6 +106,23 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if err == nil {
 		waiting, err := strconv.Atoi(strings.TrimSpace(string(data)))
 		if err == nil && waiting > 0 {
+			tids, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+			if err != nil {
+				logger.Warnf("watchdog: read tasks of process %d: %v", pid, err)
+			} else {
+				for _, tid := range tids {
+					stackPath := fmt.Sprintf("/proc/%d/task/%s/stack", pid, tid.Name())
+					stack, err := os.ReadFile(stackPath)
+					if err != nil {
+						continue
+					}
+					stackText := strings.TrimSpace(string(stack))
+					if stackText == "" {
+						continue
+					}
+					logger.Warnf("watchdog: potential hung task kernel stack (pid=%d tid=%s):\n%s", pid, tid.Name(), stackText)
+				}
+			}
 			fuseMu.Lock()
 			if fuseFd > 0 {
 				_ = syscall.Close(fuseFd)
@@ -119,7 +137,9 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 			defer func() { _ = f.Close() }()
 			if _, err = f.WriteString("1"); err != nil {
 				logger.Warn(err)
+				return
 			}
+			logger.Warnf("watchdog: FUSE abort triggered for connection %d", conn)
 		} else if err != nil {
 			logger.Warnf("watchdog: failed to parse waiting FUSE requests for connection %d: %v; abort not triggered", conn, err)
 		}


### PR DESCRIPTION
rel https://github.com/juicedata/juicefs/issues/6691

When the mount process becomes unresponsive and FUSE requests are blocked, the value of `/sys/fs/fuse/connections/%d/waiting` should be used to determine whether there are pending FUSE requests and whether it is necessary to send an abort signal. The previous approach of matching hardcoded strings in the stack trace could not cover all required scenarios.