### PR TITLE
feat: add p2p-warmup subcommand

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,7 @@ func Main(args []string) error {
 			cmdObjbench(),
 			cmdMdtest(),
 			cmdWarmup(),
+			cmdP2PWarmup(),
 			cmdRmr(),
 			cmdSync(),
 			cmdDebug(),

--- a/cmd/p2p_warmup.go
+++ b/cmd/p2p_warmup.go
@@ -58,6 +58,7 @@ Examples:
 			&cli.BoolFlag{Name: "disable-manifest-sharing", Usage: "force every peer to resolve metadata independently (escape hatch for debugging)"},
 			&cli.StringFlag{Name: "leader-timeout", Value: "10m", Usage: "follower max wait for the leader's manifest before erroring out"},
 			&cli.StringFlag{Name: "manifest-name", Usage: "manifest object basename under p2p_warmup/ (default: content-addressable hash). All peers must pass the same value to agree on the key."},
+			&cli.BoolFlag{Name: "delete-manifest", Usage: "delete the manifest matching the other flags (paths, --manifest-name) from object storage and exit without warming"},
 			// General flags
 			&cli.IntFlag{Name: "threads", Aliases: []string{"p"}, Value: 50, Usage: "concurrent fetch workers"},
 			&cli.StringFlag{Name: "file", Aliases: []string{"f"}, Usage: "file containing a list of paths"},
@@ -113,6 +114,19 @@ func p2pWarmup(c *cli.Context) error {
 	blob, err := createStorage(*format)
 	if err != nil {
 		return err
+	}
+
+	// Maintenance mode: delete the manifest matching these args and exit.
+	// Done before any warmup wiring so a typo doesn't accidentally start
+	// the heavy machinery.
+	if c.Bool("delete-manifest") {
+		name := strings.TrimSpace(c.String("manifest-name"))
+		key, err := p2p.DeleteManifest(context.Background(), blob, paths, format.BlockSize*1024, format.HashPrefix, name)
+		if err != nil {
+			return err
+		}
+		logger.Infof("deleted manifest %q", key)
+		return nil
 	}
 
 	// Determine cache directory.

--- a/cmd/p2p_warmup.go
+++ b/cmd/p2p_warmup.go
@@ -64,7 +64,7 @@ Examples:
 			&cli.BoolFlag{Name: "keep-alive", Usage: "keep serving blocks to peers after warmup completes (until SIGTERM/SIGINT)"},
 			&cli.StringFlag{Name: "keep-alive-timeout", Value: "0", Usage: "auto-shutdown after this duration in keep-alive mode (0=wait for SIGTERM); ignored without --keep-alive"},
 			&cli.StringFlag{Name: "cache-dir", Usage: "cache directory (default: from volume format)"},
-			&cli.Int64Flag{Name: "download-limit", Usage: "object-storage download bandwidth cap in Mbps per peer (0=unlimited); peer-to-peer transfers are not throttled"},
+			&cli.StringFlag{Name: "download-limit", Usage: "bandwidth limit for download from object storage in Mbps per peer (e.g. 800 or 1G); peer-to-peer transfers are not throttled"},
 		},
 	}
 }

--- a/cmd/p2p_warmup.go
+++ b/cmd/p2p_warmup.go
@@ -1,0 +1,182 @@
+/*
+ * JuiceFS, Copyright 2024 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/signal"
+	"path"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/p2p"
+	"github.com/juicedata/juicefs/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func cmdP2PWarmup() *cli.Command {
+	return &cli.Command{
+		Name:      "p2p-warmup",
+		Action:    p2pWarmup,
+		Category:  "TOOL",
+		Usage:     "Build cache using peer-to-peer block exchange",
+		ArgsUsage: "META-URL PATH ...",
+		Description: `Warm up cache across multiple nodes using P2P block exchange.
+Each node fetches different blocks from object storage and shares them with peers,
+reducing object storage load to 1/N across N peers.
+
+Examples:
+  juicefs p2p-warmup --peers-dns-a my-svc.ns.svc.cluster.local redis://redis:6379/1 /models/llama
+  juicefs p2p-warmup --peers-list 10.0.0.1:19090,10.0.0.2:19090 tikv://tikv:2379 /data/dataset`,
+		Flags: []cli.Flag{
+			// P2P flags
+			&cli.StringFlag{Name: "peers-dns-srv", Usage: "DNS SRV record for peer discovery"},
+			&cli.StringFlag{Name: "peers-dns-a", Usage: "DNS A record FQDN for peer discovery"},
+			&cli.StringFlag{Name: "peers-list", Usage: "static peer list, comma-separated"},
+			&cli.StringFlag{Name: "listen", Value: ":19090", Usage: "HTTP server listen address"},
+			&cli.StringFlag{Name: "discovery-interval", Value: "3s", Usage: "peer discovery polling interval"},
+			&cli.StringFlag{Name: "availability-interval", Value: "2s", Usage: "availability polling interval"},
+			&cli.IntFlag{Name: "min-peers", Usage: "minimum total peer count including self; wait until at least this many are discovered before starting. Discovery returning more proceeds immediately (lower bound, not fixed size). >=2 enables manifest sharing. 0 or 1 = solo mode."},
+			&cli.BoolFlag{Name: "disable-manifest-sharing", Usage: "force every peer to resolve metadata independently (escape hatch for debugging)"},
+			&cli.StringFlag{Name: "leader-timeout", Value: "10m", Usage: "follower max wait for the leader's manifest before erroring out"},
+			&cli.StringFlag{Name: "manifest-name", Usage: "manifest object basename under p2p_warmup/ (default: content-addressable hash). All peers must pass the same value to agree on the key."},
+			// General flags
+			&cli.IntFlag{Name: "threads", Aliases: []string{"p"}, Value: 50, Usage: "concurrent fetch workers"},
+			&cli.StringFlag{Name: "file", Aliases: []string{"f"}, Usage: "file containing a list of paths"},
+			&cli.BoolFlag{Name: "keep-alive", Usage: "keep serving blocks to peers after warmup completes (until SIGTERM/SIGINT)"},
+			&cli.StringFlag{Name: "keep-alive-timeout", Value: "0", Usage: "auto-shutdown after this duration in keep-alive mode (0=wait for SIGTERM); ignored without --keep-alive"},
+			&cli.StringFlag{Name: "cache-dir", Usage: "cache directory (default: from volume format)"},
+			&cli.Int64Flag{Name: "download-limit", Usage: "object-storage download bandwidth cap in Mbps per peer (0=unlimited); peer-to-peer transfers are not throttled"},
+		},
+	}
+}
+
+func p2pWarmup(c *cli.Context) error {
+	setup0(c, 2, 0) // at least META-URL + one PATH, unlimited max
+
+	addr := c.Args().Get(0)
+	removePassword(addr)
+
+	// Collect paths from positional args and --file flag.
+	paths := c.Args().Tail()
+	if fname := c.String("file"); fname != "" {
+		fd, err := os.Open(fname)
+		if err != nil {
+			logger.Fatalf("Failed to open file %s: %s", fname, err)
+		}
+		defer fd.Close()
+		scanner := bufio.NewScanner(fd)
+		for scanner.Scan() {
+			if p := strings.TrimSpace(scanner.Text()); p != "" {
+				paths = append(paths, p)
+			}
+		}
+		if err = scanner.Err(); err != nil {
+			logger.Fatalf("Reading file %s failed with error: %s", fname, err)
+		}
+	}
+	if len(paths) == 0 {
+		logger.Infof("no paths specified")
+		return nil
+	}
+
+	// Initialize meta client.
+	metaConf := meta.DefaultConf()
+	metaConf.ReadOnly = true
+	metaConf.NoBGJob = true
+	metaCli := meta.NewClient(addr, metaConf)
+	format, err := metaCli.Load(true)
+	if err != nil {
+		return err
+	}
+
+	// Create object storage from format.
+	blob, err := createStorage(*format)
+	if err != nil {
+		return err
+	}
+
+	// Determine cache directory.
+	cacheDir := c.String("cache-dir")
+	if cacheDir == "" {
+		cacheDir = defaultCacheDir()
+	}
+	// Append volume UUID to cache dir, same as chunk.Config.SelfCheck().
+	cacheDir = path.Join(cacheDir, format.UUID)
+
+	// Build WarmupConfig from CLI flags.
+	config := p2p.WarmupConfig{
+		ListenAddr:           c.String("listen"),
+		DiscoveryInterval:    utils.Duration(c.String("discovery-interval")),
+		AvailabilityInterval: utils.Duration(c.String("availability-interval")),
+		Threads:              c.Int("threads"),
+		KeepAlive:            c.Bool("keep-alive"),
+		KeepAliveTimeout:     utils.Duration(c.String("keep-alive-timeout")),
+		MinPeers:             c.Int("min-peers"),
+
+		DisableManifestSharing: c.Bool("disable-manifest-sharing"),
+		LeaderTimeout:          utils.Duration(c.String("leader-timeout")),
+		ManifestName:           strings.TrimSpace(c.String("manifest-name")),
+
+		PeersDNSSRV: c.String("peers-dns-srv"),
+		PeersDNSA:   c.String("peers-dns-a"),
+		PeersList:   c.String("peers-list"),
+
+		CacheDir:   cacheDir,
+		BlockSize:  format.BlockSize * 1024,
+		HashPrefix: format.HashPrefix,
+		Compress:   format.Compression,
+
+		DownloadLimit: utils.ParseMbps(c, "download-limit") * 1e6 / 8,
+	}
+
+	// Set up context with signal cancellation.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	return p2p.NewWarmup(config, metaCli, blob).Run(ctx, paths)
+}
+
+// defaultCacheDir returns the platform-appropriate default cache directory,
+// matching the logic in dataCacheFlags().
+func defaultCacheDir() string {
+	dir := "/var/jfsCache"
+	switch runtime.GOOS {
+	case "linux":
+		if os.Getuid() == 0 {
+			return dir
+		}
+		fallthrough
+	case "darwin":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return dir
+		}
+		dir = path.Join(homeDir, ".juicefs", "cache")
+	case "windows":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return dir
+		}
+		dir = path.Join(homeDir, ".juicefs", "cache")
+	}
+	return dir
+}

--- a/cmd/p2p_warmup.go
+++ b/cmd/p2p_warmup.go
@@ -64,6 +64,7 @@ Examples:
 			&cli.BoolFlag{Name: "keep-alive", Usage: "keep serving blocks to peers after warmup completes (until SIGTERM/SIGINT)"},
 			&cli.StringFlag{Name: "keep-alive-timeout", Value: "0", Usage: "auto-shutdown after this duration in keep-alive mode (0=wait for SIGTERM); ignored without --keep-alive"},
 			&cli.StringFlag{Name: "cache-dir", Usage: "cache directory (default: from volume format)"},
+			&cli.StringFlag{Name: "cache-size", Value: "100G", Usage: "hard cap on total cached bytes at cache-dir (e.g. 100G, 50000 = 50000 MiB); 0 disables the cap. Counts pre-existing files. Matches mount's --cache-size default."},
 			&cli.StringFlag{Name: "download-limit", Usage: "bandwidth limit for download from object storage in Mbps per peer (e.g. 800 or 1G); peer-to-peer transfers are not throttled"},
 		},
 	}
@@ -146,6 +147,7 @@ func p2pWarmup(c *cli.Context) error {
 		Compress:   format.Compression,
 
 		DownloadLimit: utils.ParseMbps(c, "download-limit") * 1e6 / 8,
+		CacheSize:     int64(utils.ParseBytes(c, "cache-size", 'M')),
 	}
 
 	// Set up context with signal cancellation.

--- a/cmd/p2p_warmup.go
+++ b/cmd/p2p_warmup.go
@@ -62,8 +62,8 @@ Examples:
 			// General flags
 			&cli.IntFlag{Name: "threads", Aliases: []string{"p"}, Value: 50, Usage: "concurrent fetch workers"},
 			&cli.StringFlag{Name: "file", Aliases: []string{"f"}, Usage: "file containing a list of paths"},
-			&cli.BoolFlag{Name: "keep-alive", Usage: "keep serving blocks to peers after warmup completes (until SIGTERM/SIGINT)"},
-			&cli.StringFlag{Name: "keep-alive-timeout", Value: "0", Usage: "auto-shutdown after this duration in keep-alive mode (0=wait for SIGTERM); ignored without --keep-alive"},
+			&cli.StringFlag{Name: "keep-alive", Value: "peers", Usage: "post-warmup behavior: 'off' exits when the local fetch is done; 'peers' (default) keeps serving until every peer completes, then exits; 'forever' serves until SIGTERM/SIGINT"},
+			&cli.StringFlag{Name: "keep-alive-timeout", Value: "0", Usage: "upper bound on the keep-alive phase (0=no bound); applies to --keep-alive=peers and =forever, ignored when =off"},
 			&cli.StringFlag{Name: "cache-dir", Usage: "cache directory (default: from volume format)"},
 			&cli.StringFlag{Name: "cache-size", Value: "100G", Usage: "hard cap on total cached bytes at cache-dir (e.g. 100G, 50000 = 50000 MiB); 0 disables the cap. Counts pre-existing files. Matches mount's --cache-size default."},
 			&cli.StringFlag{Name: "download-limit", Usage: "bandwidth limit for download from object storage in Mbps per peer (e.g. 800 or 1G); peer-to-peer transfers are not throttled"},
@@ -137,13 +137,18 @@ func p2pWarmup(c *cli.Context) error {
 	// Append volume UUID to cache dir, same as chunk.Config.SelfCheck().
 	cacheDir = path.Join(cacheDir, format.UUID)
 
+	keepAlive, err := p2p.ParseKeepAliveMode(c.String("keep-alive"))
+	if err != nil {
+		return err
+	}
+
 	// Build WarmupConfig from CLI flags.
 	config := p2p.WarmupConfig{
 		ListenAddr:           c.String("listen"),
 		DiscoveryInterval:    utils.Duration(c.String("discovery-interval")),
 		AvailabilityInterval: utils.Duration(c.String("availability-interval")),
 		Threads:              c.Int("threads"),
-		KeepAlive:            c.Bool("keep-alive"),
+		KeepAlive:            keepAlive,
 		KeepAliveTimeout:     utils.Duration(c.String("keep-alive-timeout")),
 		MinPeers:             c.Int("min-peers"),
 

--- a/pkg/chunk/block_key.go
+++ b/pkg/chunk/block_key.go
@@ -1,0 +1,60 @@
+/*
+ * JuiceFS, Copyright 2020 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chunk
+
+import "fmt"
+
+// BlockKey returns the object storage key for a single block.
+// It mirrors the private rSlice.key method in cached_store.go so that
+// external packages (e.g. pkg/p2p) can compute keys without accessing
+// cachedStore internals.
+//
+//   - id         – slice ID
+//   - blockIndex – zero-based index of the block within the slice
+//   - blockSize  – size of this specific block in bytes
+//   - hashPrefix – whether the store uses hash-prefixed key layout
+func BlockKey(id uint64, blockIndex, blockSize int, hashPrefix bool) string {
+	if hashPrefix {
+		return fmt.Sprintf("chunks/%02X/%v/%v_%v_%v", id%256, id/1000/1000, id, blockIndex, blockSize)
+	}
+	return fmt.Sprintf("chunks/%v/%v/%v_%v_%v", id/1000/1000, id/1000, id, blockIndex, blockSize)
+}
+
+// SliceBlockKeys returns all object storage keys for a slice.
+// It mirrors the private rSlice.keys method in cached_store.go.
+//
+//   - id         – slice ID
+//   - length     – total byte length of the slice
+//   - blockSize  – maximum block size in bytes (last block may be smaller)
+//   - hashPrefix – whether the store uses hash-prefixed key layout
+//
+// Returns nil when length <= 0.
+func SliceBlockKeys(id uint64, length, blockSize int, hashPrefix bool) []string {
+	if length <= 0 {
+		return nil
+	}
+	numBlocks := (length-1)/blockSize + 1
+	keys := make([]string, numBlocks)
+	for i := 0; i < numBlocks; i++ {
+		bsize := blockSize
+		if remaining := length - i*blockSize; remaining < bsize {
+			bsize = remaining
+		}
+		keys[i] = BlockKey(id, i, bsize, hashPrefix)
+	}
+	return keys
+}

--- a/pkg/chunk/block_key_test.go
+++ b/pkg/chunk/block_key_test.go
@@ -1,0 +1,93 @@
+/*
+ * JuiceFS, Copyright 2020 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package chunk
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBlockKey_NoHashPrefix(t *testing.T) {
+	// id=123456789: id/1000000=123, id/1000=123456
+	got := BlockKey(123456789, 2, 4194304, false)
+	want := "chunks/123/123456/123456789_2_4194304"
+	if got != want {
+		t.Errorf("BlockKey() = %q, want %q", got, want)
+	}
+}
+
+func TestBlockKey_HashPrefix(t *testing.T) {
+	// id=123456789: id%256 = 123456789%256 = 21 -> hex "15"
+	got := BlockKey(123456789, 0, 4194304, true)
+	want := "chunks/15/123/123456789_0_4194304"
+	if got != want {
+		t.Errorf("BlockKey() = %q, want %q", got, want)
+	}
+}
+
+func TestSliceBlockKeys(t *testing.T) {
+	// length=10MB, blockSize=4MB -> 3 blocks: 4MB, 4MB, 2MB
+	length := 10 * 1024 * 1024
+	blockSize := 4 * 1024 * 1024
+	keys := SliceBlockKeys(100, length, blockSize, false)
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 keys, got %d", len(keys))
+	}
+	// Last block should be 2MB = 2097152 bytes
+	lastBlock := keys[2]
+	wantLast := "chunks/0/0/100_2_2097152"
+	if lastBlock != wantLast {
+		t.Errorf("last key = %q, want %q", lastBlock, wantLast)
+	}
+	// First block should be full blockSize
+	wantFirst := "chunks/0/0/100_0_4194304"
+	if keys[0] != wantFirst {
+		t.Errorf("first key = %q, want %q", keys[0], wantFirst)
+	}
+}
+
+func TestSliceBlockKeys_ExactMultiple(t *testing.T) {
+	// length=8MB, blockSize=4MB -> 2 blocks, each 4MB
+	length := 8 * 1024 * 1024
+	blockSize := 4 * 1024 * 1024
+	keys := SliceBlockKeys(100, length, blockSize, false)
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	for i, k := range keys {
+		want := "chunks/0/0/100_" + itoa(i) + "_4194304"
+		if k != want {
+			t.Errorf("key[%d] = %q, want %q", i, k, want)
+		}
+	}
+}
+
+func TestSliceBlockKeys_Empty(t *testing.T) {
+	keys := SliceBlockKeys(100, 0, 4194304, false)
+	if keys != nil {
+		t.Errorf("expected nil for length=0, got %v", keys)
+	}
+	keys = SliceBlockKeys(100, -1, 4194304, false)
+	if keys != nil {
+		t.Errorf("expected nil for length=-1, got %v", keys)
+	}
+}
+
+// itoa is a simple int-to-string helper for test assertions.
+func itoa(n int) string {
+	return fmt.Sprintf("%d", n)
+}

--- a/pkg/p2p/availability.go
+++ b/pkg/p2p/availability.go
@@ -1,0 +1,139 @@
+package p2p
+
+import (
+	"sync"
+	"time"
+)
+
+type localEntry struct {
+	key       string
+	timestamp int64 // Unix millis
+}
+
+// AvailabilityTracker tracks which blocks this node has locally and which
+// blocks each remote peer has. The local list is append-only and ordered by
+// timestamp so that incremental updates can be served efficiently via
+// LocalBlocksSince. The remote map is populated by availability polling and
+// consumed by the fetcher to decide whether to pull from a peer or object
+// storage.
+//
+// All methods are safe for concurrent use.
+type AvailabilityTracker struct {
+	mu     sync.RWMutex
+	local  []localEntry                   // append-only, ordered by timestamp
+	remote map[string]map[string]struct{} // peerAddr -> set of block keys
+}
+
+// NewAvailabilityTracker returns a ready-to-use AvailabilityTracker.
+func NewAvailabilityTracker() *AvailabilityTracker {
+	return &AvailabilityTracker{
+		remote: make(map[string]map[string]struct{}),
+	}
+}
+
+// MarkLocal records that the local node has completed the given block key.
+func (t *AvailabilityTracker) MarkLocal(key string) {
+	now := time.Now().UnixMilli()
+	t.mu.Lock()
+	t.local = append(t.local, localEntry{key: key, timestamp: now})
+	t.mu.Unlock()
+}
+
+// LocalBlocksSince returns all block keys whose timestamp is strictly greater
+// than sinceMs, along with the timestamp of the newest entry seen (0 if the
+// local list is empty). Callers should store the returned timestamp and pass
+// it as sinceMs on the next call to receive only new blocks.
+func (t *AvailabilityTracker) LocalBlocksSince(sinceMs int64) ([]string, int64) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var latestTs int64
+	if n := len(t.local); n > 0 {
+		latestTs = t.local[n-1].timestamp
+	}
+
+	// Binary search for the first entry with timestamp > sinceMs.
+	// local is ordered by insertion time which corresponds to monotonically
+	// non-decreasing timestamps (same-millisecond entries keep their order).
+	lo, hi := 0, len(t.local)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if t.local[mid].timestamp <= sinceMs {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+
+	entries := t.local[lo:]
+	if len(entries) == 0 {
+		return nil, latestTs
+	}
+
+	keys := make([]string, len(entries))
+	for i, e := range entries {
+		keys[i] = e.key
+	}
+	return keys, latestTs
+}
+
+// LocalDoneCount returns the total number of blocks recorded via MarkLocal.
+func (t *AvailabilityTracker) LocalDoneCount() int {
+	t.mu.RLock()
+	n := len(t.local)
+	t.mu.RUnlock()
+	return n
+}
+
+// UpdateRemote adds keys to the set of blocks known to be held by peerAddr.
+// The update is additive — existing keys are never removed (call RemovePeer to
+// clear all state for a peer).
+func (t *AvailabilityTracker) UpdateRemote(peerAddr string, keys []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	set, ok := t.remote[peerAddr]
+	if !ok {
+		set = make(map[string]struct{}, len(keys))
+		t.remote[peerAddr] = set
+	}
+	for _, k := range keys {
+		set[k] = struct{}{}
+	}
+}
+
+// PeerHas reports whether peerAddr is known to hold the given block key.
+func (t *AvailabilityTracker) PeerHas(peerAddr, key string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	set, ok := t.remote[peerAddr]
+	if !ok {
+		return false
+	}
+	_, has := set[key]
+	return has
+}
+
+// FindPeerWith returns the address of the first peer that is known to hold
+// key, or "" if no such peer exists. The order of iteration over the internal
+// map is not guaranteed; callers that need determinism should post-process the
+// full list themselves.
+func (t *AvailabilityTracker) FindPeerWith(key string) string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for addr, set := range t.remote {
+		if _, ok := set[key]; ok {
+			return addr
+		}
+	}
+	return ""
+}
+
+// RemovePeer deletes all availability data for the given peer address.
+func (t *AvailabilityTracker) RemovePeer(peerAddr string) {
+	t.mu.Lock()
+	delete(t.remote, peerAddr)
+	t.mu.Unlock()
+}

--- a/pkg/p2p/availability_test.go
+++ b/pkg/p2p/availability_test.go
@@ -1,0 +1,97 @@
+package p2p
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAvailabilityTracker_MarkLocal(t *testing.T) {
+	tr := NewAvailabilityTracker()
+	tr.MarkLocal("key1")
+
+	keys, ts := tr.LocalBlocksSince(0)
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+	if keys[0] != "key1" {
+		t.Errorf("expected key1, got %s", keys[0])
+	}
+	if ts <= 0 {
+		t.Errorf("expected ts > 0, got %d", ts)
+	}
+}
+
+func TestAvailabilityTracker_IncrementalLocal(t *testing.T) {
+	tr := NewAvailabilityTracker()
+	tr.MarkLocal("key1")
+
+	_, ts1 := tr.LocalBlocksSince(0)
+
+	time.Sleep(2 * time.Millisecond)
+
+	tr.MarkLocal("key2")
+
+	keys, _ := tr.LocalBlocksSince(ts1)
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key after ts1, got %d: %v", len(keys), keys)
+	}
+	if keys[0] != "key2" {
+		t.Errorf("expected key2, got %s", keys[0])
+	}
+}
+
+func TestAvailabilityTracker_UpdateRemote(t *testing.T) {
+	tr := NewAvailabilityTracker()
+	tr.UpdateRemote("peer1", []string{"key1", "key2"})
+
+	if !tr.PeerHas("peer1", "key1") {
+		t.Error("expected peer1 to have key1")
+	}
+	if !tr.PeerHas("peer1", "key2") {
+		t.Error("expected peer1 to have key2")
+	}
+	if tr.PeerHas("peer1", "key3") {
+		t.Error("expected peer1 NOT to have key3")
+	}
+}
+
+func TestAvailabilityTracker_FindPeerWith(t *testing.T) {
+	tr := NewAvailabilityTracker()
+	tr.UpdateRemote("peer1", []string{"key1"})
+	tr.UpdateRemote("peer2", []string{"key1", "key2"})
+
+	found := tr.FindPeerWith("key1")
+	if found != "peer1" && found != "peer2" {
+		t.Errorf("expected peer1 or peer2, got %q", found)
+	}
+
+	notFound := tr.FindPeerWith("key3")
+	if notFound != "" {
+		t.Errorf("expected empty string for missing key, got %q", notFound)
+	}
+}
+
+func TestAvailabilityTracker_RemovePeer(t *testing.T) {
+	tr := NewAvailabilityTracker()
+	tr.UpdateRemote("peer1", []string{"key1"})
+
+	if !tr.PeerHas("peer1", "key1") {
+		t.Fatal("expected peer1 to have key1 before removal")
+	}
+
+	tr.RemovePeer("peer1")
+
+	if tr.PeerHas("peer1", "key1") {
+		t.Error("expected peer1 NOT to have key1 after removal")
+	}
+}
+
+func TestAvailabilityTracker_LocalDoneCount(t *testing.T) {
+	tr := NewAvailabilityTracker()
+	tr.MarkLocal("key1")
+	tr.MarkLocal("key2")
+
+	if count := tr.LocalDoneCount(); count != 2 {
+		t.Errorf("expected count 2, got %d", count)
+	}
+}

--- a/pkg/p2p/discovery.go
+++ b/pkg/p2p/discovery.go
@@ -1,0 +1,157 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var logger = logrus.WithField("pkg", "p2p")
+
+// PeerDiscovery resolves peers from DNS SRV, DNS A, and static list sources.
+type PeerDiscovery struct {
+	dnsSRV      string
+	dnsA        string
+	staticList  string
+	defaultPort int
+
+	mu    sync.RWMutex
+	peers []string // cached last resolve
+}
+
+// NewPeerDiscovery creates a PeerDiscovery with the given sources and default port.
+func NewPeerDiscovery(dnsSRV, dnsA, staticList string, defaultPort int) *PeerDiscovery {
+	return &PeerDiscovery{
+		dnsSRV:      dnsSRV,
+		dnsA:        dnsA,
+		staticList:  staticList,
+		defaultPort: defaultPort,
+	}
+}
+
+// Resolve queries all configured sources, deduplicates, caches and returns the result.
+func (d *PeerDiscovery) Resolve(ctx context.Context) ([]string, error) {
+	seen := make(map[string]struct{})
+	var result []string
+
+	add := func(addrs []string) {
+		for _, a := range addrs {
+			if _, ok := seen[a]; !ok {
+				seen[a] = struct{}{}
+				result = append(result, a)
+			}
+		}
+	}
+
+	// 1. Static peers
+	add(parseStaticPeers(d.staticList))
+
+	// 2. DNS A
+	if d.dnsA != "" {
+		addrs, err := resolveDNSA(ctx, d.dnsA, d.defaultPort)
+		if err != nil {
+			logger.WithError(err).Warnf("DNS A lookup failed for %s", d.dnsA)
+		} else {
+			add(addrs)
+		}
+	}
+
+	// 3. DNS SRV
+	if d.dnsSRV != "" {
+		addrs, err := resolveDNSSRV(ctx, d.dnsSRV)
+		if err != nil {
+			logger.WithError(err).Warnf("DNS SRV lookup failed for %s", d.dnsSRV)
+		} else {
+			add(addrs)
+		}
+	}
+
+	// Cache result
+	d.mu.Lock()
+	d.peers = result
+	d.mu.Unlock()
+
+	return result, nil
+}
+
+// Peers returns a copy of the last resolved peer list (thread-safe).
+func (d *PeerDiscovery) Peers() []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if len(d.peers) == 0 {
+		return nil
+	}
+	cp := make([]string, len(d.peers))
+	copy(cp, d.peers)
+	return cp
+}
+
+// RunLoop periodically calls Resolve until ctx is cancelled.
+func (d *PeerDiscovery) RunLoop(ctx context.Context, interval time.Duration) {
+	// Resolve immediately on first call
+	if _, err := d.Resolve(ctx); err != nil {
+		logger.WithError(err).Warn("peer discovery resolve failed")
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := d.Resolve(ctx); err != nil {
+				logger.WithError(err).Warn("peer discovery resolve failed")
+			}
+		}
+	}
+}
+
+// parseStaticPeers splits a comma-separated list, trims whitespace, and skips empty entries.
+func parseStaticPeers(list string) []string {
+	if list == "" {
+		return nil
+	}
+	parts := strings.Split(list, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// resolveDNSA resolves host via DNS A lookup and returns addresses formatted as "ip:port".
+func resolveDNSA(ctx context.Context, host string, port int) ([]string, error) {
+	addrs, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		result = append(result, fmt.Sprintf("%s:%d", a, port))
+	}
+	return result, nil
+}
+
+// resolveDNSSRV resolves a DNS SRV record and returns addresses formatted as "target:port".
+func resolveDNSSRV(ctx context.Context, name string) ([]string, error) {
+	_, addrs, err := net.DefaultResolver.LookupSRV(ctx, "", "", name)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(addrs))
+	for _, srv := range addrs {
+		target := strings.TrimSuffix(srv.Target, ".")
+		result = append(result, fmt.Sprintf("%s:%d", target, srv.Port))
+	}
+	return result, nil
+}

--- a/pkg/p2p/discovery_test.go
+++ b/pkg/p2p/discovery_test.go
@@ -1,0 +1,127 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestParseStaticPeers(t *testing.T) {
+	peers := parseStaticPeers("10.0.0.1:19090,10.0.0.2:19090")
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d", len(peers))
+	}
+	if peers[0] != "10.0.0.1:19090" {
+		t.Errorf("expected 10.0.0.1:19090, got %s", peers[0])
+	}
+	if peers[1] != "10.0.0.2:19090" {
+		t.Errorf("expected 10.0.0.2:19090, got %s", peers[1])
+	}
+}
+
+func TestParseStaticPeers_Empty(t *testing.T) {
+	peers := parseStaticPeers("")
+	if len(peers) != 0 {
+		t.Fatalf("expected 0 peers, got %d", len(peers))
+	}
+}
+
+func TestParseStaticPeers_Whitespace(t *testing.T) {
+	peers := parseStaticPeers(" a , b ")
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d", len(peers))
+	}
+	if peers[0] != "a" {
+		t.Errorf("expected 'a', got %q", peers[0])
+	}
+	if peers[1] != "b" {
+		t.Errorf("expected 'b', got %q", peers[1])
+	}
+}
+
+func TestDiscovery_StaticOnly(t *testing.T) {
+	d := NewPeerDiscovery("", "", "10.0.0.1:19090,10.0.0.2:19090", 19090)
+	peers, err := d.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d: %v", len(peers), peers)
+	}
+}
+
+func TestDiscovery_DeduplicatesAddrs(t *testing.T) {
+	// Same address in static list twice → should deduplicate to 1
+	d := NewPeerDiscovery("", "", "10.0.0.1:19090,10.0.0.1:19090", 19090)
+	peers, err := d.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer after dedup, got %d: %v", len(peers), peers)
+	}
+}
+
+func TestDiscovery_PeersCachesLastResolve(t *testing.T) {
+	d := NewPeerDiscovery("", "", "10.0.0.1:19090", 19090)
+
+	// Before any Resolve, Peers() returns empty
+	initial := d.Peers()
+	if len(initial) != 0 {
+		t.Fatalf("expected 0 peers before resolve, got %d", len(initial))
+	}
+
+	_, err := d.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cached := d.Peers()
+	if len(cached) != 1 {
+		t.Fatalf("expected 1 cached peer, got %d", len(cached))
+	}
+	if cached[0] != "10.0.0.1:19090" {
+		t.Errorf("unexpected cached peer: %s", cached[0])
+	}
+}
+
+func TestDiscovery_PeersReturnsCopy(t *testing.T) {
+	d := NewPeerDiscovery("", "", "10.0.0.1:19090", 19090)
+	_, _ = d.Resolve(context.Background())
+
+	p1 := d.Peers()
+	p1[0] = "mutated"
+
+	p2 := d.Peers()
+	if p2[0] == "mutated" {
+		t.Error("Peers() should return a copy, not the internal slice")
+	}
+}
+
+func TestDiscovery_RunLoop(t *testing.T) {
+	d := NewPeerDiscovery("", "", "10.0.0.1:19090", 19090)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.RunLoop(ctx, 10*time.Millisecond)
+	}()
+
+	// Give the loop time to run at least once
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLoop did not exit after context cancellation")
+	}
+
+	// After the loop ran, the cache should be populated
+	peers := d.Peers()
+	if len(peers) == 0 {
+		t.Error("expected cached peers after RunLoop, got none")
+	}
+}

--- a/pkg/p2p/fetcher.go
+++ b/pkg/p2p/fetcher.go
@@ -152,9 +152,13 @@ func (f *Fetcher) CacheBlock(key string, data []byte) error {
 // FetchBlock fetches a block (cache > peer > storage) and writes it to the
 // disk cache. fromPeer is true when the data came from a peer.
 func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer bool, err error) {
-	// Cache-hit fast path: skip fetch if file exists on disk with expected size.
+	// Cache-hit fast path: skip the fetch when the on-disk file matches any
+	// of the layouts mount accepts (logical / +checksum / +tier / both).
+	// Use the same predicate as scanExistingCache so the two views agree —
+	// otherwise a file announced via /available would still be re-fetched
+	// here on its way through the worker queue.
 	cachePath := filepath.Join(f.cacheDir, "raw", block.Key)
-	if fi, statErr := os.Stat(cachePath); statErr == nil && fi.Size() == int64(block.Size) {
+	if fi, statErr := os.Stat(cachePath); statErr == nil && validCacheFileSize(fi.Size(), block.Size) {
 		f.stats.FromCache.Add(1)
 		return false, nil
 	}

--- a/pkg/p2p/fetcher.go
+++ b/pkg/p2p/fetcher.go
@@ -1,0 +1,318 @@
+package p2p
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/juicedata/juicefs/pkg/compress"
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juju/ratelimit"
+)
+
+// FetchStats counts blocks by source. FromCache means the block was already
+// on disk with the expected size and the fetch was skipped.
+type FetchStats struct {
+	FromPeers   atomic.Int64
+	FromStorage atomic.Int64
+	FromCache   atomic.Int64
+	Failed      atomic.Int64
+	BytesPeer   atomic.Int64
+	BytesStore  atomic.Int64
+}
+
+// Fetcher retrieves blocks from the best available source (cache > peer >
+// object storage) and writes them to the local disk cache.
+type Fetcher struct {
+	storage      object.ObjectStorage
+	cacheDir     string
+	blockSize    int
+	httpClient   *http.Client
+	availability *AvailabilityTracker
+	stats        FetchStats
+	downLimit    *ratelimit.Bucket   // object storage download throttle; nil = unlimited
+	compressor   compress.Compressor // decompresses storage payloads; noOp for uncompressed volumes
+	// True for noOp compressor: return io.ReadAll's buffer directly
+	// instead of decompressing into a fresh allocation.
+	skipDecompress bool
+}
+
+// NewFetcher constructs a Fetcher. compressor must match the volume's
+// format.Compression so FetchFromStorage produces the layout mount expects
+// on disk; nil is treated as noOp for uncompressed volumes.
+func NewFetcher(storage object.ObjectStorage, cacheDir string, blockSize int, client *http.Client, compressor compress.Compressor) *Fetcher {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if compressor == nil {
+		compressor = compress.NewCompressor("")
+	}
+	return &Fetcher{
+		storage:        storage,
+		cacheDir:       cacheDir,
+		blockSize:      blockSize,
+		httpClient:     client,
+		compressor:     compressor,
+		skipDecompress: compressor.Name() == "Noop",
+	}
+}
+
+// SetAvailability wires the tracker used by FetchBlock to find peers.
+func (f *Fetcher) SetAvailability(at *AvailabilityTracker) {
+	f.availability = at
+}
+
+// SetDownloadLimit throttles object-storage reads to the bucket's fill rate.
+// Pass nil to disable.
+func (f *Fetcher) SetDownloadLimit(b *ratelimit.Bucket) {
+	f.downLimit = b
+}
+
+// FetchFromPeer issues GET http://{peerAddr}/block/{key} and returns the
+// response body. The caller is responsible for validating length/integrity.
+func (f *Fetcher) FetchFromPeer(ctx context.Context, peerAddr, key string) ([]byte, error) {
+	url := fmt.Sprintf("http://%s/block/%s", peerAddr, key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("peer fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("peer fetch %s: status %d", url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("peer fetch %s: read body: %w", url, err)
+	}
+	return data, nil
+}
+
+// FetchFromStorage downloads key and decompresses to the logical size mount
+// expects on disk. The download limiter accounts raw network bytes
+// (compressed when applicable), not the decompressed output.
+func (f *Fetcher) FetchFromStorage(ctx context.Context, key string, size int) ([]byte, error) {
+	rc, err := f.storage.Get(ctx, key, 0, -1)
+	if err != nil {
+		return nil, fmt.Errorf("storage get %q: %w", key, err)
+	}
+	defer rc.Close()
+
+	raw, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("storage read %q: %w", key, err)
+	}
+	if f.downLimit != nil && len(raw) > 0 {
+		f.downLimit.Wait(int64(len(raw)))
+	}
+
+	if f.skipDecompress {
+		if len(raw) != size {
+			return nil, fmt.Errorf("storage object %q size %d != expected logical size %d (corrupt or truncated)", key, len(raw), size)
+		}
+		return raw, nil
+	}
+
+	out := make([]byte, size)
+	n, err := f.compressor.Decompress(out, raw)
+	if err != nil {
+		return nil, fmt.Errorf("decompress %q: %w", key, err)
+	}
+	if n != size {
+		return nil, fmt.Errorf("decompress %q: produced %d bytes, expected %d (corrupt or truncated object)", key, n, size)
+	}
+	return out, nil
+}
+
+// CacheBlock writes data to {cacheDir}/raw/{key}, creating parent directories
+// as needed.
+func (f *Fetcher) CacheBlock(key string, data []byte) error {
+	path := filepath.Join(f.cacheDir, "raw", key)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("mkdir %q: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write block %q: %w", path, err)
+	}
+	return nil
+}
+
+// FetchBlock fetches a block (cache > peer > storage) and writes it to the
+// disk cache. fromPeer is true when the data came from a peer.
+func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer bool, err error) {
+	// Cache-hit fast path: skip fetch if file exists on disk with expected size.
+	cachePath := filepath.Join(f.cacheDir, "raw", block.Key)
+	if fi, statErr := os.Stat(cachePath); statErr == nil && fi.Size() == int64(block.Size) {
+		f.stats.FromCache.Add(1)
+		return false, nil
+	}
+
+	var data []byte
+
+	// Attempt peer download if we have an availability tracker.
+	if f.availability != nil {
+		if peerAddr := f.availability.FindPeerWith(block.Key); peerAddr != "" {
+			data, err = f.FetchFromPeer(ctx, peerAddr, block.Key)
+			if err == nil {
+				fromPeer = true
+			}
+			// On peer failure fall through to storage.
+		}
+	}
+
+	if !fromPeer {
+		data, err = f.FetchFromStorage(ctx, block.Key, block.Size)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Write to local disk cache.
+	if cacheErr := f.CacheBlock(block.Key, data); cacheErr != nil {
+		return fromPeer, cacheErr
+	}
+
+	// Update counters.
+	n := int64(len(data))
+	if fromPeer {
+		f.stats.FromPeers.Add(1)
+		f.stats.BytesPeer.Add(n)
+	} else {
+		f.stats.FromStorage.Add(1)
+		f.stats.BytesStore.Add(n)
+	}
+	return fromPeer, nil
+}
+
+// MaxBlockAttempts bounds retries for blocks that fail in non-NoSuchKey ways
+// (NoSuchKey is short-circuited by isStorageNotFound). 5 absorbs transient
+// peer/HTTP failures — worst case ~25s with the 5s peer timeout — while
+// guaranteeing the warmup terminates.
+const MaxBlockAttempts = 5
+
+// isStorageNotFound reports whether the object is missing from storage.
+// Permanent — the worker abandons immediately rather than burning retries.
+// String-matching mirrors pkg/chunk/cached_store.go since backends share no
+// typed "not found" error.
+func isStorageNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "NoSuchKey") ||
+		strings.Contains(s, "not found") ||
+		strings.Contains(s, "No such file")
+}
+
+// RunWorkers spawns numWorkers goroutines that pop blocks, claim them via
+// CAS Pending→Downloading, and fetch. On success: MarkDone + MarkLocal. On
+// failure: re-push until MaxBlockAttempts, then MarkFailed so the warmup can
+// complete even with unfetchable blocks. The returned WaitGroup signals when
+// the queue is closed and drained.
+func (f *Fetcher) RunWorkers(ctx context.Context, queue *FetchQueue, tracker *AvailabilityTracker, numWorkers int) *sync.WaitGroup {
+	var wg sync.WaitGroup
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				block := queue.WaitAndPop()
+				if block == nil {
+					// Queue closed and empty.
+					return
+				}
+
+				// Claim the block atomically.
+				if !block.TryDownload() {
+					// Another worker already claimed it.
+					continue
+				}
+
+				_, err := f.FetchBlock(ctx, block)
+				if err != nil {
+					if isStorageNotFound(err) {
+						// Permanent: object is gone (e.g. JuiceFS slice
+						// compaction during warmup). Don't burn retries.
+						block.MarkFailed()
+						f.stats.Failed.Add(1)
+						logger.Warnf("block %q abandoned: not found in object storage (likely deleted by compaction): %v", block.Key, err)
+						continue
+					}
+					attempts := block.IncrAttempts()
+					if attempts >= MaxBlockAttempts {
+						block.MarkFailed()
+						f.stats.Failed.Add(1)
+						logger.Warnf("block %q abandoned after %d attempts: %v", block.Key, attempts, err)
+						continue
+					}
+					block.ResetToPending()
+					queue.Push(block)
+					continue
+				}
+
+				block.MarkDone()
+				if tracker != nil {
+					tracker.MarkLocal(block.Key)
+				}
+			}
+		}()
+	}
+	return &wg
+}
+
+// pollResponse is the JSON structure returned by a peer's /available endpoint.
+type pollResponse struct {
+	Blocks    []string `json:"blocks"`
+	UpdatedAt int64    `json:"updated_at"`
+}
+
+// PollAvailability queries the peer's /available?since={sinceMs}, updates the
+// tracker for peerAddr, and returns the response's updated_at timestamp.
+func (f *Fetcher) PollAvailability(ctx context.Context, peerAddr string, sinceMs int64) (int64, error) {
+	url := fmt.Sprintf("http://%s/available?since=%d", peerAddr, sinceMs)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("poll availability %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("poll availability %s: status %d", url, resp.StatusCode)
+	}
+
+	var pr pollResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return 0, fmt.Errorf("poll availability %s: decode: %w", url, err)
+	}
+
+	if f.availability != nil && len(pr.Blocks) > 0 {
+		f.availability.UpdateRemote(peerAddr, pr.Blocks)
+	}
+	return pr.UpdatedAt, nil
+}
+
+// Stats returns a snapshot of the current fetch statistics.
+func (f *Fetcher) Stats() (fromPeers, fromStorage, fromCache, failed, bytesPeer, bytesStorage int64) {
+	return f.stats.FromPeers.Load(),
+		f.stats.FromStorage.Load(),
+		f.stats.FromCache.Load(),
+		f.stats.Failed.Load(),
+		f.stats.BytesPeer.Load(),
+		f.stats.BytesStore.Load()
+}

--- a/pkg/p2p/fetcher.go
+++ b/pkg/p2p/fetcher.go
@@ -75,9 +75,14 @@ func (f *Fetcher) SetDownloadLimit(b *ratelimit.Bucket) {
 	f.downLimit = b
 }
 
-// FetchFromPeer issues GET http://{peerAddr}/block/{key} and returns the
-// response body. The caller is responsible for validating length/integrity.
-func (f *Fetcher) FetchFromPeer(ctx context.Context, peerAddr, key string) ([]byte, error) {
+// FetchFromPeer issues GET /block/{key} against peerAddr and returns the
+// response body. The body is capped at the largest layout mount accepts
+// for `size` (logical + checksum trailer + tier byte) so a misbehaving
+// peer cannot stream arbitrary bytes into memory, and is rejected outright
+// if its length is not one of the four valid cache layouts — otherwise the
+// caller would write a malformed file to cache that mount would later reject.
+// On any failure the caller falls through to storage.
+func (f *Fetcher) FetchFromPeer(ctx context.Context, peerAddr, key string, size int) ([]byte, error) {
 	url := fmt.Sprintf("http://%s/block/%s", peerAddr, key)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -93,9 +98,19 @@ func (f *Fetcher) FetchFromPeer(ctx context.Context, peerAddr, key string) ([]by
 		return nil, fmt.Errorf("peer fetch %s: status %d", url, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	max := maxCacheFileSize(size)
+	if resp.ContentLength > 0 && resp.ContentLength > max {
+		return nil, fmt.Errorf("peer fetch %s: Content-Length %d exceeds max %d", url, resp.ContentLength, max)
+	}
+	// LimitReader stops at max+1 so an oversized body produces a length
+	// that the validCacheFileSize check below rejects, rather than
+	// silently truncating to max.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, max+1))
 	if err != nil {
 		return nil, fmt.Errorf("peer fetch %s: read body: %w", url, err)
+	}
+	if !validCacheFileSize(int64(len(data)), size) {
+		return nil, fmt.Errorf("peer fetch %s: body length %d invalid for logical size %d", url, len(data), size)
 	}
 	return data, nil
 }
@@ -168,7 +183,7 @@ func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer bool, 
 	// Attempt peer download if we have an availability tracker.
 	if f.availability != nil {
 		if peerAddr := f.availability.FindPeerWith(block.Key); peerAddr != "" {
-			data, err = f.FetchFromPeer(ctx, peerAddr, block.Key)
+			data, err = f.FetchFromPeer(ctx, peerAddr, block.Key, block.Size)
 			if err == nil {
 				fromPeer = true
 			}

--- a/pkg/p2p/fetcher.go
+++ b/pkg/p2p/fetcher.go
@@ -368,6 +368,36 @@ func (f *Fetcher) PollAvailability(ctx context.Context, peerAddr string, sinceMs
 	return pr.UpdatedAt, nil
 }
 
+// statusResponse is the subset of a peer's /status we consume here.
+type statusResponse struct {
+	Completed bool `json:"completed"`
+}
+
+// PollCompleted queries the peer's /status and reports its "completed" flag.
+// Used by keep-alive=peers to decide when every peer has finished warming.
+func (f *Fetcher) PollCompleted(ctx context.Context, peerAddr string) (bool, error) {
+	url := fmt.Sprintf("http://%s/status", peerAddr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("poll status %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("poll status %s: status %d", url, resp.StatusCode)
+	}
+
+	var sr statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return false, fmt.Errorf("poll status %s: decode: %w", url, err)
+	}
+	return sr.Completed, nil
+}
+
 // Stats returns a snapshot of the current fetch statistics.
 func (f *Fetcher) Stats() (fromPeers, fromStorage, fromCache, skippedFull, failed, bytesPeer, bytesStorage int64) {
 	return f.stats.FromPeers.Load(),

--- a/pkg/p2p/fetcher.go
+++ b/pkg/p2p/fetcher.go
@@ -18,11 +18,14 @@ import (
 )
 
 // FetchStats counts blocks by source. FromCache means the block was already
-// on disk with the expected size and the fetch was skipped.
+// on disk with the expected size and the fetch was skipped. SkippedFull
+// counts blocks the cache-size cap refused to write — these are terminal
+// but not announced via MarkLocal.
 type FetchStats struct {
 	FromPeers   atomic.Int64
 	FromStorage atomic.Int64
 	FromCache   atomic.Int64
+	SkippedFull atomic.Int64
 	Failed      atomic.Int64
 	BytesPeer   atomic.Int64
 	BytesStore  atomic.Int64
@@ -42,6 +45,8 @@ type Fetcher struct {
 	// True for noOp compressor: return io.ReadAll's buffer directly
 	// instead of decompressing into a fresh allocation.
 	skipDecompress bool
+	cacheSize      int64        // hard cap on cumulative cached bytes (0 = unlimited)
+	cacheUsed      atomic.Int64 // running estimate; seeded by scanExistingCache, incremented per write
 }
 
 // NewFetcher constructs a Fetcher. compressor must match the volume's
@@ -73,6 +78,22 @@ func (f *Fetcher) SetAvailability(at *AvailabilityTracker) {
 // Pass nil to disable.
 func (f *Fetcher) SetDownloadLimit(b *ratelimit.Bucket) {
 	f.downLimit = b
+}
+
+// SetCacheSize installs an absolute byte cap on cumulative cache usage.
+// Pass 0 to disable. Counting is approximate: workers race the
+// load-check-add window, so peak usage may exceed cacheSize by up to
+// numWorkers * blockSize — acceptable for a cap whose purpose is bounding
+// growth, not exact accounting.
+func (f *Fetcher) SetCacheSize(n int64) {
+	f.cacheSize = n
+}
+
+// AddCacheUsed increments the in-memory usage counter — used by
+// scanExistingCache to seed the counter from pre-existing files so the cap
+// applies to total on-disk bytes, not just bytes this run wrote.
+func (f *Fetcher) AddCacheUsed(n int64) {
+	f.cacheUsed.Add(n)
 }
 
 // FetchFromPeer issues GET /block/{key} against peerAddr and returns the
@@ -165,17 +186,34 @@ func (f *Fetcher) CacheBlock(key string, data []byte) error {
 }
 
 // FetchBlock fetches a block (cache > peer > storage) and writes it to the
-// disk cache. fromPeer is true when the data came from a peer.
-func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer bool, err error) {
+// disk cache. fromPeer is true when the data came from a peer. written is
+// true when the block is on disk after this call (cache hit OR a successful
+// new write); false with a nil err means the cache-size cap refused the
+// write — the caller MUST treat the block as terminal but skip MarkLocal,
+// otherwise peers would request a block that does not actually exist on disk.
+func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer, written bool, err error) {
 	// Cache-hit fast path: skip the fetch when the on-disk file matches any
 	// of the layouts mount accepts (logical / +checksum / +tier / both).
 	// Use the same predicate as scanExistingCache so the two views agree —
 	// otherwise a file announced via /available would still be re-fetched
-	// here on its way through the worker queue.
+	// here on its way through the worker queue. The cap is intentionally
+	// NOT consulted on the fast path: a block already on disk costs nothing
+	// to "keep" and we still want it announced.
 	cachePath := filepath.Join(f.cacheDir, "raw", block.Key)
 	if fi, statErr := os.Stat(cachePath); statErr == nil && validCacheFileSize(fi.Size(), block.Size) {
 		f.stats.FromCache.Add(1)
-		return false, nil
+		return false, true, nil
+	}
+
+	// Cache-size cap: refuse to write when this block would push cumulative
+	// usage past the configured cap. Done before any I/O so a saturated
+	// cache does not also burn peer/storage bandwidth. Check is approximate
+	// (workers race the load-check-add window) but accurate to within
+	// numWorkers * blockSize, which is acceptable for a cap whose purpose
+	// is bounding growth, not exact accounting.
+	if f.cacheSize > 0 && f.cacheUsed.Load()+int64(block.Size) > f.cacheSize {
+		f.stats.SkippedFull.Add(1)
+		return false, false, nil
 	}
 
 	var data []byte
@@ -194,17 +232,18 @@ func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer bool, 
 	if !fromPeer {
 		data, err = f.FetchFromStorage(ctx, block.Key, block.Size)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 	}
 
 	// Write to local disk cache.
 	if cacheErr := f.CacheBlock(block.Key, data); cacheErr != nil {
-		return fromPeer, cacheErr
+		return fromPeer, false, cacheErr
 	}
 
 	// Update counters.
 	n := int64(len(data))
+	f.cacheUsed.Add(n)
 	if fromPeer {
 		f.stats.FromPeers.Add(1)
 		f.stats.BytesPeer.Add(n)
@@ -212,7 +251,7 @@ func (f *Fetcher) FetchBlock(ctx context.Context, block *Block) (fromPeer bool, 
 		f.stats.FromStorage.Add(1)
 		f.stats.BytesStore.Add(n)
 	}
-	return fromPeer, nil
+	return fromPeer, true, nil
 }
 
 // MaxBlockAttempts bounds retries for blocks that fail in non-NoSuchKey ways
@@ -259,7 +298,7 @@ func (f *Fetcher) RunWorkers(ctx context.Context, queue *FetchQueue, tracker *Av
 					continue
 				}
 
-				_, err := f.FetchBlock(ctx, block)
+				_, written, err := f.FetchBlock(ctx, block)
 				if err != nil {
 					if isStorageNotFound(err) {
 						// Permanent: object is gone (e.g. JuiceFS slice
@@ -282,7 +321,10 @@ func (f *Fetcher) RunWorkers(ctx context.Context, queue *FetchQueue, tracker *Av
 				}
 
 				block.MarkDone()
-				if tracker != nil {
+				// Only announce blocks that are actually on disk. Cache-size
+				// cap skips return written=false; announcing those would
+				// mislead peers into requesting a missing file.
+				if written && tracker != nil {
 					tracker.MarkLocal(block.Key)
 				}
 			}
@@ -327,10 +369,11 @@ func (f *Fetcher) PollAvailability(ctx context.Context, peerAddr string, sinceMs
 }
 
 // Stats returns a snapshot of the current fetch statistics.
-func (f *Fetcher) Stats() (fromPeers, fromStorage, fromCache, failed, bytesPeer, bytesStorage int64) {
+func (f *Fetcher) Stats() (fromPeers, fromStorage, fromCache, skippedFull, failed, bytesPeer, bytesStorage int64) {
 	return f.stats.FromPeers.Load(),
 		f.stats.FromStorage.Load(),
 		f.stats.FromCache.Load(),
+		f.stats.SkippedFull.Load(),
 		f.stats.Failed.Load(),
 		f.stats.BytesPeer.Load(),
 		f.stats.BytesStore.Load()

--- a/pkg/p2p/fetcher_test.go
+++ b/pkg/p2p/fetcher_test.go
@@ -353,12 +353,15 @@ func TestFetcher_FetchBlock_SkipsExistingWithMatchingSize(t *testing.T) {
 	f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
 
 	block := &Block{Key: key, Size: len(data)}
-	fromPeer, err := f.FetchBlock(context.Background(), block)
+	fromPeer, written, err := f.FetchBlock(context.Background(), block)
 	if err != nil {
 		t.Fatalf("FetchBlock: unexpected error: %v", err)
 	}
 	if fromPeer {
 		t.Error("FetchBlock: fromPeer should be false on cache hit")
+	}
+	if !written {
+		t.Error("FetchBlock: written should be true on cache hit")
 	}
 	if got := storage.getCalls.Load(); got != 0 {
 		t.Errorf("storage.Get called %d times on cache hit, want 0", got)
@@ -399,7 +402,7 @@ func TestFetcher_FetchBlock_CacheHitForTrailerLayouts(t *testing.T) {
 			f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
 
 			block := &Block{Key: key, Size: c.logical}
-			if _, err := f.FetchBlock(context.Background(), block); err != nil {
+			if _, _, err := f.FetchBlock(context.Background(), block); err != nil {
 				t.Fatalf("FetchBlock: %v", err)
 			}
 			if got := storage.getCalls.Load(); got != 0 {
@@ -424,7 +427,7 @@ func TestFetcher_FetchBlock_RefetchesWhenSizeMismatches(t *testing.T) {
 	f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
 
 	block := &Block{Key: key, Size: len(fresh)}
-	if _, err := f.FetchBlock(context.Background(), block); err != nil {
+	if _, _, err := f.FetchBlock(context.Background(), block); err != nil {
 		t.Fatalf("FetchBlock: unexpected error: %v", err)
 	}
 	if got := storage.getCalls.Load(); got != 1 {
@@ -522,7 +525,7 @@ func TestRunWorkers_AbandonsImmediatelyOnNotFound(t *testing.T) {
 	queue.Close()
 	wg.Wait()
 
-	_, _, _, failed, _, _ := f.Stats()
+	_, _, _, _, failed, _, _ := f.Stats()
 	if failed != 1 {
 		t.Errorf("Failed counter = %d, want 1", failed)
 	}
@@ -640,6 +643,155 @@ func (s *flakyStorage) Delete(_ context.Context, key string, _ ...object.AttrGet
 
 func (s *flakyStorage) Head(_ context.Context, _ string) (object.Object, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+// TestFetcher_FetchBlock_CacheHitBypassesCacheSizeCap asserts that the
+// cache-hit fast path runs before the cap check. A block already on disk
+// costs zero new bytes, so guarding it would force a phantom skip on every
+// worker pass over an already-warmed block — defeating warmup completion
+// when the cap is set tight relative to existing cache.
+func TestFetcher_FetchBlock_CacheHitBypassesCacheSizeCap(t *testing.T) {
+	cacheDir := t.TempDir()
+	key := "chunks/0/0/42_0_22"
+	data := []byte("already-cached-content") // 22 bytes
+	writeRawBlock(t, cacheDir, key, data)
+
+	storage := newTrackingStorage()
+	f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
+	f.SetCacheSize(1) // intentionally tighter than data size
+
+	block := &Block{Key: key, Size: len(data)}
+	_, written, err := f.FetchBlock(context.Background(), block)
+	if err != nil {
+		t.Fatalf("FetchBlock: unexpected error: %v", err)
+	}
+	if !written {
+		t.Error("written = false on cache hit, want true")
+	}
+	if got := f.stats.FromCache.Load(); got != 1 {
+		t.Errorf("FromCache = %d, want 1", got)
+	}
+	if got := f.stats.SkippedFull.Load(); got != 0 {
+		t.Errorf("SkippedFull = %d, want 0 when fast-path satisfied", got)
+	}
+}
+
+// TestRunWorkers_SkippedBlocksDoNotAnnounce asserts that blocks skipped by
+// the cache-size cap are marked terminal (warmup completes) but are NOT
+// announced via MarkLocal — announcing would make peers fetch from a node
+// that does not actually hold the block, returning 404 and burning a round
+// trip before they fall back to storage.
+func TestRunWorkers_SkippedBlocksDoNotAnnounce(t *testing.T) {
+	storage := newTrackingStorage()
+	storage.data["skip-me"] = []byte("payload")
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, http.DefaultClient, nil)
+	tracker := NewAvailabilityTracker()
+	f.SetAvailability(tracker)
+	f.SetCacheSize(1) // any 7-byte block exceeds the cap
+
+	block := &Block{Key: "skip-me", Size: 7}
+	queue := NewFetchQueue(1)
+	queue.PushAll([]*Block{block})
+
+	wg := f.RunWorkers(context.Background(), queue, tracker, 1)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !block.IsTerminal() {
+		if time.Now().After(deadline) {
+			t.Fatalf("block did not reach terminal state in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	queue.Close()
+	wg.Wait()
+
+	if block.State() != BlockDone {
+		t.Errorf("block state = %d, want BlockDone (skipped blocks complete the warmup)", block.State())
+	}
+	if got := tracker.LocalDoneCount(); got != 0 {
+		t.Errorf("LocalDoneCount = %d, want 0 (skipped blocks must not be announced)", got)
+	}
+	if got := f.stats.SkippedFull.Load(); got != 1 {
+		t.Errorf("SkippedFull = %d, want 1", got)
+	}
+}
+
+// TestFetcher_FetchBlock_CacheSizeCapStopsWritesAfterLimit verifies that
+// once cumulative successful writes reach the configured cacheSize, further
+// blocks are skipped without I/O. The cap is the *only* protection against
+// the cache subtree growing unbounded — without it, a user pointing warmup
+// at a multi-TB dataset has no way to opt into a smaller working set.
+func TestFetcher_FetchBlock_CacheSizeCapStopsWritesAfterLimit(t *testing.T) {
+	storage := newTrackingStorage()
+	storage.data["a"] = make([]byte, 60)
+	storage.data["b"] = make([]byte, 60)
+
+	f := NewFetcher(storage, t.TempDir(), 4*1024*1024, http.DefaultClient, nil)
+	f.SetCacheSize(100) // first 60-byte block fits, second pushes past 100
+
+	for _, key := range []string{"a", "b"} {
+		_, _, err := f.FetchBlock(context.Background(), &Block{Key: key, Size: 60})
+		if err != nil {
+			t.Fatalf("FetchBlock %q: %v", key, err)
+		}
+	}
+
+	if got := f.stats.FromStorage.Load(); got != 1 {
+		t.Errorf("FromStorage = %d, want 1 (only the first block fits)", got)
+	}
+	if got := f.stats.SkippedFull.Load(); got != 1 {
+		t.Errorf("SkippedFull = %d, want 1 (second block exceeds cap)", got)
+	}
+}
+
+// TestFetcher_FetchBlock_CacheSizeZeroIsUnlimited locks in the contract that
+// zero (or unset) cacheSize disables the cap. A regression here would silently
+// brick existing deployments that rely on the unbounded default.
+func TestFetcher_FetchBlock_CacheSizeZeroIsUnlimited(t *testing.T) {
+	storage := newTrackingStorage()
+	storage.data["big"] = make([]byte, 1<<20) // 1 MiB
+
+	f := NewFetcher(storage, t.TempDir(), 4*1024*1024, http.DefaultClient, nil)
+	// SetCacheSize NOT called — defaults to 0 (unlimited).
+
+	_, written, err := f.FetchBlock(context.Background(), &Block{Key: "big", Size: 1 << 20})
+	if err != nil {
+		t.Fatalf("FetchBlock: %v", err)
+	}
+	if !written {
+		t.Error("written=false despite unlimited cap")
+	}
+	if got := f.stats.SkippedFull.Load(); got != 0 {
+		t.Errorf("SkippedFull = %d, want 0 with cacheSize=0", got)
+	}
+}
+
+// TestFetcher_AddCacheUsed_SeedsCounter exercises the path where the warmup
+// scans pre-existing cache files at startup and pre-populates the byte
+// counter so the cap accounts for files this run did not write. Without
+// seeding, a run reusing a near-full cache from a prior session would let
+// the warmup write up to (cacheSize) more bytes on top — doubling actual
+// usage.
+func TestFetcher_AddCacheUsed_SeedsCounter(t *testing.T) {
+	storage := newTrackingStorage()
+	storage.data["new"] = make([]byte, 20)
+
+	f := NewFetcher(storage, t.TempDir(), 4*1024*1024, http.DefaultClient, nil)
+	f.SetCacheSize(100)
+	f.AddCacheUsed(95) // simulate scan finding 95 bytes pre-cached
+
+	// 95 + 20 = 115 > 100 → must skip.
+	_, written, err := f.FetchBlock(context.Background(), &Block{Key: "new", Size: 20})
+	if err != nil {
+		t.Fatalf("FetchBlock: %v", err)
+	}
+	if written {
+		t.Error("written=true despite seeded counter exceeding cap")
+	}
+	if got := f.stats.SkippedFull.Load(); got != 1 {
+		t.Errorf("SkippedFull = %d, want 1", got)
+	}
 }
 
 func TestIsStorageNotFound(t *testing.T) {

--- a/pkg/p2p/fetcher_test.go
+++ b/pkg/p2p/fetcher_test.go
@@ -94,12 +94,92 @@ func TestFetcher_FetchFromPeer(t *testing.T) {
 
 	// Override the HTTP client to use the test server's transport but speak to
 	// the real address (the server uses http://, so we just pass the addr).
-	got, err := f.FetchFromPeer(context.Background(), peerAddr, "chunks/0/0/100_0_4194304")
+	got, err := f.FetchFromPeer(context.Background(), peerAddr, "chunks/0/0/100_0_4194304", len(wantData))
 	if err != nil {
 		t.Fatalf("FetchFromPeer: unexpected error: %v", err)
 	}
 	if string(got) != string(wantData) {
 		t.Errorf("FetchFromPeer: got %q, want %q", got, wantData)
+	}
+}
+
+// TestFetcher_FetchFromPeer_RejectsOversizedBody confirms a peer cannot
+// drown the fetcher in memory by sending a body bigger than the largest
+// layout mount accepts for the requested logical size.
+func TestFetcher_FetchFromPeer_RejectsOversizedBody(t *testing.T) {
+	const logical = 100
+	// One byte past the largest accepted layout (logical + checksum + tier).
+	checksumLen := ((logical-1)/(32<<10) + 1) * 4
+	tooBig := make([]byte, logical+checksumLen+int(cacheTierIDLength)+1)
+
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(tooBig)
+	}))
+	defer peer.Close()
+
+	f := NewFetcher(nil, t.TempDir(), 4194304, peer.Client(), nil)
+	_, err := f.FetchFromPeer(context.Background(), peer.Listener.Addr().String(), "chunks/0/0/k_0_100", logical)
+	if err == nil {
+		t.Fatal("expected error on oversized body")
+	}
+}
+
+// TestFetcher_FetchFromPeer_RejectsInvalidLength confirms a body whose
+// length is not one of the four valid cache layouts is rejected, so the
+// caller falls through to storage rather than caching bytes mount would
+// later refuse to open.
+func TestFetcher_FetchFromPeer_RejectsInvalidLength(t *testing.T) {
+	const logical = 100
+	// logical + 3: not 0, not tier(1), not checksum(4), not checksum+tier(5).
+	body := make([]byte, logical+3)
+
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(body)
+	}))
+	defer peer.Close()
+
+	f := NewFetcher(nil, t.TempDir(), 4194304, peer.Client(), nil)
+	_, err := f.FetchFromPeer(context.Background(), peer.Listener.Addr().String(), "chunks/0/0/k_0_100", logical)
+	if err == nil {
+		t.Fatal("expected error on body whose length is not a valid cache layout")
+	}
+}
+
+// TestFetcher_FetchFromPeer_AcceptsValidLayouts confirms each of the four
+// layouts mount accepts (logical / +tier / +checksum / +checksum+tier)
+// passes through unchanged.
+func TestFetcher_FetchFromPeer_AcceptsValidLayouts(t *testing.T) {
+	const logical = 100
+	checksumLen := ((logical-1)/(32<<10) + 1) * 4
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"logical only", logical},
+		{"logical + tier", logical + 1},
+		{"logical + checksum", logical + checksumLen},
+		{"logical + checksum + tier", logical + checksumLen + 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := make([]byte, c.n)
+			peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/octet-stream")
+				_, _ = w.Write(body)
+			}))
+			defer peer.Close()
+
+			f := NewFetcher(nil, t.TempDir(), 4194304, peer.Client(), nil)
+			got, err := f.FetchFromPeer(context.Background(), peer.Listener.Addr().String(), "chunks/0/0/k_0_100", logical)
+			if err != nil {
+				t.Fatalf("FetchFromPeer: %v", err)
+			}
+			if len(got) != c.n {
+				t.Errorf("got %d bytes, want %d", len(got), c.n)
+			}
+		})
 	}
 }
 

--- a/pkg/p2p/fetcher_test.go
+++ b/pkg/p2p/fetcher_test.go
@@ -103,6 +103,49 @@ func TestFetcher_FetchFromPeer(t *testing.T) {
 	}
 }
 
+func TestFetcher_PollCompleted(t *testing.T) {
+	cases := []struct {
+		name      string
+		completed bool
+	}{
+		{"peer still warming", false},
+		{"peer done", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/status" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"completed":%v,"progress":{"total":10,"done":3}}`, tc.completed)
+			}))
+			defer peer.Close()
+
+			f := NewFetcher(nil, t.TempDir(), 4194304, peer.Client(), nil)
+			got, err := f.PollCompleted(context.Background(), peer.Listener.Addr().String())
+			if err != nil {
+				t.Fatalf("PollCompleted: unexpected error: %v", err)
+			}
+			if got != tc.completed {
+				t.Errorf("PollCompleted = %v, want %v", got, tc.completed)
+			}
+		})
+	}
+}
+
+func TestFetcher_PollCompleted_ErrorsOnUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	deadAddr := srv.Listener.Addr().String()
+	srv.Close()
+
+	f := NewFetcher(nil, t.TempDir(), 4194304, &http.Client{Timeout: time.Second}, nil)
+	if _, err := f.PollCompleted(context.Background(), deadAddr); err == nil {
+		t.Error("PollCompleted on a dead peer: want error, got nil")
+	}
+}
+
 // TestFetcher_FetchFromPeer_RejectsOversizedBody confirms a peer cannot
 // drown the fetcher in memory by sending a body bigger than the largest
 // layout mount accepts for the requested logical size.

--- a/pkg/p2p/fetcher_test.go
+++ b/pkg/p2p/fetcher_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -290,6 +291,44 @@ func TestFetcher_FetchBlock_SkipsExistingWithMatchingSize(t *testing.T) {
 	}
 	if got := f.stats.FromPeers.Load(); got != 0 {
 		t.Errorf("FromPeers = %d, want 0", got)
+	}
+}
+
+// TestFetcher_FetchBlock_CacheHitForTrailerLayouts confirms the fast-path
+// recognises files mount may have written with a checksum and/or tier
+// trailer — without this, p2p-warmup re-downloads every block on a peer
+// that runs `--verify-cache-checksum=extend` or multi-tier caching.
+func TestFetcher_FetchBlock_CacheHitForTrailerLayouts(t *testing.T) {
+	cases := []struct {
+		name    string
+		logical int
+		onDisk  int // total bytes to write
+	}{
+		{"logical only", 100, 100},
+		{"logical + tier", 100, 100 + 1},
+		{"logical + checksum (1 csBlock)", 100, 100 + 4},
+		{"logical + checksum + tier", 100, 100 + 4 + 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cacheDir := t.TempDir()
+			key := "chunks/0/0/42_0_" + strconv.Itoa(c.logical)
+			writeRawBlock(t, cacheDir, key, make([]byte, c.onDisk))
+
+			storage := newTrackingStorage()
+			f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
+
+			block := &Block{Key: key, Size: c.logical}
+			if _, err := f.FetchBlock(context.Background(), block); err != nil {
+				t.Fatalf("FetchBlock: %v", err)
+			}
+			if got := storage.getCalls.Load(); got != 0 {
+				t.Errorf("storage.Get called %d times on cache hit, want 0", got)
+			}
+			if got := f.stats.FromCache.Load(); got != 1 {
+				t.Errorf("FromCache = %d, want 1", got)
+			}
+		})
 	}
 }
 

--- a/pkg/p2p/fetcher_test.go
+++ b/pkg/p2p/fetcher_test.go
@@ -1,0 +1,547 @@
+package p2p
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/compress"
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juju/ratelimit"
+)
+
+// trackingStorage is a test double for object.ObjectStorage that records Get
+// calls and can serve predefined block data. Methods not overridden fall
+// through to DefaultObjectStorage.
+type trackingStorage struct {
+	object.DefaultObjectStorage
+	mu       sync.Mutex
+	data     map[string][]byte
+	getCalls atomic.Int32
+}
+
+func newTrackingStorage() *trackingStorage {
+	return &trackingStorage{data: make(map[string][]byte)}
+}
+
+func (s *trackingStorage) String() string { return "tracking" }
+
+func (s *trackingStorage) Get(_ context.Context, key string, off, limit int64, _ ...object.AttrGetter) (io.ReadCloser, error) {
+	s.getCalls.Add(1)
+	s.mu.Lock()
+	data, ok := s.data[key]
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", key)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *trackingStorage) Put(_ context.Context, key string, in io.Reader, _ ...object.AttrGetter) error {
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.data[key] = data
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *trackingStorage) Delete(_ context.Context, key string, _ ...object.AttrGetter) error {
+	s.mu.Lock()
+	delete(s.data, key)
+	s.mu.Unlock()
+	return nil
+}
+
+// Head explicit override — DefaultObjectStorage.Head still uses the legacy
+// signature so the embedded version does not satisfy the interface.
+func (s *trackingStorage) Head(_ context.Context, _ string) (object.Object, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestFetcher_FetchFromPeer(t *testing.T) {
+	wantData := []byte("block-data-from-peer")
+
+	// Mock peer HTTP server returning fixed block data.
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/block/chunks/0/0/100_0_4194304" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(wantData)
+	}))
+	defer peer.Close()
+
+	f := NewFetcher(nil, t.TempDir(), 4194304, peer.Client(), nil)
+
+	// peer.Listener.Addr().String() gives "127.0.0.1:<port>" — strip the scheme
+	// that httptest adds so we can build the URL ourselves.
+	peerAddr := peer.Listener.Addr().String()
+
+	// Override the HTTP client to use the test server's transport but speak to
+	// the real address (the server uses http://, so we just pass the addr).
+	got, err := f.FetchFromPeer(context.Background(), peerAddr, "chunks/0/0/100_0_4194304")
+	if err != nil {
+		t.Fatalf("FetchFromPeer: unexpected error: %v", err)
+	}
+	if string(got) != string(wantData) {
+		t.Errorf("FetchFromPeer: got %q, want %q", got, wantData)
+	}
+}
+
+func TestFetcher_FetchFromStorage_DecompressesLz4(t *testing.T) {
+	// Storage holds lz4-compressed bytes (matching how JuiceFS mount writes
+	// them when format.Compression="lz4"). Fetcher must decompress so the
+	// returned payload matches the logical block layout mount expects.
+	logical := []byte("the quick brown fox jumps over the lazy dog repeatedly")
+	c := compress.NewCompressor("lz4")
+	if c == nil {
+		t.Fatal("lz4 compressor unavailable")
+	}
+	buf := make([]byte, c.CompressBound(len(logical)))
+	n, err := c.Compress(buf, logical)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+	compressed := buf[:n]
+
+	storage := newTrackingStorage()
+	storage.data["k"] = compressed
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, nil, c)
+	got, err := f.FetchFromStorage(context.Background(), "k", len(logical))
+	if err != nil {
+		t.Fatalf("FetchFromStorage: %v", err)
+	}
+	if !bytes.Equal(got, logical) {
+		t.Errorf("got %q, want %q", got, logical)
+	}
+}
+
+func TestFetcher_FetchFromStorage_NoOpPassthrough(t *testing.T) {
+	// Empty Compress → noOp compressor → bytes returned verbatim.
+	logical := []byte("uncompressed-payload")
+	storage := newTrackingStorage()
+	storage.data["k"] = logical
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, nil, compress.NewCompressor(""))
+	got, err := f.FetchFromStorage(context.Background(), "k", len(logical))
+	if err != nil {
+		t.Fatalf("FetchFromStorage: %v", err)
+	}
+	if !bytes.Equal(got, logical) {
+		t.Errorf("got %q, want %q", got, logical)
+	}
+}
+
+func TestFetcher_FetchFromStorage_NoOpRejectsWrongSize(t *testing.T) {
+	// Uncompressed volume but storage object size disagrees with the
+	// expected logical size — corrupt or truncated. The zero-copy fast-path
+	// must surface this rather than silently caching wrong-sized bytes.
+	storage := newTrackingStorage()
+	storage.data["short"] = make([]byte, 50)
+	storage.data["long"] = make([]byte, 200)
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, nil, compress.NewCompressor(""))
+
+	if _, err := f.FetchFromStorage(context.Background(), "short", 100); err == nil {
+		t.Error("expected error when storage object is shorter than expected")
+	}
+	if _, err := f.FetchFromStorage(context.Background(), "long", 100); err == nil {
+		t.Error("expected error when storage object is longer than expected")
+	}
+}
+
+func TestFetcher_FetchFromStorage_RejectsWrongDecompressedSize(t *testing.T) {
+	// Storage object decompresses to fewer bytes than expected — corrupt or
+	// truncated. Fetcher must surface an error rather than silently writing
+	// a short cache file (which mount would later reject).
+	logical := []byte("only-50-bytes-of-actual-data!!!!!!!!!!!!!!!!!!!!!!")
+	c := compress.NewCompressor("lz4")
+	if c == nil {
+		t.Fatal("lz4 compressor unavailable")
+	}
+	buf := make([]byte, c.CompressBound(len(logical)))
+	n, err := c.Compress(buf, logical)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+	storage := newTrackingStorage()
+	storage.data["k"] = buf[:n]
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, nil, c)
+	_, err = f.FetchFromStorage(context.Background(), "k", len(logical)+1)
+	if err == nil {
+		t.Fatal("expected error when decompressed size mismatches expected logical size")
+	}
+}
+
+// TestFetcher_DownloadLimit_ThrottlesStorageReads exercises the bandwidth cap
+// path: with an 8 KB/s bucket and 1 KB burst, an 8 KB read must wait roughly
+// (8KB-1KB)/8KB ≈ 875ms after the read for tokens to refill.
+func TestFetcher_DownloadLimit_ThrottlesStorageReads(t *testing.T) {
+	storage := newTrackingStorage()
+	storage.data["k"] = make([]byte, 8192)
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, nil, nil)
+	f.SetDownloadLimit(ratelimit.NewBucketWithRate(8192, 1024))
+
+	start := time.Now()
+	if _, err := f.FetchFromStorage(context.Background(), "k", 8192); err != nil {
+		t.Fatalf("FetchFromStorage: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 500*time.Millisecond {
+		t.Errorf("expected throttling to delay read by ~875ms, got %v", elapsed)
+	}
+}
+
+// TestFetcher_DownloadLimit_NilIsUnlimited makes sure a nil limiter does not
+// introduce any wait or panic.
+func TestFetcher_DownloadLimit_NilIsUnlimited(t *testing.T) {
+	storage := newTrackingStorage()
+	storage.data["k"] = make([]byte, 8192)
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, nil, nil)
+	f.SetDownloadLimit(nil)
+
+	start := time.Now()
+	if _, err := f.FetchFromStorage(context.Background(), "k", 8192); err != nil {
+		t.Fatalf("FetchFromStorage: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("nil limiter should not delay; elapsed=%v", elapsed)
+	}
+}
+
+func TestFetcher_CacheBlock(t *testing.T) {
+	cacheDir := t.TempDir()
+	f := NewFetcher(nil, cacheDir, 4194304, http.DefaultClient, nil)
+
+	key := "chunks/0/0/42_0_1024"
+	data := []byte("cached-block-content")
+
+	if err := f.CacheBlock(key, data); err != nil {
+		t.Fatalf("CacheBlock: unexpected error: %v", err)
+	}
+
+	// Verify the file exists at the expected path.
+	path := filepath.Join(cacheDir, "raw", key)
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile %q: %v", path, err)
+	}
+	if string(onDisk) != string(data) {
+		t.Errorf("on-disk content: got %q, want %q", onDisk, data)
+	}
+}
+
+// writeRawBlock writes data to {cacheDir}/raw/{key} for tests that need a
+// pre-existing cached block. Mirrors the helper in integration_test.go but is
+// kept here to keep each test file self-contained.
+func writeRawBlock(t *testing.T, cacheDir, key string, data []byte) {
+	t.Helper()
+	path := filepath.Join(cacheDir, "raw", key)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("MkdirAll %q: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("WriteFile %q: %v", path, err)
+	}
+}
+
+func TestFetcher_FetchBlock_SkipsExistingWithMatchingSize(t *testing.T) {
+	cacheDir := t.TempDir()
+	key := "chunks/0/0/42_0_22"
+	data := []byte("already-cached-content") // 22 bytes
+	writeRawBlock(t, cacheDir, key, data)
+
+	storage := newTrackingStorage()
+	f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
+
+	block := &Block{Key: key, Size: len(data)}
+	fromPeer, err := f.FetchBlock(context.Background(), block)
+	if err != nil {
+		t.Fatalf("FetchBlock: unexpected error: %v", err)
+	}
+	if fromPeer {
+		t.Error("FetchBlock: fromPeer should be false on cache hit")
+	}
+	if got := storage.getCalls.Load(); got != 0 {
+		t.Errorf("storage.Get called %d times on cache hit, want 0", got)
+	}
+	if got := f.stats.FromCache.Load(); got != 1 {
+		t.Errorf("FromCache = %d, want 1", got)
+	}
+	if got := f.stats.FromStorage.Load(); got != 0 {
+		t.Errorf("FromStorage = %d, want 0", got)
+	}
+	if got := f.stats.FromPeers.Load(); got != 0 {
+		t.Errorf("FromPeers = %d, want 0", got)
+	}
+}
+
+func TestFetcher_FetchBlock_RefetchesWhenSizeMismatches(t *testing.T) {
+	cacheDir := t.TempDir()
+	key := "chunks/0/0/42_0_24"
+	stale := []byte("wrong-size")                // 10 bytes
+	fresh := []byte("correct-size-content-ok!!") // 25 bytes
+	writeRawBlock(t, cacheDir, key, stale)
+
+	storage := newTrackingStorage()
+	storage.data[key] = fresh
+	f := NewFetcher(storage, cacheDir, 4*1024*1024, http.DefaultClient, nil)
+
+	block := &Block{Key: key, Size: len(fresh)}
+	if _, err := f.FetchBlock(context.Background(), block); err != nil {
+		t.Fatalf("FetchBlock: unexpected error: %v", err)
+	}
+	if got := storage.getCalls.Load(); got != 1 {
+		t.Errorf("storage.Get called %d times, want 1", got)
+	}
+	onDisk, err := os.ReadFile(filepath.Join(cacheDir, "raw", key))
+	if err != nil {
+		t.Fatalf("read cache file: %v", err)
+	}
+	if !bytes.Equal(onDisk, fresh) {
+		t.Errorf("cache content: got %q, want %q", onDisk, fresh)
+	}
+	if got := f.stats.FromCache.Load(); got != 0 {
+		t.Errorf("FromCache = %d, want 0 on size mismatch", got)
+	}
+}
+
+func TestFetcher_PollPeerAvailability(t *testing.T) {
+	// Mock peer returning a JSON availability response.
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/available" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"blocks":     []string{"key1", "key2"},
+			"updated_at": int64(1000),
+		})
+	}))
+	defer peer.Close()
+
+	tracker := NewAvailabilityTracker()
+	f := NewFetcher(nil, t.TempDir(), 4194304, peer.Client(), nil)
+	f.SetAvailability(tracker)
+
+	peerAddr := peer.Listener.Addr().String()
+	updatedAt, err := f.PollAvailability(context.Background(), peerAddr, 0)
+	if err != nil {
+		t.Fatalf("PollAvailability: unexpected error: %v", err)
+	}
+	if updatedAt != 1000 {
+		t.Errorf("PollAvailability: updatedAt = %d, want 1000", updatedAt)
+	}
+
+	// Verify the tracker was updated with the two keys.
+	if !tracker.PeerHas(peerAddr, "key1") {
+		t.Errorf("tracker does not have key1 for peer %s", peerAddr)
+	}
+	if !tracker.PeerHas(peerAddr, "key2") {
+		t.Errorf("tracker does not have key2 for peer %s", peerAddr)
+	}
+}
+
+func TestRunWorkers_AbandonsImmediatelyOnNotFound(t *testing.T) {
+	// Storage returns "not found" (the canonical permanent failure). Worker
+	// must abandon the block on the FIRST attempt — retrying won't bring
+	// the object back, and burning the full retry budget would just delay
+	// completion of an entire warmup that should fail-fast on this block.
+	storage := newTrackingStorage() // empty → Get returns "not found: <key>"
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, http.DefaultClient, nil)
+	tracker := NewAvailabilityTracker()
+	f.SetAvailability(tracker)
+
+	block := &Block{Key: "missing-block", Size: 100}
+	queue := NewFetchQueue(1)
+	queue.PushAll([]*Block{block})
+
+	wg := f.RunWorkers(context.Background(), queue, tracker, 1)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if block.IsTerminal() {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("block did not reach terminal state in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if block.State() != BlockFailed {
+		t.Errorf("block state = %d, want BlockFailed", block.State())
+	}
+	// attempts is incremented only for transient failures; not-found
+	// short-circuits before IncrAttempts.
+	if got := block.attempts.Load(); got != 0 {
+		t.Errorf("attempts = %d, want 0 (not-found should not increment retry counter)", got)
+	}
+	if got := storage.getCalls.Load(); got != 1 {
+		t.Errorf("storage.Get calls = %d, want 1 (no retries on not-found)", got)
+	}
+
+	queue.Close()
+	wg.Wait()
+
+	_, _, _, failed, _, _ := f.Stats()
+	if failed != 1 {
+		t.Errorf("Failed counter = %d, want 1", failed)
+	}
+}
+
+func TestRunWorkers_AbandonsAfterMaxAttempts(t *testing.T) {
+	// Storage returns a transient (non-not-found) error every time. Worker
+	// retries up to MaxBlockAttempts before abandoning. Distinct from the
+	// not-found path because transient errors might recover.
+	var attempts atomic.Int32
+	storage := &flakyStorage{
+		fail:     1 << 30, // never succeeds
+		attempts: &attempts,
+	}
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, http.DefaultClient, nil)
+	tracker := NewAvailabilityTracker()
+	f.SetAvailability(tracker)
+
+	block := &Block{Key: "transient-fail-block", Size: 100}
+	queue := NewFetchQueue(1)
+	queue.PushAll([]*Block{block})
+
+	wg := f.RunWorkers(context.Background(), queue, tracker, 1)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if block.IsTerminal() {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("block did not reach terminal state in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if block.State() != BlockFailed {
+		t.Errorf("block state = %d, want BlockFailed", block.State())
+	}
+	if got := block.attempts.Load(); got != MaxBlockAttempts {
+		t.Errorf("attempts = %d, want %d", got, MaxBlockAttempts)
+	}
+
+	queue.Close()
+	wg.Wait()
+}
+
+func TestRunWorkers_TransientFailureRetries(t *testing.T) {
+	// Storage fails the first 2 times then succeeds. Block should retry and
+	// finish in BlockDone, not BlockFailed.
+	var attempts atomic.Int32
+	storage := &flakyStorage{
+		fail:     2, // first 2 attempts fail
+		attempts: &attempts,
+		data:     []byte("hello"),
+	}
+
+	f := NewFetcher(storage, t.TempDir(), 4194304, http.DefaultClient, nil)
+	tracker := NewAvailabilityTracker()
+	f.SetAvailability(tracker)
+
+	block := &Block{Key: "flaky-block", Size: 5}
+	queue := NewFetchQueue(1)
+	queue.PushAll([]*Block{block})
+
+	wg := f.RunWorkers(context.Background(), queue, tracker, 1)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if block.IsTerminal() {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("block did not reach terminal state in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if block.State() != BlockDone {
+		t.Errorf("block state = %d, want BlockDone", block.State())
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("Get attempts = %d, want 3 (2 fail + 1 success)", got)
+	}
+
+	queue.Close()
+	wg.Wait()
+}
+
+// flakyStorage fails the first `fail` Gets, then succeeds with `data`.
+type flakyStorage struct {
+	object.DefaultObjectStorage
+	fail     int32
+	attempts *atomic.Int32
+	data     []byte
+}
+
+func (s *flakyStorage) String() string { return "flaky" }
+
+func (s *flakyStorage) Get(_ context.Context, key string, off, limit int64, _ ...object.AttrGetter) (io.ReadCloser, error) {
+	n := s.attempts.Add(1)
+	if n <= s.fail {
+		return nil, fmt.Errorf("flaky failure %d", n)
+	}
+	return io.NopCloser(bytes.NewReader(s.data)), nil
+}
+
+func (s *flakyStorage) Put(_ context.Context, key string, in io.Reader, _ ...object.AttrGetter) error {
+	return nil
+}
+
+func (s *flakyStorage) Delete(_ context.Context, key string, _ ...object.AttrGetter) error {
+	return nil
+}
+
+func (s *flakyStorage) Head(_ context.Context, _ string) (object.Object, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestIsStorageNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"S3-style NoSuchKey", fmt.Errorf("s3 GET failed: NoSuchKey: The specified key does not exist"), true},
+		{"generic not found", fmt.Errorf("storage get %q: not found: foo", "k"), true},
+		{"file backend No such file", fmt.Errorf("open /var/x: No such file or directory"), true},
+		{"timeout (transient)", fmt.Errorf("read tcp 127.0.0.1:80: i/o timeout"), false},
+		{"connection refused (transient)", fmt.Errorf("dial tcp: connect: connection refused"), false},
+		{"permission denied (permanent but not not-found)", fmt.Errorf("AccessDenied: forbidden"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isStorageNotFound(c.err); got != c.want {
+				t.Errorf("isStorageNotFound(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/p2p/integration_test.go
+++ b/pkg/p2p/integration_test.go
@@ -20,12 +20,12 @@ func TestIntegration_TwoPeers(t *testing.T) {
 	cache1, cache2 := t.TempDir(), t.TempDir()
 
 	// Write fake blocks to each cache directory.
-	writeBlock(t, cache1, "chunks/0/0/1_0_100", "data-block-1")
-	writeBlock(t, cache2, "chunks/0/0/1_1_100", "data-block-2")
+	writeBlock(t, cache1, "chunks/0/0/1_0_12", "data-block-1")
+	writeBlock(t, cache2, "chunks/0/0/1_1_12", "data-block-2")
 
 	// Start peer1 server with block1 marked as local.
 	at1 := NewAvailabilityTracker()
-	at1.MarkLocal("chunks/0/0/1_0_100")
+	at1.MarkLocal("chunks/0/0/1_0_12")
 	srv1 := NewServer("uuid-1", at1, cache1)
 	ln1, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -36,7 +36,7 @@ func TestIntegration_TwoPeers(t *testing.T) {
 
 	// Start peer2 server with block2 marked as local.
 	at2 := NewAvailabilityTracker()
-	at2.MarkLocal("chunks/0/0/1_1_100")
+	at2.MarkLocal("chunks/0/0/1_1_12")
 	srv2 := NewServer("uuid-2", at2, cache2)
 	ln2, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -51,7 +51,7 @@ func TestIntegration_TwoPeers(t *testing.T) {
 
 	// --- Test: peer2 fetches block1 from peer1 ---
 	fetcher2 := NewFetcher(nil, cache2, 4*1024*1024, client, nil)
-	data, err := fetcher2.FetchFromPeer(context.Background(), peer1Addr, "chunks/0/0/1_0_100")
+	data, err := fetcher2.FetchFromPeer(context.Background(), peer1Addr, "chunks/0/0/1_0_12", 12)
 	if err != nil {
 		t.Fatalf("peer2.FetchFromPeer block1: %v", err)
 	}
@@ -60,10 +60,10 @@ func TestIntegration_TwoPeers(t *testing.T) {
 	}
 
 	// --- Test: CacheBlock writes block1 to peer2's cache, verify on disk ---
-	if err := fetcher2.CacheBlock("chunks/0/0/1_0_100", data); err != nil {
+	if err := fetcher2.CacheBlock("chunks/0/0/1_0_12", data); err != nil {
 		t.Fatalf("peer2.CacheBlock: %v", err)
 	}
-	onDisk, err := os.ReadFile(filepath.Join(cache2, "raw", "chunks/0/0/1_0_100"))
+	onDisk, err := os.ReadFile(filepath.Join(cache2, "raw", "chunks/0/0/1_0_12"))
 	if err != nil {
 		t.Fatalf("read cached block on disk: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestIntegration_TwoPeers(t *testing.T) {
 
 	// --- Test: peer1 fetches block2 from peer2 ---
 	fetcher1 := NewFetcher(nil, cache1, 4*1024*1024, client, nil)
-	data2, err := fetcher1.FetchFromPeer(context.Background(), peer2Addr, "chunks/0/0/1_1_100")
+	data2, err := fetcher1.FetchFromPeer(context.Background(), peer2Addr, "chunks/0/0/1_1_12", 12)
 	if err != nil {
 		t.Fatalf("peer1.FetchFromPeer block2: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestIntegration_TwoPeers(t *testing.T) {
 	if ts <= 0 {
 		t.Errorf("PollAvailability: updated_at = %d, want > 0", ts)
 	}
-	if !at3.PeerHas(peer1Addr, "chunks/0/0/1_0_100") {
+	if !at3.PeerHas(peer1Addr, "chunks/0/0/1_0_12") {
 		t.Errorf("at3 should know peer1 has block1 after polling")
 	}
 
@@ -188,7 +188,7 @@ func TestIntegration_PreCachedBlocksServedAfterScan(t *testing.T) {
 		t.Fatal("peer2 should see pre-cached block on peer1 after scan; /available did not report it")
 	}
 
-	data, err := fetcher2.FetchFromPeer(context.Background(), peer1Addr, "chunks/0/0/1_0_18")
+	data, err := fetcher2.FetchFromPeer(context.Background(), peer1Addr, "chunks/0/0/1_0_18", 18)
 	if err != nil {
 		t.Fatalf("FetchFromPeer: %v", err)
 	}

--- a/pkg/p2p/integration_test.go
+++ b/pkg/p2p/integration_test.go
@@ -1,0 +1,211 @@
+package p2p
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIntegration_TwoPeers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Setup two temp cache directories.
+	cache1, cache2 := t.TempDir(), t.TempDir()
+
+	// Write fake blocks to each cache directory.
+	writeBlock(t, cache1, "chunks/0/0/1_0_100", "data-block-1")
+	writeBlock(t, cache2, "chunks/0/0/1_1_100", "data-block-2")
+
+	// Start peer1 server with block1 marked as local.
+	at1 := NewAvailabilityTracker()
+	at1.MarkLocal("chunks/0/0/1_0_100")
+	srv1 := NewServer("uuid-1", at1, cache1)
+	ln1, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen peer1: %v", err)
+	}
+	defer ln1.Close()
+	go http.Serve(ln1, srv1.Handler()) //nolint:errcheck
+
+	// Start peer2 server with block2 marked as local.
+	at2 := NewAvailabilityTracker()
+	at2.MarkLocal("chunks/0/0/1_1_100")
+	srv2 := NewServer("uuid-2", at2, cache2)
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen peer2: %v", err)
+	}
+	defer ln2.Close()
+	go http.Serve(ln2, srv2.Handler()) //nolint:errcheck
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	peer1Addr := ln1.Addr().String()
+	peer2Addr := ln2.Addr().String()
+
+	// --- Test: peer2 fetches block1 from peer1 ---
+	fetcher2 := NewFetcher(nil, cache2, 4*1024*1024, client, nil)
+	data, err := fetcher2.FetchFromPeer(context.Background(), peer1Addr, "chunks/0/0/1_0_100")
+	if err != nil {
+		t.Fatalf("peer2.FetchFromPeer block1: %v", err)
+	}
+	if string(data) != "data-block-1" {
+		t.Errorf("peer2 fetched block1: got %q, want %q", data, "data-block-1")
+	}
+
+	// --- Test: CacheBlock writes block1 to peer2's cache, verify on disk ---
+	if err := fetcher2.CacheBlock("chunks/0/0/1_0_100", data); err != nil {
+		t.Fatalf("peer2.CacheBlock: %v", err)
+	}
+	onDisk, err := os.ReadFile(filepath.Join(cache2, "raw", "chunks/0/0/1_0_100"))
+	if err != nil {
+		t.Fatalf("read cached block on disk: %v", err)
+	}
+	if string(onDisk) != "data-block-1" {
+		t.Errorf("cached block on disk: got %q, want %q", onDisk, "data-block-1")
+	}
+
+	// --- Test: peer1 fetches block2 from peer2 ---
+	fetcher1 := NewFetcher(nil, cache1, 4*1024*1024, client, nil)
+	data2, err := fetcher1.FetchFromPeer(context.Background(), peer2Addr, "chunks/0/0/1_1_100")
+	if err != nil {
+		t.Fatalf("peer1.FetchFromPeer block2: %v", err)
+	}
+	if string(data2) != "data-block-2" {
+		t.Errorf("peer1 fetched block2: got %q, want %q", data2, "data-block-2")
+	}
+
+	// --- Test: availability polling from peer2's fetcher to peer1 ---
+	at3 := NewAvailabilityTracker()
+	fetcher2.SetAvailability(at3)
+	ts, err := fetcher2.PollAvailability(context.Background(), peer1Addr, 0)
+	if err != nil {
+		t.Fatalf("PollAvailability: %v", err)
+	}
+	if ts <= 0 {
+		t.Errorf("PollAvailability: updated_at = %d, want > 0", ts)
+	}
+	if !at3.PeerHas(peer1Addr, "chunks/0/0/1_0_100") {
+		t.Errorf("at3 should know peer1 has block1 after polling")
+	}
+
+	// --- Test: /uuid endpoint returns correct UUID for peer1 ---
+	resp, err := client.Get("http://" + peer1Addr + "/uuid")
+	if err != nil {
+		t.Fatalf("GET /uuid peer1: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /uuid peer1: status %d", resp.StatusCode)
+	}
+	var uuidBody struct {
+		UUID string `json:"uuid"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&uuidBody); err != nil {
+		t.Fatalf("decode /uuid: %v", err)
+	}
+	if uuidBody.UUID != "uuid-1" {
+		t.Errorf("/uuid: got %q, want %q", uuidBody.UUID, "uuid-1")
+	}
+
+	// --- Test: /status endpoint returns correct progress ---
+	srv1.SetProgress(10, 5)
+	resp2, err := client.Get("http://" + peer1Addr + "/status")
+	if err != nil {
+		t.Fatalf("GET /status peer1: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("GET /status peer1: status %d", resp2.StatusCode)
+	}
+	var statusBody struct {
+		Completed bool `json:"completed"`
+		Progress  struct {
+			Total int64 `json:"total"`
+			Done  int64 `json:"done"`
+		} `json:"progress"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&statusBody); err != nil {
+		t.Fatalf("decode /status: %v", err)
+	}
+	if statusBody.Completed {
+		t.Error("/status: expected completed=false when done(5) < total(10)")
+	}
+	if statusBody.Progress.Total != 10 {
+		t.Errorf("/status: total = %d, want 10", statusBody.Progress.Total)
+	}
+	if statusBody.Progress.Done != 5 {
+		t.Errorf("/status: done = %d, want 5", statusBody.Progress.Done)
+	}
+}
+
+func TestIntegration_PreCachedBlocksServedAfterScan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Peer1 simulates a restart with pre-existing cached blocks on disk.
+	cache1 := t.TempDir()
+	writeBlock(t, cache1, "chunks/0/0/1_0_18", "pre-cached-content")
+
+	config1 := WarmupConfig{
+		ListenAddr:           "127.0.0.1:0",
+		DiscoveryInterval:    time.Hour,
+		AvailabilityInterval: time.Hour,
+		Threads:              1,
+		CacheDir:             cache1,
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w1 := NewWarmup(config1, nil, nil)
+
+	if n := w1.scanExistingCache(); n != 1 {
+		t.Fatalf("scanExistingCache: got %d, want 1", n)
+	}
+	ln1, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen peer1: %v", err)
+	}
+	defer ln1.Close()
+	go http.Serve(ln1, w1.server.Handler()) //nolint:errcheck
+	peer1Addr := ln1.Addr().String()
+
+	// Peer2 is cold and must discover peer1's pre-cached block via /available.
+	cache2 := t.TempDir()
+	tracker2 := NewAvailabilityTracker()
+	fetcher2 := NewFetcher(nil, cache2, 4*1024*1024, &http.Client{Timeout: 5 * time.Second}, nil)
+	fetcher2.SetAvailability(tracker2)
+
+	if _, err := fetcher2.PollAvailability(context.Background(), peer1Addr, 0); err != nil {
+		t.Fatalf("PollAvailability: %v", err)
+	}
+	if !tracker2.PeerHas(peer1Addr, "chunks/0/0/1_0_18") {
+		t.Fatal("peer2 should see pre-cached block on peer1 after scan; /available did not report it")
+	}
+
+	data, err := fetcher2.FetchFromPeer(context.Background(), peer1Addr, "chunks/0/0/1_0_18")
+	if err != nil {
+		t.Fatalf("FetchFromPeer: %v", err)
+	}
+	if string(data) != "pre-cached-content" {
+		t.Errorf("fetched content: got %q, want %q", data, "pre-cached-content")
+	}
+}
+
+// writeBlock writes data to {cacheDir}/raw/{key}, creating parent directories
+// as needed. It is a test helper and calls t.Fatal on any error.
+func writeBlock(t *testing.T, cacheDir, key, data string) {
+	t.Helper()
+	path := filepath.Join(cacheDir, "raw", key)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("writeBlock MkdirAll %q: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		t.Fatalf("writeBlock WriteFile %q: %v", path, err)
+	}
+}

--- a/pkg/p2p/integration_test.go
+++ b/pkg/p2p/integration_test.go
@@ -164,7 +164,7 @@ func TestIntegration_PreCachedBlocksServedAfterScan(t *testing.T) {
 	}
 	w1 := NewWarmup(config1, nil, nil)
 
-	if n := w1.scanExistingCache(); n != 1 {
+	if n, _ := w1.scanExistingCache(); n != 1 {
 		t.Fatalf("scanExistingCache: got %d, want 1", n)
 	}
 	ln1, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/p2p/manifest.go
+++ b/pkg/p2p/manifest.go
@@ -1,0 +1,180 @@
+package p2p
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+)
+
+// ManifestVersion is the current schema version. Bump on incompatible changes.
+const ManifestVersion = 1
+
+// Manifest is the leader-resolved block list for a warmup run. The leader
+// uploads it once; followers download it instead of re-scanning meta.
+// Blocks are stored sorted by Key so every peer derives the same Index for
+// the same block — required for partition scheduling agreement.
+type Manifest struct {
+	Version     int             `json:"version"`
+	CreatedAt   int64           `json:"created_at"` // unix millis
+	Paths       []string        `json:"paths"`
+	BlockSize   int             `json:"block_size"`
+	HashPrefix  bool            `json:"hash_prefix"`
+	TotalBlocks int             `json:"total_blocks"`
+	TotalBytes  int64           `json:"total_bytes"`
+	Blocks      []ManifestBlock `json:"blocks"`
+}
+
+// ManifestBlock is the per-block info needed to fetch: the storage key and
+// expected size (size powers FetchBlock's cache-hit fast-path).
+type ManifestBlock struct {
+	Key  string `json:"k"`
+	Size int    `json:"s"`
+}
+
+// ManifestKeyPrefix groups all manifests under one prefix so operators can
+// target them with a single lifecycle rule or list query.
+const ManifestKeyPrefix = "p2p_warmup/"
+
+// ManifestKey picks the object-storage key for a manifest. Two modes:
+//
+//   - name == "": content-addressable. The key is derived from paths +
+//     block_size + hash_prefix (path order doesn't matter), so peers with
+//     the same warmup args agree on the key automatically.
+//   - name != "": uses the given basename. Lets operators pick a readable
+//     identifier, but avoiding collisions across volumes / path-sets is
+//     then their responsibility.
+//
+// TODO: automatic manifest cleanup is not implemented. Uploaded manifests
+// accumulate under ManifestKeyPrefix until an operator removes them
+// manually or via a bucket lifecycle rule.
+func ManifestKey(paths []string, blockSize int, hashPrefix bool, name string) string {
+	if name != "" {
+		return ManifestKeyPrefix + name + ".json.gz"
+	}
+	sorted := make([]string, len(paths))
+	copy(sorted, paths)
+	sort.Strings(sorted)
+
+	h := sha256.New()
+	for _, p := range sorted {
+		h.Write([]byte(p))
+		h.Write([]byte{0}) // null separator
+	}
+	fmt.Fprintf(h, "blocksize=%d\n", blockSize)
+	fmt.Fprintf(h, "hashprefix=%v\n", hashPrefix)
+	digest := hex.EncodeToString(h.Sum(nil))
+	return ManifestKeyPrefix + "manifest-" + digest + ".json.gz"
+}
+
+// BuildManifest constructs a Manifest from a block list, sorting by Key and
+// summing totals. Paths are stored verbatim; ManifestKey's hash is
+// order-insensitive, so caller order doesn't affect the storage key.
+func BuildManifest(paths []string, blockSize int, hashPrefix bool, blocks []*Block) *Manifest {
+	mblocks := make([]ManifestBlock, len(blocks))
+	var totalBytes int64
+	for i, b := range blocks {
+		mblocks[i] = ManifestBlock{Key: b.Key, Size: b.Size}
+		totalBytes += int64(b.Size)
+	}
+	sort.Slice(mblocks, func(i, j int) bool { return mblocks[i].Key < mblocks[j].Key })
+
+	return &Manifest{
+		Version:     ManifestVersion,
+		CreatedAt:   time.Now().UnixMilli(),
+		Paths:       paths,
+		BlockSize:   blockSize,
+		HashPrefix:  hashPrefix,
+		TotalBlocks: len(blocks),
+		TotalBytes:  totalBytes,
+		Blocks:      mblocks,
+	}
+}
+
+// Validate confirms the manifest matches the current warmup args (paths,
+// block size, hash prefix). Path comparison is order-insensitive. A mismatch
+// usually means another warmup is reusing the same --manifest-name — without
+// this check, followers would silently fetch the wrong block set.
+func (m *Manifest) Validate(paths []string, blockSize int, hashPrefix bool) error {
+	if m.BlockSize != blockSize {
+		return fmt.Errorf("blocksize mismatch: manifest=%d, expected=%d", m.BlockSize, blockSize)
+	}
+	if m.HashPrefix != hashPrefix {
+		return fmt.Errorf("hashprefix mismatch: manifest=%v, expected=%v", m.HashPrefix, hashPrefix)
+	}
+	got := append([]string(nil), m.Paths...)
+	want := append([]string(nil), paths...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !pathsEqual(got, want) {
+		return fmt.Errorf("paths mismatch: manifest=%v, expected=%v", m.Paths, paths)
+	}
+	return nil
+}
+
+func pathsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ManifestToBlocks converts a parsed manifest into scheduler-ready *Blocks.
+// Index is the manifest position — same across peers, so partition
+// scheduling agrees.
+func ManifestToBlocks(m *Manifest) []*Block {
+	blocks := make([]*Block, len(m.Blocks))
+	for i, mb := range m.Blocks {
+		blocks[i] = &Block{
+			Key:   mb.Key,
+			Index: i,
+			Size:  mb.Size,
+		}
+	}
+	return blocks
+}
+
+// Marshal encodes the manifest as JSON and gzip-compresses the result.
+func (m *Manifest) Marshal() ([]byte, error) {
+	jsonBytes, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal json: %w", err)
+	}
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(jsonBytes); err != nil {
+		return nil, fmt.Errorf("gzip write: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return nil, fmt.Errorf("gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalManifest decodes a gzipped JSON manifest produced by Marshal.
+func UnmarshalManifest(data []byte) (*Manifest, error) {
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gr.Close()
+	jsonBytes, err := io.ReadAll(gr)
+	if err != nil {
+		return nil, fmt.Errorf("gzip read: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(jsonBytes, &m); err != nil {
+		return nil, fmt.Errorf("unmarshal json: %w", err)
+	}
+	return &m, nil
+}

--- a/pkg/p2p/manifest_store.go
+++ b/pkg/p2p/manifest_store.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"time"
+
+	"github.com/juicedata/juicefs/pkg/object"
 )
 
 // uploadManifest builds a Manifest for the given paths/blocks and uploads it
@@ -88,6 +90,22 @@ func (w *Warmup) fetchManifestBytes(ctx context.Context, key string) ([]byte, er
 	}
 	defer rc.Close()
 	return io.ReadAll(rc)
+}
+
+// DeleteManifest removes the manifest object identified by paths + config
+// (or by name when non-empty) from object storage. Returns the key it
+// attempted to delete so the caller can log it precisely. "Not found" is
+// treated as success — operators retry cleanup commands and the second
+// call should not be an error.
+func DeleteManifest(ctx context.Context, blob object.ObjectStorage, paths []string, blockSize int, hashPrefix bool, name string) (string, error) {
+	key := ManifestKey(paths, blockSize, hashPrefix, name)
+	if blob == nil {
+		return key, fmt.Errorf("DeleteManifest: nil object storage")
+	}
+	if err := blob.Delete(ctx, key); err != nil && !isStorageNotFound(err) {
+		return key, fmt.Errorf("delete manifest %q: %w", key, err)
+	}
+	return key, nil
 }
 
 // tryFetchValidManifest does a single Get on the manifest object and returns

--- a/pkg/p2p/manifest_store.go
+++ b/pkg/p2p/manifest_store.go
@@ -1,0 +1,121 @@
+package p2p
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"time"
+)
+
+// uploadManifest builds a Manifest for the given paths/blocks and uploads it
+// to object storage at ManifestKey(...). Used by the leader peer.
+//
+// Before uploading, the existing object (if any) is validated against this
+// run's paths/config:
+//   - matches → upload skipped (idempotent re-run / crash recovery).
+//   - mismatches → refuse to overwrite; another warmup is using the same
+//     --manifest-name and would lose its manifest.
+//   - corrupt/unparseable → log warning and overwrite (best-effort recovery).
+//   - missing or transient Get error → proceed with the upload.
+func (w *Warmup) uploadManifest(ctx context.Context, paths []string, blocks []*Block) error {
+	if w.storage == nil {
+		return fmt.Errorf("uploadManifest: nil object storage")
+	}
+	manifest := BuildManifest(paths, w.config.BlockSize, w.config.HashPrefix, blocks)
+	key := ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+
+	if existing, err := w.fetchManifestBytes(ctx, key); err == nil {
+		old, perr := UnmarshalManifest(existing)
+		if perr != nil {
+			logger.Warnf("manifest at %q exists but is not parseable; overwriting (%v)", key, perr)
+		} else if verr := old.Validate(paths, w.config.BlockSize, w.config.HashPrefix); verr == nil {
+			logger.Infof("manifest at %q already matches our content; skipping upload", key)
+			return nil
+		} else {
+			hint := ""
+			if w.config.ManifestName != "" {
+				hint = fmt.Sprintf(" — another warmup is using --manifest-name=%q. Pick a different name or delete the existing object.", w.config.ManifestName)
+			}
+			return fmt.Errorf("refusing to overwrite manifest %q (existing %s)%s", key, verr, hint)
+		}
+	}
+
+	data, err := manifest.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := w.storage.Put(ctx, key, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("put manifest %q: %w", key, err)
+	}
+	return nil
+}
+
+// downloadManifest polls object storage for a manifest matching paths and the
+// current Warmup config, retrying every pollInterval until either the manifest
+// arrives or timeout elapses. Used by follower peers waiting for the leader's
+// upload. Any storage error is treated as transient (retry until timeout); a
+// permanent storage failure surfaces as a timeout error.
+func (w *Warmup) downloadManifest(ctx context.Context, paths []string, timeout, pollInterval time.Duration) (*Manifest, error) {
+	if w.storage == nil {
+		return nil, fmt.Errorf("downloadManifest: nil object storage")
+	}
+	key := ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		data, err := w.fetchManifestBytes(ctx, key)
+		if err == nil {
+			return UnmarshalManifest(data)
+		}
+		lastErr = err
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("manifest %q not available after %v: %w", key, timeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func (w *Warmup) fetchManifestBytes(ctx context.Context, key string) ([]byte, error) {
+	rc, err := w.storage.Get(ctx, key, 0, -1)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+// tryFetchValidManifest does a single Get on the manifest object and returns
+// the parsed manifest only when it exists, decodes correctly, and matches our
+// paths/blocksize/hashprefix. Any failure returns nil so the caller can fall
+// through to the canonical leader/follower path.
+//
+// Used as a fast-path at the start of resolveOrDownloadManifest so that a peer
+// joining a warmed cluster — including one that incorrectly elects itself
+// leader because it happens to have the smallest address — reuses the existing
+// manifest instead of triggering a redundant meta-engine scan.
+func (w *Warmup) tryFetchValidManifest(ctx context.Context, paths []string) *Manifest {
+	if w.storage == nil {
+		return nil
+	}
+	key := ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+	data, err := w.fetchManifestBytes(ctx, key)
+	if err != nil {
+		return nil
+	}
+	m, perr := UnmarshalManifest(data)
+	if perr != nil {
+		logger.WithError(perr).Warnf("manifest at %q exists but is unparseable; ignoring", key)
+		return nil
+	}
+	if verr := m.Validate(paths, w.config.BlockSize, w.config.HashPrefix); verr != nil {
+		logger.WithError(verr).Warnf("manifest at %q exists but mismatches our config; ignoring", key)
+		return nil
+	}
+	return m
+}

--- a/pkg/p2p/manifest_store_test.go
+++ b/pkg/p2p/manifest_store_test.go
@@ -381,3 +381,69 @@ func TestWarmup_DownloadManifest_TimesOut(t *testing.T) {
 		t.Fatal("downloadManifest should have timed out")
 	}
 }
+
+// TestDeleteManifest_RemovesExisting locks in that DeleteManifest computes
+// the same key as upload/download and actually wipes the object. Operators
+// invoking `p2p-warmup --delete-manifest` rely on this — a wrong key would
+// silently leave orphans, and silence is the worst failure mode for
+// cleanup commands.
+func TestDeleteManifest_RemovesExisting(t *testing.T) {
+	storage := newTrackingStorage()
+	paths := []string{"/models/llama"}
+	const blockSize = 4 * 1024 * 1024
+	const hashPrefix = false
+	key := ManifestKey(paths, blockSize, hashPrefix, "")
+
+	// Seed the storage with a fake manifest body so we can observe deletion.
+	storage.data[key] = []byte("fake-manifest-payload")
+
+	gotKey, err := DeleteManifest(context.Background(), storage, paths, blockSize, hashPrefix, "")
+	if err != nil {
+		t.Fatalf("DeleteManifest: unexpected error: %v", err)
+	}
+	if gotKey != key {
+		t.Errorf("returned key = %q, want %q", gotKey, key)
+	}
+	if _, exists := storage.data[key]; exists {
+		t.Errorf("manifest still present at %q after DeleteManifest", key)
+	}
+}
+
+// TestDeleteManifest_NotFoundIsSuccess asserts idempotency — deleting a key
+// that does not exist is not an error. Otherwise running the command twice
+// (e.g. retry after a flake) would fail the second time, contradicting the
+// "clean up an orphan" mental model.
+func TestDeleteManifest_NotFoundIsSuccess(t *testing.T) {
+	storage := newTrackingStorage()
+	paths := []string{"/nothing-here"}
+
+	gotKey, err := DeleteManifest(context.Background(), storage, paths, 4*1024*1024, false, "")
+	if err != nil {
+		t.Errorf("DeleteManifest on missing key: got %v, want nil (idempotent)", err)
+	}
+	if gotKey == "" {
+		t.Error("returned key should not be empty even on no-op delete")
+	}
+}
+
+// TestDeleteManifest_NamedManifest verifies the --manifest-name path uses the
+// caller-supplied basename rather than content-addressable hash, so cleanup
+// of a named manifest does not depend on knowing the original paths.
+func TestDeleteManifest_NamedManifest(t *testing.T) {
+	storage := newTrackingStorage()
+	const name = "nightly"
+	key := ManifestKey(nil, 0, false, name) // name path ignores paths/blockSize/hashPrefix
+	storage.data[key] = []byte("payload")
+
+	// Pass deliberately wrong paths/blocksize — name should override.
+	gotKey, err := DeleteManifest(context.Background(), storage, []string{"/anything"}, 99, true, name)
+	if err != nil {
+		t.Fatalf("DeleteManifest: %v", err)
+	}
+	if gotKey != key {
+		t.Errorf("returned key = %q, want %q (name should override hash inputs)", gotKey, key)
+	}
+	if _, exists := storage.data[key]; exists {
+		t.Errorf("named manifest still present at %q", key)
+	}
+}

--- a/pkg/p2p/manifest_store_test.go
+++ b/pkg/p2p/manifest_store_test.go
@@ -1,0 +1,383 @@
+package p2p
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestWarmupWithStorage(t *testing.T, storage *trackingStorage) *Warmup {
+	t.Helper()
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             t.TempDir(),
+		BlockSize:            4 * 1024 * 1024,
+		HashPrefix:           false,
+	}
+	return NewWarmup(config, nil, storage)
+}
+
+func TestWarmup_UploadManifest_PutsGzippedJSON(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+
+	paths := []string{"/models/llama"}
+	blocks := []*Block{
+		{Key: "chunks/0/0/1_0_100", Size: 100},
+		{Key: "chunks/0/0/1_1_200", Size: 200},
+	}
+
+	if err := w.uploadManifest(context.Background(), paths, blocks); err != nil {
+		t.Fatalf("uploadManifest: %v", err)
+	}
+
+	wantKey := ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+	storage.mu.Lock()
+	data, ok := storage.data[wantKey]
+	storage.mu.Unlock()
+	if !ok {
+		t.Fatalf("manifest not stored at expected key %q", wantKey)
+	}
+
+	got, err := UnmarshalManifest(data)
+	if err != nil {
+		t.Fatalf("stored bytes are not valid manifest: %v", err)
+	}
+	if got.TotalBlocks != 2 {
+		t.Errorf("uploaded manifest TotalBlocks = %d, want 2", got.TotalBlocks)
+	}
+	if got.TotalBytes != 300 {
+		t.Errorf("uploaded manifest TotalBytes = %d, want 300", got.TotalBytes)
+	}
+}
+
+func TestWarmup_UploadManifest_SkipsWhenContentMatches(t *testing.T) {
+	// Crash-recovery path: leader restarts, finds its own manifest from the
+	// previous run, and proceeds without a redundant PUT.
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.ManifestName = "llama-7b"
+
+	paths := []string{"/p"}
+	blocks := []*Block{{Key: "chunks/0/0/1_0_100", Size: 100}}
+
+	matching := BuildManifest(paths, w.config.BlockSize, w.config.HashPrefix, blocks)
+	matchingData, _ := matching.Marshal()
+	key := ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+	storage.data[key] = matchingData
+
+	if err := w.uploadManifest(context.Background(), paths, blocks); err != nil {
+		t.Fatalf("uploadManifest should skip on content match: %v", err)
+	}
+
+	// The original bytes must still be there — Put was skipped.
+	storage.mu.Lock()
+	stored := storage.data[key]
+	storage.mu.Unlock()
+	if !reflect.DeepEqual(stored, matchingData) {
+		t.Errorf("matching content path should have skipped Put; stored bytes changed")
+	}
+}
+
+func TestWarmup_UploadManifest_RefusesWhenContentDiffers(t *testing.T) {
+	// True collision: another warmup uploaded a manifest under the same name
+	// with different paths. Leader must refuse to overwrite.
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.ManifestName = "shared"
+
+	requestedPaths := []string{"/wanted"}
+	otherPaths := []string{"/different"}
+	other := BuildManifest(otherPaths, w.config.BlockSize, w.config.HashPrefix, []*Block{
+		{Key: "chunks/0/0/9_0_42", Size: 42},
+	})
+	otherData, _ := other.Marshal()
+	key := ManifestKey(requestedPaths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+	storage.data[key] = otherData
+
+	err := w.uploadManifest(context.Background(), requestedPaths, []*Block{
+		{Key: "chunks/0/0/1_0_100", Size: 100},
+	})
+	if err == nil {
+		t.Fatal("expected error when existing manifest has different content")
+	}
+	if !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Errorf("error should announce the refusal: %v", err)
+	}
+	if !strings.Contains(err.Error(), "shared") {
+		t.Errorf("error should mention the conflicting --manifest-name: %v", err)
+	}
+
+	storage.mu.Lock()
+	stored := storage.data[key]
+	storage.mu.Unlock()
+	if !reflect.DeepEqual(stored, otherData) {
+		t.Errorf("refusal must not modify the existing manifest")
+	}
+}
+
+func TestWarmup_UploadManifest_OverwritesUnparseable(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+
+	paths := []string{"/p"}
+	key := ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)
+	storage.data[key] = []byte("not-a-gzipped-json")
+
+	blocks := []*Block{{Key: "chunks/0/0/1_0_100", Size: 100}}
+	if err := w.uploadManifest(context.Background(), paths, blocks); err != nil {
+		t.Fatalf("uploadManifest should overwrite corrupt object: %v", err)
+	}
+
+	storage.mu.Lock()
+	stored := storage.data[key]
+	storage.mu.Unlock()
+	got, err := UnmarshalManifest(stored)
+	if err != nil {
+		t.Fatalf("stored bytes are not a valid manifest after overwrite: %v", err)
+	}
+	if got.TotalBlocks != 1 {
+		t.Errorf("overwrote manifest TotalBlocks = %d, want 1", got.TotalBlocks)
+	}
+}
+
+func TestWarmup_DownloadManifest_ReturnsParsed(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+
+	paths := []string{"/models/llama"}
+	original := BuildManifest(paths, w.config.BlockSize, w.config.HashPrefix, []*Block{
+		{Key: "chunks/0/0/1_0_100", Size: 100},
+	})
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	storage.data[ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)] = data
+
+	got, err := w.downloadManifest(context.Background(), paths, 1*time.Second, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("downloadManifest: %v", err)
+	}
+	if !reflect.DeepEqual(got.Blocks, original.Blocks) {
+		t.Errorf("downloaded blocks differ:\n got: %+v\nwant: %+v", got.Blocks, original.Blocks)
+	}
+}
+
+func TestWarmup_DownloadManifest_PollsUntilAvailable(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+
+	paths := []string{"/p"}
+
+	// Inject the manifest after 150ms — downloadManifest should be polling.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		m := BuildManifest(paths, w.config.BlockSize, w.config.HashPrefix, []*Block{
+			{Key: "chunks/0/0/1_0_50", Size: 50},
+		})
+		data, _ := m.Marshal()
+		storage.mu.Lock()
+		storage.data[ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)] = data
+		storage.mu.Unlock()
+	}()
+
+	start := time.Now()
+	got, err := w.downloadManifest(context.Background(), paths, 2*time.Second, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("downloadManifest: %v", err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("returned too quickly: %v (manifest was injected after 150ms)", elapsed)
+	}
+	if got.TotalBlocks != 1 {
+		t.Errorf("TotalBlocks = %d, want 1", got.TotalBlocks)
+	}
+}
+
+func TestWarmup_ResolveOrDownload_FollowerPathLoadsManifest(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.MinPeers = 3
+	w.config.LeaderTimeout = 1 * time.Second
+	w.listenAddr = "127.0.0.1:20002" // self is NOT lowest
+
+	paths := []string{"/p"}
+	leaderManifest := BuildManifest(paths, w.config.BlockSize, w.config.HashPrefix, []*Block{
+		{Key: "chunks/0/0/1_0_42", Size: 42},
+		{Key: "chunks/0/0/1_1_99", Size: 99},
+	})
+	data, _ := leaderManifest.Marshal()
+	storage.data[ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)] = data
+
+	peers := []string{"127.0.0.1:20001", "127.0.0.1:20003"} // 20001 is leader
+
+	blocks, err := w.resolveOrDownloadManifest(context.Background(), paths, peers)
+	if err != nil {
+		t.Fatalf("resolveOrDownloadManifest: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Errorf("got %d blocks, want 2", len(blocks))
+	}
+	if blocks[0].Key != "chunks/0/0/1_0_42" {
+		t.Errorf("blocks[0].Key = %q", blocks[0].Key)
+	}
+	// Follower must NOT call resolver, so storage.Get for manifest is the
+	// only Get; no other meta-engine traffic happens here.
+}
+
+func TestWarmup_ResolveOrDownload_ReusesManifestEvenForSelfPerceivedLeader(t *testing.T) {
+	// Scale-out scenario: a new peer with the smallest address joins a
+	// cluster whose manifest was already uploaded by a different leader.
+	// Without the manifest-reuse fast-path, this peer would mis-elect itself
+	// leader and run a redundant meta-engine scan. With the fast-path, it
+	// reuses the existing manifest and never touches the meta engine.
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.MinPeers = 3
+	// w.resolver stays nil — if the fast-path fails and the leader branch
+	// runs, resolveOrDownloadManifest will error out, surfacing the bug.
+	w.listenAddr = "127.0.0.1:10000" // smallest among peers below
+
+	paths := []string{"/p"}
+	existing := BuildManifest(paths, w.config.BlockSize, w.config.HashPrefix, []*Block{
+		{Key: "chunks/0/0/1_0_42", Size: 42},
+	})
+	data, _ := existing.Marshal()
+	storage.data[ManifestKey(paths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)] = data
+
+	peers := []string{"127.0.0.1:20001", "127.0.0.1:20002"} // both larger than self
+
+	blocks, err := w.resolveOrDownloadManifest(context.Background(), paths, peers)
+	if err != nil {
+		t.Fatalf("resolveOrDownloadManifest: %v (fast-path should have skipped resolve)", err)
+	}
+	if len(blocks) != 1 {
+		t.Errorf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].Key != "chunks/0/0/1_0_42" {
+		t.Errorf("blocks[0].Key = %q", blocks[0].Key)
+	}
+}
+
+func TestWarmup_ResolveOrDownload_FastPathSkippedWhenNoManifest(t *testing.T) {
+	// Cold start: storage is empty. Self-perceived leader (smallest address)
+	// must fall through the fast-path and resolve via meta — verified
+	// indirectly by the resolver=nil error path.
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.MinPeers = 3
+	w.listenAddr = "127.0.0.1:10000"
+
+	peers := []string{"127.0.0.1:20001", "127.0.0.1:20002"}
+
+	_, err := w.resolveOrDownloadManifest(context.Background(), []string{"/p"}, peers)
+	if err == nil {
+		t.Fatal("expected error when manifest is absent and resolver is nil")
+	}
+	if !strings.Contains(err.Error(), "meta resolver not available") {
+		t.Errorf("expected meta-resolver error, got: %v", err)
+	}
+}
+
+func TestWarmup_ResolveOrDownload_FollowerRejectsCollidingManifest(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.MinPeers = 3
+	w.config.LeaderTimeout = 1 * time.Second
+	w.config.ManifestName = "shared" // operator-supplied name → collision-prone
+	w.listenAddr = "127.0.0.1:20002"
+
+	// Simulate another warmup having uploaded a manifest under the same name
+	// but for completely different paths.
+	requestedPaths := []string{"/wanted/here"}
+	otherPaths := []string{"/totally/different"}
+	otherManifest := BuildManifest(otherPaths, w.config.BlockSize, w.config.HashPrefix, []*Block{
+		{Key: "chunks/0/0/9_0_42", Size: 42},
+	})
+	data, _ := otherManifest.Marshal()
+	storage.data[ManifestKey(requestedPaths, w.config.BlockSize, w.config.HashPrefix, w.config.ManifestName)] = data
+
+	peers := []string{"127.0.0.1:20001", "127.0.0.1:20003"}
+
+	_, err := w.resolveOrDownloadManifest(context.Background(), requestedPaths, peers)
+	if err == nil {
+		t.Fatal("expected error on manifest content mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "manifest content mismatch") {
+		t.Errorf("error should describe content mismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "shared") {
+		t.Errorf("error should include the conflicting --manifest-name: %v", err)
+	}
+}
+
+func TestWarmup_ResolveOrDownload_MinPeersOneIsSolo(t *testing.T) {
+	// New semantic: MinPeers counts INCLUDING self.
+	// MinPeers=1 means "just me", so manifest sharing should be off
+	// even if other addresses appear in the peers list (e.g. stale DNS).
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.MinPeers = 1
+	w.config.LeaderTimeout = 200 * time.Millisecond
+	w.listenAddr = "127.0.0.1:20002"
+
+	// peers list contains a lower address — under old semantic (gate `> 0`)
+	// this would route us to the follower path and downloadManifest would
+	// be called (and would time out since no manifest exists).
+	// Under new semantic (gate `> 1`), MinPeers=1 is solo: the call
+	// should hit the nil-resolver error from the leader/solo branch.
+	peers := []string{"127.0.0.1:20001"}
+
+	_, err := w.resolveOrDownloadManifest(context.Background(), []string{"/p"}, peers)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "meta resolver not available") {
+		t.Errorf("expected solo-path error (nil resolver), got: %v", err)
+	}
+	// Confirm no follower behaviour: storage.Get must NOT have been called
+	// (which would happen if we tried to download a manifest).
+	if storage.getCalls.Load() != 0 {
+		t.Errorf("storage.Get called %d times; expected 0 (solo mode)", storage.getCalls.Load())
+	}
+}
+
+func TestWarmup_ResolveOrDownload_DisableForcesLocalResolve(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+	w.config.MinPeers = 3
+	w.config.DisableManifestSharing = true
+	w.listenAddr = "127.0.0.1:20002" // would be follower if sharing enabled
+
+	peers := []string{"127.0.0.1:20001", "127.0.0.1:20003"}
+
+	// resolver is nil (no meta), so the local-resolve path returns the
+	// nil-resolver error. This proves the dispatch chose the resolve branch
+	// rather than the download branch.
+	_, err := w.resolveOrDownloadManifest(context.Background(), []string{"/p"}, peers)
+	if err == nil {
+		t.Fatal("expected nil-resolver error, got nil")
+	}
+	if !strings.Contains(err.Error(), "meta resolver not available") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestWarmup_DownloadManifest_TimesOut(t *testing.T) {
+	storage := newTrackingStorage()
+	w := newTestWarmupWithStorage(t, storage)
+
+	paths := []string{"/never-exists"}
+
+	_, err := w.downloadManifest(context.Background(), paths, 200*time.Millisecond, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("downloadManifest should have timed out")
+	}
+}

--- a/pkg/p2p/manifest_test.go
+++ b/pkg/p2p/manifest_test.go
@@ -1,0 +1,255 @@
+package p2p
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestManifest_KeyIsDeterministic(t *testing.T) {
+	k1 := ManifestKey([]string{"/models/llama"}, 4*1024*1024, false, "")
+	k2 := ManifestKey([]string{"/models/llama"}, 4*1024*1024, false, "")
+	if k1 != k2 {
+		t.Errorf("ManifestKey not deterministic: %q != %q", k1, k2)
+	}
+}
+
+func TestManifest_KeyIsOrderInsensitive(t *testing.T) {
+	k1 := ManifestKey([]string{"/a", "/b"}, 4*1024*1024, false, "")
+	k2 := ManifestKey([]string{"/b", "/a"}, 4*1024*1024, false, "")
+	if k1 != k2 {
+		t.Errorf("ManifestKey order-sensitive: %q != %q", k1, k2)
+	}
+}
+
+func TestManifest_KeyDiffersOnPaths(t *testing.T) {
+	k1 := ManifestKey([]string{"/a"}, 4*1024*1024, false, "")
+	k2 := ManifestKey([]string{"/b"}, 4*1024*1024, false, "")
+	if k1 == k2 {
+		t.Errorf("ManifestKey should differ for different paths, both got %q", k1)
+	}
+}
+
+func TestManifest_KeyDiffersOnBlockSize(t *testing.T) {
+	k1 := ManifestKey([]string{"/a"}, 4*1024*1024, false, "")
+	k2 := ManifestKey([]string{"/a"}, 8*1024*1024, false, "")
+	if k1 == k2 {
+		t.Errorf("ManifestKey should differ for different block sizes")
+	}
+}
+
+func TestManifest_KeyDiffersOnHashPrefix(t *testing.T) {
+	k1 := ManifestKey([]string{"/a"}, 4*1024*1024, false, "")
+	k2 := ManifestKey([]string{"/a"}, 4*1024*1024, true, "")
+	if k1 == k2 {
+		t.Errorf("ManifestKey should differ for different hashPrefix")
+	}
+}
+
+func TestManifest_KeyDefaultPrefixed(t *testing.T) {
+	k := ManifestKey([]string{"/a"}, 4*1024*1024, false, "")
+	const wantPrefix = "p2p_warmup/manifest-"
+	const wantSuffix = ".json.gz"
+	if !strings.HasPrefix(k, wantPrefix) || !strings.HasSuffix(k, wantSuffix) {
+		t.Errorf("default key %q does not match %q...%q", k, wantPrefix, wantSuffix)
+	}
+}
+
+func TestManifest_KeyWithNameOverride(t *testing.T) {
+	k := ManifestKey([]string{"/a"}, 4*1024*1024, false, "llama-7b")
+	const want = "p2p_warmup/llama-7b.json.gz"
+	if k != want {
+		t.Errorf("named key got %q, want %q", k, want)
+	}
+}
+
+func TestManifest_KeyNameIgnoresContentInputs(t *testing.T) {
+	// When name is set, paths/blocksize/hashPrefix do not affect the key.
+	k1 := ManifestKey([]string{"/a"}, 4*1024*1024, false, "myrun")
+	k2 := ManifestKey([]string{"/totally/different"}, 8*1024*1024, true, "myrun")
+	if k1 != k2 {
+		t.Errorf("named key should ignore content inputs: %q != %q", k1, k2)
+	}
+}
+
+func TestManifest_ValidateAcceptsMatching(t *testing.T) {
+	m := &Manifest{
+		Paths:      []string{"/a", "/b"},
+		BlockSize:  4 * 1024 * 1024,
+		HashPrefix: false,
+	}
+	if err := m.Validate([]string{"/a", "/b"}, 4*1024*1024, false); err != nil {
+		t.Errorf("Validate should accept matching content: %v", err)
+	}
+}
+
+func TestManifest_ValidateAcceptsReorderedPaths(t *testing.T) {
+	m := &Manifest{
+		Paths:      []string{"/a", "/b"},
+		BlockSize:  4 * 1024 * 1024,
+		HashPrefix: false,
+	}
+	if err := m.Validate([]string{"/b", "/a"}, 4*1024*1024, false); err != nil {
+		t.Errorf("Validate should accept reordered paths: %v", err)
+	}
+}
+
+func TestManifest_ValidateRejectsBlockSizeMismatch(t *testing.T) {
+	m := &Manifest{
+		Paths:      []string{"/a"},
+		BlockSize:  4 * 1024 * 1024,
+		HashPrefix: false,
+	}
+	err := m.Validate([]string{"/a"}, 8*1024*1024, false)
+	if err == nil {
+		t.Fatal("Validate should reject blocksize mismatch")
+	}
+	if !strings.Contains(err.Error(), "blocksize") {
+		t.Errorf("error should mention blocksize: %v", err)
+	}
+}
+
+func TestManifest_ValidateRejectsHashPrefixMismatch(t *testing.T) {
+	m := &Manifest{
+		Paths:      []string{"/a"},
+		BlockSize:  4 * 1024 * 1024,
+		HashPrefix: false,
+	}
+	err := m.Validate([]string{"/a"}, 4*1024*1024, true)
+	if err == nil {
+		t.Fatal("Validate should reject hashprefix mismatch")
+	}
+	if !strings.Contains(err.Error(), "hashprefix") {
+		t.Errorf("error should mention hashprefix: %v", err)
+	}
+}
+
+func TestManifest_ValidateRejectsPathsMismatch(t *testing.T) {
+	m := &Manifest{
+		Paths:      []string{"/a"},
+		BlockSize:  4 * 1024 * 1024,
+		HashPrefix: false,
+	}
+	err := m.Validate([]string{"/b"}, 4*1024*1024, false)
+	if err == nil {
+		t.Fatal("Validate should reject paths mismatch")
+	}
+	if !strings.Contains(err.Error(), "paths") {
+		t.Errorf("error should mention paths: %v", err)
+	}
+}
+
+func TestManifest_RoundTrip(t *testing.T) {
+	original := &Manifest{
+		Version:     1,
+		CreatedAt:   1714000000000,
+		Paths:       []string{"/models/llama"},
+		BlockSize:   4 * 1024 * 1024,
+		HashPrefix:  false,
+		TotalBlocks: 3,
+		TotalBytes:  4198400,
+		Blocks: []ManifestBlock{
+			{Key: "chunks/0/5/5001_0_2048", Size: 2048},
+			{Key: "chunks/0/5/5002_0_4194304", Size: 4194304},
+			{Key: "chunks/0/5/5004_0_2097152", Size: 2097152},
+		},
+	}
+
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	got, err := UnmarshalManifest(data)
+	if err != nil {
+		t.Fatalf("UnmarshalManifest: %v", err)
+	}
+	if !reflect.DeepEqual(got, original) {
+		t.Errorf("round-trip mismatch:\n got: %#v\nwant: %#v", got, original)
+	}
+}
+
+func TestManifest_MarshalIsGzipped(t *testing.T) {
+	m := &Manifest{
+		Version:     1,
+		Paths:       []string{"/p"},
+		BlockSize:   4 * 1024 * 1024,
+		TotalBlocks: 1,
+		Blocks:      []ManifestBlock{{Key: "k", Size: 10}},
+	}
+	data, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// gzip magic number: 0x1f, 0x8b
+	if len(data) < 2 || data[0] != 0x1f || data[1] != 0x8b {
+		t.Errorf("Marshal output is not gzipped: first bytes = %x", data[:min(2, len(data))])
+	}
+}
+
+func TestBuildManifest_ConvertsBlocks(t *testing.T) {
+	blocks := []*Block{
+		{Key: "chunks/0/5/5001_0_2048", Size: 2048},
+		{Key: "chunks/0/5/5002_0_4194304", Size: 4194304},
+	}
+	m := BuildManifest([]string{"/p"}, 4194304, false, blocks)
+	if m.Version != 1 {
+		t.Errorf("Version = %d, want 1", m.Version)
+	}
+	if m.TotalBlocks != 2 {
+		t.Errorf("TotalBlocks = %d, want 2", m.TotalBlocks)
+	}
+	if m.TotalBytes != 4196352 {
+		t.Errorf("TotalBytes = %d, want %d", m.TotalBytes, 4196352)
+	}
+	if len(m.Blocks) != 2 {
+		t.Fatalf("Blocks len = %d, want 2", len(m.Blocks))
+	}
+	if m.Blocks[0].Key != "chunks/0/5/5001_0_2048" || m.Blocks[0].Size != 2048 {
+		t.Errorf("Blocks[0] = %+v", m.Blocks[0])
+	}
+}
+
+func TestBuildManifest_SortsBlocksByKey(t *testing.T) {
+	// Input order: 5002 before 5001 — manifest should sort.
+	blocks := []*Block{
+		{Key: "chunks/0/5/5002_0_4194304", Size: 4194304},
+		{Key: "chunks/0/5/5001_0_2048", Size: 2048},
+	}
+	m := BuildManifest([]string{"/p"}, 4194304, false, blocks)
+	if m.Blocks[0].Key != "chunks/0/5/5001_0_2048" {
+		t.Errorf("Blocks[0].Key = %q, want sorted result", m.Blocks[0].Key)
+	}
+	if m.Blocks[1].Key != "chunks/0/5/5002_0_4194304" {
+		t.Errorf("Blocks[1].Key = %q, want sorted result", m.Blocks[1].Key)
+	}
+}
+
+func TestManifestToBlocks_PreservesIndex(t *testing.T) {
+	m := &Manifest{
+		Blocks: []ManifestBlock{
+			{Key: "a", Size: 1},
+			{Key: "b", Size: 2},
+			{Key: "c", Size: 3},
+		},
+	}
+	blocks := ManifestToBlocks(m)
+	if len(blocks) != 3 {
+		t.Fatalf("len = %d, want 3", len(blocks))
+	}
+	for i, b := range blocks {
+		if b.Index != i {
+			t.Errorf("Blocks[%d].Index = %d, want %d", i, b.Index, i)
+		}
+	}
+	if blocks[0].Key != "a" || blocks[0].Size != 1 {
+		t.Errorf("Blocks[0] = %+v", blocks[0])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/p2p/resolver.go
+++ b/pkg/p2p/resolver.go
@@ -1,0 +1,169 @@
+package p2p
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juicedata/juicefs/pkg/chunk"
+	"github.com/juicedata/juicefs/pkg/meta"
+)
+
+const chunkSize = meta.ChunkSize // 64MB = 1 << 26
+
+// MetaResolver resolves filesystem paths to a flat list of blocks
+// via the JuiceFS metadata engine.
+type MetaResolver struct {
+	meta       meta.Meta
+	blockSize  int
+	hashPrefix bool
+}
+
+// NewMetaResolver creates a MetaResolver.
+func NewMetaResolver(m meta.Meta, blockSize int, hashPrefix bool) *MetaResolver {
+	return &MetaResolver{
+		meta:       m,
+		blockSize:  blockSize,
+		hashPrefix: hashPrefix,
+	}
+}
+
+// Resolve resolves all paths to blocks, deduplicates by key, and returns a flat block list.
+func (r *MetaResolver) Resolve(ctx meta.Context, paths []string) ([]*Block, error) {
+	seen := make(map[string]struct{})
+	var result []*Block
+
+	for _, p := range paths {
+		blocks, err := r.resolvePath(ctx, p)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %q: %w", p, err)
+		}
+		for _, b := range blocks {
+			if _, ok := seen[b.Key]; !ok {
+				seen[b.Key] = struct{}{}
+				result = append(result, b)
+			}
+		}
+	}
+	return result, nil
+}
+
+// resolvePath resolves a single path to blocks.
+// It first tries meta.Resolve for engines that support it (e.g. Redis),
+// and falls back to walking path components via Lookup.
+func (r *MetaResolver) resolvePath(ctx meta.Context, path string) ([]*Block, error) {
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		// Root directory
+		return r.resolveDir(ctx, meta.RootInode)
+	}
+
+	ino, attr, err := r.lookupPath(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	switch attr.Typ {
+	case meta.TypeDirectory:
+		return r.resolveDir(ctx, ino)
+	case meta.TypeFile:
+		return r.resolveFile(ctx, ino, attr.Length)
+	default:
+		// Skip non-file, non-directory entries (symlinks, devices, etc.)
+		return nil, nil
+	}
+}
+
+// lookupPath resolves a path by walking each component via Lookup.
+// Falls back from Resolve (single-call, not always supported) to
+// component-by-component Lookup.
+func (r *MetaResolver) lookupPath(ctx meta.Context, path string) (meta.Ino, meta.Attr, error) {
+	var ino meta.Ino
+	var attr meta.Attr
+
+	// Try Resolve first (efficient single-call, supported by Redis)
+	if st := r.meta.Resolve(ctx, meta.RootInode, path, &ino, &attr, false); st == 0 {
+		return ino, attr, nil
+	}
+
+	// Fall back to walking path components via Lookup
+	parent := meta.RootInode
+	parts := strings.Split(path, "/")
+	for _, name := range parts {
+		if name == "" {
+			continue
+		}
+		if st := r.meta.Lookup(ctx, parent, name, &ino, &attr, false); st != 0 {
+			return 0, meta.Attr{}, fmt.Errorf("lookup %q in inode %d: %s", name, parent, st)
+		}
+		parent = ino
+	}
+	return ino, attr, nil
+}
+
+// resolveFile resolves a single file inode to blocks by iterating over its chunks.
+func (r *MetaResolver) resolveFile(ctx meta.Context, ino meta.Ino, size uint64) ([]*Block, error) {
+	if size == 0 {
+		return nil, nil
+	}
+
+	chunkCnt := (size + chunkSize - 1) / chunkSize
+	var result []*Block
+
+	for idx := uint32(0); idx < uint32(chunkCnt); idx++ {
+		var slices []meta.Slice
+		if st := r.meta.Read(ctx, ino, idx, &slices); st != 0 {
+			return nil, fmt.Errorf("read inode %d chunk %d: %s", ino, idx, st)
+		}
+
+		for _, s := range slices {
+			if s.Id == 0 {
+				continue // hole in sparse file
+			}
+			keys := chunk.SliceBlockKeys(s.Id, int(s.Size), r.blockSize, r.hashPrefix)
+			for i, key := range keys {
+				bsize := r.blockSize
+				if remaining := int(s.Size) - i*r.blockSize; remaining < bsize {
+					bsize = remaining
+				}
+				result = append(result, &Block{
+					Key:     key,
+					SliceID: s.Id,
+					Index:   i,
+					Size:    bsize,
+				})
+			}
+		}
+	}
+	return result, nil
+}
+
+// resolveDir resolves a directory inode by recursing into its children.
+func (r *MetaResolver) resolveDir(ctx meta.Context, ino meta.Ino) ([]*Block, error) {
+	var entries []*meta.Entry
+	if st := r.meta.Readdir(ctx, ino, 1, &entries); st != 0 {
+		return nil, fmt.Errorf("readdir inode %d: %s", ino, st)
+	}
+
+	var result []*Block
+	for _, e := range entries {
+		name := string(e.Name)
+		if name == "." || name == ".." {
+			continue
+		}
+		switch e.Attr.Typ {
+		case meta.TypeDirectory:
+			blocks, err := r.resolveDir(ctx, e.Inode)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, blocks...)
+		case meta.TypeFile:
+			blocks, err := r.resolveFile(ctx, e.Inode, e.Attr.Length)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, blocks...)
+		}
+	}
+	return result, nil
+}

--- a/pkg/p2p/resolver_test.go
+++ b/pkg/p2p/resolver_test.go
@@ -1,0 +1,270 @@
+package p2p
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+)
+
+// newTestMeta creates an in-memory meta engine for testing.
+func newTestMeta(t *testing.T) meta.Meta {
+	t.Helper()
+	_ = os.Remove("/tmp/juicefs.memkv.setting.json")
+	m := meta.NewClient("memkv://", nil)
+	format := &meta.Format{
+		Name:      "test-resolver",
+		BlockSize: 4096,
+		Capacity:  1 << 30,
+		DirStats:  true,
+	}
+	if err := m.Init(format, true); err != nil {
+		t.Fatalf("init meta: %v", err)
+	}
+	return m
+}
+
+// createFile creates a file under parent with the given name and writes a single
+// slice of the given size, returning the file's inode.
+func createFile(t *testing.T, m meta.Meta, ctx meta.Context, parent meta.Ino, name string, size uint32) meta.Ino {
+	t.Helper()
+	var ino meta.Ino
+	if st := m.Create(ctx, parent, name, 0644, 022, 0, &ino, nil); st != 0 {
+		t.Fatalf("create %q: %s", name, st)
+	}
+	if size == 0 {
+		return ino
+	}
+	var sliceID uint64
+	if st := m.NewSlice(ctx, &sliceID); st != 0 {
+		t.Fatalf("new slice: %s", st)
+	}
+	if st := m.Write(ctx, ino, 0, 0, meta.Slice{Id: sliceID, Size: size, Len: size}, time.Now()); st != 0 {
+		t.Fatalf("write %q: %s", name, st)
+	}
+	return ino
+}
+
+func TestMetaResolver_ResolveFile(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20 // 4MB
+
+	// Create a 5MB file: should produce 2 blocks (4MB + 1MB)
+	createFile(t, m, ctx, meta.RootInode, "testfile", 5<<20)
+
+	resolver := NewMetaResolver(m, blockSize, false)
+	blocks, err := resolver.Resolve(ctx, []string{"/testfile"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+
+	// First block: 4MB
+	if blocks[0].Size != blockSize {
+		t.Errorf("block 0 size: got %d, want %d", blocks[0].Size, blockSize)
+	}
+	if blocks[0].Index != 0 {
+		t.Errorf("block 0 index: got %d, want 0", blocks[0].Index)
+	}
+
+	// Second block: 1MB
+	expectedSecond := 1 << 20
+	if blocks[1].Size != expectedSecond {
+		t.Errorf("block 1 size: got %d, want %d", blocks[1].Size, expectedSecond)
+	}
+	if blocks[1].Index != 1 {
+		t.Errorf("block 1 index: got %d, want 1", blocks[1].Index)
+	}
+
+	// Keys must not be empty
+	for i, b := range blocks {
+		if b.Key == "" {
+			t.Errorf("block %d has empty key", i)
+		}
+		if b.SliceID == 0 {
+			t.Errorf("block %d has zero slice ID", i)
+		}
+	}
+}
+
+func TestMetaResolver_ResolveDirectory(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20 // 4MB
+
+	// Create a directory with two files
+	var dirIno meta.Ino
+	if st := m.Mkdir(ctx, meta.RootInode, "mydir", 0755, 0, 0, &dirIno, nil); st != 0 {
+		t.Fatalf("mkdir: %s", st)
+	}
+
+	// File 1: 3MB -> 1 block
+	createFile(t, m, ctx, dirIno, "small.bin", 3<<20)
+	// File 2: 5MB -> 2 blocks
+	createFile(t, m, ctx, dirIno, "large.bin", 5<<20)
+
+	resolver := NewMetaResolver(m, blockSize, false)
+	blocks, err := resolver.Resolve(ctx, []string{"/mydir"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// 1 block (3MB) + 2 blocks (5MB) = 3 blocks
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(blocks))
+	}
+}
+
+func TestMetaResolver_SkipsZeroSliceID(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20 // 4MB
+
+	// Create a file
+	var ino meta.Ino
+	if st := m.Create(ctx, meta.RootInode, "sparse", 0644, 022, 0, &ino, nil); st != 0 {
+		t.Fatalf("create: %s", st)
+	}
+
+	// Write a slice to chunk 1 (skip chunk 0 to leave it as a hole)
+	var sliceID uint64
+	if st := m.NewSlice(ctx, &sliceID); st != 0 {
+		t.Fatalf("new slice: %s", st)
+	}
+	sliceSize := uint32(2 << 20) // 2MB
+	if st := m.Write(ctx, ino, 1, 0, meta.Slice{Id: sliceID, Size: sliceSize, Len: sliceSize}, time.Now()); st != 0 {
+		t.Fatalf("write: %s", st)
+	}
+
+	// We need the file to span at least 2 chunks. The file length after writing to chunk 1
+	// at offset 0 should be chunkSize + sliceSize.
+	// Let's verify by reading the attr.
+	var attr meta.Attr
+	if st := m.GetAttr(ctx, ino, &attr); st != 0 {
+		t.Fatalf("getattr: %s", st)
+	}
+	t.Logf("sparse file length: %d (expecting >= %d)", attr.Length, uint64(chunkSize)+uint64(sliceSize))
+
+	resolver := NewMetaResolver(m, blockSize, false)
+	blocks, err := resolver.resolveFile(ctx, ino, attr.Length)
+	if err != nil {
+		t.Fatalf("resolveFile: %v", err)
+	}
+
+	// Only chunk 1 has data; chunk 0 should produce no blocks (all zeros / hole).
+	// The 2MB data in chunk 1 -> 1 block.
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block (hole skipped), got %d", len(blocks))
+	}
+	if blocks[0].SliceID != sliceID {
+		t.Errorf("block slice ID: got %d, want %d", blocks[0].SliceID, sliceID)
+	}
+}
+
+func TestMetaResolver_Deduplication(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20 // 4MB
+
+	createFile(t, m, ctx, meta.RootInode, "file1", 3<<20)
+
+	resolver := NewMetaResolver(m, blockSize, false)
+	// Resolve the same path twice
+	blocks, err := resolver.Resolve(ctx, []string{"/file1", "/file1"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Should be deduplicated: only 1 block, not 2
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block (deduplicated), got %d", len(blocks))
+	}
+}
+
+func TestMetaResolver_EmptyFile(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20
+
+	createFile(t, m, ctx, meta.RootInode, "empty", 0)
+
+	resolver := NewMetaResolver(m, blockSize, false)
+	blocks, err := resolver.Resolve(ctx, []string{"/empty"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if len(blocks) != 0 {
+		t.Fatalf("expected 0 blocks for empty file, got %d", len(blocks))
+	}
+}
+
+func TestMetaResolver_HashPrefix(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20
+
+	createFile(t, m, ctx, meta.RootInode, "hashed", 3<<20)
+
+	resolver := NewMetaResolver(m, blockSize, true)
+	blocks, err := resolver.Resolve(ctx, []string{"/hashed"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+
+	// Hash-prefixed keys start with "chunks/XX/" where XX is a hex prefix
+	key := blocks[0].Key
+	if len(key) == 0 {
+		t.Fatal("block key is empty")
+	}
+	// Hash prefix format: chunks/<2-hex>/<id/1000000>/<id>_<idx>_<size>
+	if key[:7] != "chunks/" {
+		t.Errorf("expected key to start with 'chunks/', got %q", key)
+	}
+}
+
+func TestMetaResolver_NonexistentPath(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+
+	resolver := NewMetaResolver(m, 4<<20, false)
+	_, err := resolver.Resolve(ctx, []string{"/does/not/exist"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent path, got nil")
+	}
+}
+
+func TestMetaResolver_NestedDirectories(t *testing.T) {
+	m := newTestMeta(t)
+	ctx := meta.Background()
+	blockSize := 4 << 20
+
+	// Create /a/b/file.bin (3MB)
+	var aIno, bIno meta.Ino
+	if st := m.Mkdir(ctx, meta.RootInode, "a", 0755, 0, 0, &aIno, nil); st != 0 {
+		t.Fatalf("mkdir a: %s", st)
+	}
+	if st := m.Mkdir(ctx, aIno, "b", 0755, 0, 0, &bIno, nil); st != 0 {
+		t.Fatalf("mkdir b: %s", st)
+	}
+	createFile(t, m, ctx, bIno, "file.bin", 3<<20)
+
+	resolver := NewMetaResolver(m, blockSize, false)
+	blocks, err := resolver.Resolve(ctx, []string{"/a"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block from nested dir, got %d", len(blocks))
+	}
+}

--- a/pkg/p2p/scheduler.go
+++ b/pkg/p2p/scheduler.go
@@ -1,0 +1,146 @@
+package p2p
+
+import (
+	"hash/fnv"
+	"sort"
+	"sync"
+)
+
+// Scheduler orders pending blocks for a single peer's fetch queue.
+type Scheduler struct {
+	blocks []*Block
+}
+
+// NewScheduler creates a Scheduler bound to the given block list.
+func NewScheduler(blocks []*Block) *Scheduler {
+	return &Scheduler{blocks: blocks}
+}
+
+// pendingBlocks returns all blocks currently in the Pending state.
+func (s *Scheduler) pendingBlocks() []*Block {
+	var out []*Block
+	for _, b := range s.blocks {
+		if b.State() == BlockPending {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// OrderForPeer sorts the Pending blocks into a peer-specific order. Two
+// goals at once:
+//
+//   - Spread initial storage hits: each peer sorts by hash(key, myAddr),
+//     so different peers see different fronts. While availability polling
+//     ramps up, concurrent storage fetches land on disjoint blocks instead
+//     of dogpiling the same one.
+//   - No orphaned ownership: every peer's queue still contains every block,
+//     so a peer dying mid-warmup does not leave any block uncovered.
+//
+// The order is deterministic per (block-set, peer), so the same peer always
+// produces the same queue from the same input. This is a Rendezvous-Hashing
+// approximation.
+func (s *Scheduler) OrderForPeer(myAddr string) []*Block {
+	pending := s.pendingBlocks()
+	sort.Slice(pending, func(i, j int) bool {
+		return hashKeyForPeer(pending[i].Key, myAddr) < hashKeyForPeer(pending[j].Key, myAddr)
+	})
+	return pending
+}
+
+// hashKeyForPeer derives a 64-bit ordering key from (peerAddr, key).
+// FNV-1a is chosen for cross-Go-version stability and good spread on short
+// strings.
+//
+// Peer-first ordering is intentional. FNV mixes weakly on trailing-byte
+// changes, so peers with similar names ("peer0", "peer1") fed last would
+// produce correlated orderings — defeating the spread goal. Feeding the
+// peer first diverges the hash state before the shared key bytes mix in.
+//
+// The 0x00 separator prevents (peer=AB, key=C) from colliding with
+// (peer=A, key=BC).
+func hashKeyForPeer(key, peerAddr string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(peerAddr))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(key))
+	return h.Sum64()
+}
+
+// FetchQueue is a thread-safe FIFO queue of *Block values.
+type FetchQueue struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	items  []*Block
+	closed bool
+}
+
+// NewFetchQueue creates a FetchQueue with the given initial capacity hint.
+func NewFetchQueue(capacity int) *FetchQueue {
+	q := &FetchQueue{
+		items: make([]*Block, 0, capacity),
+	}
+	q.cond = sync.NewCond(&q.mu)
+	return q
+}
+
+// Push appends b to the queue and signals one waiter.
+func (q *FetchQueue) Push(b *Block) {
+	q.mu.Lock()
+	q.items = append(q.items, b)
+	q.cond.Signal()
+	q.mu.Unlock()
+}
+
+// PushAll appends all blocks to the queue and broadcasts to all waiters.
+func (q *FetchQueue) PushAll(blocks []*Block) {
+	q.mu.Lock()
+	q.items = append(q.items, blocks...)
+	q.cond.Broadcast()
+	q.mu.Unlock()
+}
+
+// Pop returns and removes the front block without blocking. Returns nil if
+// the queue is empty.
+func (q *FetchQueue) Pop() *Block {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.items) == 0 {
+		return nil
+	}
+	b := q.items[0]
+	q.items = q.items[1:]
+	return b
+}
+
+// WaitAndPop blocks until a block is available or the queue is closed. Returns
+// nil when the queue is closed and empty.
+func (q *FetchQueue) WaitAndPop() *Block {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.items) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if len(q.items) == 0 {
+		return nil
+	}
+	b := q.items[0]
+	q.items = q.items[1:]
+	return b
+}
+
+// Close marks the queue as closed and wakes all blocked WaitAndPop callers.
+func (q *FetchQueue) Close() {
+	q.mu.Lock()
+	q.closed = true
+	q.cond.Broadcast()
+	q.mu.Unlock()
+}
+
+// Len returns the current number of items in the queue.
+func (q *FetchQueue) Len() int {
+	q.mu.Lock()
+	n := len(q.items)
+	q.mu.Unlock()
+	return n
+}

--- a/pkg/p2p/scheduler_test.go
+++ b/pkg/p2p/scheduler_test.go
@@ -1,0 +1,229 @@
+package p2p
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// makeBlocks creates n blocks with sequential indices for testing.
+func makeBlocks(n int) []*Block {
+	blocks := make([]*Block, n)
+	for i := 0; i < n; i++ {
+		blocks[i] = &Block{
+			Key:   fmt.Sprintf("chunk/%d", i),
+			Index: i,
+		}
+	}
+	return blocks
+}
+
+func TestOrderForPeer_DeterministicAndCovers(t *testing.T) {
+	// Same peer + same blocks must produce the same order on every call,
+	// and the order must be a permutation of the pending set (no drops,
+	// no duplicates). This is what lets every peer carry every block
+	// without any inter-peer coordination.
+	blocks := makeBlocks(500)
+	s := NewScheduler(blocks)
+
+	a := s.OrderForPeer("10.0.0.1:19090")
+	b := s.OrderForPeer("10.0.0.1:19090")
+
+	if len(a) != len(blocks) || len(b) != len(blocks) {
+		t.Fatalf("expected %d blocks, got a=%d b=%d", len(blocks), len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("non-deterministic order at index %d: %q vs %q", i, a[i].Key, b[i].Key)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(a))
+	for _, blk := range a {
+		if _, dup := seen[blk.Key]; dup {
+			t.Errorf("duplicate key in ordering: %q", blk.Key)
+		}
+		seen[blk.Key] = struct{}{}
+	}
+	if len(seen) != len(blocks) {
+		t.Errorf("ordering covers %d distinct keys, want %d", len(seen), len(blocks))
+	}
+}
+
+func TestOrderForPeer_DiffersPerPeer(t *testing.T) {
+	// Different peers should see substantially different orders so that
+	// the front of each peer's queue is statistically distinct — that's
+	// what spreads concurrent storage hits across distinct blocks.
+	blocks := makeBlocks(1000)
+	s := NewScheduler(blocks)
+
+	a := s.OrderForPeer("10.0.0.1:19090")
+	b := s.OrderForPeer("10.0.0.2:19090")
+
+	// Count agreement in the first 100 positions.
+	agree := 0
+	for i := 0; i < 100; i++ {
+		if a[i].Key == b[i].Key {
+			agree++
+		}
+	}
+	// With independent hashes, expected agreement ≈ 100/1000 = 10%. A
+	// hard ceiling of 25 catches a regression where peer addr is ignored
+	// while leaving plenty of room for statistical variance.
+	if agree > 25 {
+		t.Errorf("orders too similar: %d/100 head positions agree (peer addr ignored?)", agree)
+	}
+}
+
+func TestOrderForPeer_AvoidsIndexSkew(t *testing.T) {
+	// Regression for the previous Index%N partition: with every block's
+	// Index=0, that scheme collapsed every block to peer 0. The hashed
+	// peer-aware order must not exhibit that — different peers must see
+	// different blocks at the front of their queues.
+	const numBlocks = 600
+	blocks := make([]*Block, numBlocks)
+	for i := 0; i < numBlocks; i++ {
+		blocks[i] = &Block{Key: fmt.Sprintf("chunks/0/0/%d_0_4194304", i), Index: 0}
+	}
+	s := NewScheduler(blocks)
+
+	a := s.OrderForPeer("peer0")
+	b := s.OrderForPeer("peer1")
+	c := s.OrderForPeer("peer2")
+	if a[0].Key == b[0].Key && b[0].Key == c[0].Key {
+		t.Errorf("all peers see the same head block; ordering ignored peerAddr")
+	}
+}
+
+func TestOrderForPeer_OnlyPendingBlocks(t *testing.T) {
+	blocks := makeBlocks(5)
+	blocks[2].TryDownload() // Downloading
+	blocks[3].TryDownload()
+	blocks[3].MarkDone() // Done
+
+	s := NewScheduler(blocks)
+	out := s.OrderForPeer("peer0")
+	if len(out) != 3 {
+		t.Fatalf("expected 3 pending blocks, got %d", len(out))
+	}
+	for _, b := range out {
+		if b.State() != BlockPending {
+			t.Errorf("non-pending block %q in ordering (state=%d)", b.Key, b.State())
+		}
+	}
+}
+
+func TestFetchQueue_PopAndPush(t *testing.T) {
+	q := NewFetchQueue(10)
+
+	// Pop on empty -> nil
+	if b := q.Pop(); b != nil {
+		t.Errorf("expected nil on empty Pop, got %v", b)
+	}
+
+	block := &Block{Key: "test", Index: 0}
+	q.Push(block)
+
+	// Pop returns the block
+	got := q.Pop()
+	if got == nil {
+		t.Fatal("expected block, got nil")
+	}
+	if got.Key != "test" {
+		t.Errorf("expected block key 'test', got %q", got.Key)
+	}
+
+	// Pop again -> nil (queue empty)
+	if b := q.Pop(); b != nil {
+		t.Errorf("expected nil after consuming single block, got %v", b)
+	}
+}
+
+func TestFetchQueue_FIFO(t *testing.T) {
+	q := NewFetchQueue(10)
+	blocks := makeBlocks(3)
+	q.PushAll(blocks)
+
+	for i := 0; i < 3; i++ {
+		b := q.Pop()
+		if b == nil {
+			t.Fatalf("expected block %d, got nil", i)
+		}
+		if b.Index != i {
+			t.Errorf("expected FIFO order: block %d, got %d", i, b.Index)
+		}
+	}
+}
+
+func TestFetchQueue_WaitAndPop(t *testing.T) {
+	q := NewFetchQueue(10)
+	block := &Block{Key: "async", Index: 99}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var got *Block
+	go func() {
+		defer wg.Done()
+		got = q.WaitAndPop()
+	}()
+
+	// Push from this goroutine after a tiny delay
+	// Use a channel to synchronize without sleep
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		q.Push(block)
+	}()
+	<-ready
+
+	wg.Wait()
+
+	if got == nil {
+		t.Fatal("WaitAndPop returned nil, expected block")
+	}
+	if got.Key != "async" {
+		t.Errorf("expected key 'async', got %q", got.Key)
+	}
+}
+
+func TestFetchQueue_Close(t *testing.T) {
+	q := NewFetchQueue(10)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var got *Block
+	go func() {
+		defer wg.Done()
+		got = q.WaitAndPop()
+	}()
+
+	// Close the queue — WaitAndPop should return nil
+	q.Close()
+	wg.Wait()
+
+	if got != nil {
+		t.Errorf("expected nil from WaitAndPop after Close, got %v", got)
+	}
+}
+
+func TestFetchQueue_Len(t *testing.T) {
+	q := NewFetchQueue(5)
+
+	if q.Len() != 0 {
+		t.Errorf("expected Len 0, got %d", q.Len())
+	}
+
+	blocks := makeBlocks(3)
+	q.PushAll(blocks)
+
+	if q.Len() != 3 {
+		t.Errorf("expected Len 3, got %d", q.Len())
+	}
+
+	q.Pop()
+	if q.Len() != 2 {
+		t.Errorf("expected Len 2 after Pop, got %d", q.Len())
+	}
+}

--- a/pkg/p2p/server.go
+++ b/pkg/p2p/server.go
@@ -18,6 +18,18 @@ type Server struct {
 	cacheDir     string
 	totalBlocks  atomic.Int64
 	doneBlocks   atomic.Int64
+
+	// Additive /status fields, pushed by the orchestrator like SetProgress.
+	// Lock-free: slow probe reads never contend with the per-tick writers.
+	role         atomic.Value // string; "" until election decides
+	peers        atomic.Int64 // currently alive discovered peers (excluding self)
+	fromPeers    atomic.Int64
+	fromStorage  atomic.Int64
+	fromCache    atomic.Int64
+	skipped      atomic.Int64
+	failed       atomic.Int64
+	bytesPeer    atomic.Int64
+	bytesStorage atomic.Int64
 }
 
 // NewServer creates a Server with the given identity, tracker, and cache directory.
@@ -33,6 +45,31 @@ func NewServer(uuid string, availability *AvailabilityTracker, cacheDir string) 
 func (s *Server) SetProgress(total, done int) {
 	s.totalBlocks.Store(int64(total))
 	s.doneBlocks.Store(int64(done))
+}
+
+// SetRole records this node's leader-election role ("leader" or "follower").
+// Set once, after election decides.
+func (s *Server) SetRole(role string) {
+	s.role.Store(role)
+}
+
+// SetPeers records the number of currently alive discovered peers (excluding
+// self). Pushed periodically as discovery adds and drops peers.
+func (s *Server) SetPeers(n int) {
+	s.peers.Store(int64(n))
+}
+
+// SetStats records a snapshot of Fetcher.Stats() for /status. Argument order
+// matches Fetcher.Stats's return order so the orchestrator can forward it
+// directly.
+func (s *Server) SetStats(fromPeers, fromStorage, fromCache, skipped, failed, bytesPeer, bytesStorage int64) {
+	s.fromPeers.Store(fromPeers)
+	s.fromStorage.Store(fromStorage)
+	s.fromCache.Store(fromCache)
+	s.skipped.Store(skipped)
+	s.failed.Store(failed)
+	s.bytesPeer.Store(bytesPeer)
+	s.bytesStorage.Store(bytesStorage)
 }
 
 // Handler returns an http.ServeMux wired with all server routes.
@@ -51,22 +88,53 @@ func (s *Server) handleUUID(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"uuid": s.uuid})
 }
 
-// handleStatus reports overall download progress.
-// GET /status → {"completed": bool, "progress": {"total": N, "done": N}}
+// handleStatus reports overall download progress plus role, live peer count,
+// and per-source block/byte counts, letting consumers read warmup state
+// directly instead of parsing logs. Bytes are raw int64; consumers format them.
+// GET /status → {"completed", "progress":{"total","done"}, "role", "peers",
+//                "sources":{...}, "bytes":{...}}
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	total := s.totalBlocks.Load()
 	done := s.doneBlocks.Load()
 	completed := total > 0 && done >= total
 
+	// atomic.Value.Load is nil until the first SetRole; report "" so the field
+	// is always present and parseable.
+	role, _ := s.role.Load().(string)
+
 	type progress struct {
 		Total int64 `json:"total"`
 		Done  int64 `json:"done"`
+	}
+	type sources struct {
+		FromPeers   int64 `json:"from_peers"`
+		FromStorage int64 `json:"from_storage"`
+		FromCache   int64 `json:"from_cache"`
+		Skipped     int64 `json:"skipped"`
+		Failed      int64 `json:"failed"`
+	}
+	type bytesXfer struct {
+		FromPeers   int64 `json:"from_peers"`
+		FromStorage int64 `json:"from_storage"`
 	}
 	writeJSON(w, map[string]interface{}{
 		"completed": completed,
 		"progress": progress{
 			Total: total,
 			Done:  done,
+		},
+		"role":  role,
+		"peers": s.peers.Load(),
+		"sources": sources{
+			FromPeers:   s.fromPeers.Load(),
+			FromStorage: s.fromStorage.Load(),
+			FromCache:   s.fromCache.Load(),
+			Skipped:     s.skipped.Load(),
+			Failed:      s.failed.Load(),
+		},
+		"bytes": bytesXfer{
+			FromPeers:   s.bytesPeer.Load(),
+			FromStorage: s.bytesStorage.Load(),
 		},
 	})
 }

--- a/pkg/p2p/server.go
+++ b/pkg/p2p/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -96,24 +97,70 @@ func (s *Server) handleAvailable(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// validBlockKey rejects URL-derived keys whose shape could trigger filesystem
+// traversal. JuiceFS cache keys are of the form "chunks/<dirs>/<id>_<idx>_<size>"
+// — all segments are alphanumeric, so a key that path.Clean rewrites or that
+// contains absolute-path or parent-dir markers is never legitimate.
+func validBlockKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	// Reject absolute paths (POSIX leading "/", Windows leading "\" or drive
+	// letter). filepath.Join silently overrides the prefix on Windows when
+	// given a path with a drive letter, and a leading "/" is suspicious
+	// regardless.
+	if key[0] == '/' || key[0] == '\\' {
+		return false
+	}
+	if len(key) >= 2 && key[1] == ':' { // Windows drive letter like "C:"
+		return false
+	}
+	// Reject any "." or ".." segment that path.Clean would collapse.
+	for _, seg := range strings.Split(key, "/") {
+		if seg == "." || seg == ".." {
+			return false
+		}
+	}
+	// Final check: anything that path.Clean rewrites (duplicate slashes,
+	// trailing slash, embedded "./", etc.) is rejected so the on-wire key
+	// matches the cached filename exactly.
+	if path.Clean(key) != key {
+		return false
+	}
+	return true
+}
+
 // handleBlock serves raw block data from the local disk cache.
 // GET /block/<key> → binary file contents, or 404
 // The key is everything after "/block/" in the URL path.
 func (s *Server) handleBlock(w http.ResponseWriter, r *http.Request) {
 	key := strings.TrimPrefix(r.URL.Path, "/block/")
-	if key == "" {
+	if !validBlockKey(key) {
 		http.NotFound(w, r)
 		return
 	}
 
-	path := filepath.Join(s.cacheDir, "raw", key)
-	data, err := os.ReadFile(path)
+	rawRoot := filepath.Join(s.cacheDir, "raw")
+	blockPath := filepath.Join(rawRoot, key)
+
+	// Defense in depth: even after the shape check, confirm the resolved
+	// path is still under {cacheDir}/raw. filepath.Rel returns a path
+	// starting with ".." when the target escapes the root.
+	rel, err := filepath.Rel(rawRoot, blockPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		http.NotFound(w, r)
+		return
+	}
+
+	data, err := os.ReadFile(blockPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			http.NotFound(w, r)
-			return
+		// Treat every read error as 404 so the response does not leak
+		// whether the path exists but is unreadable (e.g. permission
+		// denied); log unexpected errors for the operator.
+		if !os.IsNotExist(err) {
+			logger.WithError(err).Debugf("handleBlock: read %q failed", blockPath)
 		}
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		http.NotFound(w, r)
 		return
 	}
 

--- a/pkg/p2p/server.go
+++ b/pkg/p2p/server.go
@@ -1,0 +1,132 @@
+package p2p
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Server serves block data and availability info to peers via HTTP.
+type Server struct {
+	uuid         string
+	availability *AvailabilityTracker
+	cacheDir     string
+	totalBlocks  atomic.Int64
+	doneBlocks   atomic.Int64
+}
+
+// NewServer creates a Server with the given identity, tracker, and cache directory.
+func NewServer(uuid string, availability *AvailabilityTracker, cacheDir string) *Server {
+	return &Server{
+		uuid:         uuid,
+		availability: availability,
+		cacheDir:     cacheDir,
+	}
+}
+
+// SetProgress updates the total and done block counters atomically.
+func (s *Server) SetProgress(total, done int) {
+	s.totalBlocks.Store(int64(total))
+	s.doneBlocks.Store(int64(done))
+}
+
+// Handler returns an http.ServeMux wired with all server routes.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/uuid", s.handleUUID)
+	mux.HandleFunc("/status", s.handleStatus)
+	mux.HandleFunc("/available", s.handleAvailable)
+	mux.HandleFunc("/block/", s.handleBlock)
+	return mux
+}
+
+// handleUUID responds with this node's UUID.
+// GET /uuid → {"uuid": "..."}
+func (s *Server) handleUUID(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, map[string]string{"uuid": s.uuid})
+}
+
+// handleStatus reports overall download progress.
+// GET /status → {"completed": bool, "progress": {"total": N, "done": N}}
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	total := s.totalBlocks.Load()
+	done := s.doneBlocks.Load()
+	completed := total > 0 && done >= total
+
+	type progress struct {
+		Total int64 `json:"total"`
+		Done  int64 `json:"done"`
+	}
+	writeJSON(w, map[string]interface{}{
+		"completed": completed,
+		"progress": progress{
+			Total: total,
+			Done:  done,
+		},
+	})
+}
+
+// handleAvailable returns locally available block keys, optionally filtered by
+// a ?since=<unix-millis> query parameter.
+// GET /available          → {"blocks": [...], "updated_at": ts}
+// GET /available?since=ts → incremental subset
+func (s *Server) handleAvailable(w http.ResponseWriter, r *http.Request) {
+	var sinceMs int64
+	if v := r.URL.Query().Get("since"); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			http.Error(w, "invalid since parameter", http.StatusBadRequest)
+			return
+		}
+		sinceMs = parsed
+	}
+
+	keys, updatedAt := s.availability.LocalBlocksSince(sinceMs)
+	if keys == nil {
+		keys = []string{}
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"blocks":     keys,
+		"updated_at": updatedAt,
+	})
+}
+
+// handleBlock serves raw block data from the local disk cache.
+// GET /block/<key> → binary file contents, or 404
+// The key is everything after "/block/" in the URL path.
+func (s *Server) handleBlock(w http.ResponseWriter, r *http.Request) {
+	key := strings.TrimPrefix(r.URL.Path, "/block/")
+	if key == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	path := filepath.Join(s.cacheDir, "raw", key)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// writeJSON encodes v as JSON and writes it to w with Content-Type
+// application/json and status 200.
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(v)
+}

--- a/pkg/p2p/server_test.go
+++ b/pkg/p2p/server_test.go
@@ -85,6 +85,120 @@ func TestServer_Status_Completed(t *testing.T) {
 	}
 }
 
+func TestServer_Status_ExtendedFields(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("u1", tracker, t.TempDir())
+	srv.SetProgress(6400, 6400)
+	srv.SetRole("leader")
+	srv.SetPeers(12)
+	srv.SetStats(5800, 600, 0, 0, 0, 95563022336, 11811160064)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var body struct {
+		Completed bool `json:"completed"`
+		Progress  struct {
+			Total int64 `json:"total"`
+			Done  int64 `json:"done"`
+		} `json:"progress"`
+		Role    string `json:"role"`
+		Peers   int64  `json:"peers"`
+		Sources struct {
+			FromPeers   int64 `json:"from_peers"`
+			FromStorage int64 `json:"from_storage"`
+			FromCache   int64 `json:"from_cache"`
+			Skipped     int64 `json:"skipped"`
+			Failed      int64 `json:"failed"`
+		} `json:"sources"`
+		Bytes struct {
+			FromPeers   int64 `json:"from_peers"`
+			FromStorage int64 `json:"from_storage"`
+		} `json:"bytes"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	// Baseline fields remain unchanged.
+	if !body.Completed {
+		t.Error("expected completed=true")
+	}
+	if body.Progress.Total != 6400 || body.Progress.Done != 6400 {
+		t.Errorf("progress = %d/%d, want 6400/6400", body.Progress.Done, body.Progress.Total)
+	}
+
+	// Additive fields.
+	if body.Role != "leader" {
+		t.Errorf("role = %q, want %q", body.Role, "leader")
+	}
+	if body.Peers != 12 {
+		t.Errorf("peers = %d, want 12", body.Peers)
+	}
+	if body.Sources.FromPeers != 5800 {
+		t.Errorf("sources.from_peers = %d, want 5800", body.Sources.FromPeers)
+	}
+	if body.Sources.FromStorage != 600 {
+		t.Errorf("sources.from_storage = %d, want 600", body.Sources.FromStorage)
+	}
+	if body.Sources.FromCache != 0 || body.Sources.Skipped != 0 || body.Sources.Failed != 0 {
+		t.Errorf("sources zero-fields = cache:%d skipped:%d failed:%d, want all 0",
+			body.Sources.FromCache, body.Sources.Skipped, body.Sources.Failed)
+	}
+	if body.Bytes.FromPeers != 95563022336 {
+		t.Errorf("bytes.from_peers = %d, want 95563022336", body.Bytes.FromPeers)
+	}
+	if body.Bytes.FromStorage != 11811160064 {
+		t.Errorf("bytes.from_storage = %d, want 11811160064", body.Bytes.FromStorage)
+	}
+}
+
+// A freshly constructed Server (before any role/stats push) must still serve a
+// well-formed /status: baseline fields present, additive fields at their zero
+// values. Operators poll /status from the first probe, before election runs.
+func TestServer_Status_DefaultsBeforePush(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("u1", tracker, t.TempDir())
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var body struct {
+		Completed bool   `json:"completed"`
+		Role      string `json:"role"`
+		Peers     int64  `json:"peers"`
+		Sources   struct {
+			FromPeers int64 `json:"from_peers"`
+		} `json:"sources"`
+		Bytes struct {
+			FromPeers int64 `json:"from_peers"`
+		} `json:"bytes"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if body.Completed {
+		t.Error("expected completed=false for a fresh server")
+	}
+	if body.Role != "" {
+		t.Errorf("role = %q, want empty before election", body.Role)
+	}
+	if body.Peers != 0 || body.Sources.FromPeers != 0 || body.Bytes.FromPeers != 0 {
+		t.Errorf("expected zero-valued additive fields, got peers:%d sources.from_peers:%d bytes.from_peers:%d",
+			body.Peers, body.Sources.FromPeers, body.Bytes.FromPeers)
+	}
+}
+
 func TestServer_Available(t *testing.T) {
 	tracker := NewAvailabilityTracker()
 	tracker.MarkLocal("key1")

--- a/pkg/p2p/server_test.go
+++ b/pkg/p2p/server_test.go
@@ -1,0 +1,212 @@
+package p2p
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestServer_UUID(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("test-uuid-123", tracker, t.TempDir())
+
+	req := httptest.NewRequest(http.MethodGet, "/uuid", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if got := body["uuid"]; got != "test-uuid-123" {
+		t.Errorf("expected uuid=test-uuid-123, got %q", got)
+	}
+}
+
+func TestServer_Status(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("u1", tracker, t.TempDir())
+	srv.SetProgress(100, 40)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var body struct {
+		Completed bool `json:"completed"`
+		Progress  struct {
+			Total int64 `json:"total"`
+			Done  int64 `json:"done"`
+		} `json:"progress"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if body.Completed {
+		t.Error("expected completed=false")
+	}
+	if body.Progress.Total != 100 {
+		t.Errorf("expected total=100, got %d", body.Progress.Total)
+	}
+	if body.Progress.Done != 40 {
+		t.Errorf("expected done=40, got %d", body.Progress.Done)
+	}
+}
+
+func TestServer_Status_Completed(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("u1", tracker, t.TempDir())
+	srv.SetProgress(50, 50)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	var body struct {
+		Completed bool `json:"completed"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !body.Completed {
+		t.Error("expected completed=true when done==total")
+	}
+}
+
+func TestServer_Available(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	tracker.MarkLocal("key1")
+	tracker.MarkLocal("key2")
+
+	srv := NewServer("u1", tracker, t.TempDir())
+
+	req := httptest.NewRequest(http.MethodGet, "/available", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var body struct {
+		Blocks    []string `json:"blocks"`
+		UpdatedAt int64    `json:"updated_at"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(body.Blocks) != 2 {
+		t.Errorf("expected 2 blocks, got %d: %v", len(body.Blocks), body.Blocks)
+	}
+	if body.UpdatedAt <= 0 {
+		t.Errorf("expected updated_at > 0, got %d", body.UpdatedAt)
+	}
+}
+
+func TestServer_Available_Since(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	tracker.MarkLocal("key1")
+
+	_, ts := tracker.LocalBlocksSince(0)
+
+	// Ensure key2 gets a later timestamp
+	time.Sleep(2 * time.Millisecond)
+	tracker.MarkLocal("key2")
+
+	srv := NewServer("u1", tracker, t.TempDir())
+
+	req := httptest.NewRequest(http.MethodGet, "/available?since="+itoa64(ts), nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var body struct {
+		Blocks []string `json:"blocks"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(body.Blocks) != 1 {
+		t.Errorf("expected 1 block after since, got %d: %v", len(body.Blocks), body.Blocks)
+	}
+	if body.Blocks[0] != "key2" {
+		t.Errorf("expected key2, got %q", body.Blocks[0])
+	}
+}
+
+func TestServer_Block(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a fake block file at tmpDir/raw/chunks/0/0/1_0_100
+	rawDir := filepath.Join(tmpDir, "raw", "chunks", "0", "0")
+	if err := os.MkdirAll(rawDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	blockData := []byte("hello block data")
+	blockPath := filepath.Join(rawDir, "1_0_100")
+	if err := os.WriteFile(blockPath, blockData, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("u1", tracker, tmpDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/block/chunks/0/0/1_0_100", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("expected Content-Type application/octet-stream, got %q", ct)
+	}
+	if got := rr.Body.Bytes(); string(got) != string(blockData) {
+		t.Errorf("expected %q, got %q", blockData, got)
+	}
+}
+
+func TestServer_Block_NotFound(t *testing.T) {
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("u1", tracker, t.TempDir())
+
+	req := httptest.NewRequest(http.MethodGet, "/block/nonexistent", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// itoa64 is a helper to convert int64 to string for query params.
+func itoa64(n int64) string {
+	return string(appendInt64(nil, n))
+}
+
+func appendInt64(dst []byte, n int64) []byte {
+	if n < 0 {
+		dst = append(dst, '-')
+		n = -n
+	}
+	if n < 10 {
+		return append(dst, byte('0'+n))
+	}
+	dst = appendInt64(dst, n/10)
+	return append(dst, byte('0'+n%10))
+}

--- a/pkg/p2p/server_test.go
+++ b/pkg/p2p/server_test.go
@@ -210,3 +210,118 @@ func appendInt64(dst []byte, n int64) []byte {
 	dst = appendInt64(dst, n/10)
 	return append(dst, byte('0'+n%10))
 }
+
+func TestValidBlockKey(t *testing.T) {
+	valid := []string{
+		"chunks/0/0/100_0_4194304",
+		"chunks/FF/0/9999_3_2048",
+		"chunks/0/1234567/9999999_0_8192",
+	}
+	invalid := []string{
+		"",
+		"/abs",
+		"\\abs",
+		"C:windows",
+		"C:/x",
+		"..",
+		".",
+		"/",
+		"\\",
+		"../escape",
+		"chunks/../escape",
+		"chunks/./hidden",
+		"chunks/a//b",
+		"chunks/a/",
+		"chunks/a/..",
+	}
+	for _, k := range valid {
+		if !validBlockKey(k) {
+			t.Errorf("validBlockKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range invalid {
+		if validBlockKey(k) {
+			t.Errorf("validBlockKey(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestServer_HandleBlock_RejectsPathTraversal(t *testing.T) {
+	// Place a sentinel file *outside* the cache dir; if the handler ever
+	// leaks it, the assertion below fails.
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	if err := os.MkdirAll(filepath.Join(cacheDir, "raw"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	outsideContent := []byte("CONFIDENTIAL")
+	outsidePath := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(outsidePath, outsideContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("uuid", tracker, cacheDir)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	cases := []string{
+		"/block/../secret.txt",
+		"/block/../../etc/passwd",
+		"/block/./hidden",
+		"/block/sub/../escape",
+		"/block//abs",
+		"/block/%2E%2E/secret.txt",   // URL-encoded ".."
+		"/block/%2E%2E%2Fsecret.txt", // URL-encoded "../"
+		"/block/\\windows\\path",
+		"/block/C:/x",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("status = %d, want 404 for %q", resp.StatusCode, p)
+			}
+			body := make([]byte, len(outsideContent))
+			n, _ := resp.Body.Read(body)
+			if string(body[:n]) == string(outsideContent) {
+				t.Fatalf("LEAK: handler returned outside-cache sentinel content for %q", p)
+			}
+		})
+	}
+}
+
+func TestServer_HandleBlock_ServesValidKey(t *testing.T) {
+	cacheDir := t.TempDir()
+	rawDir := filepath.Join(cacheDir, "raw", "chunks", "0", "0")
+	if err := os.MkdirAll(rawDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("block-payload")
+	if err := os.WriteFile(filepath.Join(rawDir, "100_0_13"), want, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := NewAvailabilityTracker()
+	srv := NewServer("uuid", tracker, cacheDir)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/block/chunks/0/0/100_0_13")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	got := make([]byte, 64)
+	n, _ := resp.Body.Read(got)
+	if string(got[:n]) != string(want) {
+		t.Errorf("body = %q, want %q", got[:n], want)
+	}
+}

--- a/pkg/p2p/types.go
+++ b/pkg/p2p/types.go
@@ -1,0 +1,127 @@
+package p2p
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type BlockState int32
+
+const (
+	BlockPending     BlockState = 0
+	BlockDownloading BlockState = 1
+	BlockDone        BlockState = 2
+	BlockFailed      BlockState = 3 // terminal: exhausted retry budget
+)
+
+type Block struct {
+	Key      string // Object storage key (e.g., "chunks/0/0/100_0_4194304")
+	SliceID  uint64
+	Index    int
+	Size     int
+	state    atomic.Int32
+	doneAt   atomic.Int64
+	attempts atomic.Int32 // count of failed fetch attempts so far
+}
+
+// State returns the current block state.
+func (b *Block) State() BlockState {
+	return BlockState(b.state.Load())
+}
+
+// IsTerminal reports whether the block is in a state that contributes to
+// completion (Done or Failed). Pending/Downloading do not count.
+func (b *Block) IsTerminal() bool {
+	s := b.State()
+	return s == BlockDone || s == BlockFailed
+}
+
+// TryDownload atomically transitions Pending -> Downloading (CAS). Returns true if succeeded.
+func (b *Block) TryDownload() bool {
+	return b.state.CompareAndSwap(int32(BlockPending), int32(BlockDownloading))
+}
+
+// MarkDone transitions Downloading -> Done, records timestamp.
+func (b *Block) MarkDone() {
+	b.doneAt.Store(time.Now().UnixMilli())
+	b.state.Store(int32(BlockDone))
+}
+
+// MarkFailed transitions to Failed (terminal). Used when the retry budget is
+// exhausted, e.g. the block was deleted by slice compaction mid-warmup.
+func (b *Block) MarkFailed() {
+	b.state.Store(int32(BlockFailed))
+}
+
+// ResetToPending transitions Downloading -> Pending (on failure).
+func (b *Block) ResetToPending() {
+	b.state.CompareAndSwap(int32(BlockDownloading), int32(BlockPending))
+}
+
+// IncrAttempts atomically increments the failed-attempt counter and returns
+// the new value. The fetcher uses this to decide whether to retry or abandon.
+func (b *Block) IncrAttempts() int32 {
+	return b.attempts.Add(1)
+}
+
+// DoneAt returns unix millis when marked Done, or 0.
+func (b *Block) DoneAt() int64 {
+	return b.doneAt.Load()
+}
+
+type Peer struct {
+	Addr    string // "host:port"
+	UUID    string
+	Healthy bool
+}
+
+type WarmupConfig struct {
+	// P2P settings
+	ListenAddr           string
+	DiscoveryInterval    time.Duration
+	AvailabilityInterval time.Duration
+	Threads              int
+	KeepAlive            bool
+	KeepAliveTimeout     time.Duration
+	// MinPeers is the minimum total peer count (INCLUDING self) to wait for.
+	// Acts as a synchronization barrier, not a fixed cluster size — more
+	// peers proceed immediately. 0 or 1 = solo (manifest sharing disabled).
+	MinPeers int
+
+	// Manifest sharing (active when MinPeers > 1 and not Disabled): the
+	// lexicographically smallest peer scans meta and uploads a manifest;
+	// followers download it, avoiding redundant meta-engine load.
+	DisableManifestSharing bool
+	LeaderTimeout          time.Duration // follower max wait for leader's manifest (0=use default)
+	// ManifestName is the manifest's object-storage basename. Empty = use a
+	// content-addressable hash. All peers must pass the same value to agree
+	// on the key.
+	ManifestName string
+
+	// Discovery sources
+	PeersDNSSRV string
+	PeersDNSA   string
+	PeersList   string
+
+	// JuiceFS cache settings
+	CacheDir   string
+	BlockSize  int
+	HashPrefix bool
+	// Compress is the volume's block compression algorithm ("lz4", "zstd",
+	// "none" or empty), sourced from format.Compression. Storage holds
+	// compressed bytes but the on-disk cache holds decompressed bytes; the
+	// Fetcher decompresses at the storage-fetch boundary so cache files
+	// match the layout mount's openCacheFile expects. Mismatched values
+	// cause mount to reject every cached block.
+	Compress string
+
+	// DownloadLimit is the object-storage download cap in bytes/second
+	// (0 = unlimited). Peer-to-peer transfers are not throttled.
+	DownloadLimit int64
+}
+
+// keepAliveTimeoutIgnored reports whether KeepAliveTimeout is set without
+// KeepAlive — Run() skips the keep-alive phase, so the timer never starts.
+func (c WarmupConfig) keepAliveTimeoutIgnored() bool {
+	return !c.KeepAlive && c.KeepAliveTimeout > 0
+}

--- a/pkg/p2p/types.go
+++ b/pkg/p2p/types.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -69,6 +71,33 @@ func (b *Block) DoneAt() int64 {
 	return b.doneAt.Load()
 }
 
+// KeepAliveMode controls what a peer does after its local fetch completes.
+type KeepAliveMode string
+
+const (
+	// KeepAliveOff exits as soon as the local fetch finishes.
+	KeepAliveOff KeepAliveMode = "off"
+	// KeepAlivePeers stays up serving blocks until every live peer reports
+	// completion, then exits. Default: late finishers keep pulling from LAN
+	// peers instead of falling back to object storage for their tail.
+	KeepAlivePeers KeepAliveMode = "peers"
+	// KeepAliveForever serves blocks until SIGTERM/SIGINT (or KeepAliveTimeout).
+	KeepAliveForever KeepAliveMode = "forever"
+)
+
+// ParseKeepAliveMode parses the --keep-alive flag value. Empty defaults to
+// "peers". Comparison is case-insensitive and surrounding space is trimmed.
+func ParseKeepAliveMode(s string) (KeepAliveMode, error) {
+	switch m := KeepAliveMode(strings.ToLower(strings.TrimSpace(s))); m {
+	case "":
+		return KeepAlivePeers, nil
+	case KeepAliveOff, KeepAlivePeers, KeepAliveForever:
+		return m, nil
+	default:
+		return "", fmt.Errorf("invalid --keep-alive %q (expected off, peers, or forever)", s)
+	}
+}
+
 type Peer struct {
 	Addr    string // "host:port"
 	UUID    string
@@ -81,7 +110,7 @@ type WarmupConfig struct {
 	DiscoveryInterval    time.Duration
 	AvailabilityInterval time.Duration
 	Threads              int
-	KeepAlive            bool
+	KeepAlive            KeepAliveMode
 	KeepAliveTimeout     time.Duration
 	// MinPeers is the minimum total peer count (INCLUDING self) to wait for.
 	// Acts as a synchronization barrier, not a fixed cluster size — more
@@ -126,8 +155,9 @@ type WarmupConfig struct {
 	CacheSize int64
 }
 
-// keepAliveTimeoutIgnored reports whether KeepAliveTimeout is set without
-// KeepAlive — Run() skips the keep-alive phase, so the timer never starts.
+// keepAliveTimeoutIgnored reports whether KeepAliveTimeout is set while
+// KeepAlive is off — Run() skips the keep-alive phase, so the timer never
+// starts.
 func (c WarmupConfig) keepAliveTimeoutIgnored() bool {
-	return !c.KeepAlive && c.KeepAliveTimeout > 0
+	return c.KeepAlive == KeepAliveOff && c.KeepAliveTimeout > 0
 }

--- a/pkg/p2p/types.go
+++ b/pkg/p2p/types.go
@@ -118,6 +118,12 @@ type WarmupConfig struct {
 	// DownloadLimit is the object-storage download cap in bytes/second
 	// (0 = unlimited). Peer-to-peer transfers are not throttled.
 	DownloadLimit int64
+
+	// CacheSize is the hard cap on cumulative cached bytes (0 = unlimited).
+	// Counted as: bytes from pre-existing files at scan + bytes written
+	// during this run. Workers race the load-check-add window so peak
+	// usage may exceed CacheSize by up to Threads * BlockSize.
+	CacheSize int64
 }
 
 // keepAliveTimeoutIgnored reports whether KeepAliveTimeout is set without

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -393,6 +393,18 @@ func validCacheFileSize(onDisk int64, logical int) bool {
 	return delta == checksumLen || delta == checksumLen+cacheTierIDLength
 }
 
+// maxCacheFileSize is the largest layout openCacheFile will accept for the
+// given logical size: logical + full checksum trailer + tier byte. Used by
+// FetchFromPeer to cap peer-served bodies — without a cap, a misbehaving
+// peer could stream arbitrary bytes into memory.
+func maxCacheFileSize(logical int) int64 {
+	if logical <= 0 {
+		return 0
+	}
+	checksumLen := int64((logical-1)/cacheChecksumBlock+1) * 4
+	return int64(logical) + checksumLen + cacheTierIDLength
+}
+
 // scanExistingCache walks {cacheDir}/raw and announces well-formed block
 // files via the availability tracker, returning the count. Missing roots are
 // treated as empty. Files failing validCacheFileSize are skipped — primarily

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -165,10 +165,10 @@ func (w *Warmup) Run(ctx context.Context, paths []string) error {
 		logger.Warnf("self external address not discovered; using listen address %q for election. If listen is a wildcard, leader election and partition assignment will not agree across peers — pass --listen <self-IP>:port or ensure self is reachable via the configured discovery source.", w.listenAddr)
 	}
 
-	// --keep-alive-timeout only applies inside the keep-alive phase; without
-	// --keep-alive, step 11 is skipped and the timer never starts.
+	// --keep-alive-timeout only applies inside the keep-alive phase; with
+	// --keep-alive=off, step 11 is skipped and the timer never starts.
 	if w.config.keepAliveTimeoutIgnored() {
-		logger.Warnf("--keep-alive-timeout=%s is set but --keep-alive is not; the timeout will be ignored and the process will exit immediately after warmup. Pass --keep-alive to enable post-warmup serving.", w.config.KeepAliveTimeout)
+		logger.Warnf("--keep-alive-timeout=%s is set but --keep-alive=off; the timeout will be ignored and the process will exit immediately after warmup. Use --keep-alive=peers or =forever to enable post-warmup serving.", w.config.KeepAliveTimeout)
 	}
 
 	// Publish the leader role + initial peer count to /status (peers is refreshed later by the availability poll).
@@ -265,8 +265,12 @@ func (w *Warmup) Run(ctx context.Context, paths []string) error {
 		humanize.IBytes(avgRate), humanize.IBytes(fetchRate))
 
 	// 11. Keep-alive if configured.
-	if w.config.KeepAlive {
-		logger.Info("keep-alive mode: serving blocks to peers")
+	switch w.config.KeepAlive {
+	case KeepAlivePeers:
+		logger.Info("keep-alive=peers: serving blocks until all peers complete")
+		w.keepAliveUntilPeersDone(bgCtx)
+	case KeepAliveForever:
+		logger.Info("keep-alive=forever: serving blocks to peers")
 		w.keepAlive(bgCtx)
 	}
 
@@ -676,6 +680,72 @@ func (w *Warmup) waitForCompletion(ctx context.Context, blocks []*Block, queue *
 			w.server.SetProgress(total, done)
 			if done+failed >= total {
 				queue.Close()
+				return
+			}
+		}
+	}
+}
+
+// peersAllComplete polls each live (self-excluded) peer's /status and reports
+// whether every live peer is done warming. An unreachable peer (left
+// discovery, crashed, or already exited) is treated as complete — otherwise a
+// single dead peer would block exit forever. Returns true when no live peers
+// remain.
+func (w *Warmup) peersAllComplete(ctx context.Context) bool {
+	self := w.effectiveAddr()
+	for _, addr := range w.discovery.Peers() {
+		if addr == self {
+			continue
+		}
+		done, err := w.fetcher.PollCompleted(ctx, addr)
+		if err != nil {
+			logger.WithError(err).Debugf("status poll failed for %s; treating as complete", addr)
+			continue
+		}
+		if !done {
+			return false
+		}
+	}
+	return true
+}
+
+// keepAliveUntilPeersDone keeps serving blocks until every live peer reports
+// completion, then returns. It also returns early on SIGTERM/SIGINT, ctx
+// cancellation, or — if set — KeepAliveTimeout. Peers that leave discovery are
+// no longer awaited (see peersAllComplete), so a crashed peer cannot wedge the
+// process; KeepAliveTimeout is a belt-and-suspenders upper bound.
+func (w *Warmup) keepAliveUntilPeersDone(ctx context.Context) {
+	sigCtx, sigStop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer sigStop()
+
+	var timeoutCh <-chan time.Time
+	if w.config.KeepAliveTimeout > 0 {
+		timer := time.NewTimer(w.config.KeepAliveTimeout)
+		defer timer.Stop()
+		timeoutCh = timer.C
+	}
+
+	// Check once up front so an already-finished cluster exits immediately
+	// instead of waiting a full tick.
+	if w.peersAllComplete(sigCtx) {
+		logger.Info("all peers complete; shutting down")
+		return
+	}
+
+	ticker := time.NewTicker(w.config.AvailabilityInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sigCtx.Done():
+			logger.Info("received signal, shutting down")
+			return
+		case <-timeoutCh:
+			logger.Info("keep-alive timeout reached")
+			return
+		case <-ticker.C:
+			if w.peersAllComplete(sigCtx) {
+				logger.Info("all peers complete; shutting down")
 				return
 			}
 		}

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -71,6 +71,9 @@ func NewWarmup(config WarmupConfig, m meta.Meta, storage object.ObjectStorage) *
 	}
 	fetcher := NewFetcher(storage, config.CacheDir, config.BlockSize, httpClient, compressor)
 	fetcher.SetAvailability(availability)
+	if config.CacheSize > 0 {
+		fetcher.SetCacheSize(config.CacheSize)
+	}
 	if config.DownloadLimit > 0 {
 		// 0.85 dampening / 10% burst — same convention as pkg/chunk and
 		// pkg/sync, keeps observed rate close to the cap without large bursts.
@@ -119,10 +122,18 @@ func (w *Warmup) Run(ctx context.Context, paths []string) error {
 		}
 	}()
 	logger.Infof("P2P server listening on %s (uuid=%s)", w.listenAddr, w.uuid)
+	if w.config.CacheSize > 0 {
+		logger.Infof("cache-size cap: %s (pass --cache-size 0 for unlimited)", humanize.IBytes(uint64(w.config.CacheSize)))
+	} else {
+		logger.Warnf("cache-size cap disabled (--cache-size 0); warmup will keep writing until the disk fills")
+	}
 
-	// 1b. Announce pre-cached blocks via /available and skip them in the fetch.
-	if n := w.scanExistingCache(); n > 0 {
-		logger.Infof("found %d pre-cached blocks in %s", n, w.config.CacheDir)
+	// 1b. Announce pre-cached blocks via /available and skip them in the
+	// fetch. The byte total seeds the fetcher's cache-size accounting so the
+	// cap applies to total on-disk bytes, not just bytes this run wrote.
+	if n, bytes := w.scanExistingCache(); n > 0 {
+		logger.Infof("found %d pre-cached blocks (%s) in %s", n, humanize.IBytes(uint64(bytes)), w.config.CacheDir)
+		w.fetcher.AddCacheUsed(bytes)
 	}
 
 	// 2. Initial peer discovery + filter self. MinPeers counts total peers
@@ -219,9 +230,12 @@ func (w *Warmup) Run(ctx context.Context, paths []string) error {
 	monitorCancel()
 
 	// 10. Print final stats.
-	fromPeers, fromStorage, fromCache, failed, bytesPeer, bytesStorage := w.fetcher.Stats()
-	logger.Infof("warmup complete: %d blocks (%d from peers, %d from storage, %d from cache, %d failed)",
-		total, fromPeers, fromStorage, fromCache, failed)
+	fromPeers, fromStorage, fromCache, skippedFull, failed, bytesPeer, bytesStorage := w.fetcher.Stats()
+	logger.Infof("warmup complete: %d blocks (%d from peers, %d from storage, %d from cache, %d skipped, %d failed)",
+		total, fromPeers, fromStorage, fromCache, skippedFull, failed)
+	if skippedFull > 0 {
+		logger.Warnf("%d blocks not cached: --cache-size cap reached; raise it or shrink the warmup path set to cover more", skippedFull)
+	}
 	logger.Infof("bytes transferred: %s from peers, %s from storage",
 		humanize.IBytes(uint64(bytesPeer)), humanize.IBytes(uint64(bytesStorage)))
 	elapsed := time.Since(startTime)
@@ -408,14 +422,17 @@ func maxCacheFileSize(logical int) int64 {
 }
 
 // scanExistingCache walks {cacheDir}/raw and announces well-formed block
-// files via the availability tracker, returning the count. Missing roots are
-// treated as empty. Files failing validCacheFileSize are skipped — primarily
-// truncated cache files left by a SIGKILL/OOM mid-write (CacheBlock's
-// os.WriteFile is not atomic), which would otherwise mislead peers into
-// fetching unusable bytes.
-func (w *Warmup) scanExistingCache() int {
+// files via the availability tracker, returning the count and total bytes of
+// accepted files. Missing roots are treated as empty. Files failing
+// validCacheFileSize are skipped — primarily truncated cache files left by a
+// SIGKILL/OOM mid-write (CacheBlock's os.WriteFile is not atomic), which
+// would otherwise mislead peers into fetching unusable bytes. The byte
+// total seeds Fetcher.cacheUsed so --cache-size accounts for files
+// pre-existing on disk, not just what this run writes.
+func (w *Warmup) scanExistingCache() (int, int64) {
 	root := filepath.Join(w.config.CacheDir, "raw")
 	count := 0
+	var bytes int64
 	skipped := 0
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -443,6 +460,7 @@ func (w *Warmup) scanExistingCache() int {
 
 		w.availability.MarkLocal(key)
 		count++
+		bytes += fi.Size()
 		return nil
 	})
 	if err != nil {
@@ -451,7 +469,7 @@ func (w *Warmup) scanExistingCache() int {
 	if skipped > 0 {
 		logger.Infof("scanExistingCache: skipped %d cache files with unexpected size", skipped)
 	}
-	return count
+	return count, bytes
 }
 
 // filterSelf removes our own address from peers via /uuid probe and records
@@ -607,7 +625,7 @@ func (w *Warmup) monitorProgress(ctx context.Context, blocks []*Block, queue *Fe
 			done, failed := countTerminalBlocks(blocks)
 			w.server.SetProgress(total, done)
 			pending := queue.Len()
-			_, _, _, _, bytesPeer, bytesStore := w.fetcher.Stats()
+			_, _, _, _, _, bytesPeer, bytesStore := w.fetcher.Stats()
 			elapsed := now.Sub(prevTime).Seconds()
 			var peerRate, storeRate uint64
 			if elapsed > 0 {

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -298,7 +298,9 @@ func (w *Warmup) resolveOrDownloadManifest(ctx context.Context, paths, peers []s
 	if w.resolver == nil {
 		return nil, fmt.Errorf("meta resolver not available (nil meta engine)")
 	}
-	mctx := meta.Background()
+	// Wrap the caller's ctx so SIGTERM/SIGINT cancels the meta scan instead
+	// of leaving it to run to completion on the deadlineless background ctx.
+	mctx := meta.WrapContext(ctx)
 	blocks, err := w.resolver.Resolve(mctx, paths)
 	if err != nil {
 		return nil, fmt.Errorf("resolve paths: %w", err)

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -346,6 +346,11 @@ func countTerminalBlocks(blocks []*Block) (done int, failed int) {
 // at which mount writes 4-byte CRC32C checksums when CacheChecksum is enabled.
 const cacheChecksumBlock = 32 << 10
 
+// cacheTierIDLength matches pkg/chunk/disk_cache.go tierIDLength — the
+// single-byte tier marker mount may append to cache files when multi-tier
+// storage is configured.
+const cacheTierIDLength = 1
+
 // parseLogicalSize extracts the logical block size from a key like
 // "chunks/0/0/100_0_4194304" (mirrors pkg/chunk/cached_store.go's
 // parseObjOrigSize). Returns 0 for malformed keys so callers can reject them.
@@ -361,18 +366,31 @@ func parseLogicalSize(key string) int {
 	return n
 }
 
-// validCacheFileSize accepts the two layouts pkg/chunk/disk_cache.go's
-// openCacheFile accepts: exactly logical, or logical + ceil(logical/csBlock)*4
-// (checksum trailer). Anything else is corrupt and must not be announced.
+// validCacheFileSize accepts the four layouts pkg/chunk/disk_cache.go's
+// openCacheFile accepts. Mount may append an optional checksum trailer and/or
+// a 1-byte tier marker, so the on-disk size minus the logical size must equal
+// one of:
+//
+//	① 0                            (no checksum, no tier)
+//	② cacheTierIDLength            (no checksum, tier)
+//	③ checksumLen                  (checksum, no tier)
+//	④ checksumLen + cacheTierIDLength (checksum, tier)
+//
+// Anything else is corrupt or partial and must not be announced.
+//
+// Keep this in lock-step with openCacheFile — every layout mount accepts on
+// read must also count as a cache hit here, otherwise p2p-warmup re-downloads
+// blocks the mount considers fine.
 func validCacheFileSize(onDisk int64, logical int) bool {
 	if logical <= 0 {
 		return false
 	}
-	if onDisk == int64(logical) {
+	delta := onDisk - int64(logical)
+	if delta == 0 || delta == cacheTierIDLength {
 		return true
 	}
 	checksumLen := int64((logical-1)/cacheChecksumBlock+1) * 4
-	return onDisk == int64(logical)+checksumLen
+	return delta == checksumLen || delta == checksumLen+cacheTierIDLength
 }
 
 // scanExistingCache walks {cacheDir}/raw and announces well-formed block

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -171,6 +171,15 @@ func (w *Warmup) Run(ctx context.Context, paths []string) error {
 		logger.Warnf("--keep-alive-timeout=%s is set but --keep-alive is not; the timeout will be ignored and the process will exit immediately after warmup. Pass --keep-alive to enable post-warmup serving.", w.config.KeepAliveTimeout)
 	}
 
+	// Publish the leader role + initial peer count to /status (peers is refreshed later by the availability poll).
+	manifestSharing := w.config.MinPeers > 1 && !w.config.DisableManifestSharing
+	role := "leader"
+	if manifestSharing && !isLeader(peers, w.effectiveAddr()) {
+		role = "follower"
+	}
+	w.server.SetRole(role)
+	w.server.SetPeers(len(peers))
+
 	// 3. Resolve metadata. With manifest sharing on, only the leader scans
 	// meta; followers download the leader's manifest from object storage —
 	// collapsing meta-engine load from O(N peers × M files) to O(M files).
@@ -231,6 +240,10 @@ func (w *Warmup) Run(ctx context.Context, paths []string) error {
 
 	// 10. Print final stats.
 	fromPeers, fromStorage, fromCache, skippedFull, failed, bytesPeer, bytesStorage := w.fetcher.Stats()
+	// Push the terminal snapshot: the progress monitor stops at monitorCancel
+	// above, so without this the keep-alive-phase /status would report the
+	// last 5s-tick numbers instead of the final totals.
+	w.server.SetStats(fromPeers, fromStorage, fromCache, skippedFull, failed, bytesPeer, bytesStorage)
 	logger.Infof("warmup complete: %d blocks (%d from peers, %d from storage, %d from cache, %d skipped, %d failed)",
 		total, fromPeers, fromStorage, fromCache, skippedFull, failed)
 	if skippedFull > 0 {
@@ -587,6 +600,9 @@ func (w *Warmup) pollAvailabilityOnce(ctx context.Context, lastSeen map[string]i
 		known[addr] = struct{}{}
 	}
 
+	// Refresh /status with the current live (self-excluded) peer count.
+	w.server.SetPeers(len(current))
+
 	for addr := range current {
 		sinceMs := lastSeen[addr]
 		updatedAt, err := w.fetcher.PollAvailability(ctx, addr, sinceMs)
@@ -625,7 +641,8 @@ func (w *Warmup) monitorProgress(ctx context.Context, blocks []*Block, queue *Fe
 			done, failed := countTerminalBlocks(blocks)
 			w.server.SetProgress(total, done)
 			pending := queue.Len()
-			_, _, _, _, _, bytesPeer, bytesStore := w.fetcher.Stats()
+			fromPeers, fromStorage, fromCache, skippedFull, failedFetch, bytesPeer, bytesStore := w.fetcher.Stats()
+			w.server.SetStats(fromPeers, fromStorage, fromCache, skippedFull, failedFetch, bytesPeer, bytesStore)
 			elapsed := now.Sub(prevTime).Seconds()
 			var peerRate, storeRate uint64
 			if elapsed > 0 {

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -601,7 +601,10 @@ func (w *Warmup) pollAvailabilityOnce(ctx context.Context, lastSeen map[string]i
 		}
 	}
 	for addr := range current {
-		known[addr] = struct{}{}
+		if _, ok := known[addr]; !ok {
+			logger.Infof("peer %s joined discovery", addr)
+			known[addr] = struct{}{}
+		}
 	}
 
 	// Refresh /status with the current live (self-excluded) peer count.

--- a/pkg/p2p/warmup.go
+++ b/pkg/p2p/warmup.go
@@ -1,0 +1,669 @@
+package p2p
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/google/uuid"
+	"github.com/juicedata/juicefs/pkg/compress"
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juju/ratelimit"
+)
+
+// Warmup orchestrates the P2P warmup: resolve paths to blocks, discover
+// peers, schedule and run fetches, serve blocks to other peers.
+type Warmup struct {
+	config       WarmupConfig
+	meta         meta.Meta
+	storage      object.ObjectStorage
+	uuid         string
+	discovery    *PeerDiscovery
+	availability *AvailabilityTracker
+	server       *Server
+	fetcher      *Fetcher
+	resolver     *MetaResolver
+	httpServer   *http.Server
+	listenAddr   string
+	externalAddr string // address other peers see us as; populated by filterSelf via UUID match
+}
+
+// NewWarmup creates a Warmup instance with all sub-components wired together.
+func NewWarmup(config WarmupConfig, m meta.Meta, storage object.ObjectStorage) *Warmup {
+	uid := uuid.New().String()
+
+	availability := NewAvailabilityTracker()
+
+	// Extract port from config.ListenAddr for DNS A discovery default.
+	defaultPort := 0
+	if _, portStr, err := net.SplitHostPort(config.ListenAddr); err == nil {
+		if p, err2 := net.LookupPort("tcp", portStr); err2 == nil {
+			defaultPort = p
+		}
+	}
+
+	discovery := NewPeerDiscovery(config.PeersDNSSRV, config.PeersDNSA, config.PeersList, defaultPort)
+
+	server := NewServer(uid, availability, config.CacheDir)
+
+	// 5s peer-fetch timeout: enough for a 4 MiB block on slow LANs, but
+	// ~6x faster failure detection than the 30s default — storage fallback
+	// is cheaper than waiting on a dead peer.
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	// NewCompressor returns nil for unknown algos. Abort loudly: silently
+	// using noOp would write compressed bytes to cache and mount would
+	// later reject every block.
+	compressor := compress.NewCompressor(config.Compress)
+	if compressor == nil {
+		logger.Fatalf("unsupported compression algorithm %q (expected lz4, zstd, or none)", config.Compress)
+	}
+	fetcher := NewFetcher(storage, config.CacheDir, config.BlockSize, httpClient, compressor)
+	fetcher.SetAvailability(availability)
+	if config.DownloadLimit > 0 {
+		// 0.85 dampening / 10% burst — same convention as pkg/chunk and
+		// pkg/sync, keeps observed rate close to the cap without large bursts.
+		fill := float64(config.DownloadLimit) * 0.85
+		burst := config.DownloadLimit / 10
+		if burst < 1 {
+			burst = 1
+		}
+		fetcher.SetDownloadLimit(ratelimit.NewBucketWithRate(fill, burst))
+	}
+
+	var resolver *MetaResolver
+	if m != nil {
+		resolver = NewMetaResolver(m, config.BlockSize, config.HashPrefix)
+	}
+
+	return &Warmup{
+		config:       config,
+		meta:         m,
+		storage:      storage,
+		uuid:         uid,
+		discovery:    discovery,
+		availability: availability,
+		server:       server,
+		fetcher:      fetcher,
+		resolver:     resolver,
+	}
+}
+
+// Run executes the full warmup flow and optionally enters keep-alive to keep
+// serving blocks to peers after the local fetch finishes.
+func (w *Warmup) Run(ctx context.Context, paths []string) error {
+	startTime := time.Now()
+
+	// 1. Start HTTP server.
+	ln, err := net.Listen("tcp", w.config.ListenAddr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", w.config.ListenAddr, err)
+	}
+	w.listenAddr = ln.Addr().String()
+	w.httpServer = &http.Server{Handler: w.server.Handler()}
+
+	go func() {
+		if err := w.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logger.WithError(err).Error("HTTP server error")
+		}
+	}()
+	logger.Infof("P2P server listening on %s (uuid=%s)", w.listenAddr, w.uuid)
+
+	// 1b. Announce pre-cached blocks via /available and skip them in the fetch.
+	if n := w.scanExistingCache(); n > 0 {
+		logger.Infof("found %d pre-cached blocks in %s", n, w.config.CacheDir)
+	}
+
+	// 2. Initial peer discovery + filter self. MinPeers counts total peers
+	// INCLUDING self, so we wait until len(peers) reaches MinPeers-1. More
+	// than the threshold proceeds immediately; late joiners use the
+	// manifest-reuse fast-path.
+	peers, err := w.discovery.Resolve(ctx)
+	if err != nil {
+		logger.WithError(err).Warn("initial peer discovery failed")
+	}
+	peers = w.filterSelf(ctx, peers)
+
+	if w.config.MinPeers > 1 && len(peers) < w.config.MinPeers-1 {
+		logger.Infof("waiting for at least %d total peers (currently %d others discovered)...", w.config.MinPeers, len(peers))
+		peers = w.waitForPeers(ctx, w.config.MinPeers-1)
+	}
+	logger.Infof("discovered %d peers (excluding self)", len(peers))
+
+	// DNS discovery without --min-peers >= 2 disables manifest sharing —
+	// each peer scans meta independently. Likely a misconfig.
+	if w.config.MinPeers <= 1 && (w.config.PeersDNSSRV != "" || w.config.PeersDNSA != "") {
+		logger.Warn("DNS peer discovery configured without --min-peers (>= 2); manifest sharing disabled. Each peer will independently scan metadata, increasing meta-engine load. Set --min-peers to enable coordinated warmup.")
+	}
+
+	// Multi-peer mode + self not found in peer list → effectiveAddr falls
+	// back to listenAddr. Wildcards ("[::]:port", "0.0.0.0:port") then make
+	// every peer's identity collide and election cannot agree.
+	if w.config.MinPeers > 1 && w.externalAddr == "" {
+		logger.Warnf("self external address not discovered; using listen address %q for election. If listen is a wildcard, leader election and partition assignment will not agree across peers — pass --listen <self-IP>:port or ensure self is reachable via the configured discovery source.", w.listenAddr)
+	}
+
+	// --keep-alive-timeout only applies inside the keep-alive phase; without
+	// --keep-alive, step 11 is skipped and the timer never starts.
+	if w.config.keepAliveTimeoutIgnored() {
+		logger.Warnf("--keep-alive-timeout=%s is set but --keep-alive is not; the timeout will be ignored and the process will exit immediately after warmup. Pass --keep-alive to enable post-warmup serving.", w.config.KeepAliveTimeout)
+	}
+
+	// 3. Resolve metadata. With manifest sharing on, only the leader scans
+	// meta; followers download the leader's manifest from object storage —
+	// collapsing meta-engine load from O(N peers × M files) to O(M files).
+	blocks, err := w.resolveOrDownloadManifest(ctx, paths, peers)
+	if err != nil {
+		w.shutdownHTTP()
+		return err
+	}
+	total := len(blocks)
+	if total == 0 {
+		logger.Info("no blocks to warm up")
+		w.shutdownHTTP()
+		return nil
+	}
+	w.server.SetProgress(total, 0)
+	fetchStart := time.Now()
+
+	// 4. Start background discovery loop.
+	var bgWg sync.WaitGroup
+	bgCtx, bgCancel := context.WithCancel(ctx)
+	defer bgCancel()
+
+	bgWg.Add(1)
+	go func() {
+		defer bgWg.Done()
+		w.discovery.RunLoop(bgCtx, w.config.DiscoveryInterval)
+	}()
+
+	// 5. Start availability polling loop.
+	bgWg.Add(1)
+	go w.runAvailabilityPolling(bgCtx, &bgWg)
+
+	// 6. Build the fetch queue. Each peer orders the full block set by
+	// hash(key, self): every peer holds every block (no orphaned ownership
+	// when a peer dies), but the queue fronts are statistically disjoint, so
+	// initial concurrent storage hits land on different blocks until
+	// availability polling propagates.
+	scheduler := NewScheduler(blocks)
+	queue := NewFetchQueue(total)
+	queue.PushAll(scheduler.OrderForPeer(w.effectiveAddr()))
+
+	// 7. Start fetch workers.
+	workersWg := w.fetcher.RunWorkers(ctx, queue, w.availability, w.config.Threads)
+
+	// 8. Progress monitor. Cancelled at completion so the keep-alive phase
+	// doesn't keep emitting "600/600 done, 0 B/s" lines.
+	monitorCtx, monitorCancel := context.WithCancel(bgCtx)
+	bgWg.Add(1)
+	go func() {
+		defer bgWg.Done()
+		w.monitorProgress(monitorCtx, blocks, queue)
+	}()
+
+	// 9. Wait for completion: poll until all blocks are done, then close the queue.
+	w.waitForCompletion(ctx, blocks, queue)
+	workersWg.Wait()
+	monitorCancel()
+
+	// 10. Print final stats.
+	fromPeers, fromStorage, fromCache, failed, bytesPeer, bytesStorage := w.fetcher.Stats()
+	logger.Infof("warmup complete: %d blocks (%d from peers, %d from storage, %d from cache, %d failed)",
+		total, fromPeers, fromStorage, fromCache, failed)
+	logger.Infof("bytes transferred: %s from peers, %s from storage",
+		humanize.IBytes(uint64(bytesPeer)), humanize.IBytes(uint64(bytesStorage)))
+	elapsed := time.Since(startTime)
+	fetchElapsed := time.Since(fetchStart)
+	var avgRate, fetchRate uint64
+	if secs := elapsed.Seconds(); secs > 0 {
+		avgRate = uint64(float64(bytesPeer+bytesStorage) / secs)
+	}
+	if secs := fetchElapsed.Seconds(); secs > 0 {
+		fetchRate = uint64(float64(bytesPeer+bytesStorage) / secs)
+	}
+	logger.Infof("elapsed: %s total, %s fetch; average throughput: %s/s total, %s/s fetch",
+		elapsed.Round(time.Millisecond), fetchElapsed.Round(time.Millisecond),
+		humanize.IBytes(avgRate), humanize.IBytes(fetchRate))
+
+	// 11. Keep-alive if configured.
+	if w.config.KeepAlive {
+		logger.Info("keep-alive mode: serving blocks to peers")
+		w.keepAlive(bgCtx)
+	}
+
+	// 12. Graceful shutdown.
+	bgCancel()
+	bgWg.Wait()
+	w.shutdownHTTP()
+	return nil
+}
+
+const (
+	defaultLeaderTimeout = 10 * time.Minute
+	manifestPollInterval = 5 * time.Second
+)
+
+// resolveOrDownloadManifest selects the block list source:
+//   - solo / sharing disabled → resolve via meta engine.
+//   - sharing on + valid manifest exists → reuse (covers scale-out where a
+//     new low-address peer would otherwise mis-elect and re-scan meta).
+//   - sharing on, leader → resolve + upload manifest.
+//   - sharing on, follower → poll until the leader's manifest appears.
+func (w *Warmup) resolveOrDownloadManifest(ctx context.Context, paths, peers []string) ([]*Block, error) {
+	// MinPeers counts total peers including self, so values <= 1 mean
+	// solo (no manifest sharing needed even if other addresses leak in).
+	manifestSharing := w.config.MinPeers > 1 && !w.config.DisableManifestSharing
+
+	// Manifest-reuse fast-path: skip meta scan and follower polling whenever
+	// a valid manifest is already published — both roles try this first.
+	if manifestSharing {
+		if m := w.tryFetchValidManifest(ctx, paths); m != nil {
+			logger.Infof("found existing manifest: %d blocks (%d bytes total); skipping resolve",
+				m.TotalBlocks, m.TotalBytes)
+			return ManifestToBlocks(m), nil
+		}
+	}
+
+	if manifestSharing && !isLeader(peers, w.effectiveAddr()) {
+		timeout := w.config.LeaderTimeout
+		if timeout <= 0 {
+			timeout = defaultLeaderTimeout
+		}
+		logger.Infof("follower role; waiting for leader's manifest (timeout=%v)", timeout)
+		manifest, err := w.downloadManifest(ctx, paths, timeout, manifestPollInterval)
+		if err != nil {
+			return nil, fmt.Errorf("download manifest: %w", err)
+		}
+		if err := manifest.Validate(paths, w.config.BlockSize, w.config.HashPrefix); err != nil {
+			return nil, fmt.Errorf("manifest content mismatch (another warmup may be using --manifest-name=%q): %w", w.config.ManifestName, err)
+		}
+		blocks := ManifestToBlocks(manifest)
+		logger.Infof("loaded manifest: %d blocks (%d bytes total)", manifest.TotalBlocks, manifest.TotalBytes)
+		return blocks, nil
+	}
+
+	// Leader or solo: resolve via meta engine.
+	if w.resolver == nil {
+		return nil, fmt.Errorf("meta resolver not available (nil meta engine)")
+	}
+	mctx := meta.Background()
+	blocks, err := w.resolver.Resolve(mctx, paths)
+	if err != nil {
+		return nil, fmt.Errorf("resolve paths: %w", err)
+	}
+	logger.Infof("resolved %d blocks from %d paths", len(blocks), len(paths))
+
+	if manifestSharing {
+		logger.Info("leader role; uploading manifest for followers")
+		if upErr := w.uploadManifest(ctx, paths, blocks); upErr != nil {
+			// Don't abort the leader's own warmup; followers will time out.
+			logger.WithError(upErr).Warn("upload manifest failed; followers may time out")
+		}
+	}
+	return blocks, nil
+}
+
+// isLeader reports whether selfAddr wins the leader election (lexicographically
+// smallest address among peers ∪ self). peers must exclude selfAddr. The rule
+// is deterministic, so all peers with the same view agree without coordination.
+func isLeader(peers []string, selfAddr string) bool {
+	for _, p := range peers {
+		if p < selfAddr {
+			return false
+		}
+	}
+	return true
+}
+
+// countTerminalBlocks returns Done + Failed counts. Both are terminal, so
+// the completion check uses their sum — a Failed block won't become Done and
+// blocking on it would hang the warmup.
+func countTerminalBlocks(blocks []*Block) (done int, failed int) {
+	for _, b := range blocks {
+		switch b.State() {
+		case BlockDone:
+			done++
+		case BlockFailed:
+			failed++
+		}
+	}
+	return
+}
+
+// cacheChecksumBlock matches pkg/chunk/disk_cache.go csBlock — the granularity
+// at which mount writes 4-byte CRC32C checksums when CacheChecksum is enabled.
+const cacheChecksumBlock = 32 << 10
+
+// parseLogicalSize extracts the logical block size from a key like
+// "chunks/0/0/100_0_4194304" (mirrors pkg/chunk/cached_store.go's
+// parseObjOrigSize). Returns 0 for malformed keys so callers can reject them.
+func parseLogicalSize(key string) int {
+	p := strings.LastIndexByte(key, '_')
+	if p < 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(key[p+1:])
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// validCacheFileSize accepts the two layouts pkg/chunk/disk_cache.go's
+// openCacheFile accepts: exactly logical, or logical + ceil(logical/csBlock)*4
+// (checksum trailer). Anything else is corrupt and must not be announced.
+func validCacheFileSize(onDisk int64, logical int) bool {
+	if logical <= 0 {
+		return false
+	}
+	if onDisk == int64(logical) {
+		return true
+	}
+	checksumLen := int64((logical-1)/cacheChecksumBlock+1) * 4
+	return onDisk == int64(logical)+checksumLen
+}
+
+// scanExistingCache walks {cacheDir}/raw and announces well-formed block
+// files via the availability tracker, returning the count. Missing roots are
+// treated as empty. Files failing validCacheFileSize are skipped — primarily
+// truncated cache files left by a SIGKILL/OOM mid-write (CacheBlock's
+// os.WriteFile is not atomic), which would otherwise mislead peers into
+// fetching unusable bytes.
+func (w *Warmup) scanExistingCache() int {
+	root := filepath.Join(w.config.CacheDir, "raw")
+	count := 0
+	skipped := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		key := filepath.ToSlash(rel)
+
+		fi, statErr := d.Info()
+		if statErr != nil {
+			return nil
+		}
+		logical := parseLogicalSize(key)
+		if !validCacheFileSize(fi.Size(), logical) {
+			skipped++
+			logger.Debugf("scanExistingCache: skipping %q (size %d, logical %d)", key, fi.Size(), logical)
+			return nil
+		}
+
+		w.availability.MarkLocal(key)
+		count++
+		return nil
+	})
+	if err != nil {
+		logger.Debugf("scanExistingCache: %v", err)
+	}
+	if skipped > 0 {
+		logger.Infof("scanExistingCache: skipped %d cache files with unexpected size", skipped)
+	}
+	return count
+}
+
+// filterSelf removes our own address from peers via /uuid probe and records
+// the matching address as externalAddr — the identity peers see — used by
+// leader election and partition assignment.
+func (w *Warmup) filterSelf(ctx context.Context, peers []string) []string {
+	var filtered []string
+	for _, addr := range peers {
+		peerUUID, err := w.fetchUUID(ctx, addr)
+		if err != nil {
+			logger.WithError(err).Debugf("skipping unreachable peer %s", addr)
+			continue
+		}
+		if peerUUID == w.uuid {
+			if w.externalAddr == "" {
+				w.externalAddr = addr
+				logger.Infof("self external address: %s", addr)
+			}
+			continue
+		}
+		filtered = append(filtered, addr)
+	}
+	return filtered
+}
+
+// effectiveAddr is the identity used for leader election and partition
+// assignment. Prefers externalAddr; falls back to listenAddr when filterSelf
+// failed to find self (Run warns when this fallback is taken in multi-peer
+// mode, since wildcard listen addresses break election agreement).
+func (w *Warmup) effectiveAddr() string {
+	if w.externalAddr != "" {
+		return w.externalAddr
+	}
+	return w.listenAddr
+}
+
+// fetchUUID issues GET http://{addr}/uuid and returns the peer's UUID.
+func (w *Warmup) fetchUUID(ctx context.Context, addr string) (string, error) {
+	url := fmt.Sprintf("http://%s/uuid", addr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+
+	var body struct {
+		UUID string `json:"uuid"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode uuid from %s: %w", url, err)
+	}
+	return body.UUID, nil
+}
+
+// maxConsecutivePollFailures is the threshold for dropping a peer from the
+// tracker. Beyond this, FindPeerWith would keep returning a dead address and
+// every routed fetch would burn the 5s peer timeout before storage fallback.
+const maxConsecutivePollFailures = 3
+
+// runAvailabilityPolling polls each peer for block availability and removes
+// peers that disappear from discovery or fail too many consecutive polls,
+// preventing FindPeerWith from routing fetches to dead peers.
+func (w *Warmup) runAvailabilityPolling(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	lastSeen := make(map[string]int64)
+	failures := make(map[string]int)
+	known := make(map[string]struct{})
+
+	ticker := time.NewTicker(w.config.AvailabilityInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.pollAvailabilityOnce(ctx, lastSeen, failures, known)
+		}
+	}
+}
+
+// pollAvailabilityOnce runs a single sweep. Extracted so tests can exercise
+// the failure-threshold and discovery-diff branches without driving a ticker.
+func (w *Warmup) pollAvailabilityOnce(ctx context.Context, lastSeen map[string]int64, failures map[string]int, known map[string]struct{}) {
+	self := w.effectiveAddr()
+	current := make(map[string]struct{})
+	for _, addr := range w.discovery.Peers() {
+		if addr == self {
+			continue
+		}
+		current[addr] = struct{}{}
+	}
+
+	// Discovery dropped these peers (DNS removal, scaled-down replicas, ...).
+	for addr := range known {
+		if _, ok := current[addr]; !ok {
+			logger.Infof("peer %s left discovery; clearing availability", addr)
+			w.availability.RemovePeer(addr)
+			delete(lastSeen, addr)
+			delete(failures, addr)
+			delete(known, addr)
+		}
+	}
+	for addr := range current {
+		known[addr] = struct{}{}
+	}
+
+	for addr := range current {
+		sinceMs := lastSeen[addr]
+		updatedAt, err := w.fetcher.PollAvailability(ctx, addr, sinceMs)
+		if err != nil {
+			failures[addr]++
+			logger.WithError(err).Debugf("availability poll failed for %s (%d/%d)", addr, failures[addr], maxConsecutivePollFailures)
+			if failures[addr] >= maxConsecutivePollFailures {
+				logger.Warnf("peer %s failed %d consecutive polls; clearing availability", addr, failures[addr])
+				w.availability.RemovePeer(addr)
+				delete(lastSeen, addr)
+				delete(failures, addr)
+			}
+			continue
+		}
+		failures[addr] = 0
+		if updatedAt > sinceMs {
+			lastSeen[addr] = updatedAt
+		}
+	}
+}
+
+// monitorProgress logs progress every 5 seconds until ctx is cancelled.
+func (w *Warmup) monitorProgress(ctx context.Context, blocks []*Block, queue *FetchQueue) {
+	const interval = 5 * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	total := len(blocks)
+	var prevPeer, prevStore int64
+	prevTime := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			done, failed := countTerminalBlocks(blocks)
+			w.server.SetProgress(total, done)
+			pending := queue.Len()
+			_, _, _, _, bytesPeer, bytesStore := w.fetcher.Stats()
+			elapsed := now.Sub(prevTime).Seconds()
+			var peerRate, storeRate uint64
+			if elapsed > 0 {
+				peerRate = uint64(float64(bytesPeer-prevPeer) / elapsed)
+				storeRate = uint64(float64(bytesStore-prevStore) / elapsed)
+			}
+			prevPeer, prevStore, prevTime = bytesPeer, bytesStore, now
+			logger.Infof("progress: %d/%d blocks done, %d failed, %d pending; transferred %s peers (%s/s), %s storage (%s/s)",
+				done, total, failed, pending,
+				humanize.IBytes(uint64(bytesPeer)), humanize.IBytes(peerRate),
+				humanize.IBytes(uint64(bytesStore)), humanize.IBytes(storeRate))
+		}
+	}
+}
+
+// waitForCompletion polls until every block is terminal (Done or Failed),
+// then closes the queue. Failed counts toward completion so an unfetchable
+// block (e.g. deleted by slice compaction mid-warmup) cannot hang the run.
+func (w *Warmup) waitForCompletion(ctx context.Context, blocks []*Block, queue *FetchQueue) {
+	total := len(blocks)
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			queue.Close()
+			return
+		case <-ticker.C:
+			done, failed := countTerminalBlocks(blocks)
+			w.server.SetProgress(total, done)
+			if done+failed >= total {
+				queue.Close()
+				return
+			}
+		}
+	}
+}
+
+// keepAlive blocks until KeepAliveTimeout elapses, or — if no timeout is set —
+// until SIGTERM/SIGINT or ctx cancellation.
+func (w *Warmup) keepAlive(ctx context.Context) {
+	if w.config.KeepAliveTimeout > 0 {
+		timer := time.NewTimer(w.config.KeepAliveTimeout)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			logger.Info("keep-alive timeout reached")
+			return
+		}
+	}
+
+	sigCtx, sigStop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer sigStop()
+	<-sigCtx.Done()
+	logger.Info("received signal, shutting down")
+}
+
+// waitForPeers polls discovery until the expected number of peers is reached or ctx is cancelled.
+func (w *Warmup) waitForPeers(ctx context.Context, expected int) []string {
+	ticker := time.NewTicker(w.config.DiscoveryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return w.filterSelf(ctx, w.discovery.Peers())
+		case <-ticker.C:
+			resolved, _ := w.discovery.Resolve(ctx)
+			peers := w.filterSelf(ctx, resolved)
+			logger.Infof("peer discovery: %d/%d peers found", len(peers), expected)
+			if len(peers) >= expected {
+				return peers
+			}
+		}
+	}
+}
+
+// shutdownHTTP gracefully shuts down the HTTP server with a 10-second timeout.
+func (w *Warmup) shutdownHTTP() {
+	if w.httpServer == nil {
+		return
+	}
+	shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := w.httpServer.Shutdown(shutCtx); err != nil {
+		logger.WithError(err).Warn("HTTP server shutdown error")
+	}
+}

--- a/pkg/p2p/warmup_test.go
+++ b/pkg/p2p/warmup_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestWarmup_NewAndClose(t *testing.T) {
@@ -519,6 +522,44 @@ func TestPolling_SkipsSelf(t *testing.T) {
 
 	if _, ok := known[w.externalAddr]; ok {
 		t.Errorf("self-address %q ended up in known set", w.externalAddr)
+	}
+}
+
+func TestPolling_LogsPeerJoinOnce(t *testing.T) {
+	// A newly discovered peer should be logged once (symmetric to the
+	// "left discovery" log), and not re-logged on every subsequent sweep.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/available" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"blocks":[],"updated_at":0}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	addr := srv.Listener.Addr().String()
+
+	var buf bytes.Buffer
+	origOut, origLevel := logger.Logger.Out, logger.Logger.Level
+	logger.Logger.SetOutput(&buf)
+	logger.Logger.SetLevel(logrus.InfoLevel)
+	defer func() {
+		logger.Logger.SetOutput(origOut)
+		logger.Logger.SetLevel(origLevel)
+	}()
+
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, []string{addr})
+
+	lastSeen := make(map[string]int64)
+	failures := make(map[string]int)
+	known := make(map[string]struct{})
+
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+
+	if got := strings.Count(buf.String(), "joined discovery"); got != 1 {
+		t.Errorf("join logged %d times, want exactly 1\n%s", got, buf.String())
 	}
 }
 

--- a/pkg/p2p/warmup_test.go
+++ b/pkg/p2p/warmup_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -483,6 +484,32 @@ func TestPolling_SkipsSelf(t *testing.T) {
 
 	if _, ok := known[w.externalAddr]; ok {
 		t.Errorf("self-address %q ended up in known set", w.externalAddr)
+	}
+}
+
+func TestPolling_PushesLivePeerCountToStatus(t *testing.T) {
+	// Each sweep refreshes /status with the self-excluded peer count. Bogus
+	// addresses are fine: the count comes from the discovery set before any
+	// poll, so connection failures don't affect it.
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, []string{w.externalAddr, "10.0.0.1:1", "10.0.0.2:2"})
+
+	lastSeen := make(map[string]int64)
+	failures := make(map[string]int)
+	known := make(map[string]struct{})
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	w.server.Handler().ServeHTTP(rr, req)
+	var body struct {
+		Peers int64 `json:"peers"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /status: %v", err)
+	}
+	if body.Peers != 2 {
+		t.Errorf("/status peers = %d, want 2 (3 discovered minus self)", body.Peers)
 	}
 }
 

--- a/pkg/p2p/warmup_test.go
+++ b/pkg/p2p/warmup_test.go
@@ -1,0 +1,466 @@
+package p2p
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWarmup_NewAndClose(t *testing.T) {
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              4,
+		CacheDir:             t.TempDir(),
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+	if w == nil {
+		t.Fatal("NewWarmup returned nil")
+	}
+	if w.uuid == "" {
+		t.Fatal("UUID should be set")
+	}
+	if w.availability == nil {
+		t.Fatal("availability tracker should be set")
+	}
+	if w.discovery == nil {
+		t.Fatal("discovery should be set")
+	}
+	if w.server == nil {
+		t.Fatal("server should be set")
+	}
+	if w.fetcher == nil {
+		t.Fatal("fetcher should be set")
+	}
+	// resolver should be nil when meta is nil
+	if w.resolver != nil {
+		t.Fatal("resolver should be nil when meta is nil")
+	}
+}
+
+func TestWarmup_UUIDUniqueness(t *testing.T) {
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             t.TempDir(),
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w1 := NewWarmup(config, nil, nil)
+	w2 := NewWarmup(config, nil, nil)
+	if w1.uuid == w2.uuid {
+		t.Fatalf("two Warmup instances should have different UUIDs, both got %s", w1.uuid)
+	}
+}
+
+func TestWarmup_ScanExistingCache_PopulatesTracker(t *testing.T) {
+	cacheDir := t.TempDir()
+	// Each file's bytes count must equal the logical size encoded in the
+	// last "_<n>" suffix; otherwise scanExistingCache treats the file as
+	// corrupt or partial and skips it (matching mount's openCacheFile
+	// validation contract).
+	writeRawBlock(t, cacheDir, "chunks/0/0/1_0_100", make([]byte, 100))
+	writeRawBlock(t, cacheDir, "chunks/0/0/1_1_100", make([]byte, 100))
+	writeRawBlock(t, cacheDir, "chunks/5/7/9999_0_2048", make([]byte, 2048))
+
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             cacheDir,
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+
+	n := w.scanExistingCache()
+	if n != 3 {
+		t.Errorf("scanExistingCache returned %d, want 3", n)
+	}
+	if got := w.availability.LocalDoneCount(); got != 3 {
+		t.Errorf("tracker LocalDoneCount = %d, want 3", got)
+	}
+
+	keys, _ := w.availability.LocalBlocksSince(0)
+	sort.Strings(keys)
+	want := []string{
+		"chunks/0/0/1_0_100",
+		"chunks/0/0/1_1_100",
+		"chunks/5/7/9999_0_2048",
+	}
+	sort.Strings(want)
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("tracker keys = %v, want %v", keys, want)
+	}
+}
+
+func TestWarmup_ScanExistingCache_RejectsWrongSizedFiles(t *testing.T) {
+	// Mix of valid and invalid cache files. Invalid ones (size != logical
+	// from key, and not logical+checksumTrailer) must NOT be announced
+	// — they would mislead other peers into fetching unusable bytes.
+	cacheDir := t.TempDir()
+
+	// Valid: bytes count matches logical size suffix.
+	writeRawBlock(t, cacheDir, "chunks/0/0/1_0_100", make([]byte, 100))
+	// Valid: with checksum trailer (logical=100, csBlock=32k → trailer = 4 bytes).
+	writeRawBlock(t, cacheDir, "chunks/0/0/1_1_100", make([]byte, 100+4))
+	// Invalid: file size disagrees with the logical size encoded in the key
+	// (e.g. produced by an external tool, or an unforeseen write bug).
+	writeRawBlock(t, cacheDir, "chunks/0/0/2_0_4194304", make([]byte, 1024))
+	// Invalid: partial write (e.g. killed mid-flight).
+	writeRawBlock(t, cacheDir, "chunks/0/0/3_0_2048", make([]byte, 1500))
+	// Invalid: missing logical-size suffix entirely.
+	writeRawBlock(t, cacheDir, "chunks/0/0/garbage_no_size_suffix", make([]byte, 50))
+
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             cacheDir,
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+
+	n := w.scanExistingCache()
+	if n != 2 {
+		t.Errorf("scanExistingCache returned %d, want 2 (only the two well-formed files)", n)
+	}
+
+	keys, _ := w.availability.LocalBlocksSince(0)
+	sort.Strings(keys)
+	want := []string{"chunks/0/0/1_0_100", "chunks/0/0/1_1_100"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("tracker keys = %v, want %v (corrupt/partial files must be skipped)", keys, want)
+	}
+}
+
+func TestParseLogicalSize(t *testing.T) {
+	cases := []struct {
+		key  string
+		want int
+	}{
+		{"chunks/0/0/100_0_4194304", 4194304},
+		{"chunks/5/7/9999_3_512", 512},
+		{"chunks/0/0/1_0_100", 100},
+		{"missing_suffix", 0},                    // last "_" yields non-numeric "suffix"
+		{"chunks/0/0/garbage_no_size_suffix", 0}, // trailing "suffix" is non-numeric
+		{"no-underscores", 0},
+		{"", 0},
+	}
+	for _, c := range cases {
+		if got := parseLogicalSize(c.key); got != c.want {
+			t.Errorf("parseLogicalSize(%q) = %d, want %d", c.key, got, c.want)
+		}
+	}
+}
+
+func TestValidCacheFileSize(t *testing.T) {
+	// Verify both layouts mount accepts: exact logical size, and
+	// logical + per-csBlock CRC32 trailer (4 bytes per 32 KiB block).
+	cases := []struct {
+		name    string
+		onDisk  int64
+		logical int
+		ok      bool
+	}{
+		{"exact match", 100, 100, true},
+		{"with checksum trailer (1 csBlock)", 100 + 4, 100, true},
+		{"larger logical with checksum (2 csBlocks)", 40*1024 + 8, 40 * 1024, true},
+		{"compressed-too-small", 50, 100, false},
+		{"random extra bytes", 102, 100, false},
+		{"zero logical (parse failure upstream)", 0, 0, false},
+		{"negative logical (defensive)", 100, -1, false},
+	}
+	for _, c := range cases {
+		if got := validCacheFileSize(c.onDisk, c.logical); got != c.ok {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.ok)
+		}
+	}
+}
+
+func TestWarmup_ScanExistingCache_MissingDir(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "does-not-exist")
+
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             cacheDir,
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+
+	n := w.scanExistingCache()
+	if n != 0 {
+		t.Errorf("scanExistingCache on missing dir: got %d, want 0", n)
+	}
+	if got := w.availability.LocalDoneCount(); got != 0 {
+		t.Errorf("tracker should be empty on missing dir, got %d entries", got)
+	}
+}
+
+func TestIsLeader_SoloPeer(t *testing.T) {
+	if !isLeader(nil, "10.0.0.1:19090") {
+		t.Error("solo peer should be leader")
+	}
+	if !isLeader([]string{}, "10.0.0.1:19090") {
+		t.Error("empty peer list: self should be leader")
+	}
+}
+
+func TestIsLeader_LowestAddressWins(t *testing.T) {
+	peers := []string{"10.0.0.2:19090", "10.0.0.3:19090"}
+	if !isLeader(peers, "10.0.0.1:19090") {
+		t.Error("self with lowest address should be leader")
+	}
+}
+
+func TestIsLeader_NotLowest(t *testing.T) {
+	peers := []string{"10.0.0.1:19090", "10.0.0.3:19090"}
+	if isLeader(peers, "10.0.0.2:19090") {
+		t.Error("self with non-lowest address should NOT be leader")
+	}
+}
+
+func TestIsLeader_OrderIndependent(t *testing.T) {
+	a := isLeader([]string{"a", "b", "c"}, "z")
+	b := isLeader([]string{"c", "a", "b"}, "z")
+	if a != b {
+		t.Error("isLeader result must not depend on input order")
+	}
+}
+
+func TestCountTerminalBlocks(t *testing.T) {
+	blocks := []*Block{
+		{Key: "a"}, // pending
+		{Key: "b"},
+		{Key: "c"}, // pending
+		{Key: "d"},
+		{Key: "e"}, // failed
+	}
+	blocks[1].MarkDone()
+	blocks[3].MarkDone()
+	blocks[4].MarkFailed()
+
+	done, failed := countTerminalBlocks(blocks)
+	if done != 2 {
+		t.Errorf("done = %d, want 2", done)
+	}
+	if failed != 1 {
+		t.Errorf("failed = %d, want 1", failed)
+	}
+}
+
+func TestKeepAliveTimeoutIgnored(t *testing.T) {
+	cases := []struct {
+		name string
+		ka   bool
+		kat  time.Duration
+		want bool
+	}{
+		{"both set", true, time.Hour, false},
+		{"timeout only — ignored", false, time.Hour, true},
+		{"keep-alive only — manual", true, 0, false},
+		{"neither", false, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := WarmupConfig{KeepAlive: tc.ka, KeepAliveTimeout: tc.kat}
+			if got := c.keepAliveTimeoutIgnored(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveAddr_PrefersExternal(t *testing.T) {
+	w := &Warmup{listenAddr: "[::]:19090", externalAddr: "10.0.0.5:19090"}
+	if got := w.effectiveAddr(); got != "10.0.0.5:19090" {
+		t.Errorf("effectiveAddr = %q, want externalAddr", got)
+	}
+}
+
+func TestEffectiveAddr_FallsBackToListen(t *testing.T) {
+	w := &Warmup{listenAddr: "[::]:19090"}
+	if got := w.effectiveAddr(); got != "[::]:19090" {
+		t.Errorf("effectiveAddr = %q, want listenAddr fallback", got)
+	}
+}
+
+// TestFilterSelf_DiscoversExternalAddr verifies the wildcard-listen bug fix:
+// when listenAddr is something like "[::]:port" but discovery returns concrete
+// IPs, filterSelf must record the matching peer's address as externalAddr so
+// that leader election sees a consistent identity across all peers.
+func TestFilterSelf_DiscoversExternalAddr(t *testing.T) {
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              1,
+		CacheDir:             t.TempDir(),
+		BlockSize:            4 * 1024 * 1024,
+	}
+	self := NewWarmup(config, nil, nil)
+	other := NewWarmup(config, nil, nil)
+
+	selfSrv := httptest.NewServer(self.server.Handler())
+	defer selfSrv.Close()
+	otherSrv := httptest.NewServer(other.server.Handler())
+	defer otherSrv.Close()
+
+	// Simulate the wildcard-listen scenario: listenAddr is unrelated to the
+	// addresses peers see.
+	self.listenAddr = "[::]:19090"
+
+	selfExternal := strings.TrimPrefix(selfSrv.URL, "http://")
+	otherExternal := strings.TrimPrefix(otherSrv.URL, "http://")
+
+	filtered := self.filterSelf(context.Background(), []string{selfExternal, otherExternal})
+
+	if len(filtered) != 1 || filtered[0] != otherExternal {
+		t.Errorf("filtered = %v, want [%s]", filtered, otherExternal)
+	}
+	if self.externalAddr != selfExternal {
+		t.Errorf("externalAddr = %q, want %q", self.externalAddr, selfExternal)
+	}
+	if got := self.effectiveAddr(); got != selfExternal {
+		t.Errorf("effectiveAddr = %q, want %q (not the wildcard listenAddr)", got, selfExternal)
+	}
+}
+
+// pollTestWarmup builds a Warmup wired with a controllable discovery cache
+// and an externalAddr sentinel that won't match the test peers. Tests can
+// then drive pollAvailabilityOnce directly without spinning up the
+// background ticker goroutine.
+func pollTestWarmup(t *testing.T) *Warmup {
+	t.Helper()
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              1,
+		CacheDir:             t.TempDir(),
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+	w.externalAddr = "self-sentinel:0"
+	return w
+}
+
+func setDiscoveryPeers(w *Warmup, peers []string) {
+	w.discovery.mu.Lock()
+	w.discovery.peers = peers
+	w.discovery.mu.Unlock()
+}
+
+func TestPolling_RemovesPeerOnConsecutiveFailures(t *testing.T) {
+	// Boot a server, capture its address, then close it. Connections to
+	// that address now refuse fast — perfect for exercising the failure
+	// threshold without slow timeouts.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	deadAddr := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, []string{deadAddr})
+	w.availability.UpdateRemote(deadAddr, []string{"chunks/x"})
+	if !w.availability.PeerHas(deadAddr, "chunks/x") {
+		t.Fatal("setup: tracker should hold dead peer")
+	}
+
+	lastSeen := make(map[string]int64)
+	failures := make(map[string]int)
+	known := make(map[string]struct{})
+
+	for i := 1; i < maxConsecutivePollFailures; i++ {
+		w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+		if !w.availability.PeerHas(deadAddr, "chunks/x") {
+			t.Fatalf("after %d failures, tracker entry cleared early (threshold %d)", i, maxConsecutivePollFailures)
+		}
+	}
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+	if w.availability.PeerHas(deadAddr, "chunks/x") {
+		t.Errorf("after %d consecutive failures, tracker still holds dead peer", maxConsecutivePollFailures)
+	}
+}
+
+func TestPolling_RemovesPeerOnDiscoveryDrop(t *testing.T) {
+	// Live server replying to /available; we simulate the peer leaving
+	// discovery (DNS removal, scaled-down replica) by clearing the peer
+	// list between sweeps. The tracker entry must be cleared as soon as
+	// the peer disappears, before any failure threshold accrues.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/available" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"blocks":[],"updated_at":0}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, []string{addr})
+	w.availability.UpdateRemote(addr, []string{"chunks/x"})
+
+	lastSeen := make(map[string]int64)
+	failures := make(map[string]int)
+	known := make(map[string]struct{})
+
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+	if !w.availability.PeerHas(addr, "chunks/x") {
+		t.Fatal("first sweep cleared a healthy peer")
+	}
+
+	setDiscoveryPeers(w, nil)
+
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+	if w.availability.PeerHas(addr, "chunks/x") {
+		t.Errorf("after discovery drop, tracker still holds %s", addr)
+	}
+}
+
+func TestPolling_SkipsSelf(t *testing.T) {
+	// pollAvailabilityOnce must not poll itself; doing so wastes a
+	// roundtrip and could lead to recursive announcements.
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, []string{w.externalAddr})
+
+	lastSeen := make(map[string]int64)
+	failures := make(map[string]int)
+	known := make(map[string]struct{})
+	w.pollAvailabilityOnce(context.Background(), lastSeen, failures, known)
+
+	if _, ok := known[w.externalAddr]; ok {
+		t.Errorf("self-address %q ended up in known set", w.externalAddr)
+	}
+}
+
+func TestWarmup_PortExtraction(t *testing.T) {
+	config := WarmupConfig{
+		ListenAddr:           ":8080",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             t.TempDir(),
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+	if w == nil {
+		t.Fatal("NewWarmup returned nil")
+	}
+	// The discovery should have been created (we can't directly check defaultPort
+	// but we verify construction didn't panic).
+}

--- a/pkg/p2p/warmup_test.go
+++ b/pkg/p2p/warmup_test.go
@@ -301,21 +301,56 @@ func TestCountTerminalBlocks(t *testing.T) {
 	}
 }
 
+func TestParseKeepAliveMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    KeepAliveMode
+		wantErr bool
+	}{
+		{"off", KeepAliveOff, false},
+		{"peers", KeepAlivePeers, false},
+		{"forever", KeepAliveForever, false},
+		{"PEERS", KeepAlivePeers, false}, // case-insensitive
+		{" peers ", KeepAlivePeers, false}, // trimmed
+		{"", KeepAlivePeers, false},       // default is peers
+		{"true", "", true},                // old bool value rejected
+		{"yes", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseKeepAliveMode(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseKeepAliveMode(%q): want error, got %q", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseKeepAliveMode(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseKeepAliveMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestKeepAliveTimeoutIgnored(t *testing.T) {
 	cases := []struct {
 		name string
-		ka   bool
+		mode KeepAliveMode
 		kat  time.Duration
 		want bool
 	}{
-		{"both set", true, time.Hour, false},
-		{"timeout only — ignored", false, time.Hour, true},
-		{"keep-alive only — manual", true, 0, false},
-		{"neither", false, 0, false},
+		{"peers + timeout", KeepAlivePeers, time.Hour, false},
+		{"forever + timeout", KeepAliveForever, time.Hour, false},
+		{"off + timeout — ignored", KeepAliveOff, time.Hour, true},
+		{"peers no timeout", KeepAlivePeers, 0, false},
+		{"off no timeout", KeepAliveOff, 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := WarmupConfig{KeepAlive: tc.ka, KeepAliveTimeout: tc.kat}
+			c := WarmupConfig{KeepAlive: tc.mode, KeepAliveTimeout: tc.kat}
 			if got := c.keepAliveTimeoutIgnored(); got != tc.want {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
@@ -510,6 +545,88 @@ func TestPolling_PushesLivePeerCountToStatus(t *testing.T) {
 	}
 	if body.Peers != 2 {
 		t.Errorf("/status peers = %d, want 2 (3 discovered minus self)", body.Peers)
+	}
+}
+
+// statusPeer starts a peer that reports the given completed flag on /status.
+func statusPeer(t *testing.T, completed bool) (addr string, close func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/status" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"completed":` + boolStr(completed) + `}`))
+	}))
+	return srv.Listener.Addr().String(), srv.Close
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func TestPeersAllComplete_AllDone(t *testing.T) {
+	w := pollTestWarmup(t)
+	a, ca := statusPeer(t, true)
+	defer ca()
+	b, cb := statusPeer(t, true)
+	defer cb()
+	setDiscoveryPeers(w, []string{a, b})
+
+	if !w.peersAllComplete(context.Background()) {
+		t.Error("peersAllComplete = false, want true when every live peer is done")
+	}
+}
+
+func TestPeersAllComplete_OnePending(t *testing.T) {
+	w := pollTestWarmup(t)
+	a, ca := statusPeer(t, true)
+	defer ca()
+	b, cb := statusPeer(t, false) // still warming
+	defer cb()
+	setDiscoveryPeers(w, []string{a, b})
+
+	if w.peersAllComplete(context.Background()) {
+		t.Error("peersAllComplete = true, want false while a live peer is still warming")
+	}
+}
+
+func TestPeersAllComplete_UnreachableTreatedDone(t *testing.T) {
+	// A peer that left discovery's reach (crashed / scaled down) must not block
+	// exit forever — an unreachable peer counts as done.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	deadAddr := srv.Listener.Addr().String()
+	srv.Close()
+
+	w := pollTestWarmup(t)
+	alive, c := statusPeer(t, true)
+	defer c()
+	setDiscoveryPeers(w, []string{alive, deadAddr})
+
+	if !w.peersAllComplete(context.Background()) {
+		t.Error("peersAllComplete = false, want true (unreachable peer treated as done)")
+	}
+}
+
+func TestPeersAllComplete_NoPeers(t *testing.T) {
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, nil)
+	if !w.peersAllComplete(context.Background()) {
+		t.Error("peersAllComplete = false, want true when no live peers remain")
+	}
+}
+
+func TestPeersAllComplete_SkipsSelf(t *testing.T) {
+	// Self must be excluded — a self-poll that fails (or reports our own
+	// not-yet-done status) must not block exit.
+	w := pollTestWarmup(t)
+	setDiscoveryPeers(w, []string{w.externalAddr})
+	if !w.peersAllComplete(context.Background()) {
+		t.Error("peersAllComplete = false, want true when only self is in discovery")
 	}
 }
 

--- a/pkg/p2p/warmup_test.go
+++ b/pkg/p2p/warmup_test.go
@@ -82,7 +82,7 @@ func TestWarmup_ScanExistingCache_PopulatesTracker(t *testing.T) {
 	}
 	w := NewWarmup(config, nil, nil)
 
-	n := w.scanExistingCache()
+	n, _ := w.scanExistingCache()
 	if n != 3 {
 		t.Errorf("scanExistingCache returned %d, want 3", n)
 	}
@@ -131,7 +131,7 @@ func TestWarmup_ScanExistingCache_RejectsWrongSizedFiles(t *testing.T) {
 	}
 	w := NewWarmup(config, nil, nil)
 
-	n := w.scanExistingCache()
+	n, _ := w.scanExistingCache()
 	if n != 2 {
 		t.Errorf("scanExistingCache returned %d, want 2 (only the two well-formed files)", n)
 	}
@@ -207,12 +207,44 @@ func TestWarmup_ScanExistingCache_MissingDir(t *testing.T) {
 	}
 	w := NewWarmup(config, nil, nil)
 
-	n := w.scanExistingCache()
+	n, _ := w.scanExistingCache()
 	if n != 0 {
 		t.Errorf("scanExistingCache on missing dir: got %d, want 0", n)
 	}
 	if got := w.availability.LocalDoneCount(); got != 0 {
 		t.Errorf("tracker should be empty on missing dir, got %d entries", got)
+	}
+}
+
+// TestWarmup_ScanExistingCache_AccumulatesBytes locks in the byte total used
+// to seed Fetcher.cacheUsed. Without an accurate seed, --cache-size only
+// caps NEW writes — leaving a run that inherits a near-full cache free to
+// double actual usage before the cap kicks in.
+func TestWarmup_ScanExistingCache_AccumulatesBytes(t *testing.T) {
+	cacheDir := t.TempDir()
+	writeRawBlock(t, cacheDir, "chunks/0/0/1_0_100", make([]byte, 100))
+	writeRawBlock(t, cacheDir, "chunks/0/0/1_1_100", make([]byte, 100+4)) // checksum trailer
+	writeRawBlock(t, cacheDir, "chunks/5/7/9999_0_2048", make([]byte, 2048))
+	// Corrupt file — must not contribute to the byte total.
+	writeRawBlock(t, cacheDir, "chunks/0/0/2_0_4194304", make([]byte, 1024))
+
+	config := WarmupConfig{
+		ListenAddr:           ":0",
+		DiscoveryInterval:    time.Second,
+		AvailabilityInterval: time.Second,
+		Threads:              2,
+		CacheDir:             cacheDir,
+		BlockSize:            4 * 1024 * 1024,
+	}
+	w := NewWarmup(config, nil, nil)
+
+	n, bytes := w.scanExistingCache()
+	if n != 3 {
+		t.Errorf("scanExistingCache count = %d, want 3", n)
+	}
+	const wantBytes = int64(100 + (100 + 4) + 2048)
+	if bytes != wantBytes {
+		t.Errorf("scanExistingCache bytes = %d, want %d (corrupt file excluded)", bytes, wantBytes)
 	}
 }
 

--- a/pkg/p2p/warmup_test.go
+++ b/pkg/p2p/warmup_test.go
@@ -165,19 +165,25 @@ func TestParseLogicalSize(t *testing.T) {
 }
 
 func TestValidCacheFileSize(t *testing.T) {
-	// Verify both layouts mount accepts: exact logical size, and
-	// logical + per-csBlock CRC32 trailer (4 bytes per 32 KiB block).
+	// Mirror every layout pkg/chunk/disk_cache.go's openCacheFile accepts:
+	// logical, logical+tier, logical+checksum, logical+checksum+tier.
 	cases := []struct {
 		name    string
 		onDisk  int64
 		logical int
 		ok      bool
 	}{
+		// Accepted (mount accepts these on read).
 		{"exact match", 100, 100, true},
+		{"with tier only", 100 + 1, 100, true},
 		{"with checksum trailer (1 csBlock)", 100 + 4, 100, true},
+		{"with checksum + tier (1 csBlock)", 100 + 4 + 1, 100, true},
 		{"larger logical with checksum (2 csBlocks)", 40*1024 + 8, 40 * 1024, true},
+		{"larger logical with checksum + tier (2 csBlocks)", 40*1024 + 8 + 1, 40 * 1024, true},
+		// Rejected.
 		{"compressed-too-small", 50, 100, false},
 		{"random extra bytes", 102, 100, false},
+		{"checksum minus one byte", 100 + 3, 100, false},
 		{"zero logical (parse failure upstream)", 0, 0, false},
 		{"negative logical (defensive)", 100, -1, false},
 	}


### PR DESCRIPTION
# Peer-to-peer warmup 

## 1. Overview

### 1.1 Problem

The existing `juicefs warmup` command runs on a single node, scanning the meta
engine and pulling blocks from object storage into the local disk cache. When
the same dataset has to be warmed on N instances of a distributed deployment
(Kubernetes StatefulSet, Ray cluster, etc.), two inefficiencies compound.

#### Object storage request amplification on cold start

When N nodes warm the same dataset simultaneously, every block is downloaded N
times.

- 100 GiB model file × 12 nodes = **1,200 GiB** of object storage egress
- On metered storage (S3, GCS) the cost is N×
- Even on internal storage, peers risk hitting rate limits or per-tenant
  bandwidth caps
- Job *time-to-ready* (an AI training/serving setup time) is bottlenecked
  on the per-peer storage cap — e.g. with a 100 MB/s cap, downloading a single
  100 GiB file takes 17 min 53 s, regardless of how parallel the cluster is

#### Repeated fetches when instances are added or restarted

Every time an instance joins the cluster (scale-out, node failure recovery,
rolling restart), the same data is re-fetched from object storage from scratch
— even though sibling instances already have it.

- GPU nodes added to an inference cluster, workers added to a distributed
  training job: each round pays the full storage time + cost
- For "warm cache as a service" workloads (AI inference fleets), this happens
  continuously throughout the cluster's lifetime

### 1.2 Inspiration — Naver p2pcp

[p2pcp](https://github.com/naver/p2pcp), open-sourced by Naver, is a tool for
distributing the same file from HDFS / object storage to many nodes via
peer-to-peer exchange, collapsing storage egress to roughly one node's worth
across the cluster. The core ideas:

- Each node fetches a different chunk from storage
- Each node exposes HTTP `/available` (the chunk list it currently holds) and
  `/chunk/<id>` (the chunk bytes)
- Other nodes pull missing chunks over LAN P2P instead of going to storage
- Net: cluster-wide storage egress converges to a single node's download

We hypothesized that the same design pattern (shuffled queue, availability
polling, HTTP chunk serving) would solve both problems above when applied to
JuiceFS warmup.

### 1.3 Proposal — `juicefs p2p-warmup`

Add a new subcommand `p2p-warmup` to the JuiceFS binary. It runs independently
of mount, talks directly to the meta engine and object storage, and shares the
on-disk cache directory with the mount daemon so cached blocks become
immediately useful.

We borrowed p2pcp's design pattern and adapted it for JuiceFS:

- **Manifest sharing** — to avoid hammering the meta engine N times, only the
  elected leader scans meta; the resulting block list is uploaded to object
  storage as a manifest, and followers download it. This collapses meta load
  from O(N peers × M files) to O(M files).
- **Rendezvous-hashing approximation** — collapses the partition / shuffle
  schedulers of p2pcp into a single algorithm. Every peer carries every block
  in its queue (full cover — no orphaned blocks if a peer dies), but the front
  of each peer's queue is statistically distinct, spreading concurrent storage
  hits.
- **No-communication leader election** — the lex-smallest peer address wins,
  no consensus protocol needed.
- **Shared on-disk cache directory with mount** — mount uses cached blocks
  immediately; no separate cache layout.
- **Compression-aware (lz4 / zstd)** — fetches from storage are decompressed
  before caching, matching the layout `pkg/chunk/disk_cache.go:openCacheFile`
  expects.

### 1.4 Measured performance

100 GiB single file, 12 peers (K8s StatefulSet, one pod per node),
`--download-limit 800 Mbps` (= 100 MB/s per peer):

| Scenario | Wall time | Throughput | Storage load (per peer) | vs storage-only baseline (17m 53s) |
|---|---:|---:|---:|---:|
| Cold start (12 peers in parallel) | **4m 21s** | 393 MiB/s | 11% (~45 MiB/s) | **4.1× faster** |
| Scale-out (13th peer joins) | **1m 54s** | 902 MiB/s | <1% (~8 MiB/s) | **9.4× faster** |

Cluster-wide:
- Cold start storage egress: **~89% reduction** (1,200 GiB → 132 GiB)
- Scale-out storage egress: **~99% reduction** (100 GiB → 944 MiB)

---

## 2. Design

### 2.1 Architecture

```
   ┌────────────────────┐         ┌────────────────────────┐
   │    Meta Engine     │         │    Object Storage      │
   │  (Redis/SQL/TiKV)  │         │   chunks/...   (data)  │
   │                    │         │   p2p_warmup/  (mfst)  │
   └─────────┬──────────┘         └───────────┬────────────┘
             │                                │
             │ leader scans once,             │ all peers fetch:
             │ uploads manifest               │  • manifest (small)
             │                                │  • missing blocks
             │                                │ rate-limited per peer
             ▼                                ▼

       ┌──────────┐    ┌──────────┐         ┌──────────┐
       │ peer 1   │◀──▶│ peer 2   │◀──...──▶│ peer N   │
       │  warm    │    │  warm    │         │  warm    │
       │  cache   │    │  cache   │         │  cache   │
       └────┬─────┘    └────┬─────┘         └────┬─────┘
            │               │                    │
            ▼               ▼                    ▼
       juicefs         juicefs              juicefs
        mount           mount                mount
       (reads          (reads               (reads
        cache)          cache)               cache)

   peer ⇄ peer:  LAN P2P, unthrottled
                 /available, /block/<key>, /uuid, /status
```

Three flow paths:

1. **Meta engine** — only the leader peer scans. The result is uploaded as a
   manifest object so other peers can skip the scan entirely.
2. **Object storage** — every peer fetches only the blocks it does not
   already have, throttled by `--download-limit`. Rendezvous-hash sort makes
   each peer's queue prefix distinct, so concurrent storage hits land on
   different blocks.
3. **Peer ⇄ Peer** — what one peer fetches becomes immediately available to
   the rest over LAN (no throttling). Net effect: cluster-wide storage egress
   converges to ≈1×.

Each peer process **shares the same on-disk cache directory with the mount
daemon**, so every block warmed is consumable by mount immediately — no
intermediate format conversion needed.

### 2.2 Run flow (12 steps)

`Warmup.Run()` executes sequentially:

| # | Step | Notes |
|---|---|---|
| 1 | HTTP server listen + `scanExistingCache` | Pre-existing cache files are announced via `/available`; size-validated to skip partial-write residue |
| 2 | Initial peer discovery + self-filter (`/uuid`) | Block until `--min-peers` reached (lower-bound semantics) |
| 3 | **Block list acquisition** (see §2.4) | 4-way branch |
| 4 | Background discovery loop (3s) | Tracks pod additions/removals |
| 5 | Background availability polling (2s) | Detects dead peers within 5s |
| 6 | Build fetch queue (Rendezvous-hash sort) | Each peer sees a different order |
| 7 | Start fetch worker pool (`--threads`, default 50) | Peer-fetch first, storage fallback |
| 8 | Progress monitor (5s) | Auto-cancels at completion |
| 9 | `waitForCompletion` (CAS-based) | Wait until every block reaches a terminal state (`Done` or `Failed`) |
| 10 | Final stats (elapsed / throughput) | Two clocks: total / fetch |
| 11 | Keep-alive (`off`/`peers`/`forever`, default `peers`) | `peers`: serve until every live peer completes, then exit; `forever`: until SIGTERM/timeout |
| 12 | Graceful shutdown | bgCancel + bgWg.Wait + HTTP 10s timeout |

### 2.3 Block state machine

```
            TryDownload (CAS Pending→Downloading)        MarkDone
  Pending ────────────────────────────────────► Downloading ──────► Done
       ▲                                            │
       │            ResetToPending                  │
       └────────────────────────────────────────────┘
                   (on fetch failure)
                                                    │
                              IncrAttempts ≥ 5      │
                              or NoSuchKey           ▼
                                                  Failed (terminal)
```

State is an `atomic.Int32`. **All transitions are CAS-only**, so 50 worker
goroutines racing for the same block result in exactly one winning the
download claim. `Failed` represents permanently unfetchable blocks (e.g.
deleted by JuiceFS slice compaction mid-warmup) or retry-budget exhaustion
(`MaxBlockAttempts = 5`). `waitForCompletion` counts both `Done` and `Failed`
as terminal so the warmup never hangs on an unfetchable block.

### 2.4 Block list acquisition — 4-way branch

```
Step 3 entry
   │
   ▼
manifest sharing enabled? (--min-peers > 1 && !--disable-manifest-sharing)
   │
   ├── No → solo / debug mode: this peer scans the meta engine directly
   │
   └── Yes
        │
        ▼
    Does a valid manifest already exist in object storage? (fast-path)
        │
        ├── Yes → use it as-is (skip meta scan — critical for scale-out
        │                       and crash recovery)
        │
        └── No
             │
             ▼
         Is this peer the leader? (lex-smallest IP)
             │
             ├── Yes → meta.Resolve + upload manifest
             │
             └── No → poll for manifest (within --leader-timeout)
```

#### Manifest reuse fast-path
Every peer attempts a one-shot manifest GET *before* the leader / follower
branch decision. If a valid manifest already exists, it is reused — so a peer
joining a warmed cluster (e.g. with the lex-smallest IP, which would
otherwise mis-elect itself leader) does not redundantly re-scan the meta
engine.

### 2.5 Leader election — agreement without communication

```go
func isLeader(peers []string, selfAddr string) bool {
    for _, p := range peers {
        if p < selfAddr { return false }
    }
    return true
}
```

When every peer runs this function with the same input (the full peer set),
every peer reaches the same conclusion — no consensus protocol required.
Precondition: `--min-peers` blocks until all peers are discovered, so the
input set is consistent.

### 2.6 Manifest collision protection (`--manifest-name`)

When operators name a manifest with `--manifest-name foo` for human
readability, two unrelated warmups that happen to share the name must not
silently corrupt each other's data. Two-layer defense:

- **Leader pre-check** — before PUT, the leader does a GET. If a manifest
  exists with matching paths/blocksize/hashprefix, the upload is skipped
  (idempotent crash recovery). Mismatches return a *refusing to overwrite*
  error so the operator notices.
- **Follower post-check** — after downloading the manifest, the follower
  validates that paths/blocksize/hashprefix match its own request before
  using the block list.

When `--manifest-name` is omitted, the key is derived as a content-addressable
SHA-256 of the warmup args, so peers running the same warmup converge on the
same key without any shared name.

### 2.7 Fetch order distribution — Rendezvous-hashing approximation

```go
sort.Slice(pending, func(i, j int) bool {
    return hashKeyForPeer(pending[i].Key, myAddr) < hashKeyForPeer(pending[j].Key, myAddr)
})
// hashKeyForPeer = FNV-1a(peerAddr || 0x00 || blockKey)
```

| Property | Guarantee |
|---|---|
| Every peer carries every block in its queue | full cover → no orphaned blocks if a peer dies |
| Each peer's sort order is distinct | queue prefixes diverge → concurrent storage hits land on different blocks |
| Deterministic per (block-set, peer) | restarts and debugging see the same queue |

`peerAddr` is fed into the hash *first* because FNV-1a's avalanche on small
trailing changes is weak: feeding it last would let near-identical peer
addresses (e.g. `10.0.0.10` vs `10.0.0.11`) produce correlated orderings,
weakening the spread.

### 2.8 Fetch priority

For each block a worker handles:

```
1. Local cache hit (size match) → skip
2. A peer holds it (availability tracker hit) → HTTP GET /block/<key>
   - success → cache + MarkLocal (FromPeers++)
   - failure → fall through to storage
3. Object storage download (throttled by --download-limit)
```

Peer-to-peer transfers are unthrottled — they should run at LAN speed.
`--download-limit` applies only to the storage path.

### 2.9 Compression support (`lz4` / `zstd`)

JuiceFS storage and cache layouts are asymmetric:
- **Object storage**: compressed bytes
- **Disk cache**: decompressed bytes (mount's `openCacheFile` validates the
  on-disk size against the *logical* size encoded in the key)

`FetchFromStorage` decompresses with `compress.Compressor` before caching, so
mount accepts every block p2p-warmup writes. For uncompressed volumes (the
common default), the noOp compressor short-circuits to a zero-copy path —
`io.ReadAll`'s buffer is returned directly without an extra alloc + memcpy.

### 2.10 Failure handling

| Situation | Handling |
|---|---|
| Storage `NoSuchKey` / `not found` | Abandon immediately — retrying won't bring back a deleted object (e.g. compacted slice) |
| Transient errors (timeout, connection refused, 5xx) | Retry up to 5× then abandon |
| Peer fetch failure | Immediate fall-through to storage |
| 3 consecutive availability-poll failures from a peer | Treat peer as dead, drop its entries from the availability tracker |
| Peer disappears from discovery (DNS / static list) | Permanent removal |
| `--cache-size` cap reached | Skip the block (not cached), count it as `skipped`, and mark it Done so warmup never hangs on the cap |
| `keep-alive=peers`: a peer crashes / leaves mid-wait | Treated as complete so one dead peer cannot block shutdown; `--keep-alive-timeout` is an upper bound |

### 2.11 HTTP API (each peer exposes on `:19090`)

| Endpoint | Method | Response |
|---|---|---|
| `/uuid` | GET | `{"uuid":"..."}` — used for self-identification |
| `/status` | GET | `{"completed":bool, "progress":{total,done}, "role", "peers", "sources":{from_peers,from_storage,from_cache,skipped,failed}, "bytes":{from_peers,from_storage}}` — readiness-probe + observability |
| `/available` | GET | `{"blocks":[...], "updated_at":<ms>}` |
| `/available?since=<ms>` | GET | only blocks with `updated_at > since` (incremental polling) |
| `/block/<key>` | GET | binary block data, 404 if not in cache |

Self-identification: `filterSelf` calls `/uuid` on every discovered peer; on
UUID match, the matching address is recorded as `externalAddr` (the address
this peer is reachable at from the cluster's perspective). That address seeds
both leader election and the queue ordering — using listenAddr alone (which
may be `0.0.0.0:port`) would make every peer compute the same identity and
break agreement.

### 2.12 Object storage layout

```
<bucket>/
├── chunks/...                      ← JuiceFS data blocks (existing)
└── p2p_warmup/                     ← p2p-warmup prefix (new)
    ├── manifest-<sha256>.json.gz   ← when --manifest-name is unset (content-addressable)
    └── <name>.json.gz              ← when --manifest-name=<name> is set
```

Operators can attach a lifecycle policy to the `p2p_warmup/` prefix (e.g.
expire after 7 days) for automatic cleanup.

### 2.13 Code layout

```
cmd/
  p2p_warmup.go          # CLI entry point (urfave/cli command)

pkg/
  p2p/
    types.go             # Block, BlockState, Peer, WarmupConfig, KeepAliveMode/ParseKeepAliveMode
    warmup.go            # Run() 12-step flow, leader election, availability polling, keep-alive modes
    server.go            # HTTP /uuid /status /available /block/<key>
    discovery.go         # DNS A/SRV/static dedup + RunLoop
    resolver.go          # MetaResolver: paths → blocks via meta engine
    manifest.go          # Manifest, ManifestKey, Validate
    manifest_store.go    # uploadManifest, downloadManifest, tryFetchValidManifest, DeleteManifest
    scheduler.go         # OrderForPeer (FNV-1a), FetchQueue
    fetcher.go           # FetchBlock (peer→storage fallback, cache-size cap), Workers, PollAvailability, PollCompleted
    availability.go      # AvailabilityTracker (local append-only, remote map)
```

### 2.14 Reused existing packages

| Package | Usage |
|---|---|
| `pkg/meta` | `Meta.Resolve` / `Meta.Read` / `Meta.Lookup` / `Meta.Readdir` |
| `pkg/chunk` | `BlockKey`, `SliceBlockKeys` (block key derivation) |
| `pkg/object` | `ObjectStorage` (storage backend abstraction) |
| `pkg/compress` | `Compressor` (decompression on storage fetch) |
| `pkg/utils` | `Duration`, `ParseMbps` |

The existing `juicefs warmup` command is unchanged. `cmd/main.go` gets one
line to register the new subcommand.

---

## 3. Usage

### 3.1 CLI signature

```
juicefs p2p-warmup [options] META_URL PATH [PATH ...]
```

| Flag | Default | Description |
|---|---|---|
| `--peers-dns-a` | — | DNS A record FQDN (intended for K8s headless services) |
| `--peers-dns-srv` | — | DNS SRV record |
| `--peers-list` | — | Static `host:port,...` list |
| `--listen` | `:19090` | HTTP server listen address |
| `--min-peers` | `0` | Minimum total peer count (incl. self) to wait for; more peers proceed immediately. ≥ 2 enables manifest sharing |
| `--manifest-name` | — | Manifest object basename. All peers must pass the same value |
| `--delete-manifest` | `false` | Delete the manifest matching the args (paths, `--manifest-name`) and exit without warming (maintenance) |
| `--leader-timeout` | `10m` | Follower timeout for leader's manifest |
| `--disable-manifest-sharing` | `false` | Debugging escape hatch — every peer scans meta independently |
| `--discovery-interval` | `3s` | DNS re-resolve interval |
| `--availability-interval` | `2s` | Per-peer `/available` polling interval |
| `--threads`, `-p` | `50` | Concurrent fetch workers |
| `--file`, `-f` | — | Path list file |
| `--keep-alive` | `peers` | Post-warmup behavior: `off` (exit when local fetch done), `peers` (serve until all peers complete, then exit), `forever` (serve until SIGTERM/SIGINT) |
| `--keep-alive-timeout` | `0` | Upper bound on the keep-alive phase (0 = no bound); applies to `peers`/`forever`, ignored when `off` |
| `--cache-dir` | from format | JuiceFS cache directory |
| `--cache-size` | `100G` | Hard cap on total cached bytes at cache-dir (e.g. 100G, 50000 = 50000 MiB; 0 = unlimited). Counts pre-existing files |
| `--download-limit` | `0` | Object-storage download cap (Mbps per peer; 0 = unlimited). P2P transfers unaffected. |

### 3.2 Single node (solo mode)

Functionally equivalent to the existing `juicefs warmup`:

```bash
juicefs p2p-warmup redis://localhost:6379/1 /models/llama-7b
```

Without `--min-peers`, the command runs in solo mode — manifest sharing is
disabled and the single node scans meta + downloads all blocks itself.

### 3.3 Static peer list

```bash
juicefs p2p-warmup \
  --peers-list 10.0.0.1:19090,10.0.0.2:19090,10.0.0.3:19090 \
  --min-peers 3 \
  --manifest-name llama-7b-warmup \
  redis://redis:6379/1 /models/llama-7b
```

### 3.4 Kubernetes deployment (StatefulSet + Service)

For reliable cold start, three layers must be configured together — Service,
StatefulSet, and container args.

#### Headless Service

```yaml
apiVersion: v1
kind: Service
metadata:
  name: p2p-warmup
  namespace: default
  labels: { app: p2p-warmup }
spec:
  clusterIP: None                 # Headless service → DNS A returns all pod IPs
  publishNotReadyAddresses: true  # Pod IPs visible in DNS before readinessProbe passes
                                  # → discovery succeeds at boot, virtually eliminating split-view race
  selector: { app: p2p-warmup }
  ports:
    - { name: p2p, port: 19090, targetPort: 19090 }
```

#### StatefulSet

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: p2p-warmup
spec:
  podManagementPolicy: Parallel   # Boot all pods at once (required for --min-peers synchronization)
  replicas: 12
  serviceName: p2p-warmup
  selector: { matchLabels: { app: p2p-warmup } }
  template:
    metadata: { labels: { app: p2p-warmup } }
    spec:
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            - labelSelector: { matchLabels: { app: p2p-warmup } }
              topologyKey: kubernetes.io/hostname  # one pod per node — isolate NIC bandwidth
      containers:
        - name: warmup
          image: juicedata/mount:<tag>
          args:
            - juicefs
            - p2p-warmup
            - --peers-dns-a
            - p2p-warmup.default.svc.cluster.local
            - --min-peers
            - "12"                  # match replicas
            - --manifest-name
            - llama-7b-v1           # cluster-unique to prevent collisions
            - --leader-timeout
            - "2m"
            - --threads
            - "50"
            - --keep-alive
            - peers                 # serve until all peers complete, then exit
            - --download-limit
            - "800"                 # 800 Mbps = 100 MB/s per peer
            - redis://redis:6379/1
            - /models/llama-7b
          readinessProbe:
            httpGet: { path: /status, port: 19090 }
          livenessProbe:
            httpGet: { path: /status, port: 19090 }
          volumeMounts:
            - { mountPath: /var/jfsCache, name: cache }
      volumes:
        - name: cache
          hostPath: { path: /var/jfsCache, type: DirectoryOrCreate }
```

#### Operational notes

1. Without `publishNotReadyAddresses: true`, pods are absent from DNS until
   their readinessProbe passes — and p2p-warmup pods cannot become ready
   without first discovering each other. The cluster deadlocks.
2. Without `podManagementPolicy: Parallel`, pods boot sequentially, breaking
   `--min-peers`-based leader election timing.
3. `podAntiAffinity` (one pod per node) isolates NIC bandwidth for P2P.
4. `--manifest-name` must be cluster-unique — accidentally sharing it across
   unrelated warmups would cause cross-contamination (caught by the
   collision-protection logic, but still aborts the affected warmups).
5. The default `--keep-alive peers` exits once the current cohort finishes;
   use `--keep-alive forever` to keep nodes serving so follow-up workloads
   (inference pods, etc.) can join later and fetch entirely over LAN.

### 3.5 Object storage lifecycle policy

Manifest objects accumulate under the `p2p_warmup/` prefix. AWS S3 / NCP /
MinIO recommended: a 7-day expiration rule.

```json
{
  "Rules": [{
    "ID": "juicefs-p2p-warmup-cleanup",
    "Status": "Enabled",
    "Filter": { "Prefix": "p2p_warmup/" },
    "Expiration": { "Days": 7 }
  }]
}
```

For long-running keep-alive deployments, set the lifecycle TTL longer than
the expected late-joiner interval (or skip lifecycle entirely).

### 3.6 Operational logs

```
INFO  P2P server listening on 10.0.0.10:8080 (uuid=a1b2...)
INFO  cache-size cap: 100 GiB (pass --cache-size 0 for unlimited)
INFO  found existing manifest: 6400 blocks (...); skipping resolve   ← scale-out fast-path
INFO  discovered 11 peers (excluding self)
INFO  peer 10.0.0.21:19090 joined discovery                         ← late joiner under a low --min-peers
INFO  progress: 1280/6400 blocks done, 0 failed, 5120 pending; transferred 5.0 GiB peers (180 MiB/s), 1.2 GiB storage (45 MiB/s)
...
INFO  warmup complete: 6400 blocks (5692 from peers, 708 from storage, 0 from cache, 0 skipped, 0 failed)
INFO  bytes transferred: 89 GiB from peers, 11 GiB from storage
INFO  elapsed: 4m16.145s total, 4m05.019s fetch; average throughput: 400 MiB/s total, 418 MiB/s fetch
INFO  keep-alive=peers: serving blocks until all peers complete
INFO  all peers complete; shutting down
```

`elapsed` reports two clocks:
- **total** — `Run()` entry through Step 10 (includes peer discovery wait
  and manifest wait — the operator-visible wall clock)
- **fetch** — block list acquired through Step 10 (the fetch engine itself —
  fair for peer-to-peer comparison)

Operator-signal warnings:

```
WARN  block "..." abandoned: not found in object storage (likely deleted by compaction): ...
       → data was modified during warmup, investigate

WARN  block "..." abandoned after 5 attempts: ... i/o timeout
       → transient storage / network failure
```

---

## 4. Compatibility and migration

- The existing `juicefs warmup` command is unchanged (this is a separate
  subcommand).
- Mount and format are unchanged — p2p-warmup follows the same
  `openCacheFile` validation contract.
- Apart from a one-line export of `BlockKey` / `SliceBlockKeys` from
  `pkg/chunk`, no existing code is modified.
- Default behavior is solo mode (manifest sharing disabled). Multi-peer
  features activate only when the operator passes `--min-peers >= 2`.

## 5. References

- [Naver p2pcp](https://github.com/naver/p2pcp) — design inspiration
- [Rendezvous Hashing (Wikipedia)](https://en.wikipedia.org/wiki/Rendezvous_hashing)
  — algorithmic background

