### PR TITLE
cmd/mount: improve mount process kill and diagnostics

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -78,7 +78,9 @@ func showThreadStack(agentAddr string) {
 		return nil
 	}
 	if err := fn(1); err == nil {
-		fn(2)
+		if err := fn(2); err != nil {
+			logger.Warnf("list goroutines debug=2 from %s: %s", agentAddr, err)
+		}
 	}
 }
 

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -66,13 +66,19 @@ func showThreadStack(agentAddr string) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
 	}
-	resp, err := client.Get(fmt.Sprintf("http://%s/debug/pprof/goroutine?debug=2", agentAddr))
-	if err != nil {
-		logger.Warnf("list goroutine from %s: %s", agentAddr, err)
-	} else {
+	fn := func(level int) error {
+		resp, err := client.Get(fmt.Sprintf("http://%s/debug/pprof/goroutine?debug=%d", agentAddr, level))
+		if err != nil {
+			logger.Warnf("list goroutines from %s: %s", agentAddr, err)
+			return err
+		}
 		grs, _ := io.ReadAll(resp.Body)
-		logger.Infof("list goroutines from %s:\n%s", agentAddr, string(grs))
+		logger.Infof("list goroutines (debug=%d) from %s:\n%s", level, agentAddr, string(grs))
 		_ = resp.Body.Close()
+		return nil
+	}
+	if err := fn(1); err == nil {
+		fn(2)
 	}
 }
 
@@ -83,16 +89,25 @@ func devMinor(dev uint64) uint32 {
 	return uint32(minor)
 }
 
+func processExists(pid int) bool {
+	time.Sleep(time.Second)
+	p, _ := os.FindProcess(pid)
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
 func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if pid > 0 {
 		logger.Infof("watchdog: kill %d", pid)
 		err := syscall.Kill(pid, syscall.SIGABRT)
-		if err != nil {
-			logger.Warnf("kill %d: %s", pid, err)
-			_ = syscall.Kill(pid, syscall.SIGKILL)
+		if err != nil || processExists(pid) {
+			logger.Warnf("kill %d with SIGABRT: %v", pid, err)
+			err = syscall.Kill(pid, syscall.SIGKILL)
+			if err != nil || processExists(pid) {
+				logger.Warnf("kill %d with SIGKILL: %v", pid, err)
+			}
 		}
 		// double check
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 30)
 		if atomic.LoadInt64(lastActive)+30 > time.Now().Unix() {
 			return
 		}
@@ -105,23 +120,6 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if err == nil {
 		waiting, err := strconv.Atoi(strings.TrimSpace(string(data)))
 		if err == nil && waiting > 0 {
-			tids, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
-			if err != nil {
-				logger.Warnf("watchdog: read tasks of process %d: %v", pid, err)
-			} else {
-				for _, tid := range tids {
-					stackPath := fmt.Sprintf("/proc/%d/task/%s/stack", pid, tid.Name())
-					stack, err := os.ReadFile(stackPath)
-					if err != nil {
-						continue
-					}
-					stackText := strings.TrimSpace(string(stack))
-					if stackText == "" {
-						continue
-					}
-					logger.Warnf("watchdog: potential hung task kernel stack (pid=%d tid=%s):\n%s", pid, tid.Name(), stackText)
-				}
-			}
 			fuseMu.Lock()
 			if fuseFd > 0 {
 				_ = syscall.Close(fuseFd)
@@ -160,14 +158,54 @@ func loadConfig(path string) (string, *vfs.Config, error) {
 	return "", nil, fmt.Errorf("%s is not inside JuiceFS", path)
 }
 
+func printThreadsStack(pid int) {
+	if pid <= 1 {
+		return
+	}
+	start := time.Now()
+	tids, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+	if err != nil {
+		logger.Warnf("list tasks of pid %d: %s", pid, err)
+		return
+	}
+	var b strings.Builder
+	for _, tid := range tids {
+		readThreadStats(pid, tid.Name(), &b)
+	}
+	logger.Infof("print kernel stacks of process %d takes %s:\n%s", pid, time.Since(start), b.String())
+}
+
+func readThreadStats(pid int, tid string, b *strings.Builder) {
+	dpath := fmt.Sprintf("/proc/%d/task/%s", pid, tid)
+	data, err := os.ReadFile(dpath + "/status")
+	if err != nil {
+		fmt.Fprintf(b, "%s failed: %s\n", dpath, err)
+		return
+	}
+	for _, s := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(s, "State:") {
+			fmt.Fprintf(b, "%s %s\n", dpath, s)
+			break
+		}
+	}
+	if data, err = os.ReadFile(dpath + "/stack"); err == nil {
+		b.WriteString(string(data))
+	}
+	if data, err = os.ReadFile(dpath + "/schedstat"); err == nil {
+		fmt.Fprintf(b, "schedstat: %s", data)
+	}
+	if data, err = os.ReadFile(dpath + "/syscall"); err == nil {
+		fmt.Fprintf(b, "syscall: %s", data)
+	}
+}
+
 func watchdog(ctx context.Context, mp string) {
-	var lastActive int64
+	var lastActive int64 = time.Now().Unix()
 	var pid int
 	var agentAddr string
 	var dev uint64
 	go func() {
 		time.Sleep(time.Millisecond * 100) // wait for child process
-		atomic.StoreInt64(&lastActive, time.Now().Unix())
 		for ctx.Err() == nil {
 			var confName = ".config"
 			if !vfs.IsSpecialName(confName) {
@@ -202,16 +240,29 @@ func watchdog(ctx context.Context, mp string) {
 	for ctx.Err() == nil {
 		now := time.Now().Unix()
 		if atomic.LoadInt64(&lastActive)+30 < now {
+			logger.Infof("mount point %q is not active for %s, start another check thread", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
+			go printThreadsStack(pid)
 			showThreadStack(agentAddr)
-			time.Sleep(time.Second * 30)
+			time.Sleep(time.Minute)
 			// double check
-			if atomic.LoadInt64(&lastActive)+60 < time.Now().Unix() && ctx.Err() == nil {
-				logger.Infof("mount point %q is not active for %s", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
+			if ctx.Err() != nil {
+				break
+			}
+			if atomic.LoadInt64(&lastActive)+60 < time.Now().Unix() {
+				logger.Infof("mount point %q is not active for %s, print the stacks again", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
+				go printThreadsStack(pid)
 				showThreadStack(agentAddr)
-				killMountProcess(pid, dev, &lastActive)
-				atomic.StoreInt64(&lastActive, time.Now().Unix())
-				pid = 0
-				dev = 0
+				time.Sleep(time.Second * 30)
+				if ctx.Err() != nil {
+					break
+				}
+				if atomic.LoadInt64(&lastActive)+60 < time.Now().Unix() {
+					logger.Infof("mount point %q is not active for %s", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
+					killMountProcess(pid, dev, &lastActive)
+					atomic.StoreInt64(&lastActive, time.Now().Unix())
+					pid = 0
+					dev = 0
+				}
 			}
 		}
 		time.Sleep(time.Second * 10)

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -76,8 +76,10 @@ func showThreadStack(agentAddr string) {
 		_ = resp.Body.Close()
 		return nil
 	}
-	if err := fn(1); err != nil {
-		logger.Warnf("list goroutines debug=1 from %s: %s", agentAddr, err)
+	if err := fn(1); err == nil {
+		if err := fn(2); err != nil {
+			logger.Warnf("list goroutines debug=2 from %s: %s", agentAddr, err)
+		}
 	}
 }
 

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -40,7 +40,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -70,7 +69,6 @@ func showThreadStack(agentAddr string) {
 	fn := func(level int) error {
 		resp, err := client.Get(fmt.Sprintf("http://%s/debug/pprof/goroutine?debug=%d", agentAddr, level))
 		if err != nil {
-			logger.Warnf("list goroutines from %s: %s", agentAddr, err)
 			return err
 		}
 		grs, _ := io.ReadAll(resp.Body)
@@ -113,11 +111,8 @@ func killMountProcess(pid int, dev uint64, lastActive *int64) {
 		if err != nil {
 			logger.Warnf("kill %d with SIGABRT: %v", pid, err)
 		} else if !waitProcessExit(pid, 30*time.Second, 500*time.Millisecond) {
-			logger.Warnf("process %d is still alive after SIGABRT grace period", pid)
-			err = syscall.Kill(pid, syscall.SIGKILL)
-			if err != nil || !waitProcessExit(pid, 5*time.Second, 200*time.Millisecond) {
-				logger.Warnf("kill %d with SIGKILL: %v", pid, err)
-			}
+			logger.Warnf("process %d is still alive after SIGABRT grace period. Kill it: %d", pid, pid)
+			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
 		// double check
 		time.Sleep(time.Second * 30)
@@ -217,7 +212,6 @@ func watchdog(ctx context.Context, mp string) {
 	var pid int
 	var agentAddr string
 	var dev uint64
-	var mu sync.Mutex
 	go func() {
 		time.Sleep(time.Millisecond * 100) // wait for child process
 		for ctx.Err() == nil {
@@ -229,7 +223,6 @@ func watchdog(ctx context.Context, mp string) {
 			err := syscall.Stat(filepath.Join(mp, confName), &confStat)
 			ino, _ := vfs.GetInternalNodeByName(confName)
 			if err == nil && confStat.Ino == uint64(ino) {
-				mu.Lock()
 				if dev == 0 && runtime.GOOS == "linux" {
 					var st syscall.Stat_t
 					if err := syscall.Stat(mp, &st); err == nil && st.Ino == 1 {
@@ -237,20 +230,16 @@ func watchdog(ctx context.Context, mp string) {
 					}
 				}
 				if pid == 0 {
-					mu.Unlock()
 					_, conf, err := loadConfig(mp)
-					mu.Lock()
 					if err == nil {
 						logger.Infof("watching %q, pid %d", mp, conf.Pid)
 						pid = conf.Pid
 						agentAddr = conf.Port.DebugAgent
 					} else {
 						logger.Warnf("load config: %s", err)
-						mu.Unlock()
 						continue
 					}
 				}
-				mu.Unlock()
 			}
 			atomic.StoreInt64(&lastActive, time.Now().Unix())
 			time.Sleep(time.Second * 5)
@@ -262,10 +251,8 @@ func watchdog(ctx context.Context, mp string) {
 			logger.Infof("mount point %q is not active for %s, start another check thread", mp, time.Since(time.Unix(la, 0)))
 			var pid_copy int
 			var agentAddr_copy string
-			mu.Lock()
 			pid_copy = pid
 			agentAddr_copy = agentAddr
-			mu.Unlock()
 			go printThreadsStack(pid_copy)
 			go showThreadStack(agentAddr_copy)
 			time.Sleep(time.Minute)
@@ -278,10 +265,8 @@ func watchdog(ctx context.Context, mp string) {
 				continue
 			}
 			logger.Infof("mount point %q is not active for %s, print the stacks again", mp, time.Since(time.Unix(la, 0)))
-			mu.Lock()
 			pid_copy = pid
 			agentAddr_copy = agentAddr
-			mu.Unlock()
 			go printThreadsStack(pid_copy)
 			go showThreadStack(agentAddr_copy)
 			time.Sleep(time.Second * 30)
@@ -293,12 +278,10 @@ func watchdog(ctx context.Context, mp string) {
 				continue
 			}
 			logger.Infof("mount point %q is not active for %s", mp, time.Since(time.Unix(la, 0)))
-			mu.Lock()
 			killMountProcess(pid, dev, &lastActive)
 			atomic.StoreInt64(&lastActive, time.Now().Unix())
 			pid = 0
 			dev = 0
-			mu.Unlock()
 		}
 		time.Sleep(time.Second * 10)
 	}

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -40,6 +40,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -77,10 +78,8 @@ func showThreadStack(agentAddr string) {
 		_ = resp.Body.Close()
 		return nil
 	}
-	if err := fn(1); err == nil {
-		if err := fn(2); err != nil {
-			logger.Warnf("list goroutines debug=2 from %s: %s", agentAddr, err)
-		}
+	if err := fn(1); err != nil {
+		logger.Warnf("list goroutines debug=1 from %s: %s", agentAddr, err)
 	}
 }
 
@@ -92,19 +91,31 @@ func devMinor(dev uint64) uint32 {
 }
 
 func processExists(pid int) bool {
-	time.Sleep(time.Second)
 	p, _ := os.FindProcess(pid)
 	return p.Signal(syscall.Signal(0)) == nil
+}
+
+func waitProcessExit(pid int, timeout, interval time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !processExists(pid) {
+			return true
+		}
+		time.Sleep(interval)
+	}
+	return !processExists(pid)
 }
 
 func killMountProcess(pid int, dev uint64, lastActive *int64) {
 	if pid > 0 {
 		logger.Infof("watchdog: kill %d", pid)
 		err := syscall.Kill(pid, syscall.SIGABRT)
-		if err != nil || processExists(pid) {
+		if err != nil {
 			logger.Warnf("kill %d with SIGABRT: %v", pid, err)
+		} else if !waitProcessExit(pid, 30*time.Second, 500*time.Millisecond) {
+			logger.Warnf("process %d is still alive after SIGABRT grace period", pid)
 			err = syscall.Kill(pid, syscall.SIGKILL)
-			if err != nil || processExists(pid) {
+			if err != nil || !waitProcessExit(pid, 5*time.Second, 200*time.Millisecond) {
 				logger.Warnf("kill %d with SIGKILL: %v", pid, err)
 			}
 		}
@@ -206,6 +217,7 @@ func watchdog(ctx context.Context, mp string) {
 	var pid int
 	var agentAddr string
 	var dev uint64
+	var mu sync.Mutex
 	go func() {
 		time.Sleep(time.Millisecond * 100) // wait for child process
 		for ctx.Err() == nil {
@@ -217,6 +229,7 @@ func watchdog(ctx context.Context, mp string) {
 			err := syscall.Stat(filepath.Join(mp, confName), &confStat)
 			ino, _ := vfs.GetInternalNodeByName(confName)
 			if err == nil && confStat.Ino == uint64(ino) {
+				mu.Lock()
 				if dev == 0 && runtime.GOOS == "linux" {
 					var st syscall.Stat_t
 					if err := syscall.Stat(mp, &st); err == nil && st.Ino == 1 {
@@ -224,48 +237,68 @@ func watchdog(ctx context.Context, mp string) {
 					}
 				}
 				if pid == 0 {
+					mu.Unlock()
 					_, conf, err := loadConfig(mp)
+					mu.Lock()
 					if err == nil {
 						logger.Infof("watching %q, pid %d", mp, conf.Pid)
 						pid = conf.Pid
 						agentAddr = conf.Port.DebugAgent
 					} else {
 						logger.Warnf("load config: %s", err)
+						mu.Unlock()
 						continue
 					}
 				}
+				mu.Unlock()
 			}
 			atomic.StoreInt64(&lastActive, time.Now().Unix())
 			time.Sleep(time.Second * 5)
 		}
 	}()
 	for ctx.Err() == nil {
-		now := time.Now().Unix()
-		if atomic.LoadInt64(&lastActive)+30 < now {
-			logger.Infof("mount point %q is not active for %s, start another check thread", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
-			go printThreadsStack(pid)
-			showThreadStack(agentAddr)
+		la := atomic.LoadInt64(&lastActive)
+		if time.Since(time.Unix(la, 0)) > time.Second*30 {
+			logger.Infof("mount point %q is not active for %s, start another check thread", mp, time.Since(time.Unix(la, 0)))
+			var pid_copy int
+			var agentAddr_copy string
+			mu.Lock()
+			pid_copy = pid
+			agentAddr_copy = agentAddr
+			mu.Unlock()
+			go printThreadsStack(pid_copy)
+			go showThreadStack(agentAddr_copy)
 			time.Sleep(time.Minute)
 			// double check
 			if ctx.Err() != nil {
 				break
 			}
-			if atomic.LoadInt64(&lastActive)+60 < time.Now().Unix() {
-				logger.Infof("mount point %q is not active for %s, print the stacks again", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
-				go printThreadsStack(pid)
-				showThreadStack(agentAddr)
-				time.Sleep(time.Second * 30)
-				if ctx.Err() != nil {
-					break
-				}
-				if atomic.LoadInt64(&lastActive)+60 < time.Now().Unix() {
-					logger.Infof("mount point %q is not active for %s", mp, time.Since(time.Unix(atomic.LoadInt64(&lastActive), 0)))
-					killMountProcess(pid, dev, &lastActive)
-					atomic.StoreInt64(&lastActive, time.Now().Unix())
-					pid = 0
-					dev = 0
-				}
+			if n := atomic.LoadInt64(&lastActive); n != la {
+				logger.Infof("last active time is updated from %d to %d (delta %ds), re-check", la, n, n-la)
+				continue
 			}
+			logger.Infof("mount point %q is not active for %s, print the stacks again", mp, time.Since(time.Unix(la, 0)))
+			mu.Lock()
+			pid_copy = pid
+			agentAddr_copy = agentAddr
+			mu.Unlock()
+			go printThreadsStack(pid_copy)
+			go showThreadStack(agentAddr_copy)
+			time.Sleep(time.Second * 30)
+			if ctx.Err() != nil {
+				break
+			}
+			if n := atomic.LoadInt64(&lastActive); n != la {
+				logger.Infof("last active time is updated from %d to %d (delta %ds), re-check", la, n, n-la)
+				continue
+			}
+			logger.Infof("mount point %q is not active for %s", mp, time.Since(time.Unix(la, 0)))
+			mu.Lock()
+			killMountProcess(pid, dev, &lastActive)
+			atomic.StoreInt64(&lastActive, time.Now().Unix())
+			pid = 0
+			dev = 0
+			mu.Unlock()
 		}
 		time.Sleep(time.Second * 10)
 	}

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -249,12 +249,8 @@ func watchdog(ctx context.Context, mp string) {
 		la := atomic.LoadInt64(&lastActive)
 		if time.Since(time.Unix(la, 0)) > time.Second*30 {
 			logger.Infof("mount point %q is not active for %s, start another check thread", mp, time.Since(time.Unix(la, 0)))
-			var pid_copy int
-			var agentAddr_copy string
-			pid_copy = pid
-			agentAddr_copy = agentAddr
-			go printThreadsStack(pid_copy)
-			go showThreadStack(agentAddr_copy)
+			go printThreadsStack(pid)
+			go showThreadStack(agentAddr)
 			time.Sleep(time.Minute)
 			// double check
 			if ctx.Err() != nil {
@@ -265,10 +261,8 @@ func watchdog(ctx context.Context, mp string) {
 				continue
 			}
 			logger.Infof("mount point %q is not active for %s, print the stacks again", mp, time.Since(time.Unix(la, 0)))
-			pid_copy = pid
-			agentAddr_copy = agentAddr
-			go printThreadsStack(pid_copy)
-			go showThreadStack(agentAddr_copy)
+			go printThreadsStack(pid)
+			go showThreadStack(agentAddr)
 			time.Sleep(time.Second * 30)
 			if ctx.Err() != nil {
 				break


### PR DESCRIPTION
- Fix lastActive initial value to avoid false positive at startup
- Add processExists() to verify process death before signal escalation
- Extend double-check wait from 10s to 30s for slow core dumps
- Add debug=1 goroutine aggregation before debug=2 full stacks
- Add printThreadsStack() with status/schedstat/syscall for kernel diagnosis
- Remove redundant post-kill /proc/PID/task stack reading
- Restructure watchdog to print stacks before kill for accurate diagnosis