### PR TITLE
meta/tkv: fix panic in doLookup when attr is nil

### DIFF
--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1195,6 +1195,9 @@ func (m *kvMeta) doLookup(ctx Context, parent Ino, name string, inode *Ino, attr
 		}
 		foundType, foundIno := m.parseEntry(buf)
 		*inode = foundIno
+		if attr == nil {
+			return nil // found inode but caller doesn't want attr
+		}
 		if m.conf.OpenCache > 0 && m.of.Check(foundIno, attr) {
 			return nil
 		}


### PR DESCRIPTION
Restore the nil-attr early-return that was dropped when cherry-picking PR #7039, matching `redisMeta`/`dbMeta` behavior.