### PR TITLE
cmd/sync: keep files-from symlink dirs as links

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1318,7 +1318,7 @@ func produce(tasks chan<- object.Object, srckeys, dstkeys <-chan object.Object, 
 			return fmt.Errorf("listing failed, stop syncing, waiting for pending ones")
 		}
 
-		if !config.Dirs && obj.IsDir() {
+		if !config.Dirs && obj.IsDir() && (!config.Links || !obj.IsSymlink()) {
 			if checkpointMgr != nil {
 				checkpointMgr.UpdateLastListedKey(prefix, obj)
 			}
@@ -1776,7 +1776,7 @@ func produceSingleObject(tasks chan<- object.Object, src, dst object.ObjectStora
 		logger.Warnf("head %s from %s: %s", key, src, err)
 		return err
 	}
-	if obj.IsDir() {
+	if obj.IsDir() && (!config.Links || !obj.IsSymlink()) {
 		// only `files-from` will hit this case
 		if !strings.HasSuffix(key, "/") {
 			return errDirSuffix


### PR DESCRIPTION
fix ci: https://github.com/juicedata/juicefs/actions/runs/26138813722/job/76879719178

`juicefs sync --files-from ... --links` could treat a symlinked directory as a real directory and traverse it, instead of copying the symlink itself as required by `--links`.

For example:
```
src/
├── dir-link -> dir1
└── dir1/
    └── file-link -> file1
```
files-from:
```
dir-link
dir1
```
With `--links`, `dir-link` should be copied as `dst/dir-link -> dir1`.

The old logic treated `dir-link` as a directory and continued syncing `dir-link/file-link`. Since `dst/dir-link` eventually points to `dst/dir1`, `dst/dir-link/file-link` and `dst/dir1/file-link` refer to the same filesystem location, which could cause a `file exists` error.