### PR TITLE
object: support HTTP connection max age with Go 1.26 ClientConn

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net/http"
 	_ "net/http/pprof"
 	"net/url"
 	"os"
@@ -244,7 +243,7 @@ func createStorage(format meta.Format) (object.ObjectStorage, error) {
 			if tlsSkipVerify, err = strconv.ParseBool(values.Get("tls-insecure-skip-verify")); err != nil {
 				return nil, err
 			}
-			object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = tlsSkipVerify
+			object.GetHttpTransport().TLSClientConfig.InsecureSkipVerify = tlsSkipVerify
 			values.Del("tls-insecure-skip-verify")
 			u.RawQuery = values.Encode()
 			format.Bucket = u.String()
@@ -268,8 +267,8 @@ func createStorage(format meta.Format) (object.ObjectStorage, error) {
 				return nil, fmt.Errorf("error appending CA cert to pool")
 			}
 
-			object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.RootCAs = certPool
-			object.GetHttpClient().Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{clientTLSCert}
+			object.GetHttpTransport().TLSClientConfig.RootCAs = certPool
+			object.GetHttpTransport().TLSClientConfig.Certificates = []tls.Certificate{clientTLSCert}
 		}
 	}
 

--- a/pkg/object/http_conn_max_age_go126.go
+++ b/pkg/object/http_conn_max_age_go126.go
@@ -20,6 +20,7 @@ package object
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -330,6 +331,19 @@ func (t *httpConnMaxAgeTransport) maxConnsPerHost() int {
 		return t.base.MaxIdleConnsPerHost
 	}
 	return 2
+}
+
+// jitterHTTPConnMaxAge spreads retirement times so a large batch of
+// connections does not age out at exactly the same moment.
+func jitterHTTPConnMaxAge(maxAge time.Duration) time.Duration {
+	if maxAge <= 0 {
+		return 0
+	}
+	delta := maxAge / 10
+	if delta <= 0 {
+		return maxAge
+	}
+	return maxAge - delta + time.Duration(rand.Int63n(int64(2*delta)))
 }
 
 // keyAndAddr validates the request target and returns both the pool key and the

--- a/pkg/object/http_conn_max_age_go126.go
+++ b/pkg/object/http_conn_max_age_go126.go
@@ -1,0 +1,373 @@
+//go:build go1.26
+
+/*
+ * JuiceFS, Copyright 2018 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type httpConnMaxAgeTransport struct {
+	base   *http.Transport
+	maxAge time.Duration
+
+	mu      sync.Mutex
+	buckets map[string]*connBucket
+}
+
+type connBucket struct {
+	conns   []*managedHTTPConn
+	dialing bool
+	waiters []chan struct{}
+}
+
+type managedHTTPConn struct {
+	key       string
+	cc        *http.ClientConn
+	createdAt time.Time
+	maxAge    time.Duration
+	retiring  bool
+}
+
+// newHTTPConnMaxAgeTransport wraps the shared base transport with a Go 1.26
+// ClientConn pool when max age is enabled. With max age disabled it returns
+// the original transport so legacy behavior stays unchanged.
+func newHTTPConnMaxAgeTransport(base *http.Transport, maxAge time.Duration) http.RoundTripper {
+	if maxAge <= 0 {
+		return base
+	}
+	return &httpConnMaxAgeTransport{
+		base:    base,
+		maxAge:  maxAge,
+		buckets: make(map[string]*connBucket),
+	}
+}
+
+// RoundTrip sends the request through a managed ClientConn and then rechecks
+// whether that connection should be retired after the request state changes.
+func (t *httpConnMaxAgeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	mc, err := t.pickConn(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := mc.cc.RoundTrip(req)
+	t.onConnStateChange(mc)
+	return resp, err
+}
+
+// pickConn selects a managed connection for the request, waiting when the
+// per-host pool is full and another request is expected to free capacity.
+func (t *httpConnMaxAgeTransport) pickConn(req *http.Request) (*managedHTTPConn, error) {
+	key, addr, err := keyAndAddr(req)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		candidates, toClose, waiter, dialNew := t.prepareConnAttempt(key)
+		closeClientConns(toClose)
+
+		// Reserve is done outside the pool lock because ClientConn may run the
+		// state hook synchronously from Reserve/Release/RoundTrip/Body.Close.
+		for _, mc := range candidates {
+			if mc.cc.Reserve() != nil {
+				continue
+			}
+			if t.shouldUseReservedConn(mc) {
+				return mc, nil
+			}
+			mc.cc.Release()
+			t.onConnStateChange(mc)
+		}
+
+		if dialNew {
+			return t.dialManagedConn(req, key, addr)
+		}
+		if waiter == nil {
+			continue
+		}
+		// Waiters are edge-triggered: any pool state change wakes them up and
+		// they retry the full selection flow from scratch.
+		select {
+		case <-waiter:
+		case <-req.Context().Done():
+			t.removeWaiter(key, waiter)
+			return nil, req.Context().Err()
+		}
+	}
+}
+
+// prepareConnAttempt sweeps the bucket, returns immediately usable candidates,
+// or decides whether the caller should become the single dialer or wait.
+func (t *httpConnMaxAgeTransport) prepareConnAttempt(key string) ([]*managedHTTPConn, []*http.ClientConn, chan struct{}, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	bucket := t.getOrCreateBucketLocked(key)
+	candidates, toClose := t.sweepBucketLocked(bucket)
+	if len(candidates) > 0 {
+		return candidates, toClose, nil, false
+	}
+
+	if len(bucket.conns) < t.maxConnsPerHost() && !bucket.dialing {
+		bucket.dialing = true
+		return nil, toClose, nil, true
+	}
+
+	waiter := make(chan struct{})
+	bucket.waiters = append(bucket.waiters, waiter)
+	return nil, toClose, waiter, false
+}
+
+// dialManagedConn creates a new ClientConn for the host and installs a state
+// hook so later request completions can retire or wake waiters for it.
+func (t *httpConnMaxAgeTransport) dialManagedConn(req *http.Request, key, addr string) (*managedHTTPConn, error) {
+	cc, err := t.base.NewClientConn(req.Context(), req.URL.Scheme, addr)
+	if err != nil {
+		t.finishDial(key, nil)
+		return nil, err
+	}
+	if err := cc.Reserve(); err != nil {
+		_ = cc.Close()
+		t.finishDial(key, nil)
+		return nil, err
+	}
+
+	mc := &managedHTTPConn{
+		key:       key,
+		cc:        cc,
+		createdAt: time.Now(),
+		maxAge:    jitterHTTPConnMaxAge(t.maxAge),
+	}
+	cc.SetStateHook(func(*http.ClientConn) {
+		t.onConnStateChange(mc)
+	})
+	t.finishDial(key, mc)
+	return mc, nil
+}
+
+// finishDial clears the dialing flag, publishes the new connection if one was
+// created, and wakes every waiter to let them compete for the new capacity.
+func (t *httpConnMaxAgeTransport) finishDial(key string, mc *managedHTTPConn) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	bucket := t.getOrCreateBucketLocked(key)
+	bucket.dialing = false
+	if mc != nil {
+		bucket.conns = append(bucket.conns, mc)
+	}
+	t.notifyWaitersLocked(bucket)
+	t.cleanupBucketLocked(key, bucket)
+}
+
+// shouldUseReservedConn confirms that a connection reserved outside the pool
+// lock is still valid, still pooled, and not already marked for retirement.
+func (t *httpConnMaxAgeTransport) shouldUseReservedConn(mc *managedHTTPConn) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	bucket := t.buckets[mc.key]
+	return bucket != nil && t.containsLocked(bucket, mc) && !mc.retiring && mc.cc.Err() == nil && !t.expiredLocked(mc)
+}
+
+// onConnStateChange reacts to ClientConn state transitions. The pool only
+// mutates state under lock; Close happens after unlocking to avoid re-entering
+// this hook while the mutex is still held.
+func (t *httpConnMaxAgeTransport) onConnStateChange(mc *managedHTTPConn) {
+	var closeConn *http.ClientConn
+
+	t.mu.Lock()
+	bucket := t.buckets[mc.key]
+	if bucket == nil || !t.containsLocked(bucket, mc) {
+		t.mu.Unlock()
+		return
+	}
+
+	if mc.cc.Err() != nil {
+		t.removeLocked(bucket, mc)
+	} else if t.expiredLocked(mc) {
+		mc.retiring = true
+		if mc.cc.InFlight() == 0 {
+			t.removeLocked(bucket, mc)
+			closeConn = mc.cc
+		}
+	}
+	t.notifyWaitersLocked(bucket)
+	t.cleanupBucketLocked(mc.key, bucket)
+	t.mu.Unlock()
+
+	if closeConn != nil {
+		_ = closeConn.Close()
+	}
+}
+
+// sweepBucketLocked rebuilds the live connection slice in one pass so the
+// caller never deletes from the slice while iterating over it.
+func (t *httpConnMaxAgeTransport) sweepBucketLocked(bucket *connBucket) ([]*managedHTTPConn, []*http.ClientConn) {
+	kept := bucket.conns[:0]
+	var candidates []*managedHTTPConn
+	var toClose []*http.ClientConn
+
+	for _, mc := range bucket.conns {
+		if mc.cc.Err() != nil {
+			toClose = append(toClose, mc.cc)
+			continue
+		}
+		if t.expiredLocked(mc) {
+			mc.retiring = true
+			if mc.cc.InFlight() == 0 {
+				toClose = append(toClose, mc.cc)
+				continue
+			}
+		}
+		kept = append(kept, mc)
+		if !mc.retiring && mc.cc.Available() > 0 {
+			candidates = append(candidates, mc)
+		}
+	}
+	bucket.conns = kept
+	return candidates, toClose
+}
+
+// removeWaiter unregisters a waiter that timed out or was canceled before the
+// bucket had a chance to wake it up.
+func (t *httpConnMaxAgeTransport) removeWaiter(key string, waiter chan struct{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	bucket := t.buckets[key]
+	if bucket == nil {
+		return
+	}
+	for i, w := range bucket.waiters {
+		if w == waiter {
+			bucket.waiters = append(bucket.waiters[:i], bucket.waiters[i+1:]...)
+			break
+		}
+	}
+	t.cleanupBucketLocked(key, bucket)
+}
+
+// notifyWaitersLocked wakes every blocked picker because any pool state change
+// may make a connection reusable or permit one more dial.
+func (t *httpConnMaxAgeTransport) notifyWaitersLocked(bucket *connBucket) {
+	for _, waiter := range bucket.waiters {
+		close(waiter)
+	}
+	bucket.waiters = nil
+}
+
+// getOrCreateBucketLocked returns the per-host bucket, creating it on demand.
+func (t *httpConnMaxAgeTransport) getOrCreateBucketLocked(key string) *connBucket {
+	bucket := t.buckets[key]
+	if bucket == nil {
+		bucket = &connBucket{}
+		t.buckets[key] = bucket
+	}
+	return bucket
+}
+
+// cleanupBucketLocked removes empty buckets once they no longer hold pooled
+// connections, an active dialer, or blocked waiters.
+func (t *httpConnMaxAgeTransport) cleanupBucketLocked(key string, bucket *connBucket) {
+	if len(bucket.conns) == 0 && !bucket.dialing && len(bucket.waiters) == 0 {
+		delete(t.buckets, key)
+	}
+}
+
+// expiredLocked reports whether the connection has exceeded its configured
+// lifetime and should stop accepting new requests.
+func (t *httpConnMaxAgeTransport) expiredLocked(mc *managedHTTPConn) bool {
+	return time.Since(mc.createdAt) >= mc.maxAge
+}
+
+// containsLocked reports whether the bucket still owns the managed connection.
+func (t *httpConnMaxAgeTransport) containsLocked(bucket *connBucket, mc *managedHTTPConn) bool {
+	for _, conn := range bucket.conns {
+		if conn == mc {
+			return true
+		}
+	}
+	return false
+}
+
+// removeLocked removes a managed connection from the bucket if it is still
+// present. The caller is responsible for any later Close.
+func (t *httpConnMaxAgeTransport) removeLocked(bucket *connBucket, mc *managedHTTPConn) {
+	for i, conn := range bucket.conns {
+		if conn == mc {
+			bucket.conns = append(bucket.conns[:i], bucket.conns[i+1:]...)
+			return
+		}
+	}
+}
+
+// maxConnsPerHost derives the pool cap from the shared base transport and
+// falls back to a conservative default when the base transport leaves it unset.
+func (t *httpConnMaxAgeTransport) maxConnsPerHost() int {
+	if t.base.MaxIdleConnsPerHost > 0 {
+		return t.base.MaxIdleConnsPerHost
+	}
+	return 2
+}
+
+// keyAndAddr validates the request target and returns both the pool key and the
+// canonical host:port used by Transport.NewClientConn.
+func keyAndAddr(req *http.Request) (string, string, error) {
+	if req.URL == nil {
+		return "", "", fmt.Errorf("http: nil Request.URL")
+	}
+	addr := canonicalHTTPAddr(req.URL)
+	if addr == "" {
+		return "", "", fmt.Errorf("http: no Host in request URL")
+	}
+	return req.URL.Scheme + "://" + addr, addr, nil
+}
+
+// canonicalHTTPAddr normalizes a request URL into host:port form.
+func canonicalHTTPAddr(u *url.URL) string {
+	host := u.Hostname()
+	if host == "" {
+		return ""
+	}
+	port := u.Port()
+	if port == "" {
+		switch u.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			return ""
+		}
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// closeClientConns closes a batch of ClientConn values outside pool locks.
+func closeClientConns(conns []*http.ClientConn) {
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+}

--- a/pkg/object/http_conn_max_age_go126_test.go
+++ b/pkg/object/http_conn_max_age_go126_test.go
@@ -1,0 +1,420 @@
+//go:build go1.26
+
+/*
+ * JuiceFS, Copyright 2018 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type connIDKey struct{}
+
+func newConnIDServer(handler http.HandlerFunc) *httptest.Server {
+	var nextID int64
+	server := httptest.NewUnstartedServer(handler)
+	server.Config.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
+		return context.WithValue(ctx, connIDKey{}, atomic.AddInt64(&nextID, 1))
+	}
+	server.Start()
+	return server
+}
+
+func newHTTP2ConnIDServer(handler http.HandlerFunc) *httptest.Server {
+	var nextID int64
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.Config.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
+		return context.WithValue(ctx, connIDKey{}, atomic.AddInt64(&nextID, 1))
+	}
+	server.StartTLS()
+	return server
+}
+
+func TestHTTPConnMaxAgeTransportRetiresExpiredIdleConn(t *testing.T) {
+	server := newConnIDServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, r.Context().Value(connIDKey{}))
+	})
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: newHTTPConnMaxAgeTransport(&http.Transport{}, 10*time.Millisecond),
+	}
+
+	first := getConnID(t, client, server.URL)
+	time.Sleep(50 * time.Millisecond)
+	second := getConnID(t, client, server.URL)
+
+	if first == second {
+		t.Fatalf("connection was reused after max age: first=%d second=%d", first, second)
+	}
+}
+
+func TestHTTPConnMaxAgeTransportDoesNotCloseInFlightConn(t *testing.T) {
+	releaseBody := make(chan struct{})
+	server := newConnIDServer(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Context().Value(connIDKey{})
+		if r.URL.Path != "/hold" {
+			fmt.Fprint(w, id)
+			return
+		}
+		w.Header().Set("X-Conn-ID", fmt.Sprint(id))
+		w.(http.Flusher).Flush()
+		<-releaseBody
+		fmt.Fprint(w, id)
+	})
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: newHTTPConnMaxAgeTransport(&http.Transport{}, 10*time.Millisecond),
+	}
+
+	resp, err := client.Get(server.URL + "/hold")
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	firstID, err := strconv.ParseInt(resp.Header.Get("X-Conn-ID"), 10, 64)
+	if err != nil {
+		t.Fatalf("invalid first connection id: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	secondID := getConnID(t, client, server.URL)
+	if firstID == secondID {
+		t.Fatalf("expired in-flight connection accepted a new request: first=%d second=%d", firstID, secondID)
+	}
+
+	close(releaseBody)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expired in-flight response was interrupted: %v", err)
+	}
+	if string(body) != strconv.FormatInt(firstID, 10) {
+		t.Fatalf("unexpected first response body: %q", body)
+	}
+}
+
+func TestHTTPConnMaxAgeTransportDisabledReturnsBaseTransport(t *testing.T) {
+	base := &http.Transport{}
+	if got := newHTTPConnMaxAgeTransport(base, 0); got != base {
+		t.Fatalf("disabled max age should return the base transport: got %T", got)
+	}
+}
+
+func TestHTTPConnMaxAgeTransportRetiresExpiredHTTP2Conn(t *testing.T) {
+	releaseBody := make(chan struct{})
+	server := newHTTP2ConnIDServer(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Context().Value(connIDKey{})
+		if r.URL.Path != "/hold" {
+			fmt.Fprint(w, id)
+			return
+		}
+		w.Header().Set("X-Conn-ID", fmt.Sprint(id))
+		w.(http.Flusher).Flush()
+		<-releaseBody
+		fmt.Fprint(w, id)
+	})
+	defer server.Close()
+
+	base := server.Client().Transport.(*http.Transport).Clone()
+	base.ForceAttemptHTTP2 = true
+	client := &http.Client{
+		Transport: newHTTPConnMaxAgeTransport(base, 10*time.Millisecond),
+	}
+
+	resp, err := client.Get(server.URL + "/hold")
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.ProtoMajor != 2 {
+		t.Fatalf("first request did not use HTTP/2: %s", resp.Proto)
+	}
+	firstID, err := strconv.ParseInt(resp.Header.Get("X-Conn-ID"), 10, 64)
+	if err != nil {
+		t.Fatalf("invalid first connection id: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	secondResp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+	defer secondResp.Body.Close()
+	if secondResp.ProtoMajor != 2 {
+		t.Fatalf("second request did not use HTTP/2: %s", secondResp.Proto)
+	}
+	body, err := io.ReadAll(secondResp.Body)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	secondID, err := strconv.ParseInt(string(body), 10, 64)
+	if err != nil {
+		t.Fatalf("parse second connection id %q: %v", body, err)
+	}
+	if firstID == secondID {
+		t.Fatalf("expired HTTP/2 connection accepted a new request: first=%d second=%d", firstID, secondID)
+	}
+
+	close(releaseBody)
+	firstBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expired HTTP/2 in-flight response was interrupted: %v", err)
+	}
+	if string(firstBody) != strconv.FormatInt(firstID, 10) {
+		t.Fatalf("unexpected first response body: %q", firstBody)
+	}
+}
+
+func TestHTTPConnMaxAgeTransportHTTP2ConcurrentMissUsesSingleConn(t *testing.T) {
+	server := newHTTP2ConnIDServer(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		fmt.Fprint(w, r.Context().Value(connIDKey{}))
+	})
+	defer server.Close()
+
+	base := server.Client().Transport.(*http.Transport).Clone()
+	base.ForceAttemptHTTP2 = true
+	base.MaxIdleConnsPerHost = 1
+	client := &http.Client{
+		Transport: newHTTPConnMaxAgeTransport(base, time.Minute),
+	}
+
+	const n = 8
+	start := make(chan struct{})
+	ids := make(chan int64, n)
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer resp.Body.Close()
+			if resp.ProtoMajor != 2 {
+				errs <- fmt.Errorf("unexpected protocol %s", resp.Proto)
+				return
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				errs <- err
+				return
+			}
+			id, err := strconv.ParseInt(string(body), 10, 64)
+			if err != nil {
+				errs <- err
+				return
+			}
+			ids <- id
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(ids)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent request failed: %v", err)
+		}
+	}
+
+	var first int64
+	for id := range ids {
+		if first == 0 {
+			first = id
+			continue
+		}
+		if id != first {
+			t.Fatalf("concurrent HTTP/2 misses opened multiple connections: first=%d got=%d", first, id)
+		}
+	}
+}
+
+func TestHTTPConnMaxAgeTransportHTTP1BusyConnWaitsInsteadOfDialing(t *testing.T) {
+	releaseBody := make(chan struct{})
+	server := newConnIDServer(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Context().Value(connIDKey{})
+		if r.URL.Path != "/hold" {
+			fmt.Fprint(w, id)
+			return
+		}
+		w.Header().Set("X-Conn-ID", fmt.Sprint(id))
+		w.(http.Flusher).Flush()
+		<-releaseBody
+		fmt.Fprint(w, id)
+	})
+	defer server.Close()
+
+	base := &http.Transport{MaxIdleConnsPerHost: 1}
+	client := &http.Client{
+		Transport: newHTTPConnMaxAgeTransport(base, time.Minute),
+	}
+
+	resp, err := client.Get(server.URL + "/hold")
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	firstID, err := strconv.ParseInt(resp.Header.Get("X-Conn-ID"), 10, 64)
+	if err != nil {
+		t.Fatalf("invalid first connection id: %v", err)
+	}
+
+	result := make(chan int64, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		id, err := getConnIDWithError(client, server.URL)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		result <- id
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("second request failed early: %v", err)
+	case id := <-result:
+		t.Fatalf("second request completed before busy conn was released: second=%d first=%d", id, firstID)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseBody)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read first response: %v", err)
+	}
+	if string(body) != strconv.FormatInt(firstID, 10) {
+		t.Fatalf("unexpected first response body: %q", body)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("second request failed after release: %v", err)
+	case id := <-result:
+		if id != firstID {
+			t.Fatalf("second request used a different connection instead of waiting: first=%d second=%d", firstID, id)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second request")
+	}
+}
+
+func TestHTTPConnMaxAgeTransportSweepDoesNotSkipLiveConn(t *testing.T) {
+	server := newConnIDServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, r.Context().Value(connIDKey{}))
+	})
+	defer server.Close()
+
+	base := &http.Transport{}
+	rt := newHTTPConnMaxAgeTransport(base, time.Minute)
+	transport, ok := rt.(*httpConnMaxAgeTransport)
+	if !ok {
+		t.Fatalf("unexpected transport type %T", rt)
+	}
+
+	reqURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	addr := canonicalHTTPAddr(reqURL)
+	key := reqURL.Scheme + "://" + addr
+
+	closedConn := newTestManagedConn(t, base, key, reqURL, 0)
+	liveConn := newTestManagedConn(t, base, key, reqURL, 0)
+	expiredConn := newTestManagedConn(t, base, key, reqURL, -time.Hour)
+	if err := closedConn.cc.Close(); err != nil {
+		t.Fatalf("close conn: %v", err)
+	}
+
+	transport.buckets[key] = &connBucket{conns: []*managedHTTPConn{closedConn, liveConn, expiredConn}}
+	got, err := transport.pickConn(newConnRequest(t, reqURL))
+	if err != nil {
+		t.Fatalf("pick conn: %v", err)
+	}
+	defer got.cc.Release()
+	if got != liveConn {
+		t.Fatalf("sweep skipped the only live connection")
+	}
+}
+
+func getConnID(t *testing.T, client *http.Client, url string) int64 {
+	t.Helper()
+	id, err := getConnIDWithError(client, url)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return id
+}
+
+func getConnIDWithError(client *http.Client, target string) (int64, error) {
+	resp, err := client.Get(target)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	id, err := strconv.ParseInt(string(body), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func newTestManagedConn(t *testing.T, base *http.Transport, key string, reqURL *url.URL, age time.Duration) *managedHTTPConn {
+	t.Helper()
+	cc, err := base.NewClientConn(context.Background(), reqURL.Scheme, canonicalHTTPAddr(reqURL))
+	if err != nil {
+		t.Fatalf("new client conn: %v", err)
+	}
+	return &managedHTTPConn{
+		key:       key,
+		cc:        cc,
+		createdAt: time.Now().Add(age),
+		maxAge:    time.Millisecond,
+	}
+}
+
+func newConnRequest(t *testing.T, reqURL *url.URL) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	return req
+}

--- a/pkg/object/http_conn_max_age_legacy.go
+++ b/pkg/object/http_conn_max_age_legacy.go
@@ -1,0 +1,33 @@
+//go:build !go1.26
+
+/*
+ * JuiceFS, Copyright 2018 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"net/http"
+	"time"
+)
+
+// newHTTPConnMaxAgeTransport keeps pre-Go-1.26 builds on the shared base
+// transport because ClientConn-based retirement is not available there.
+func newHTTPConnMaxAgeTransport(base *http.Transport, maxAge time.Duration) http.RoundTripper {
+	if maxAge > 0 {
+		logger.Warnf("JFS_HTTP_CONN_MAX_AGE requires Go 1.26, ignored")
+	}
+	return base
+}

--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -414,7 +414,7 @@ func newOBS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	// Empty proxy url string has no effect
 	// there is a bug in the retry of PUT (did not call Seek(0,0) before retry), so disable the retry here
 	c, err := obs.New(accessKey, secretKey, endpoint, obs.WithSecurityToken(token),
-		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithHttpTransport(httpClient.Transport.(*http.Transport)))
+		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithHttpTransport(GetHttpTransport()))
 	if err != nil {
 		return nil, fmt.Errorf("fail to initialize OBS: %q", err)
 	}

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -35,7 +35,38 @@ import (
 
 var resolver = dnscache.New(time.Minute)
 var httpClient *http.Client
+var httpTransport *http.Transport
 
+// parseHTTPConnMaxAge reads the opt-in connection max age from the environment.
+// Invalid values are ignored so the process can keep the previous behavior.
+func parseHTTPConnMaxAge() time.Duration {
+	value := os.Getenv("JFS_HTTP_CONN_MAX_AGE")
+	if value == "" {
+		return 0
+	}
+	maxAge, err := time.ParseDuration(value)
+	if err != nil || maxAge < 0 {
+		logger.Warnf("invalid JFS_HTTP_CONN_MAX_AGE=%q, ignored", value)
+		return 0
+	}
+	return maxAge
+}
+
+// jitterHTTPConnMaxAge spreads retirement times so a large batch of connections
+// does not age out at exactly the same moment.
+func jitterHTTPConnMaxAge(maxAge time.Duration) time.Duration {
+	if maxAge <= 0 {
+		return 0
+	}
+	delta := maxAge / 10
+	if delta <= 0 {
+		return maxAge
+	}
+	return maxAge - delta + time.Duration(rand.Int63n(int64(2*delta)))
+}
+
+// splitIPsByVersion keeps IPv6 and IPv4 addresses separate so dialing can
+// preserve the existing happy-eyeballs style fallback order.
 func splitIPsByVersion(ips []net.IP) ([]net.IP, []net.IP) {
 	ipv6 := make([]net.IP, 0, len(ips))
 	ipv4 := make([]net.IP, 0, len(ips))
@@ -125,6 +156,8 @@ func dialParallel(ctx context.Context, dialer *net.Dialer, network string, prima
 	}
 }
 
+// dialRandom tries the provided addresses in a randomized order until one
+// succeeds or the context is canceled.
 func dialRandom(ctx context.Context, dialer *net.Dialer, network string, ips []net.IP, port string) (net.Conn, error) {
 	var lastErr error
 	n := len(ips)
@@ -148,46 +181,59 @@ func dialRandom(ctx context.Context, dialer *net.Dialer, network string, ips []n
 	return nil, lastErr
 }
 
+// init builds the shared HTTP transport first, then optionally wraps it with
+// connection max-age management while keeping the base *http.Transport exposed
+// for SDK paths that require the concrete type.
 func init() {
 	dialer := &net.Dialer{Timeout: time.Second * 10}
-	httpClient = &http.Client{
-		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			TLSHandshakeTimeout:   time.Second * 20,
-			ResponseHeaderTimeout: time.Second * 30,
-			IdleConnTimeout:       time.Second * 300,
-			MaxIdleConnsPerHost:   500,
-			ReadBufferSize:        32 << 10,
-			WriteBufferSize:       32 << 10,
-			DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-				host, port, err := net.SplitHostPort(address)
-				if err != nil {
-					return nil, err
-				}
-				if ip := net.ParseIP(host); ip != nil {
-					return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-				}
-				ips, err := resolver.Fetch(host)
-				if err != nil {
-					return nil, err
-				}
-				if len(ips) == 0 {
-					return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
-				}
-				ipv6, ipv4 := splitIPsByVersion(ips)
-				return dialParallel(ctx, dialer, network, ipv6, ipv4, port)
-			},
-			DisableCompression: true,
-			TLSClientConfig:    &tls.Config{},
+	httpConnMaxAge := parseHTTPConnMaxAge()
+	httpTransport = &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		TLSHandshakeTimeout:   time.Second * 20,
+		ResponseHeaderTimeout: time.Second * 30,
+		IdleConnTimeout:       time.Second * 300,
+		MaxIdleConnsPerHost:   500,
+		ReadBufferSize:        32 << 10,
+		WriteBufferSize:       32 << 10,
+		DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(address)
+			if err != nil {
+				return nil, err
+			}
+			if ip := net.ParseIP(host); ip != nil {
+				return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			}
+			ips, err := resolver.Fetch(host)
+			if err != nil {
+				return nil, err
+			}
+			if len(ips) == 0 {
+				return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+			}
+			ipv6, ipv4 := splitIPsByVersion(ips)
+			return dialParallel(ctx, dialer, network, ipv6, ipv4, port)
 		},
-		Timeout: time.Hour,
+		DisableCompression: true,
+		TLSClientConfig:    &tls.Config{},
+	}
+	httpClient = &http.Client{
+		Transport: newHTTPConnMaxAgeTransport(httpTransport, httpConnMaxAge),
+		Timeout:   time.Hour,
 	}
 }
 
+// GetHttpClient returns the shared object-storage HTTP client.
 func GetHttpClient() *http.Client {
 	return httpClient
 }
 
+// GetHttpTransport returns the shared base transport for integrations that
+// need direct access to the concrete *http.Transport.
+func GetHttpTransport() *http.Transport {
+	return httpTransport
+}
+
+// cleanup drains and closes a response body so its connection can be reused.
 func cleanup(response *http.Response) {
 	if response != nil && response.Body != nil {
 		_, _ = io.Copy(io.Discard, response.Body)

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -52,19 +52,6 @@ func parseHTTPConnMaxAge() time.Duration {
 	return maxAge
 }
 
-// jitterHTTPConnMaxAge spreads retirement times so a large batch of connections
-// does not age out at exactly the same moment.
-func jitterHTTPConnMaxAge(maxAge time.Duration) time.Duration {
-	if maxAge <= 0 {
-		return 0
-	}
-	delta := maxAge / 10
-	if delta <= 0 {
-		return maxAge
-	}
-	return maxAge - delta + time.Duration(rand.Int63n(int64(2*delta)))
-}
-
 // splitIPsByVersion keeps IPv6 and IPv4 addresses separate so dialing can
 // preserve the existing happy-eyeballs style fallback order.
 func splitIPsByVersion(ips []net.IP) ([]net.IP, []net.IP) {

--- a/pkg/object/swift.go
+++ b/pkg/object/swift.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -151,7 +150,7 @@ func newSwiftOSS(endpoint, username, apiKey, token string) (ObjectStorage, error
 		ApiKey:    apiKey,
 		AuthToken: token,
 		AuthUrl:   authURL,
-		Transport: httpClient.Transport.(*http.Transport),
+		Transport: GetHttpTransport(),
 	}
 	err = conn.Authenticate(context.Background())
 	if err != nil {

--- a/pkg/object/tos.go
+++ b/pkg/object/tos.go
@@ -321,7 +321,7 @@ func newTOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		hostParts[1]+"."+hostParts[2],
 		tos.WithRegion(strings.TrimPrefix(hostParts[1], "tos-")),
 		tos.WithCredentials(credentials),
-		tos.WithEnableVerifySSL(httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify),
+		tos.WithEnableVerifySSL(GetHttpTransport().TLSClientConfig.InsecureSkipVerify),
 		tos.WithEnableCRC(!disableChecksum))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

This PR adds opt-in HTTP connection max-age support for the shared object HTTP client.

When `JFS_HTTP_CONN_MAX_AGE` is set and JuiceFS is built with Go 1.26+, the shared object HTTP client uses `net/http` `ClientConn` to retire expired connections gracefully:

* stop assigning new requests to expired connections
* allow in-flight requests to finish
* close expired connections after they become idle

When the variable is unset, set to `0`, or JuiceFS is built with Go < 1.26, the default behavior remains unchanged.

Related to #7045.

## Motivation

#7045 is about old pooled HTTP connections remaining alive for a long time, which may prevent DNS changes from taking effect promptly.

Go 1.26 exposes `net/http` `ClientConn`, which makes it possible to manage connection lifetime at the HTTP connection-management layer instead of relying on `net.Conn` read/write boundary detection.

Compared with a `net.Conn` wrapper approach, this avoids closing connections from the raw Read/Write path and allows in-flight requests to finish before expired connections are closed.

## Design

### 1. Keep the base transport as `*http.Transport`

The shared object HTTP stack is split into:

* a shared base `*http.Transport`
* a shared `*http.Client`

When max age is disabled, the client uses the base transport directly.

When max age is enabled on Go 1.26+, the client uses a custom `RoundTripper` backed by `ClientConn`. The base `*http.Transport` is still kept and exposed through `GetHttpTransport()` for integrations that require the concrete transport type.

This avoids breaking existing code paths that previously relied on:

```go
object.GetHttpClient().Transport.(*http.Transport)
```

### 2. Use `ClientConn` to retire expired connections gracefully

For the shared object HTTP client path, the Go 1.26+ implementation maintains a small per-host `ClientConn` pool.

For each host:

* connections are tracked with `createdAt`, `maxAge`, and retiring state
* once a connection exceeds max age, it is marked retiring
* retiring connections do not accept new requests
* if a retiring connection still has in-flight requests, it stays alive
* once `InFlight() == 0`, it is closed

The implementation uses the common `ClientConn` interface, so the retirement logic is shared by HTTP/1 and HTTP/2 connections.

### 3. Bound connection creation under concurrency

The custom transport also bounds connection creation under concurrency:

* at most one in-progress dial per host
* waiters are woken when pool state changes
* per-host connection limits are derived from the base transport
* expired/dead connections are swept safely

### 4. Keep pre-Go-1.26 behavior unchanged

For Go versions before 1.26:

* the shared client keeps using the base transport directly
* `JFS_HTTP_CONN_MAX_AGE` is ignored with a warning

This preserves compatibility with the current minimum Go version in `go.mod`.

## Scope and coverage

This PR intentionally scopes graceful retirement to the shared object HTTP client path.

It does not force all SDK integrations onto the custom `RoundTripper`.

Some integrations still require direct access to `*http.Transport`, for example:

* TLS configuration paths in `cmd/format.go`
* SDK integrations such as OBS / Swift / TOS

For those paths, this PR keeps using the shared base transport via `GetHttpTransport()` to avoid a broader refactor.

So the boundary is:

* shared object HTTP client path: `ClientConn` max-age retirement
* direct `*http.Transport` integrations: continue to use the shared base `*http.Transport`

## User-facing behavior

This is opt-in and disabled by default.

For example:

```bash
JFS_HTTP_CONN_MAX_AGE=30m
```

The value is parsed with `time.ParseDuration`, so values such as `10m`, `30m`, and `1h` are supported.

If unset or set to `0`, behavior remains unchanged.

On Go < 1.26, the setting is ignored with a warning.

## Tests

Added Go 1.26+ tests covering:

* max age disabled behavior
* retiring expired idle connections
* keeping in-flight requests running before closing expired connections
* HTTP/1 and HTTP/2 paths
* concurrent request scheduling around the per-host connection pool

## Verification

Verified locally with:

```bash
go test -count=1 ./pkg/object -run 'TestHTTPConnMaxAgeTransport' -timeout 60s -v
go test -count=1 ./pkg/object
go test -race -count=1 ./pkg/object -run 'TestHTTPConnMaxAgeTransport' -timeout 60s -v
go test -count=1 -run '^$' ./cmd
```

Also verified the legacy path with Go 1.25:

```bash
go test -count=1 -run '^$' ./pkg/object ./cmd
```

`go test -run '^$' ./cmd` was used as a compile check because the full `./cmd` test suite requires a local Redis service.

`git diff --check` also passes.

## Notes

This PR uses an environment variable to keep the change scoped and low-risk. A CLI/config option can be added later without changing the core connection-retirement logic.
