### PR TITLE
meta/trash: add trash_cleanup_overdue_seconds metric to monitor trash backlog

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -349,6 +349,7 @@ type baseMeta struct {
 	groupQuotaUsedSpaceG  *prometheus.GaugeVec
 	groupQuotaUsedInodesG *prometheus.GaugeVec
 
+	trashOverdueG prometheus.Gauge
 	bgjobDels     *prometheus.CounterVec
 	bgjobDuration *prometheus.HistogramVec
 
@@ -511,6 +512,10 @@ func newBaseMeta(addr string, conf *Config) *baseMeta {
 			[]string{"gid"},
 		),
 
+		trashOverdueG: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "trash_cleanup_overdue_seconds",
+			Help: "Seconds since the oldest trash entry expired, or 0 if none are overdue.",
+		}),
 		bgjobDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    "juicefs_bgjob_duration_seconds",
@@ -565,6 +570,7 @@ func (m *baseMeta) InitSharedMetrics(reg prometheus.Registerer) {
 		subdir = ""
 	}
 	m.subdirInfoG.WithLabelValues(subdir).Set(1)
+	reg.MustRegister(m.trashOverdueG)
 
 	go func() {
 		for {
@@ -3064,6 +3070,7 @@ func (m *baseMeta) cleanupTrash(ctx Context) {
 			return
 		case <-time.After(utils.JitterIt(time.Hour)):
 		}
+		m.trashOverdueG.Set(0) // cleanup to not expose stale overdue metrics
 		if st := m.en.doGetAttr(ctx, TrashInode, nil); st != 0 {
 			if st != syscall.ENOENT {
 				logger.Warnf("getattr inode %d: %s", TrashInode, st)
@@ -3182,6 +3189,7 @@ func (m *baseMeta) CleanupTrashBefore(ctx Context, edge time.Time, increProgress
 			entries = entries[1:]
 			continue
 		}
+		m.trashOverdueG.Set(max(edge.Sub(ts).Seconds(), 0)) // entries are sorted ascendingly
 		if !ts.Before(edge) {
 			break
 		}


### PR DESCRIPTION
This PR adds a `trash_cleanup_overdue_seconds` metric to expose how far trash cleanup is lagging behind the configured retention window.

When trash cleanup cannot keep up or gets stuck on old trash entries, we have no visibility unless inspecting logs or the trash dir manually. This metric helps detect delayed trash cleanup early, makes alerting on cleanup health much easier.

Since each JuiceFS instance exports this metric independently, users should aggregate it using `max()` to get a volume-level backlog.