### PR TITLE
vfs/gateway: share read-only page-cache across concurrent openers

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -448,6 +448,24 @@ func (fs *FileSystem) open(ctx meta.Context, path string, flags uint32, followLi
 	return
 }
 
+// OpenForRead is like Open with MODE_MASK_R but uses a shared per-inode
+// FileReader so that concurrent read-only openers of the same file share one
+// page-cache, avoiding redundant object-storage I/O and excess memory usage.
+func (fs *FileSystem) OpenForRead(ctx meta.Context, path string) (*File, syscall.Errno) {
+	f, err := fs.open(ctx, path, vfs.MODE_MASK_R, true)
+	if err != 0 || f == nil {
+		return f, err
+	}
+	// Pre-bind the shared read-only FileReader so pread() won't fall back to
+	// the per-fd reader.Open() path.
+	f.Lock()
+	if f.rdata == nil {
+		f.rdata = fs.reader.OpenReadOnly(f.inode, uint64(f.info.Size()))
+	}
+	f.Unlock()
+	return f, 0
+}
+
 func (fs *FileSystem) Access(ctx meta.Context, path string, flags int) (err syscall.Errno) {
 	l := vfs.NewLogContext(ctx)
 	defer func() { fs.log(l, "Access (%s): %s", path, errstr(err)) }()

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -576,7 +576,10 @@ func (n *jfsObjects) GetObjectNInfo(ctx context.Context, bucket, object string, 
 	if err != nil {
 		return
 	}
-	f, eno := n.fs.Open(mctx, n.path(bucket, object), vfs.MODE_MASK_R)
+	// Use OpenForRead so that concurrent GET requests for the same object share
+	// one per-inode page-cache, mirroring kernel page-cache behaviour and
+	// avoiding redundant object-storage I/O.
+	f, eno := n.fs.OpenForRead(mctx, n.path(bucket, object))
 	if eno != 0 {
 		return nil, jfsToObjectErr(ctx, eno, bucket, object)
 	}

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -74,6 +74,10 @@ type FileReader interface {
 
 type DataReader interface {
 	Open(inode Ino, length uint64) FileReader
+	// OpenReadOnly returns a FileReader backed by a shared per-inode cache.
+	// Multiple callers opening the same inode read-only share one fileReader,
+	// mirroring the kernel page-cache behaviour observable under FUSE mounts.
+	OpenReadOnly(inode Ino, length uint64) FileReader
 	Truncate(inode Ino, length uint64)
 	Invalidate(inode Ino, off, length uint64)
 }
@@ -292,7 +296,8 @@ type fileReader struct {
 	last     **sliceReader
 
 	sync.Mutex
-	closing bool
+	closing  bool
+	readOnly bool // true if this fileReader is shared among read-only openers
 
 	// protected by r
 	refs uint16
@@ -683,6 +688,19 @@ func (f *fileReader) visit(fn func(s *sliceReader) bool) {
 }
 
 func (f *fileReader) Close(ctx meta.Context) {
+	if f.readOnly {
+		f.r.Lock()
+		f.refs--
+		remaining := f.refs
+		if remaining == 0 {
+			delete(f.r.roFiles, f.inode)
+		}
+		f.r.Unlock()
+		if remaining > 0 {
+			// Other openers are still using this shared reader; keep it alive.
+			return
+		}
+	}
 	f.Lock()
 	f.closing = true
 	f.visit(func(s *sliceReader) bool {
@@ -698,6 +716,7 @@ type dataReader struct {
 	m              meta.Meta
 	store          chunk.ChunkStore
 	files          map[Ino]*fileReader
+	roFiles        map[Ino]*fileReader // shared read-only fileReader per inode
 	blockSize      uint64
 	bufferSize     int64
 	readAheadMax   uint64
@@ -716,6 +735,7 @@ func NewDataReader(conf *Config, m meta.Meta, store chunk.ChunkStore) DataReader
 		m:              m,
 		store:          store,
 		files:          make(map[Ino]*fileReader),
+		roFiles:        make(map[Ino]*fileReader),
 		blockSize:      uint64(conf.Chunk.BlockSize),
 		bufferSize:     int64(conf.Chunk.BufferSize),
 		readAheadTotal: uint64(readAheadTotal),
@@ -743,6 +763,12 @@ func (r *dataReader) checkReadBuffer() {
 				f = f.next
 			}
 		}
+		// Also release idle buffers held by shared read-only readers.
+		for _, f := range r.roFiles {
+			r.Unlock()
+			f.releaseIdleBuffer()
+			r.Lock()
+		}
 		r.Unlock()
 		time.Sleep(time.Second)
 	}
@@ -764,6 +790,36 @@ func (r *dataReader) Open(inode Ino, length uint64) FileReader {
 	return f
 }
 
+// OpenReadOnly returns a shared FileReader for read-only access.  All callers
+// opening the same inode read-only share a single fileReader so their page
+// cache (slices) is reused across concurrent requests, avoiding redundant
+// object-storage I/O and excess memory usage.
+func (r *dataReader) OpenReadOnly(inode Ino, length uint64) FileReader {
+	r.Lock()
+	defer r.Unlock()
+	if f, ok := r.roFiles[inode]; ok {
+		// Reuse the existing shared reader; bump the ref so Close knows when
+		// the last opener has finished.
+		f.Lock()
+		if length > f.length {
+			f.length = length
+		}
+		f.Unlock()
+		f.refs++
+		return f
+	}
+	f := &fileReader{
+		r:        r,
+		inode:    inode,
+		length:   length,
+		readOnly: true,
+	}
+	f.last = &(f.slices)
+	f.refs = 1
+	r.roFiles[inode] = f
+	return f
+}
+
 func (r *dataReader) visit(inode Ino, fn func(*fileReader)) {
 	// r could be hold inside f, so Unlock r first to avoid deadlock
 	r.Lock()
@@ -772,6 +828,11 @@ func (r *dataReader) visit(inode Ino, fn func(*fileReader)) {
 	for f != nil {
 		fs = append(fs, f)
 		f = f.next
+	}
+	// Also visit the shared read-only reader so that Truncate/Invalidate
+	// correctly expire its cached slices.
+	if ro, ok := r.roFiles[inode]; ok {
+		fs = append(fs, ro)
 	}
 	r.Unlock()
 	for _, f := range fs {

--- a/pkg/vfs/reader_test.go
+++ b/pkg/vfs/reader_test.go
@@ -1,0 +1,150 @@
+/*
+ * JuiceFS, Copyright 2020 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vfs
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/juicedata/juicefs/pkg/chunk"
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestDataReader(t *testing.T) DataReader {
+	t.Helper()
+	format := &meta.Format{
+		Name:      "test",
+		UUID:      uuid.New().String(),
+		Storage:   "mem",
+		BlockSize: 4096,
+	}
+	m := meta.NewClient("memkv://", meta.DefaultConf())
+	if err := m.Init(format, true); err != nil {
+		t.Fatalf("meta init: %v", err)
+	}
+	chunkConf := chunk.Config{
+		BlockSize:   format.BlockSize * 1024,
+		MaxUpload:   2,
+		MaxDownload: 10,
+		BufferSize:  30 << 20,
+		CacheSize:   0,
+		CacheDir:    "memory",
+	}
+	blob, _ := object.CreateStorage("mem", "", "", "", "")
+	store := chunk.NewCachedStore(blob, chunkConf, prometheus.NewRegistry())
+	conf := &Config{
+		Meta:   meta.DefaultConf(),
+		Format: *format,
+		Chunk:  &chunkConf,
+	}
+	return NewDataReader(conf, m, store)
+}
+
+// TestOpenReadOnly_SharedInstance verifies that two OpenReadOnly calls for the
+// same inode return the same underlying fileReader (i.e. the same pointer),
+// while Open always returns a fresh independent instance.
+func TestOpenReadOnly_SharedInstance(t *testing.T) {
+	r := newTestDataReader(t)
+	dr := r.(*dataReader)
+
+	const inode Ino = 42
+	const length uint64 = 1024
+
+	f1 := r.OpenReadOnly(inode, length)
+	f2 := r.OpenReadOnly(inode, length)
+
+	assert.Same(t, f1, f2, "OpenReadOnly should return the same fileReader for the same inode")
+
+	dr.Lock()
+	refs := dr.roFiles[inode].refs
+	dr.Unlock()
+	assert.Equal(t, uint16(2), refs, "ref count should be 2 after two OpenReadOnly calls")
+
+	// Open (write path) must still return a fresh, independent instance.
+	fw := r.Open(inode, length)
+	assert.NotSame(t, f1, fw, "Open should return an independent fileReader")
+	fw.Close(meta.Background())
+}
+
+// TestOpenReadOnly_CloseRefCounting verifies that the shared fileReader is kept
+// alive until the last opener closes it, and removed from roFiles afterwards.
+func TestOpenReadOnly_CloseRefCounting(t *testing.T) {
+	r := newTestDataReader(t)
+	dr := r.(*dataReader)
+
+	const inode Ino = 7
+	const length uint64 = 512
+
+	f1 := r.OpenReadOnly(inode, length)
+	f2 := r.OpenReadOnly(inode, length)
+
+	// First close: reader should still be in roFiles (refs drops to 1).
+	f1.Close(meta.Background())
+	dr.Lock()
+	_, stillPresent := dr.roFiles[inode]
+	dr.Unlock()
+	assert.True(t, stillPresent, "shared fileReader should survive after first Close")
+
+	// Second close: refs reaches 0, reader must be removed from roFiles.
+	f2.Close(meta.Background())
+	dr.Lock()
+	_, stillPresent = dr.roFiles[inode]
+	dr.Unlock()
+	assert.False(t, stillPresent, "shared fileReader should be removed after last Close")
+}
+
+// TestOpenReadOnly_IndependentInodes verifies that different inodes get
+// separate shared readers.
+func TestOpenReadOnly_IndependentInodes(t *testing.T) {
+	r := newTestDataReader(t)
+
+	fa := r.OpenReadOnly(Ino(1), 100)
+	fb := r.OpenReadOnly(Ino(2), 100)
+
+	assert.NotSame(t, fa, fb, "different inodes must have independent shared readers")
+
+	fa.Close(meta.Background())
+	fb.Close(meta.Background())
+}
+
+// TestOpenReadOnly_LengthUpdate verifies that if a second opener provides a
+// larger length, the shared fileReader's length is updated.
+func TestOpenReadOnly_LengthUpdate(t *testing.T) {
+	r := newTestDataReader(t)
+	dr := r.(*dataReader)
+
+	const inode Ino = 99
+	f1 := r.OpenReadOnly(inode, 1024)
+	f2 := r.OpenReadOnly(inode, 2048) // larger length
+
+	assert.Same(t, f1, f2)
+
+	dr.Lock()
+	fr := dr.roFiles[inode]
+	dr.Unlock()
+
+	fr.Lock()
+	got := fr.length
+	fr.Unlock()
+	assert.Equal(t, uint64(2048), got, "shared fileReader length should be updated to the larger value")
+
+	f1.Close(meta.Background())
+	f2.Close(meta.Background())
+}


### PR DESCRIPTION
Problem
gateway mode every HTTP GET opens a new fileReader (via reader.Open), which carries its own independent slices list.  When N concurrent requests read the same object, each one fetches the same 4 MB block from object storage independently, uses N × 4 MB of readahead buffer, and drives readBufferUsed up linearly – triggering the backpressure sleep in fileReader.Read long before the configured buffer limit is reached.

This is in contrast to FUSE mounts, where the kernel page-cache is per-inode: once any fd reads a block, every subsequent fd gets it from the cache for free.

Solution
--------
Introduce a shared, reference-counted fileReader for read-os:

* dataReader gains a new roFiles map[Ino]*fileReader field that holds at most one shared fileReader per inode.
* DataReader interface gets a new OpenReadOnly(inode, length) method. The first read-only opener creates the shared fileReader and stores it in roFiles; subsequent openent refs and get the same instance back.  The shared reader is destroyed only when the last opener calls Close().
* fileReader gains a readOnly bool flag so Close() knows to decrement the shared ref-count instead of immediately  the reader.
* dataReader.visit() (called by Truncate and Invalidate) now also visits roFiles[inode], so cache invalidation works correctly.
* checkReadBuffer() includes roFiles readers in its idle-buffer sweep.
* fs.FileSystem gains OpenForRead() which calls OpenReadOnly internally.
* gateway.GetObjectNInfo switches from fs.Open to fs.OpenForRead.

Effect
------
* N concurrent GETs on the same objobject-storage fetch, 1 × 4 MB buffer instead of N × 4 MB.
* Backpressure threshold is no longer proportional to concurrent request count; hot objects no longer starve unrelated requests.
* Write paths and non-gateway FUSE paths are entirely unaffected.