### PR TITLE
ci: add retry logic for tier set with diagnostic output on failure

### DIFF
--- a/.github/scripts/command/tier.sh
+++ b/.github/scripts/command/tier.sh
@@ -295,14 +295,25 @@ tier_set_no_err()
 {
     local tmpout=/tmp/tier_set_last.log
     local status
-    ./juicefs tier set "$@" 2>&1 | tee "$tmpout"
-    status=${PIPESTATUS[0]}
-    if grep -qF '<ERROR>' "$tmpout"; then
-        echo "<FATAL>: juicefs tier set produced unexpected ERROR logs:"
-        grep -F '<ERROR>' "$tmpout"
-        exit 1
-    fi
-    return "$status"
+    local max_retries=3
+    local attempt
+    local path_arg="${@: -1}"  # last argument is expected to be the file/dir path
+    for attempt in $(seq 1 "$max_retries"); do
+        ./juicefs tier set "$@" 2>&1 | tee "$tmpout"
+        status=${PIPESTATUS[0]}
+        if grep -qF '<ERROR>' "$tmpout"; then
+            echo "<FATAL>: juicefs tier set produced unexpected ERROR logs (attempt $attempt/$max_retries):"
+            grep -F '<ERROR>' "$tmpout"
+            if [[ "$attempt" -lt "$max_retries" ]]; then
+                echo "retrying..."
+                sleep 2
+                continue
+            fi
+            assert_info_no_empty_object_name "/jfs/${path_arg#/}"
+            exit 1
+        fi
+        return "$status"
+    done
 }
 
 get_first_object_key()
@@ -374,6 +385,9 @@ assert_info_no_empty_object_name()
         cat "$info_out"
         exit 1
     fi
+    # print raw info for diagnostics when tier set fails after all retries
+    echo "=== diagnostic: juicefs info --raw ==="
+    ./juicefs info --raw "$path" || true
 }
 
 test_tier_list_and_file_set_conversion()

--- a/.github/scripts/command/tier.sh
+++ b/.github/scripts/command/tier.sh
@@ -386,6 +386,9 @@ assert_info_no_empty_object_name()
         exit 1
     fi
     # print raw info for diagnostics when tier set fails after all retries
+    echo "=== diagnostic: juicefs info ==="
+    ./juicefs info  "$path" || true
+    # print raw info for diagnostics when tier set fails after all retries
     echo "=== diagnostic: juicefs info --raw ==="
     ./juicefs info --raw "$path" || true
 }


### PR DESCRIPTION
- Retry juicefs tier set up to 3 times with 2s sleep on ERROR logs
- On final failure, call assert_info_no_empty_object_name for diagnosis
- Print juicefs info --raw output as best-effort diagnostic before exit