### PR TITLE
pkg/object: nil-guard pointer fields in S3-family responses

### DIFF
--- a/pkg/object/ibmcos.go
+++ b/pkg/object/ibmcos.go
@@ -173,11 +173,11 @@ func (s *ibmcos) Head(ctx context.Context, key string) (Object, error) {
 	}
 	return &obj{
 		key,
-		*r.ContentLength,
-		*r.LastModified,
+		aws.Int64Value(r.ContentLength),
+		aws.TimeValue(r.LastModified),
 		strings.HasSuffix(key, "/"),
-		*r.StorageClass,
-		*r.Restore,
+		aws.StringValue(r.StorageClass),
+		aws.StringValue(r.Restore),
 	}, nil
 }
 
@@ -212,23 +212,32 @@ func (s *ibmcos) List(ctx context.Context, prefix, start, token, delimiter strin
 	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		oKey, err := decodeKey(*o.Key, resp.EncodingType)
+		rawKey := aws.StringValue(o.Key)
+		oKey, err := decodeKey(rawKey, resp.EncodingType)
 		if err != nil {
-			return nil, false, "", errors.WithMessagef(err, "failed to decode key %s", *o.Key)
+			return nil, false, "", errors.WithMessagef(err, "failed to decode key %s", rawKey)
 		}
-		objs[i] = &obj{oKey, *o.Size, *o.LastModified, strings.HasSuffix(oKey, "/"), *o.StorageClass, ""}
+		objs[i] = &obj{
+			oKey,
+			aws.Int64Value(o.Size),
+			aws.TimeValue(o.LastModified),
+			strings.HasSuffix(oKey, "/"),
+			aws.StringValue(o.StorageClass),
+			"",
+		}
 	}
 	if delimiter != "" {
 		for _, p := range resp.CommonPrefixes {
-			prefix, err := decodeKey(*p.Prefix, resp.EncodingType)
+			rawPrefix := aws.StringValue(p.Prefix)
+			prefix, err := decodeKey(rawPrefix, resp.EncodingType)
 			if err != nil {
-				return nil, false, "", errors.WithMessagef(err, "failed to decode commonPrefixes %s", *p.Prefix)
+				return nil, false, "", errors.WithMessagef(err, "failed to decode commonPrefixes %s", rawPrefix)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, "", ""})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}
-	return objs, *resp.IsTruncated, *resp.NextMarker, nil
+	return objs, aws.BoolValue(resp.IsTruncated), aws.StringValue(resp.NextMarker), nil
 }
 
 func (s *ibmcos) ListAll(ctx context.Context, prefix, marker string, followLink bool) (<-chan Object, error) {
@@ -247,7 +256,11 @@ func (s *ibmcos) CreateMultipartUpload(ctx context.Context, key string) (*Multip
 	if err != nil {
 		return nil, err
 	}
-	return &MultipartUpload{UploadID: *resp.UploadId, MinPartSize: 5 << 20, MaxCount: 10000}, nil
+	uploadID := aws.StringValue(resp.UploadId)
+	if uploadID == "" {
+		return nil, fmt.Errorf("ibmcos: CreateMultipartUpload returned empty UploadId for %s", key)
+	}
+	return &MultipartUpload{UploadID: uploadID, MinPartSize: 5 << 20, MaxCount: 10000}, nil
 }
 
 func (s *ibmcos) UploadPart(ctx context.Context, key string, uploadID string, num int, body []byte) (*Part, error) {
@@ -263,7 +276,7 @@ func (s *ibmcos) UploadPart(ctx context.Context, key string, uploadID string, nu
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, ETag: *resp.ETag}, nil
+	return &Part{Num: num, ETag: aws.StringValue(resp.ETag)}, nil
 }
 
 func (s *ibmcos) UploadPartCopy(ctx context.Context, key string, uploadID string, num int, srcKey string, off, size int64) (*Part, error) {
@@ -308,13 +321,9 @@ func (s *ibmcos) ListUploads(ctx context.Context, marker string) ([]*PendingPart
 	}
 	parts := make([]*PendingPart, len(result.Uploads))
 	for i, u := range result.Uploads {
-		parts[i] = &PendingPart{*u.Key, *u.UploadId, *u.Initiated}
+		parts[i] = &PendingPart{aws.StringValue(u.Key), aws.StringValue(u.UploadId), aws.TimeValue(u.Initiated)}
 	}
-	var nextMarker string
-	if result.NextKeyMarker != nil {
-		nextMarker = *result.NextKeyMarker
-	}
-	return parts, nextMarker, nil
+	return parts, aws.StringValue(result.NextKeyMarker), nil
 }
 
 func newIBMCOS(endpoint, apiKey, serviceInstanceID, token string) (ObjectStorage, error) {

--- a/pkg/object/ks3.go
+++ b/pkg/object/ks3.go
@@ -42,6 +42,20 @@ import (
 
 const s3StorageClassHdr = "X-Amz-Storage-Class"
 
+// ks3DerefTime returns *p when non-nil, else the zero time. The ks3 SDK does
+// not ship a nil-safe pointer helper for time.Time.
+func ks3DerefTime(p *time.Time) time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return *p
+}
+
+// ks3DerefBool returns *p when non-nil, else false.
+func ks3DerefBool(p *bool) bool {
+	return p != nil && *p
+}
+
 type ks3 struct {
 	bucket string
 	s3     *s3.S3
@@ -92,11 +106,11 @@ func (s *ks3) Head(ctx context.Context, key string) (Object, error) {
 	}
 	return &obj{
 		key,
-		*r.ContentLength,
-		*r.LastModified,
+		aws.ToLong(r.ContentLength),
+		ks3DerefTime(r.LastModified),
 		strings.HasSuffix(key, "/"),
 		sc,
-		*r.Restore,
+		aws.ToString(r.Restore),
 	}, nil
 }
 
@@ -208,27 +222,32 @@ func (s *ks3) List(ctx context.Context, prefix, start, token, delimiter string, 
 	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		oKey, err := decodeKey(*o.Key, resp.EncodingType)
+		rawKey := aws.ToString(o.Key)
+		oKey, err := decodeKey(rawKey, resp.EncodingType)
 		if err != nil {
-			return nil, false, "", errors.WithMessagef(err, "failed to decode key %s", *o.Key)
+			return nil, false, "", errors.WithMessagef(err, "failed to decode key %s", rawKey)
 		}
-		objs[i] = &obj{oKey, *o.Size, *o.LastModified, strings.HasSuffix(oKey, "/"), *o.StorageClass, ""}
+		objs[i] = &obj{
+			oKey,
+			aws.ToLong(o.Size),
+			ks3DerefTime(o.LastModified),
+			strings.HasSuffix(oKey, "/"),
+			aws.ToString(o.StorageClass),
+			"",
+		}
 	}
 	if delimiter != "" {
 		for _, p := range resp.CommonPrefixes {
-			prefix, err := decodeKey(*p.Prefix, resp.EncodingType)
+			rawPrefix := aws.ToString(p.Prefix)
+			prefix, err := decodeKey(rawPrefix, resp.EncodingType)
 			if err != nil {
-				return nil, false, "", errors.WithMessagef(err, "failed to decode commonPrefixes %s", *p.Prefix)
+				return nil, false, "", errors.WithMessagef(err, "failed to decode commonPrefixes %s", rawPrefix)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, "", ""})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}
-	var nextMarker string
-	if resp.NextMarker != nil {
-		nextMarker = *resp.NextMarker
-	}
-	return objs, *resp.IsTruncated, nextMarker, nil
+	return objs, ks3DerefBool(resp.IsTruncated), aws.ToString(resp.NextMarker), nil
 }
 
 func (s *ks3) ListAll(ctx context.Context, prefix, marker string, followLink bool) (<-chan Object, error) {
@@ -247,7 +266,11 @@ func (s *ks3) CreateMultipartUpload(ctx context.Context, key string) (*Multipart
 	if err != nil {
 		return nil, err
 	}
-	return &MultipartUpload{UploadID: *resp.UploadID, MinPartSize: 5 << 20, MaxCount: 10000}, nil
+	uploadID := aws.ToString(resp.UploadID)
+	if uploadID == "" {
+		return nil, fmt.Errorf("ks3: CreateMultipartUpload returned empty UploadID for %s", key)
+	}
+	return &MultipartUpload{UploadID: uploadID, MinPartSize: 5 << 20, MaxCount: 10000}, nil
 }
 
 func (s *ks3) UploadPart(ctx context.Context, key string, uploadID string, num int, body []byte) (*Part, error) {
@@ -263,7 +286,7 @@ func (s *ks3) UploadPart(ctx context.Context, key string, uploadID string, num i
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, ETag: *resp.ETag}, nil
+	return &Part{Num: num, ETag: aws.ToString(resp.ETag)}, nil
 }
 
 func (s *ks3) Restore(ctx context.Context, key string, days int32) error {
@@ -289,7 +312,10 @@ func (s *ks3) UploadPartCopy(ctx context.Context, key string, uploadID string, n
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, ETag: *resp.CopyPartResult.ETag}, nil
+	if resp.CopyPartResult == nil {
+		return nil, fmt.Errorf("ks3: UploadPartCopy returned no CopyPartResult for %s part %d", key, num)
+	}
+	return &Part{Num: num, ETag: aws.ToString(resp.CopyPartResult.ETag)}, nil
 }
 
 func (s *ks3) AbortUpload(ctx context.Context, key string, uploadID string) {
@@ -330,13 +356,9 @@ func (s *ks3) ListUploads(ctx context.Context, marker string) ([]*PendingPart, s
 	}
 	parts := make([]*PendingPart, len(result.Uploads))
 	for i, u := range result.Uploads {
-		parts[i] = &PendingPart{*u.Key, *u.UploadID, *u.Initiated}
+		parts[i] = &PendingPart{aws.ToString(u.Key), aws.ToString(u.UploadID), ks3DerefTime(u.Initiated)}
 	}
-	var nextMarker string
-	if result.NextKeyMarker != nil {
-		nextMarker = *result.NextKeyMarker
-	}
-	return parts, nextMarker, nil
+	return parts, aws.ToString(result.NextKeyMarker), nil
 }
 
 var ks3Regions = map[string]string{

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -72,13 +72,14 @@ func (q *qingstor) Head(ctx context.Context, key string) (Object, error) {
 		if e, ok := err.(*errors.QingStorError); ok && e.StatusCode == http.StatusNotFound {
 			return nil, os.ErrNotExist
 		}
+		return nil, err
 	}
 	return &obj{
 		key,
-		*r.ContentLength,
-		*r.LastModified,
+		aws.ToInt64(r.ContentLength),
+		aws.ToTime(r.LastModified),
 		strings.HasSuffix(key, "/"),
-		*r.XQSStorageClass,
+		aws.ToString(r.XQSStorageClass),
 		"",
 	}, nil
 }
@@ -170,8 +171,8 @@ func (q *qingstor) Put(ctx context.Context, key string, in io.Reader, getters ..
 	if err != nil {
 		return err
 	}
-	if *out.StatusCode != 201 {
-		return fmt.Errorf("unexpected code: %d", *out.StatusCode)
+	if code := aws.ToInt(out.StatusCode); code != 201 {
+		return fmt.Errorf("unexpected code: %d", code)
 	}
 	return nil
 }
@@ -187,8 +188,8 @@ func (q *qingstor) Copy(ctx context.Context, dst, src string) error {
 	if err != nil {
 		return err
 	}
-	if *out.StatusCode != 201 {
-		return fmt.Errorf("unexpected code: %d", *out.StatusCode)
+	if code := aws.ToInt(out.StatusCode); code != 201 {
+		return fmt.Errorf("unexpected code: %d", code)
 	}
 	return nil
 }
@@ -223,22 +224,23 @@ func (q *qingstor) List(ctx context.Context, prefix, start, token, delimiter str
 	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		k := out.Keys[i]
+		oKey := aws.ToString(k.Key)
 		objs[i] = &obj{
-			*k.Key,
-			*k.Size,
-			time.Unix(int64(*k.Modified), 0),
-			strings.HasSuffix(*k.Key, "/"),
-			*k.StorageClass,
+			oKey,
+			aws.ToInt64(k.Size),
+			time.Unix(int64(aws.ToInt(k.Modified)), 0),
+			strings.HasSuffix(oKey, "/"),
+			aws.ToString(k.StorageClass),
 			"",
 		}
 	}
 	if delimiter != "" {
 		for _, p := range out.CommonPrefixes {
-			objs = append(objs, &obj{*p, 0, time.Unix(0, 0), true, "", ""})
+			objs = append(objs, &obj{aws.ToString(p), 0, time.Unix(0, 0), true, "", ""})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}
-	return objs, *out.HasMore, *out.NextMarker, nil
+	return objs, aws.ToBool(out.HasMore), aws.ToString(out.NextMarker), nil
 }
 
 func (q *qingstor) ListAll(ctx context.Context, prefix, marker string, followLink bool) (<-chan Object, error) {
@@ -254,7 +256,11 @@ func (q *qingstor) CreateMultipartUpload(ctx context.Context, key string) (*Mult
 	if err != nil {
 		return nil, err
 	}
-	return &MultipartUpload{UploadID: *r.UploadID, MinPartSize: 4 << 20, MaxCount: 10000}, nil
+	uploadID := aws.ToString(r.UploadID)
+	if uploadID == "" {
+		return nil, fmt.Errorf("qingstor: InitiateMultipartUpload returned empty UploadID for %s", key)
+	}
+	return &MultipartUpload{UploadID: uploadID, MinPartSize: 4 << 20, MaxCount: 10000}, nil
 }
 
 func (q *qingstor) UploadPart(ctx context.Context, key string, uploadID string, num int, data []byte) (*Part, error) {
@@ -267,7 +273,7 @@ func (q *qingstor) UploadPart(ctx context.Context, key string, uploadID string, 
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, Size: len(data), ETag: strings.Trim(*r.ETag, "\"")}, nil
+	return &Part{Num: num, Size: len(data), ETag: strings.Trim(aws.ToString(r.ETag), "\"")}, nil
 }
 
 func (q *qingstor) UploadPartCopy(ctx context.Context, key string, uploadID string, num int, srcKey string, off, size int64) (*Part, error) {
@@ -281,7 +287,7 @@ func (q *qingstor) UploadPartCopy(ctx context.Context, key string, uploadID stri
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, Size: int(size), ETag: strings.Trim(*r.ETag, "\"")}, nil
+	return &Part{Num: num, Size: int(size), ETag: strings.Trim(aws.ToString(r.ETag), "\"")}, nil
 }
 
 func (q *qingstor) AbortUpload(ctx context.Context, key string, uploadID string) {
@@ -317,13 +323,9 @@ func (q *qingstor) ListUploads(ctx context.Context, marker string) ([]*PendingPa
 	}
 	parts := make([]*PendingPart, len(result.Uploads))
 	for i, u := range result.Uploads {
-		parts[i] = &PendingPart{*u.Key, *u.UploadID, *u.Created}
+		parts[i] = &PendingPart{aws.ToString(u.Key), aws.ToString(u.UploadID), aws.ToTime(u.Created)}
 	}
-	var nextMarker string
-	if result.NextKeyMarker != nil {
-		nextMarker = *result.NextKeyMarker
-	}
-	return parts, nextMarker, nil
+	return parts, aws.ToString(result.NextKeyMarker), nil
 }
 
 func newQingStor(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) {

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -111,8 +111,8 @@ func (s *s3client) Head(ctx context.Context, key string) (Object, error) {
 	}
 	return &obj{
 		key,
-		*r.ContentLength,
-		*r.LastModified,
+		aws.ToInt64(r.ContentLength),
+		aws.ToTime(r.LastModified),
 		strings.HasSuffix(key, "/"),
 		getOrDefaultScValue(string(r.StorageClass), string(types.StorageClassStandard)),
 		aws.ToString(r.Restore),
@@ -260,17 +260,18 @@ func (s *s3client) List(ctx context.Context, prefix, start, token, delimiter str
 	objs := make([]Object, n)
 	for i := 0; i < n; i++ {
 		o := resp.Contents[i]
-		oKey, err := decodeKey(*o.Key, aws.String(string(resp.EncodingType)))
+		rawKey := aws.ToString(o.Key)
+		oKey, err := decodeKey(rawKey, aws.String(string(resp.EncodingType)))
 		if err != nil {
-			return nil, false, "", errors.WithMessagef(err, "failed to decode key %s", *o.Key)
+			return nil, false, "", errors.WithMessagef(err, "failed to decode key %s", rawKey)
 		}
 		if !strings.HasPrefix(oKey, prefix) || oKey < start {
 			return nil, false, "", fmt.Errorf("found invalid key %s from List, prefix: %s, marker: %s", oKey, prefix, start)
 		}
 		objs[i] = &obj{
 			oKey,
-			*o.Size,
-			*o.LastModified,
+			aws.ToInt64(o.Size),
+			aws.ToTime(o.LastModified),
 			strings.HasSuffix(oKey, "/"),
 			getOrDefaultScValue(string(o.StorageClass), string(types.ObjectStorageClassStandard)),
 			"",
@@ -278,23 +279,16 @@ func (s *s3client) List(ctx context.Context, prefix, start, token, delimiter str
 	}
 	if delimiter != "" {
 		for _, p := range resp.CommonPrefixes {
-			prefix, err := decodeKey(*p.Prefix, aws.String(string(resp.EncodingType)))
+			rawPrefix := aws.ToString(p.Prefix)
+			prefix, err := decodeKey(rawPrefix, aws.String(string(resp.EncodingType)))
 			if err != nil {
-				return nil, false, "", errors.WithMessagef(err, "failed to decode commonPrefixes %s", *p.Prefix)
+				return nil, false, "", errors.WithMessagef(err, "failed to decode commonPrefixes %s", rawPrefix)
 			}
 			objs = append(objs, &obj{prefix, 0, time.Unix(0, 0), true, "", ""})
 		}
 		sort.Slice(objs, func(i, j int) bool { return objs[i].Key() < objs[j].Key() })
 	}
-	var isTruncated bool
-	if resp.IsTruncated != nil {
-		isTruncated = *resp.IsTruncated
-	}
-	var nextMarker string
-	if resp.NextContinuationToken != nil {
-		nextMarker = *resp.NextContinuationToken
-	}
-	return objs, isTruncated, nextMarker, nil
+	return objs, aws.ToBool(resp.IsTruncated), aws.ToString(resp.NextContinuationToken), nil
 }
 
 func (s *s3client) ListAll(ctx context.Context, prefix, marker string, followLink bool) (<-chan Object, error) {
@@ -311,7 +305,11 @@ func (s *s3client) CreateMultipartUpload(ctx context.Context, key string) (*Mult
 	if err != nil {
 		return nil, err
 	}
-	return &MultipartUpload{UploadID: *resp.UploadId, MinPartSize: 5 << 20, MaxCount: 10000}, nil
+	uploadID := aws.ToString(resp.UploadId)
+	if uploadID == "" {
+		return nil, fmt.Errorf("s3: CreateMultipartUpload returned empty UploadId for %s", key)
+	}
+	return &MultipartUpload{UploadID: uploadID, MinPartSize: 5 << 20, MaxCount: 10000}, nil
 }
 
 func (s *s3client) UploadPart(ctx context.Context, key string, uploadID string, num int, body []byte) (*Part, error) {
@@ -327,7 +325,7 @@ func (s *s3client) UploadPart(ctx context.Context, key string, uploadID string, 
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, ETag: *resp.ETag}, nil
+	return &Part{Num: num, ETag: aws.ToString(resp.ETag)}, nil
 }
 
 func (s *s3client) UploadPartCopy(ctx context.Context, key string, uploadID string, num int, srcKey string, off, size int64) (*Part, error) {
@@ -342,7 +340,10 @@ func (s *s3client) UploadPartCopy(ctx context.Context, key string, uploadID stri
 	if err != nil {
 		return nil, err
 	}
-	return &Part{Num: num, ETag: *resp.CopyPartResult.ETag}, nil
+	if resp.CopyPartResult == nil {
+		return nil, fmt.Errorf("s3: UploadPartCopy returned no CopyPartResult for %s part %d", key, num)
+	}
+	return &Part{Num: num, ETag: aws.ToString(resp.CopyPartResult.ETag)}, nil
 }
 
 func (s *s3client) AbortUpload(ctx context.Context, key string, uploadID string) {
@@ -381,13 +382,9 @@ func (s *s3client) ListUploads(ctx context.Context, marker string) ([]*PendingPa
 	}
 	parts := make([]*PendingPart, len(result.Uploads))
 	for i, u := range result.Uploads {
-		parts[i] = &PendingPart{*u.Key, *u.UploadId, *u.Initiated}
+		parts[i] = &PendingPart{aws.ToString(u.Key), aws.ToString(u.UploadId), aws.ToTime(u.Initiated)}
 	}
-	var nextMarker string
-	if result.NextKeyMarker != nil {
-		nextMarker = *result.NextKeyMarker
-	}
-	return parts, nextMarker, nil
+	return parts, aws.ToString(result.NextKeyMarker), nil
 }
 
 func (s *s3client) Restore(ctx context.Context, key string, days int32) error {


### PR DESCRIPTION
The S3, IBM COS, KS3 and QingStor backends were unconditionally dereferencing pointer-valued response fields (Head/List/UploadPart/ UploadPartCopy/CreateMultipartUpload/ListUploads). The respective SDKs mark these as nilable; an S3-compatible gateway that omits a field on a partial or 5xx response would crash the mount process with a nil pointer panic instead of surfacing a recoverable error.

Replace the unchecked dereferences with the nil-safe pointer helpers each SDK ships (aws.ToInt64/ToTime/ToString/ToBool for aws-sdk-go-v2, aws.Int64Value/TimeValue/StringValue/BoolValue for ibm-cos-sdk-go, aws.ToString/ToLong plus local ks3DerefTime/ks3DerefBool for ks3sdklib). For nested pointers (CopyPartResult, UploadId) return an explicit error when the SDK returns no usable result. Also fix a pre-existing bug in qingstor.Head where a non-404 error fell through to dereference r.