### PR TITLE
pkg/object: block path traversal in the file:// backend

### DIFF
--- a/pkg/object/file.go
+++ b/pkg/object/file.go
@@ -45,7 +45,10 @@ type filestore struct {
 }
 
 func (d *filestore) Symlink(oldName, newName string) error {
-	p := d.path(newName)
+	p, err := d.path(newName)
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(filepath.Dir(p)); err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(p), os.FileMode(0777)); err != nil {
 			return err
@@ -57,7 +60,11 @@ func (d *filestore) Symlink(oldName, newName string) error {
 }
 
 func (d *filestore) Readlink(name string) (string, error) {
-	return os.Readlink(d.path(name))
+	p, err := d.path(name)
+	if err != nil {
+		return "", err
+	}
+	return os.Readlink(p)
 }
 
 func (d *filestore) String() string {
@@ -67,15 +74,42 @@ func (d *filestore) String() string {
 	return "file://" + d.root
 }
 
-func (d *filestore) path(key string) string {
+// path resolves an object-storage key to an on-disk path while preventing
+// the resolved path from escaping the configured root via ".." segments.
+// filepath.Join / filepath.Clean collapse ".." after the join, so without
+// this guard a key like "../../etc/shadow" would land outside d.root and
+// turn a metadata-engine compromise (or operator-supplied key in the
+// file:// sync target) into arbitrary local read/write.
+func (d *filestore) path(key string) (string, error) {
+	var p string
 	if strings.HasSuffix(d.root, dirSuffix) {
-		return filepath.Join(d.root, key)
+		p = filepath.Join(d.root, key)
+	} else {
+		p = filepath.Clean(d.root + key)
 	}
-	return filepath.Clean(d.root + key)
+	// ToSlash normalises separators so the comparison is OS-agnostic and
+	// also blocks Windows-style "..\\" segments smuggled in by callers
+	// that originate on a different OS.
+	pSlash := filepath.ToSlash(p)
+	if strings.HasPrefix(pSlash, filepath.ToSlash(d.root)) {
+		return p, nil
+	}
+	// Accept the legitimate "key == root" case (e.g. List/Head of the
+	// bucket prefix itself with an empty key): filepath.Clean strips
+	// the trailing slash from a trailing-slash root, so the prefix
+	// check above misses this one form even though the resolved path
+	// hasn't escaped anywhere.
+	if pSlash == filepath.ToSlash(filepath.Clean(d.root)) {
+		return p, nil
+	}
+	return "", fmt.Errorf("invalid key %q: resolved path %q escapes root %q", key, p, d.root)
 }
 
 func (d *filestore) Head(ctx context.Context, key string) (Object, error) {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return nil, err
+	}
 	fi, err := os.Lstat(p)
 	if err != nil {
 		return nil, err
@@ -118,7 +152,10 @@ type SectionReaderCloser struct {
 }
 
 func (d *filestore) Get(ctx context.Context, key string, off, limit int64, getters ...AttrGetter) (io.ReadCloser, error) {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return nil, err
+	}
 
 	f, err := os.Open(p)
 	if err != nil {
@@ -145,7 +182,10 @@ func (d *filestore) Get(ctx context.Context, key string, off, limit int64, gette
 }
 
 func (d *filestore) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) (err error) {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return err
+	}
 
 	if strings.HasSuffix(key, dirSuffix) || key == "" && strings.HasSuffix(d.root, dirSuffix) {
 		return os.MkdirAll(p, os.FileMode(0777))
@@ -210,8 +250,11 @@ func (d *filestore) Copy(ctx context.Context, dst, src string) error {
 }
 
 func (d *filestore) Delete(ctx context.Context, key string, getters ...AttrGetter) error {
-	err := os.Remove(d.path(key))
-	if err != nil && os.IsNotExist(err) {
+	p, err := d.path(key)
+	if err != nil {
+		return err
+	}
+	if err = os.Remove(p); err != nil && os.IsNotExist(err) {
 		err = nil
 	}
 	return err
@@ -342,12 +385,18 @@ func (d *filestore) List(ctx context.Context, prefix, marker, token, delimiter s
 }
 
 func (d *filestore) Chmod(key string, mode os.FileMode) error {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return err
+	}
 	return os.Chmod(p, mode)
 }
 
 func (d *filestore) Chown(key string, owner, group string) error {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return err
+	}
 	uid := utils.LookupUser(owner)
 	gid := utils.LookupGroup(group)
 	if uid == -1 || gid == -1 {

--- a/pkg/object/file_unix.go
+++ b/pkg/object/file_unix.go
@@ -42,6 +42,9 @@ func getOwnerGroup(info os.FileInfo) (string, string) {
 }
 
 func (d *filestore) Chtimes(key string, mtime time.Time) error {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return err
+	}
 	return lchtimes(p, time.Time{}, mtime)
 }

--- a/pkg/object/file_windows.go
+++ b/pkg/object/file_windows.go
@@ -34,6 +34,9 @@ func lookupGroup(name string) int {
 }
 
 func (d *filestore) Chtimes(key string, mtime time.Time) error {
-	p := d.path(key)
+	p, err := d.path(key)
+	if err != nil {
+		return err
+	}
 	return os.Chtimes(p, time.Time{}, mtime)
 }

--- a/pkg/object/filesystem_test.go
+++ b/pkg/object/filesystem_test.go
@@ -52,6 +52,63 @@ func TestDisk2(t *testing.T) {
 	testFileSystem(t, s)
 }
 
+func TestFilestorePathTraversal(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	// Bait file outside the root — Get/Delete must not be able to reach it.
+	outside := root + string(os.PathSeparator) + "outside_bait.txt"
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed bait: %s", err)
+	}
+	defer os.Remove(outside)
+
+	d := &filestore{root: root + "/inner/"}
+	if err := os.MkdirAll(d.root, 0o755); err != nil {
+		t.Fatalf("mkdir inner: %s", err)
+	}
+
+	for _, key := range []string{
+		"../outside_bait.txt",
+		"../../etc/shadow",
+		"sub/../../outside_bait.txt",
+	} {
+		if _, err := d.Get(ctx, key, 0, -1); err == nil {
+			t.Errorf("Get(%q) should have been rejected", key)
+		}
+		if err := d.Put(ctx, key, bytes.NewReader([]byte("x"))); err == nil {
+			t.Errorf("Put(%q) should have been rejected", key)
+		}
+		if err := d.Delete(ctx, key); err == nil {
+			t.Errorf("Delete(%q) should have been rejected", key)
+		}
+		if _, err := d.Head(ctx, key); err == nil {
+			t.Errorf("Head(%q) should have been rejected", key)
+		}
+	}
+
+	// Bait file must be untouched after the rejected calls above.
+	if b, err := os.ReadFile(outside); err != nil || string(b) != "secret" {
+		t.Errorf("bait file was modified or removed: data=%q err=%v", b, err)
+	}
+
+	// Sanity: a legitimate key still works.
+	if err := d.Put(ctx, "ok.txt", bytes.NewReader([]byte("hi"))); err != nil {
+		t.Fatalf("legitimate Put failed: %s", err)
+	}
+	if _, err := d.Head(ctx, "ok.txt"); err != nil {
+		t.Fatalf("legitimate Head failed: %s", err)
+	}
+
+	// Regression guard: the empty key against a trailing-slash root
+	// resolves via filepath.Join to the cleaned root (no trailing
+	// slash), which a naive HasPrefix check would reject. pkg/sync
+	// drives this exact call on every job start; an over-eager
+	// traversal check broke TestSync and sync_encrypt in CI.
+	if _, err := d.path(""); err != nil {
+		t.Fatalf("empty key against trailing-slash root must be allowed: %s", err)
+	}
+}
+
 func TestSftp2(t *testing.T) { //skip mutate
 	if os.Getenv("SFTP_HOST") == "" {
 		t.SkipNow()


### PR DESCRIPTION
filestore.path resolved object keys via filepath.Join / filepath.Clean, which collapse '..' segments after the join. A key like '../../etc/shadow' against root '/data/jfs/' landed at '/etc/shadow', giving any caller (metadata engine, jfs-sync operator input) arbitrary local read/write through Get/Put/Delete/Head/Chmod/Chown/Symlink.

Have path() also verify that the resolved path still starts with the configured root (compared via ToSlash so Windows backslash separators in keys can't smuggle traversal segments past the check) and propagate the failure through every caller. Add a focused test that exercises Get/Put/Delete/Head with several '..'-escape payloads and asserts the bait file outside the root remains untouched.