### PR TITLE
pkg/object: bound ListAll pagination retries with jittered backoff

### DIFF
--- a/pkg/object/sharding.go
+++ b/pkg/object/sharding.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"math/rand"
 	"strings"
 	"time"
 )
@@ -99,6 +100,53 @@ func (s *sharded) GetTier(ctx context.Context) Tier {
 
 const maxResults = 10000
 
+const (
+	listInitialBackoff = 100 * time.Millisecond
+	listMaxBackoff     = 30 * time.Second
+	listMaxAttempts    = 10
+)
+
+// listWithRetry retries store.List under transient failures with exponential
+// backoff plus full jitter, bounded by listMaxAttempts and listMaxBackoff.
+// It returns immediately if ctx is cancelled; context errors are not retried.
+// On non-retryable exhaustion the last underlying error is returned so callers
+// can surface it through the nil sentinel on their output channel.
+func listWithRetry(ctx context.Context, store ObjectStorage, prefix, marker, token string, limit int64, followLink bool) (objs []Object, hasMore bool, nextToken string, err error) {
+	backoff := listInitialBackoff
+	for attempt := 0; attempt < listMaxAttempts; attempt++ {
+		objs, hasMore, nextToken, err = store.List(ctx, prefix, marker, token, "", limit, followLink)
+		if err == nil {
+			return
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		if attempt == listMaxAttempts-1 {
+			break
+		}
+		logger.Warnf("Fail to list %s marker %q (attempt %d/%d): %s",
+			store, marker, attempt+1, listMaxAttempts, err)
+		// Full-jitter backoff: sleep a uniform random value in [0, backoff)
+		// then double the cap. Mirrors the AWS "Exponential Backoff and
+		// Jitter" recommendation and prevents N parallel listers from
+		// synchronising their retries.
+		wait := time.Duration(rand.Int63n(int64(backoff)))
+		if backoff < listMaxBackoff {
+			backoff *= 2
+			if backoff > listMaxBackoff {
+				backoff = listMaxBackoff
+			}
+		}
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			return
+		case <-time.After(wait):
+		}
+	}
+	return
+}
+
 // ListAll lists all keys that starts at marker from object storage.
 func ListAll(ctx context.Context, store ObjectStorage, prefix, marker string, followLink, sort bool) (<-chan Object, error) {
 	if ch, err := store.ListAll(ctx, prefix, marker, followLink); err == nil {
@@ -142,15 +190,12 @@ func ListAll(ctx context.Context, store ObjectStorage, prefix, marker string, fo
 			marker = lastkey
 			startTime = time.Now()
 			logger.Debugf("Continue listing objects from %s marker %q", store, marker)
-			var nextToken2 string
-			objs, hasMore, nextToken2, err = store.List(ctx, prefix, marker, nextToken, "", maxResults, followLink)
-			for err != nil {
-				logger.Warnf("Fail to list: %s, retry again", err.Error())
-				// slow down
-				time.Sleep(time.Millisecond * 100)
-				objs, hasMore, nextToken, err = store.List(ctx, prefix, marker, nextToken, "", maxResults, followLink)
+			objs, hasMore, nextToken, err = listWithRetry(ctx, store, prefix, marker, nextToken, maxResults, followLink)
+			if err != nil {
+				logger.Errorf("Can't list %s marker %q: %s", store, marker, err)
+				out <- nil
+				return
 			}
-			nextToken = nextToken2
 			logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Since(startTime))
 		}
 	}()

--- a/pkg/object/sharding_test.go
+++ b/pkg/object/sharding_test.go
@@ -1,0 +1,120 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// flakyStore wraps an ObjectStorage and forces List to fail the first
+// failuresBeforeSuccess invocations with err.
+type flakyStore struct {
+	ObjectStorage
+	failuresBeforeSuccess int32
+	calls                 atomic.Int32
+	err                   error
+}
+
+func (f *flakyStore) List(ctx context.Context, prefix, marker, token, delimiter string, limit int64, followLink bool) ([]Object, bool, string, error) {
+	n := f.calls.Add(1)
+	if n <= f.failuresBeforeSuccess {
+		return nil, false, "", f.err
+	}
+	return f.ObjectStorage.List(ctx, prefix, marker, token, delimiter, limit, followLink)
+}
+
+func TestListWithRetryEventualSuccess(t *testing.T) {
+	base, _ := CreateStorage("mem", "", "", "", "")
+	if err := base.Put(context.Background(), "a", bytes.NewReader([]byte("x"))); err != nil {
+		t.Fatalf("seed: %s", err)
+	}
+	fs := &flakyStore{ObjectStorage: base, failuresBeforeSuccess: 3, err: errors.New("transient")}
+
+	objs, _, _, err := listWithRetry(context.Background(), fs, "", "", "", 100, true)
+	if err != nil {
+		t.Fatalf("expected eventual success, got %v after %d calls", err, fs.calls.Load())
+	}
+	if len(objs) == 0 {
+		t.Fatalf("expected at least one object after retry")
+	}
+	if got := fs.calls.Load(); got != 4 {
+		t.Fatalf("expected 4 List calls (3 failures + 1 success), got %d", got)
+	}
+}
+
+func TestListWithRetryExhaustion(t *testing.T) {
+	base, _ := CreateStorage("mem", "", "", "", "")
+	wantErr := errors.New("perma fail")
+	fs := &flakyStore{ObjectStorage: base, failuresBeforeSuccess: 1 << 30, err: wantErr}
+
+	start := time.Now()
+	_, _, _, err := listWithRetry(context.Background(), fs, "", "", "", 100, true)
+	elapsed := time.Since(start)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wantErr after exhaustion, got %v", err)
+	}
+	if got := fs.calls.Load(); got != int32(listMaxAttempts) {
+		t.Fatalf("expected exactly %d attempts, got %d", listMaxAttempts, got)
+	}
+	// Sanity: even with full-jitter, the total sleep must be bounded by the
+	// sum of doubling caps (100ms + 200ms + ... up to 30s) ~~ 58s. We just
+	// assert we didn't sleep forever like the old code.
+	if elapsed > 2*time.Minute {
+		t.Fatalf("retry took too long: %s", elapsed)
+	}
+}
+
+func TestListWithRetryContextCanceled(t *testing.T) {
+	base, _ := CreateStorage("mem", "", "", "", "")
+	fs := &flakyStore{ObjectStorage: base, failuresBeforeSuccess: 1 << 30, err: errors.New("perma fail")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the first failed attempt.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	_, _, _, err := listWithRetry(ctx, fs, "", "", "", 100, true)
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("did not honour cancel promptly: %s", elapsed)
+	}
+}
+
+func TestListWithRetrySkipsContextErrors(t *testing.T) {
+	base, _ := CreateStorage("mem", "", "", "", "")
+	// Return context.Canceled directly — must not be retried.
+	fs := &flakyStore{ObjectStorage: base, failuresBeforeSuccess: 1 << 30, err: fmt.Errorf("wrapped: %w", context.Canceled)}
+
+	_, _, _, err := listWithRetry(context.Background(), fs, "", "", "", 100, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled passthrough, got %v", err)
+	}
+	if got := fs.calls.Load(); got != 1 {
+		t.Fatalf("context errors must not trigger retry, got %d calls", got)
+	}
+}


### PR DESCRIPTION
ListAll's pagination retry was time.Sleep(100ms) inside an unconditional for-err-loop: no max attempts, no exponential backoff, no jitter, and no ctx.Done() check, so a permanently-failing remote (deleted bucket, bad creds, persistent 5xx) became a 10-RPS busy-loop logging 'Fail to list' forever, unaffected by caller cancellation. The loop also had a latent pagination bug — the retry path wrote the next-token into 'nextToken' but the outer code then overwrote it with the failed call's empty 'nextToken2', losing the cursor on first successful retry.

Extract listWithRetry: exponential backoff (100ms -> 30s cap) with full jitter per the AWS retry guidance, hard cap of listMaxAttempts=10, and a select on ctx.Done() between attempts. Context errors are returned without retry. ListAll now propagates the final error through the documented nil-on-channel sentinel.

Tests:
- TestListWithRetryEventualSuccess: 3 transient failures + success, exact call count.
- TestListWithRetryExhaustion: bounded attempts and bounded total elapsed.
- TestListWithRetryContextCanceled: mid-flight cancel returns within 5s.
- TestListWithRetrySkipsContextErrors: context-wrapped errors are not retried.