### PR TITLE
pkg/object: tune shared HTTP transport and isolate per-backend clones

### DIFF
--- a/pkg/object/obs.go
+++ b/pkg/object/obs.go
@@ -428,7 +428,7 @@ func newOBS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	// Empty proxy url string has no effect
 	// there is a bug in the retry of PUT (did not call Seek(0,0) before retry), so disable the retry here
 	c, err := obs.New(accessKey, secretKey, endpoint, obs.WithSecurityToken(token),
-		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithHttpTransport(httpClient.Transport.(*http.Transport)))
+		obs.WithProxyUrl(urlString), obs.WithMaxRetryCount(0), obs.WithHttpTransport(NewHTTPTransport()))
 	if err != nil {
 		return nil, fmt.Errorf("fail to initialize OBS: %q", err)
 	}

--- a/pkg/object/restful.go
+++ b/pkg/object/restful.go
@@ -148,44 +148,82 @@ func dialRandom(ctx context.Context, dialer *net.Dialer, network string, ips []n
 	return nil, lastErr
 }
 
-func init() {
+// newSharedTransport builds the default *http.Transport used by every
+// backend. Exported indirectly via NewHTTPTransport so a backend that
+// needs to customise TLS (or hands the transport to a third-party SDK
+// that does) can take an independent clone rather than mutating the
+// shared instance.
+func newSharedTransport() *http.Transport {
 	dialer := &net.Dialer{Timeout: time.Second * 10}
-	httpClient = &http.Client{
-		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			TLSHandshakeTimeout:   time.Second * 20,
-			ResponseHeaderTimeout: time.Second * 30,
-			IdleConnTimeout:       time.Second * 300,
-			MaxIdleConnsPerHost:   500,
-			ReadBufferSize:        32 << 10,
-			WriteBufferSize:       32 << 10,
-			DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-				host, port, err := net.SplitHostPort(address)
-				if err != nil {
-					return nil, err
-				}
-				if ip := net.ParseIP(host); ip != nil {
-					return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-				}
-				ips, err := resolver.Fetch(host)
-				if err != nil {
-					return nil, err
-				}
-				if len(ips) == 0 {
-					return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
-				}
-				ipv6, ipv4 := splitIPsByVersion(ips)
-				return dialParallel(ctx, dialer, network, ipv6, ipv4, port)
-			},
-			DisableCompression: true,
-			TLSClientConfig:    &tls.Config{},
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		TLSHandshakeTimeout:   time.Second * 20,
+		ResponseHeaderTimeout: time.Second * 30,
+		IdleConnTimeout:       time.Second * 300,
+		// MaxIdleConns was previously unset, defaulting to 100 in
+		// net/http and silently capping total idle reuse below the
+		// per-host 500. Bump to 5000 to actually exercise the
+		// per-host budget across many backend hosts/buckets.
+		MaxIdleConns:        5000,
+		MaxIdleConnsPerHost: 500,
+		// ForceAttemptHTTP2 lets ALPN negotiate h2 on servers that
+		// offer it; falls back to HTTP/1.1 cleanly when the server
+		// (or middlebox) doesn't.
+		ForceAttemptHTTP2: true,
+		ReadBufferSize:    32 << 10,
+		WriteBufferSize:   32 << 10,
+		DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(address)
+			if err != nil {
+				return nil, err
+			}
+			if ip := net.ParseIP(host); ip != nil {
+				return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			}
+			ips, err := resolver.Fetch(host)
+			if err != nil {
+				return nil, err
+			}
+			if len(ips) == 0 {
+				return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+			}
+			ipv6, ipv4 := splitIPsByVersion(ips)
+			return dialParallel(ctx, dialer, network, ipv6, ipv4, port)
 		},
+		DisableCompression: true,
+		TLSClientConfig:    &tls.Config{},
+	}
+}
+
+func init() {
+	httpClient = &http.Client{
+		Transport: newSharedTransport(),
+		// Client-level Timeout is a coarse safety net for connections
+		// that get stuck mid-body-read past every finer-grained timeout
+		// on the transport. Per-request bounds belong on the caller's
+		// ctx (context.WithTimeout).
 		Timeout: time.Hour,
 	}
 }
 
 func GetHttpClient() *http.Client {
 	return httpClient
+}
+
+// NewHTTPTransport returns a deep clone of the package-shared
+// *http.Transport. Backends that pass a *http.Transport into a
+// third-party SDK (e.g. OBS, Swift) MUST use this rather than
+// httpClient.Transport.(*http.Transport) directly — those SDKs are
+// free to mutate fields such as TLSClientConfig.InsecureSkipVerify,
+// and a mutation on the shared transport corrupts every other
+// backend in the same process.
+func NewHTTPTransport() *http.Transport {
+	if t, ok := httpClient.Transport.(*http.Transport); ok {
+		return t.Clone()
+	}
+	// Shouldn't happen in practice — fall back to a fresh transport
+	// rather than panic on the type assertion.
+	return newSharedTransport()
 }
 
 func cleanup(response *http.Response) {

--- a/pkg/object/restful_test.go
+++ b/pkg/object/restful_test.go
@@ -19,6 +19,7 @@ package object
 import (
 	"context"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -107,6 +108,45 @@ func TestDialParallel_BothFail(t *testing.T) {
 		"0")
 	if err == nil {
 		t.Fatal("expected error when both groups fail, got nil")
+	}
+}
+
+func TestSharedHTTPTransportTuning(t *testing.T) {
+	tr, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("httpClient.Transport is not *http.Transport: %T", httpClient.Transport)
+	}
+	if tr.MaxIdleConns < tr.MaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConns=%d must be >= MaxIdleConnsPerHost=%d, otherwise per-host reuse is silently capped",
+			tr.MaxIdleConns, tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxIdleConnsPerHost < 500 {
+		t.Fatalf("MaxIdleConnsPerHost dropped below historical 500: %d", tr.MaxIdleConnsPerHost)
+	}
+	if !tr.ForceAttemptHTTP2 {
+		t.Fatalf("ForceAttemptHTTP2 should be true so ALPN can negotiate h2 on servers that offer it")
+	}
+}
+
+func TestNewHTTPTransportReturnsIsolatedClone(t *testing.T) {
+	a := NewHTTPTransport()
+	b := NewHTTPTransport()
+	if a == b {
+		t.Fatalf("NewHTTPTransport returned the same *http.Transport twice — clones must be independent")
+	}
+	if a.TLSClientConfig == b.TLSClientConfig {
+		t.Fatalf("TLSClientConfig must be independent across clones to avoid cross-backend corruption")
+	}
+	// Mutating one clone's TLS config must not bleed into the shared
+	// transport or any other clone — this is the exact corruption
+	// path that motivated extracting the helper.
+	a.TLSClientConfig.InsecureSkipVerify = true
+	if b.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("mutating clone a's TLSClientConfig leaked into clone b")
+	}
+	shared := httpClient.Transport.(*http.Transport)
+	if shared.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("mutating a clone's TLSClientConfig leaked into the shared httpClient transport")
 	}
 }
 

--- a/pkg/object/swift.go
+++ b/pkg/object/swift.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -151,7 +150,7 @@ func newSwiftOSS(endpoint, username, apiKey, token string) (ObjectStorage, error
 		ApiKey:    apiKey,
 		AuthToken: token,
 		AuthUrl:   authURL,
-		Transport: httpClient.Transport.(*http.Transport),
+		Transport: NewHTTPTransport(),
 	}
 	err = conn.Authenticate(context.Background())
 	if err != nil {


### PR DESCRIPTION
The package-shared http.Client had three tuning gaps and one isolation hazard:

- MaxIdleConnsPerHost was 500 but MaxIdleConns was unset (default 100), so the total idle pool was silently capped below the per-host budget whenever traffic spanned more than ~2 hosts.
- ForceAttemptHTTP2 was unset, so a hand-built Transport never negotiated h2 even when servers offered it via ALPN.
- obs.go and swift.go handed httpClient.Transport.(*http.Transport) straight into third-party SDKs that are free to mutate fields like TLSClientConfig.InsecureSkipVerify. A single corrupted backend would taint every other backend in the same process.

Extract newSharedTransport, bump MaxIdleConns to 5000, set ForceAttemptHTTP2=true, and add NewHTTPTransport() that returns a fresh *http.Transport.Clone() of the shared one. Migrate obs.go and swift.go to the clone helper. tos.go reads .InsecureSkipVerify read-only and cos.go wraps the RoundTripper without mutation, so both stay on the shared transport.

The 1-hour client-level Timeout is left intact as a coarse safety net for connections stuck mid-body-read; removing it would cascade into every call site that does not yet wrap with context.WithTimeout, which is out of this finding's scope.

Tests:
- TestSharedHTTPTransportTuning locks in MaxIdleConns >= MaxIdleConnsPerHost and ForceAttemptHTTP2.
- TestNewHTTPTransportReturnsIsolatedClone asserts each clone has an independent TLSClientConfig and that mutating a clone does not bleed into the shared transport or any other clone.