### PR TITLE
pkg/object: make chunkDecryptReader pool ownership explicit

### DIFF
--- a/pkg/object/encrypt_chunked.go
+++ b/pkg/object/encrypt_chunked.go
@@ -117,15 +117,36 @@ type limitedReadCloser struct {
 	io.Closer
 }
 
+// chunkBufPool is the subset of sync.Pool that chunkDecryptReader needs.
+// Promoting the field to an interface lets tests substitute a counting
+// pool that detects double-Put and leaks (see TestChunkDecryptReader
+// PoolBalance) without forcing them to fish through the live sync.Pool
+// internals.
+type chunkBufPool interface {
+	Get() any
+	Put(any)
+}
+
 type chunkDecryptReader struct {
-	r        io.ReadCloser
-	enc      *dataEncryptor
-	buf      []byte
-	pool     *sync.Pool
-	skip     int64
+	r    io.ReadCloser
+	enc  *dataEncryptor
+	buf  []byte
+	pool chunkBufPool
+	skip int64
+	// chunkBuf is the SOLE owner-tracker for a buffer borrowed from
+	// pool: non-nil iff this reader currently holds one. Every code
+	// path in Read either releases the buffer via putChunkBuf (errors
+	// and full-consume) or leaves it owned in chunkBuf for the next
+	// Read or Close to drain (partial-consume).
 	chunkBuf *[]byte
 }
 
+// putChunkBuf returns the borrowed chunk buffer to the pool and clears
+// every reference to it (including r.buf, which is a sub-slice into
+// chunkBuf and would otherwise dangle). Idempotent: safe to call when
+// no buffer is held. This is the SOLE call site that returns a chunk
+// buffer to the pool — chunkDecryptReader.Read never calls pool.Put
+// directly, so there is exactly one ownership-transfer rule to audit.
 func (r *chunkDecryptReader) putChunkBuf() {
 	if r.chunkBuf != nil {
 		r.pool.Put(r.chunkBuf)
@@ -135,6 +156,8 @@ func (r *chunkDecryptReader) putChunkBuf() {
 }
 
 func (r *chunkDecryptReader) Read(p []byte) (int, error) {
+	// Carry-over plaintext from a previous Read whose caller buffer
+	// was too small. Drain it before fetching another ciphertext chunk.
 	if len(r.buf) > 0 {
 		n := copy(p, r.buf)
 		r.buf = r.buf[n:]
@@ -143,29 +166,32 @@ func (r *chunkDecryptReader) Read(p []byte) (int, error) {
 		}
 		return n, nil
 	}
-	chunkBuf := r.pool.Get().(*[]byte)
-	defer func() {
-		if len(r.buf) == 0 {
-			r.pool.Put(chunkBuf)
-		}
-	}()
 
-	n, err := io.ReadFull(r.r, *chunkBuf)
-	chunk := (*chunkBuf)[:n]
+	// Borrow a chunk buffer. Assigning to r.chunkBuf immediately makes
+	// the reader the canonical owner; every exit point below either
+	// calls putChunkBuf (errors and full-consume) or leaves r.chunkBuf
+	// set so the next Read / Close releases it (partial-consume).
+	r.chunkBuf = r.pool.Get().(*[]byte)
+
+	n, err := io.ReadFull(r.r, *r.chunkBuf)
+	chunk := (*r.chunkBuf)[:n]
 	if err != io.ErrUnexpectedEOF && err != nil {
+		r.putChunkBuf()
 		return 0, err
 	}
-
 	if len(chunk) < chunkHeaderSize {
+		r.putChunkBuf()
 		return 0, fmt.Errorf("Decrypt: truncated chunk header")
 	}
 	ctLen := int(binary.BigEndian.Uint32(chunk[:chunkHeaderSize]))
 	if chunkHeaderSize+ctLen > len(chunk) {
+		r.putChunkBuf()
 		return 0, fmt.Errorf("Decrypt: chunk data truncated: need %d, have %d", chunkHeaderSize+ctLen, len(chunk))
 	}
 
 	plain, decErr := r.enc.Decrypt(chunk[chunkHeaderSize : chunkHeaderSize+ctLen])
 	if decErr != nil {
+		r.putChunkBuf()
 		return 0, fmt.Errorf("Decrypt: %s", decErr)
 	}
 
@@ -173,6 +199,7 @@ func (r *chunkDecryptReader) Read(p []byte) (int, error) {
 		skip := r.skip
 		r.skip = 0
 		if skip >= int64(len(plain)) {
+			r.putChunkBuf()
 			return 0, io.EOF
 		}
 		plain = plain[skip:]
@@ -180,8 +207,12 @@ func (r *chunkDecryptReader) Read(p []byte) (int, error) {
 
 	n = copy(p, plain)
 	if n < len(plain) {
+		// Partial consume: keep the chunk borrowed; the next Read or
+		// Close will release it via putChunkBuf.
 		r.buf = plain[n:]
-		r.chunkBuf = chunkBuf
+	} else {
+		// Fully consumed: release immediately.
+		r.putChunkBuf()
 	}
 	return n, nil
 }

--- a/pkg/object/encrypt_chunked_test.go
+++ b/pkg/object/encrypt_chunked_test.go
@@ -21,10 +21,168 @@ import (
 	"context"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// trackedPool wraps sync.Pool's Get/Put with explicit borrow tracking
+// so the test can assert exactly one Put per Get, no buffer being Put
+// twice, and zero live borrows at the end. Each Get returns a freshly
+// allocated buffer (no reuse) so identity equality is a reliable
+// double-Put signal.
+type trackedPool struct {
+	size     int
+	mu       sync.Mutex
+	live     map[*[]byte]bool
+	gets     atomic.Int64
+	puts     atomic.Int64
+	doublePu atomic.Int64
+	alien    atomic.Int64
+}
+
+func newTrackedPool(size int) *trackedPool {
+	return &trackedPool{size: size, live: map[*[]byte]bool{}}
+}
+
+func (p *trackedPool) Get() any {
+	p.gets.Add(1)
+	buf := make([]byte, p.size)
+	pb := &buf
+	p.mu.Lock()
+	p.live[pb] = true
+	p.mu.Unlock()
+	return pb
+}
+
+func (p *trackedPool) Put(x any) {
+	p.puts.Add(1)
+	pb := x.(*[]byte)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.live[pb] {
+		// Either a double-Put (already removed) or an alien buffer.
+		// Bookkeeping is enough; the test fails the assertion.
+		p.doublePu.Add(1)
+		return
+	}
+	delete(p.live, pb)
+}
+
+func (p *trackedPool) liveCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.live)
+}
+
+// TestChunkDecryptReaderPoolBalance is the regression guard for the
+// audit's "future maintainer will get it wrong" concern: every
+// Read/Close codepath in chunkDecryptReader must Put exactly one
+// buffer for every Get. We exercise the partial-consume path
+// (one-byte reads), the full-consume path (read a whole chunk at
+// once), and the Close-before-drain path.
+func TestChunkDecryptReaderPoolBalance(t *testing.T) {
+	ctx := context.Background()
+	memStore, err := CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	dc, err := NewDataEncryptor(NewRSAEncryptor(rsaKey), AES256GCM_RSA)
+	require.NoError(t, err)
+
+	// Build a chunkedEncrypted just like NewChunkedEncrypted does, but
+	// with our tracked pool so we can audit every Get/Put.
+	overhead := dc.MaxOverhead()
+	encSize := plainChunkSize + chunkHeaderSize + int64(overhead)
+	pool := newTrackedPool(int(encSize))
+	ce := &chunkedEncrypted{
+		ObjectStorage: memStore,
+		enc:           dc,
+		overhead:      overhead,
+		encChunkSize:  encSize,
+	}
+	ce.plainPool = sync.Pool{New: func() any { buf := make([]byte, plainChunkSize); return &buf }}
+	// encChunkPool is unused by writes; Put uses plainPool. For reads we
+	// inject our tracked pool directly into the decrypt reader below.
+
+	// A body that spans multiple chunks plus a partial tail — exercises
+	// both full-chunk and partial-chunk paths.
+	const bodySize = plainChunkSize*2 + 1024
+	body := make([]byte, bodySize)
+	for i := range body {
+		body[i] = byte((i * 7) % 251)
+	}
+	require.NoError(t, ce.Put(ctx, "k", bytes.NewReader(body)))
+
+	openDecryptReader := func() *chunkDecryptReader {
+		// Fetch the encrypted payload from the wrapped storage and wire
+		// up a chunkDecryptReader backed by the tracked pool.
+		rc, err := memStore.Get(ctx, "k", 0, -1)
+		require.NoError(t, err)
+		return &chunkDecryptReader{r: rc, enc: dc, pool: pool}
+	}
+
+	check := func(label string) {
+		if got := pool.doublePu.Load(); got != 0 {
+			t.Fatalf("%s: %d double-Put detected", label, got)
+		}
+		if got := pool.alien.Load(); got != 0 {
+			t.Fatalf("%s: %d alien-buf Put detected", label, got)
+		}
+		if got := pool.liveCount(); got != 0 {
+			t.Fatalf("%s: %d buffer(s) leaked from the pool", label, got)
+		}
+		if g, p := pool.gets.Load(), pool.puts.Load(); g != p {
+			t.Fatalf("%s: Gets=%d Puts=%d (must be equal)", label, g, p)
+		}
+	}
+
+	// (1) Partial-consume: drain one byte at a time so the leftover-buf
+	// branch is exercised heavily.
+	dr := openDecryptReader()
+	got := make([]byte, 0, bodySize)
+	one := make([]byte, 1)
+	for {
+		n, err := dr.Read(one)
+		if n > 0 {
+			got = append(got, one[:n]...)
+		}
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+	require.Equal(t, body, got)
+	require.NoError(t, dr.Close())
+	check("partial-consume")
+
+	// (2) Full-consume: a buffer big enough to drain a whole chunk in
+	// one Read exercises the immediate-release branch.
+	dr = openDecryptReader()
+	big := make([]byte, plainChunkSize+1)
+	got = got[:0]
+	for {
+		n, err := dr.Read(big)
+		if n > 0 {
+			got = append(got, big[:n]...)
+		}
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+	require.Equal(t, body, got)
+	require.NoError(t, dr.Close())
+	check("full-consume")
+
+	// (3) Close-before-drain: read partway, then close. The leftover
+	// chunk must be returned to the pool by Close, not leaked.
+	dr = openDecryptReader()
+	mid := make([]byte, 1024)
+	_, err = dr.Read(mid)
+	require.NoError(t, err)
+	require.NoError(t, dr.Close())
+	check("close-before-drain")
+}
 
 func TestChunkedEncryptedConcurrentGet(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
chunkDecryptReader.Read split chunk-buffer ownership across two mechanisms — a defer that put the buffer back when r.buf was empty, and a putChunkBuf method that handled the case where the previous Read had stashed leftover plaintext in r.buf with the chunkBuf still borrowed. A careful trace shows neither path produced a double-Put today, but the audit's complaint stands: the rule "defer puts when r.buf is empty, otherwise putChunkBuf later" lives across a closure and a method, and the next maintainer touching this code is one early-return away from breaking it.

Make r.chunkBuf the single source of truth: assigned immediately when a buffer is borrowed from the pool, cleared (and the buffer returned) by putChunkBuf only. Every error path in Read now calls putChunkBuf explicitly; the full-consume path calls it; the partial-consume path leaves r.chunkBuf set so the next Read or Close releases it. No defer, no two-place rule.

Promote chunkDecryptReader.pool from *sync.Pool to a small chunkBufPool interface so the test can inject a tracked pool. *sync.Pool satisfies the interface implicitly, so the production wiring (Get passes &e.encChunkPool) is unchanged.

Test TestChunkDecryptReaderPoolBalance wraps sync.Pool's Get/Put with a borrow map: every Get returns a fresh buffer (so identity equality catches double-Put), every Put either removes the borrow or increments a doublePu counter. The test drives a body that spans multiple chunks plus a tail through three paths — partial-consume (one-byte reads), full-consume (chunk-sized buffer), and Close-before-drain — and after each asserts Gets == Puts, zero double-Puts, zero alien Puts, and zero live borrows.