### PR TITLE
meta: avoid creating massive tkv tombstones for quota keys that were never set

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -4475,23 +4475,31 @@ func (m *redisMeta) doDelQuota(ctx Context, qtype uint32, key uint64) error {
 }
 
 func (m *redisMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota, map[uint64]*Quota, error) {
+	format := m.getFormat()
+	dirQuotas := make(map[uint64]*Quota)
+	userQuotas := make(map[uint64]*Quota)
+	groupQuotas := make(map[uint64]*Quota)
+
 	quotaTypes := []struct {
-		qtype uint32
-		name  string
+		enabled bool
+		qtype   uint32
+		name    string
+		quotas  map[uint64]*Quota
 	}{
-		{DirQuotaType, "dir"},
-		{UserQuotaType, "user"},
-		{GroupQuotaType, "group"},
+		{format.DirStats, DirQuotaType, "dir", dirQuotas},
+		{format.UserGroupQuota, UserQuotaType, "user", userQuotas},
+		{format.UserGroupQuota, GroupQuotaType, "group", groupQuotas},
 	}
 
-	quotaMaps := make([]map[uint64]*Quota, 3)
-	for i, qt := range quotaTypes {
+	for _, qt := range quotaTypes {
+		if !qt.enabled {
+			continue
+		}
+
 		config, err := m.getQuotaKeys(qt.qtype)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to load %s quotas: %w", qt.name, err)
 		}
-
-		quotas := make(map[uint64]*Quota)
 		if err := m.hscan(ctx, config.usedInodesKey, func(keys []string) error {
 			for i := 0; i < len(keys); i += 2 {
 				key := keys[i]
@@ -4522,7 +4530,7 @@ func (m *redisMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Qu
 					return err
 				}
 
-				quotas[id] = &Quota{
+				qt.quotas[id] = &Quota{
 					MaxSpace:   maxSpace,
 					MaxInodes:  maxInodes,
 					UsedSpace:  usedSpace,
@@ -4533,10 +4541,9 @@ func (m *redisMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Qu
 		}); err != nil {
 			return nil, nil, nil, err
 		}
-		quotaMaps[i] = quotas
 	}
 
-	return quotaMaps[0], quotaMaps[1], quotaMaps[2], nil
+	return dirQuotas, userQuotas, groupQuotas, nil
 }
 
 func (m *redisMeta) doFlushQuotas(ctx Context, quotas []*iQuota) error {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -4395,15 +4395,20 @@ func (m *dbMeta) doDelQuota(ctx Context, qtype uint32, key uint64) error {
 }
 
 func (m *dbMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota, map[uint64]*Quota, error) {
+	format := m.getFormat()
 	var dirQuotasList []dirQuota
 	var userGroupQuotasList []userGroupQuota
 
 	err := m.simpleTxn(ctx, func(s *xorm.Session) error {
-		if e := s.Find(&dirQuotasList); e != nil {
-			return e
+		if format.DirStats {
+			if e := s.Find(&dirQuotasList); e != nil {
+				return e
+			}
 		}
-		if e := s.Find(&userGroupQuotasList); e != nil {
-			return e
+		if format.UserGroupQuota {
+			if e := s.Find(&userGroupQuotasList); e != nil {
+				return e
+			}
 		}
 		return nil
 	})

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -3534,34 +3534,28 @@ func (m *kvMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota
 	userQuotas := make(map[uint64]*Quota)
 	groupQuotas := make(map[uint64]*Quota)
 
-	if format.DirStats {
-		pairs, err := m.scanValues(ctx, m.fmtKey("QD"), -1, nil)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load dir quotas: %w", err)
-		}
-		for k, v := range pairs {
-			id := uint64(m.decodeInode([]byte(k[2:]))) // skip prefix
-			dirQuotas[id] = m.parseQuota(v)
-		}
+	quotaTypes := []struct {
+		enabled bool
+		prefix  string
+		name    string
+		quotas  map[uint64]*Quota
+		decode  func(k string) uint64
+	}{
+		{format.DirStats, "QD", "dir", dirQuotas, func(k string) uint64 { return uint64(m.decodeInode([]byte(k[2:]))) }}, // skip prefix
+		{format.UserGroupQuota, "QU", "user", userQuotas, func(k string) uint64 { return binary.BigEndian.Uint64([]byte(k[2:])) }},
+		{format.UserGroupQuota, "QG", "group", groupQuotas, func(k string) uint64 { return binary.BigEndian.Uint64([]byte(k[2:])) }},
 	}
 
-	if format.UserGroupQuota {
-		pairs, err := m.scanValues(ctx, m.fmtKey("QU"), -1, nil)
+	for _, qt := range quotaTypes {
+		if !qt.enabled {
+			continue
+		}
+		pairs, err := m.scanValues(ctx, m.fmtKey(qt.prefix), -1, nil)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load user quotas: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to load %q quotas: %w", qt.name, err)
 		}
 		for k, v := range pairs {
-			id := binary.BigEndian.Uint64([]byte(k[2:])) // skip prefix
-			userQuotas[id] = m.parseQuota(v)
-		}
-
-		pairs, err = m.scanValues(ctx, m.fmtKey("QG"), -1, nil)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load group quotas: %w", err)
-		}
-		for k, v := range pairs {
-			id := binary.BigEndian.Uint64([]byte(k[2:])) // skip prefix
-			groupQuotas[id] = m.parseQuota(v)
+			qt.quotas[qt.decode(k)] = m.parseQuota(v)
 		}
 	}
 

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2108,7 +2108,9 @@ func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, oldA
 		}
 		tx.delete(m.entryKey(parent, name))
 		tx.delete(m.dirStatKey(inode))
-		tx.delete(m.dirQuotaKey(inode))
+		if quotaKey := m.dirQuotaKey(inode); tx.get(quotaKey) != nil { // avoid creating massive tombstones for quota keys we never set.
+			tx.delete(quotaKey)
+		}
 		if trash > 0 {
 			tx.set(m.inodeKey(inode), m.marshal(&attr))
 			tx.set(m.entryKey(trash, m.trashEntry(parent, inode, name)), buf)
@@ -2377,7 +2379,9 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 					}
 				}
 				if dtyp == TypeDirectory {
-					tx.delete(m.dirQuotaKey(dino))
+					if quotaKey := m.dirQuotaKey(dino); tx.get(quotaKey) != nil { // avoid creating massive tombstones for quota keys we never set.
+						tx.delete(quotaKey)
+					}
 				}
 			}
 		}
@@ -3525,40 +3529,43 @@ func (m *kvMeta) doDelQuota(ctx Context, qtype uint32, key uint64) error {
 }
 
 func (m *kvMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota, map[uint64]*Quota, error) {
-	quotaTypes := []struct {
-		prefix string
-		name   string
-	}{
-		{"QD", "dir"},
-		{"QU", "user"},
-		{"QG", "group"},
-	}
+	format := m.getFormat()
+	dirQuotas := make(map[uint64]*Quota)
+	userQuotas := make(map[uint64]*Quota)
+	groupQuotas := make(map[uint64]*Quota)
 
-	quotaMaps := make([]map[uint64]*Quota, 3)
-	for i, qt := range quotaTypes {
-		pairs, err := m.scanValues(ctx, m.fmtKey(qt.prefix), -1, nil)
+	if format.DirStats {
+		pairs, err := m.scanValues(ctx, m.fmtKey("QD"), -1, nil)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load %s quotas: %w", qt.name, err)
+			return nil, nil, nil, fmt.Errorf("failed to load dir quotas: %w", err)
 		}
-		var quotas map[uint64]*Quota
-		if len(pairs) == 0 {
-			quotas = make(map[uint64]*Quota)
-		} else {
-			quotas = make(map[uint64]*Quota, len(pairs))
-			for k, v := range pairs {
-				var id uint64
-				if qt.prefix == "QD" {
-					id = uint64(m.decodeInode([]byte(k[2:]))) // skip prefix
-				} else {
-					id = binary.BigEndian.Uint64([]byte(k[2:])) // skip prefix
-				}
-				quotas[id] = m.parseQuota(v)
-			}
+		for k, v := range pairs {
+			id := uint64(m.decodeInode([]byte(k[2:]))) // skip prefix
+			dirQuotas[id] = m.parseQuota(v)
 		}
-		quotaMaps[i] = quotas
 	}
 
-	return quotaMaps[0], quotaMaps[1], quotaMaps[2], nil
+	if format.UserGroupQuota {
+		pairs, err := m.scanValues(ctx, m.fmtKey("QU"), -1, nil)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to load user quotas: %w", err)
+		}
+		for k, v := range pairs {
+			id := binary.BigEndian.Uint64([]byte(k[2:])) // skip prefix
+			userQuotas[id] = m.parseQuota(v)
+		}
+
+		pairs, err = m.scanValues(ctx, m.fmtKey("QG"), -1, nil)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to load group quotas: %w", err)
+		}
+		for k, v := range pairs {
+			id := binary.BigEndian.Uint64([]byte(k[2:])) // skip prefix
+			groupQuotas[id] = m.parseQuota(v)
+		}
+	}
+
+	return dirQuotas, userQuotas, groupQuotas, nil
 }
 
 func (m *kvMeta) cleanUgUsage(ctx Context, qtype uint32) error {


### PR DESCRIPTION
Currently, `rmdir` and `rename` always issue a delete for `QD<inode>`, even if the directory never had quota configured. With an MVCC backend such as TiKV/etcd, deleting always leaves a tombstone record regardless of whether the key existed. Those tombstone records make subsequent scans over the `QD` prefix very expensive. In one of our clusters, when users deleted massive directories, the TiKV cluster became overloaded and slowed down significantly. The root cause was that the periodic background `refresh` calls `loadQuotas`, which scans the entire `QD` prefix, eventually exhausting all CPU.