### PR TITLE
meta/sql: change setting.Value from varchar(4096) to text

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -54,7 +54,7 @@ const MaxFieldsCountOfTable = 19 // node table
 
 type setting struct {
 	Name  string `xorm:"pk"`
-	Value string `xorm:"varchar(4096) notnull"`
+	Value string `xorm:"text notnull"`
 }
 
 type counter struct {


### PR DESCRIPTION
Change the column type to TEXT which has no length limit and is the correct type for storing arbitrary-length JSON. xorm's Sync2 natively supports varchar->text migration on MySQL and PostgreSQL.

Fixes juicedata/juicefs#7151