### PR TITLE
meta/tkv: batch get quota key to reduce one rpc

### DIFF
--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2220,8 +2220,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 				return syscall.EEXIST
 			}
 			dtyp, dino = m.parseEntry(dbuf)
-			dgets := tx.gets(m.inodeKey(dino), m.dirQuotaKey(dino))
-			a := dgets[0]
+			a := tx.get(m.inodeKey(dino))
 			if a == nil { // corrupt entry
 				logger.Warnf("no attribute for inode %d (%d, %s)", dino, parentDst, nameDst)
 				trash = 0
@@ -2265,9 +2264,6 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 					dupdate = true
 					if trash > 0 {
 						tattr.Parent = trash
-					}
-					if dgets[1] != nil { // avoid creating massive tombstones for quota keys we never set.
-						tx.delete(m.dirQuotaKey(dino))
 					}
 				} else {
 					if trash == 0 {
@@ -2380,6 +2376,11 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 					tx.deleteKeys(m.xattrKey(dino, ""))
 					if tattr.Parent == 0 {
 						tx.deleteKeys(m.fmtKey("A", dino, "P"))
+					}
+				}
+				if dtyp == TypeDirectory {
+					if quotaKey := m.dirQuotaKey(dino); tx.get(quotaKey) != nil { // avoid creating massive tombstones for quota keys we never set.
+						tx.delete(quotaKey)
 					}
 				}
 			}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2048,7 +2048,7 @@ func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, oldA
 		if pinode != nil {
 			*pinode = inode
 		}
-		rs := tx.gets(m.inodeKey(parent), m.inodeKey(inode))
+		rs := tx.gets(m.inodeKey(parent), m.inodeKey(inode), m.dirQuotaKey(inode))
 		if rs[0] == nil {
 			return syscall.ENOENT
 		}
@@ -2108,8 +2108,8 @@ func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, oldA
 		}
 		tx.delete(m.entryKey(parent, name))
 		tx.delete(m.dirStatKey(inode))
-		if quotaKey := m.dirQuotaKey(inode); tx.get(quotaKey) != nil { // avoid creating massive tombstones for quota keys we never set.
-			tx.delete(quotaKey)
+		if rs[2] != nil { // avoid creating massive tombstones for quota keys we never set.
+			tx.delete(m.dirQuotaKey(inode))
 		}
 		if trash > 0 {
 			tx.set(m.inodeKey(inode), m.marshal(&attr))
@@ -2169,7 +2169,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			}
 			return nil
 		}
-		rs := tx.gets(m.inodeKey(parentSrc), m.inodeKey(parentDst), m.inodeKey(ino))
+		rs := tx.gets(m.inodeKey(parentSrc), m.inodeKey(parentDst), m.inodeKey(ino), m.entryKey(parentDst, nameDst))
 		if rs[0] == nil || rs[1] == nil || rs[2] == nil {
 			return syscall.ENOENT
 		}
@@ -2204,7 +2204,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			return syscall.EACCES
 		}
 
-		dbuf := tx.get(m.entryKey(parentDst, nameDst))
+		dbuf := rs[3]
 		if dbuf == nil && m.conf.CaseInsensi {
 			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
 				if string(e.Name) != nameSrc || parentDst != parentSrc {
@@ -2220,7 +2220,8 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 				return syscall.EEXIST
 			}
 			dtyp, dino = m.parseEntry(dbuf)
-			a := tx.get(m.inodeKey(dino))
+			dgets := tx.gets(m.inodeKey(dino), m.dirQuotaKey(dino))
+			a := dgets[0]
 			if a == nil { // corrupt entry
 				logger.Warnf("no attribute for inode %d (%d, %s)", dino, parentDst, nameDst)
 				trash = 0
@@ -2264,6 +2265,9 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 					dupdate = true
 					if trash > 0 {
 						tattr.Parent = trash
+					}
+					if dgets[1] != nil { // avoid creating massive tombstones for quota keys we never set.
+						tx.delete(m.dirQuotaKey(dino))
 					}
 				} else {
 					if trash == 0 {
@@ -2378,11 +2382,6 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 						tx.deleteKeys(m.fmtKey("A", dino, "P"))
 					}
 				}
-				if dtyp == TypeDirectory {
-					if quotaKey := m.dirQuotaKey(dino); tx.get(quotaKey) != nil { // avoid creating massive tombstones for quota keys we never set.
-						tx.delete(quotaKey)
-					}
-				}
 			}
 		}
 		if parentDst != parentSrc {
@@ -2423,7 +2422,7 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 
 func (m *kvMeta) doLink(ctx Context, inode, parent Ino, name string, attr *Attr) syscall.Errno {
 	return errno(m.txn(ctx, func(tx *kvTxn) error {
-		rs := tx.gets(m.inodeKey(parent), m.inodeKey(inode))
+		rs := tx.gets(m.inodeKey(parent), m.inodeKey(inode), m.entryKey(parent, name))
 		if rs[0] == nil || rs[1] == nil {
 			return syscall.ENOENT
 		}
@@ -2448,7 +2447,7 @@ func (m *kvMeta) doLink(ctx Context, inode, parent Ino, name string, attr *Attr)
 		if (iattr.Flags&FlagAppend) != 0 || (iattr.Flags&FlagImmutable) != 0 {
 			return syscall.EPERM
 		}
-		buf := tx.get(m.entryKey(parent, name))
+		buf := rs[2]
 		if buf != nil || m.conf.CaseInsensi && m.resolveCase(ctx, parent, name) != nil {
 			return syscall.EEXIST
 		}


### PR DESCRIPTION
Supplement to #7142: reduce one extra RPC caused by `tx.get(quotaKey)`.