### PR TITLE
meta/badger: run simpleTxn as read-only transaction

### DIFF
--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -177,8 +177,22 @@ func (c *badgerClient) config(key string) interface{} {
 	return nil
 }
 
+// simpleTxn runs f in a read-only transaction: reads skip conflict
+// tracking, and writes are rejected with badger.ErrReadOnlyTxn.
 func (c *badgerClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {
-	return c.txn(ctx, f, retry)
+	tx := &badgerTxn{c.client.NewTransaction(false), c}
+	defer tx.t.Discard()
+	defer func() {
+		if r := recover(); r != nil {
+			fe, ok := r.(error)
+			if ok {
+				err = fe
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	return f(&kvTxn{tx, retry})
 }
 
 func (c *badgerClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) (err error) {

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -320,6 +320,55 @@ func TestBadgerScanKeysOnlyNilValues(t *testing.T) {
 	}
 }
 
+func TestBadgerSimpleTxnReadOnly(t *testing.T) {
+	c, err := newBadgerClient(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.close()
+
+	if err := c.txn(Background(), func(kt *kvTxn) error {
+		kt.set([]byte("ro_key"), []byte("ro_value"))
+		return nil
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	var got []byte
+	var scanned int
+	if err := c.simpleTxn(Background(), func(kt *kvTxn) error {
+		got = kt.get([]byte("ro_key"))
+		kt.scan([]byte("ro_"), nextKey([]byte("ro_")), false, func(k, v []byte) bool {
+			scanned++
+			return true
+		})
+		return nil
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ro_value" || scanned != 1 {
+		t.Fatalf("simpleTxn read: got %q, scanned %d", got, scanned)
+	}
+
+	err = c.simpleTxn(Background(), func(kt *kvTxn) error {
+		kt.set([]byte("ro_key2"), []byte("v"))
+		return nil
+	}, 0)
+	if err != badger.ErrReadOnlyTxn {
+		t.Fatalf("expected ErrReadOnlyTxn, got %v", err)
+	}
+	var leaked []byte
+	if err := c.simpleTxn(Background(), func(kt *kvTxn) error {
+		leaked = kt.get([]byte("ro_key2"))
+		return nil
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	if leaked != nil {
+		t.Fatalf("write in read-only txn must not be committed, got %q", leaked)
+	}
+}
+
 func TestBadgerDeleteTxnTooBig(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Actually `simpleTxn` runs a read-write transaction.

In Badger, an update transaction allocates a `pendingWrites` map plus a `conflictKeys` map, and every Get and every iterator `Item()` appends a key fingerprint to the conflict read-set. Yet, all `simpleTxn` callers are pure reads.