### PR TITLE
CI: add resource cleanup in TestWebdav to prevent temp dir cleanup fa…

### DIFF
--- a/pkg/fs/http_test.go
+++ b/pkg/fs/http_test.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -29,6 +30,12 @@ import (
 
 func TestWebdav(t *testing.T) {
 	jfs := createTestFS(t)
+	defer func() {
+		if err := jfs.Close(); err != nil {
+			t.Logf("jfs.Close() failed: %v (may cause cleanup issues)", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}()
 	webdavFS := &webdavFS{meta.NewContext(uint32(os.Getpid()), uint32(os.Getuid()), []uint32{uint32(os.Getgid())}), jfs, uint16(utils.GetUmask()), WebdavConfig{EnableProppatch: true}}
 	ctx := context.Background()
 	_, err := webdavFS.Stat(ctx, "/")


### PR DESCRIPTION
rel https://github.com/juicedata/juicefs/actions/runs/27912233456/job/82591237745

Problem :
Intermittent test failure - TempDir RemoveAll cleanup: directory not empty . The flushLog goroutine holds the access log file open when Go tries to cleanup.

Fix : 
Added defer jfs.Close() + 10ms wait to properly release resources before temp dir cleanup.