### PR TITLE
test(fs): close FileSystem in createTestFS to fix TempDir cleanup race

### DIFF
--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -369,10 +369,11 @@ func createTestFS(t testing.TB) *FileSystem {
 	objStore, _ := object.CreateStorage("mem", "", "", "", "")
 	store := chunk.NewCachedStore(objStore, *conf.Chunk, nil)
 	jfs, err := NewFileSystem(&conf, m, store, nil)
-	jfs.checkAccessFile = time.Millisecond
-	jfs.rotateAccessLog = 500
 	if err != nil {
 		t.Fatalf("initialize  failed: %s", err)
 	}
+	jfs.checkAccessFile = time.Millisecond
+	jfs.rotateAccessLog = 500
+	t.Cleanup(func() { _ = jfs.Close() })
 	return jfs
 }


### PR DESCRIPTION
https://github.com/juicedata/juicefs/actions/runs/27912233456/job/82591237745

The background flushLog goroutine kept running after a test returned and could recreate the access log file (via rotation) inside t.TempDir() during cleanup, causing 'directory not empty' failures (e.g. TestWebdav).

Register t.Cleanup(jfs.Close) so the goroutine stops and the log file is closed before the temp dir is removed (LIFO ordering).