### PR TITLE
meta: fix openfiles cleanup goroutine leak on Shutdown

### DIFF
--- a/pkg/meta/openfile.go
+++ b/pkg/meta/openfile.go
@@ -43,9 +43,11 @@ func (o *openFile) release() {
 
 type openfiles struct {
 	sync.Mutex
-	expire time.Duration
-	limit  uint64
-	files  map[Ino]*openFile
+	expire    time.Duration
+	limit     uint64
+	files     map[Ino]*openFile
+	stop      chan struct{}
+	closeOnce sync.Once
 }
 
 func newOpenFiles(expire time.Duration, limit uint64) *openfiles {
@@ -53,9 +55,14 @@ func newOpenFiles(expire time.Duration, limit uint64) *openfiles {
 		expire: expire,
 		limit:  limit,
 		files:  make(map[Ino]*openFile),
+		stop:   make(chan struct{}),
 	}
 	go of.cleanup()
 	return of
+}
+
+func (o *openfiles) close() {
+	o.closeOnce.Do(func() { close(o.stop) })
 }
 
 func (o *openfiles) cleanup() {
@@ -101,7 +108,11 @@ func (o *openfiles) cleanup() {
 			}
 		}
 		o.Unlock()
-		time.Sleep(time.Millisecond * time.Duration(1000*(cnt+1-deleted*2)/(cnt+1)))
+		select {
+		case <-o.stop:
+			return
+		case <-time.After(time.Millisecond * time.Duration(1000*(cnt+1-deleted*2)/(cnt+1))):
+		}
 	}
 }
 

--- a/pkg/meta/openfile_growth_test.go
+++ b/pkg/meta/openfile_growth_test.go
@@ -1,0 +1,31 @@
+package meta
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestOpenfilesNoGoroutineLeakOnShutdown(t *testing.T) {
+	settle := func() {
+		runtime.GC()
+		time.Sleep(300 * time.Millisecond)
+		runtime.GC()
+	}
+
+	settle()
+	base := runtime.NumGoroutine()
+
+	const cycles = 100
+	for i := 0; i < cycles; i++ {
+		m := NewClient("memkv://", nil)
+		if err := m.Shutdown(); err != nil {
+			t.Fatalf("shutdown: %v", err)
+		}
+	}
+
+	settle()
+	if leaked := runtime.NumGoroutine() - base; leaked > cycles/10 {
+		t.Fatalf("leaked %d goroutines after %d NewClient+Shutdown cycles", leaked, cycles)
+	}
+}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -296,6 +296,7 @@ func newRedisMeta(driver, addr string, conf *Config) (Meta, error) {
 }
 
 func (m *redisMeta) Shutdown() error {
+	m.of.close()
 	if m.cache != nil {
 		m.cache.close()
 		m.cache = nil

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -545,6 +545,7 @@ func newSQLMeta(driver, addr string, conf *Config) (Meta, error) {
 }
 
 func (m *dbMeta) Shutdown() error {
+	m.of.close()
 	return m.db.Close()
 }
 

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -128,6 +128,7 @@ func newKVMeta(driver, addr string, conf *Config) (Meta, error) {
 }
 
 func (m *kvMeta) Shutdown() error {
+	m.of.close()
 	return m.client.close()
 }
 


### PR DESCRIPTION
Fixes #7207

`newOpenFiles` starts a `cleanup` goroutine that `Shutdown` never stops, leaking one goroutine per `meta.NewClient`. The fix adds a stop channel to `openfiles` and closes it in `Shutdown`, matching the other `baseMeta` goroutines that are stopped via `CloseSession`.

Verified with `memkv`: 100× `NewClient`+`Shutdown` leaks +100 goroutines before, +0 after. Regression test included; `go test -race` clean.