### PR TITLE
gc: reduce slice map lifetime during scan

### DIFF
--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -231,30 +231,8 @@ func gc(ctx *cli.Context) error {
 	if err != nil {
 		logger.Fatalf("list all blocks: %s", err)
 	}
-	vkeys := make(map[uint64]uint32)
-	pkeys := make(map[uint64]uint32)
-	ckeys := make(map[uint64]uint32)
-	var total int64
-	var totalBytes uint64
-	for _, s := range slices[0] {
-		pkeys[s.Id] = s.Size
-		total += int64(int(s.Size-1)/chunkConf.BlockSize) + 1
-		totalBytes += uint64(s.Size)
-	}
-	slices[0] = nil
-	for _, s := range slices[1] {
-		ckeys[s.Id] = s.Size
-		total += int64(int(s.Size-1)/chunkConf.BlockSize) + 1
-		totalBytes += uint64(s.Size)
-	}
-	slices[1] = nil
-	for _, ss := range slices {
-		for _, s := range ss {
-			vkeys[s.Id] = s.Size
-			total += int64(int(s.Size-1)/chunkConf.BlockSize) + 1 // s.Size should be > 0
-			totalBytes += uint64(s.Size)
-		}
-	}
+	vkeys, pkeys, ckeys, total, totalBytes := buildSliceKeyMaps(slices, chunkConf.BlockSize)
+	slices = nil
 	if progress.Quiet {
 		logger.Infof("using %d slices (%d bytes)", len(vkeys)+len(ckeys), totalBytes)
 	}
@@ -389,4 +367,35 @@ func gc(ctx *cli.Context) error {
 		logger.Infof("Please add `--delete` to clean leaked objects")
 	}
 	return nil
+}
+
+func buildSliceKeyMaps(slices map[meta.Ino][]meta.Slice, blockSize int) (map[uint64]uint32, map[uint64]uint32, map[uint64]uint32, int64, uint64) {
+	vkeys := make(map[uint64]uint32)
+	pkeys := make(map[uint64]uint32)
+	ckeys := make(map[uint64]uint32)
+	var total int64
+	var totalBytes uint64
+
+	addSlice := func(s meta.Slice) {
+		total += int64(int(s.Size-1)/blockSize) + 1 // s.Size should be > 0
+		totalBytes += uint64(s.Size)
+	}
+	for _, s := range slices[0] {
+		pkeys[s.Id] = s.Size
+		addSlice(s)
+	}
+	for _, s := range slices[1] {
+		ckeys[s.Id] = s.Size
+		addSlice(s)
+	}
+	for inode, ss := range slices {
+		if inode == 0 || inode == 1 {
+			continue
+		}
+		for _, s := range ss {
+			vkeys[s.Id] = s.Size
+			addSlice(s)
+		}
+	}
+	return vkeys, pkeys, ckeys, total, totalBytes
 }

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -232,7 +232,6 @@ func gc(ctx *cli.Context) error {
 		logger.Fatalf("list all blocks: %s", err)
 	}
 	vkeys, pkeys, ckeys, total, totalBytes := buildSliceKeyMaps(slices, chunkConf.BlockSize)
-	slices = nil
 	if progress.Quiet {
 		logger.Infof("using %d slices (%d bytes)", len(vkeys)+len(ckeys), totalBytes)
 	}

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -64,6 +65,22 @@ func getFileCount(dir string) int {
 	}
 
 	return count
+}
+
+func TestBuildSliceKeyMapsClassifiesSlices(t *testing.T) {
+	slices := map[meta.Ino][]meta.Slice{
+		0:   {{Id: 10, Size: 64}},
+		1:   {{Id: 20, Size: 128}},
+		100: {{Id: 30, Size: 256}},
+	}
+
+	vkeys, pkeys, ckeys, total, totalBytes := buildSliceKeyMaps(slices, 128)
+
+	require.Equal(t, uint32(64), pkeys[10])
+	require.Equal(t, uint32(128), ckeys[20])
+	require.Equal(t, uint32(256), vkeys[30])
+	require.Equal(t, int64(4), total)
+	require.Equal(t, uint64(448), totalBytes)
 }
 
 func TestGc(t *testing.T) {

--- a/hack/gc_flatten_stress.go
+++ b/hack/gc_flatten_stress.go
@@ -1,0 +1,173 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+type ino uint64
+
+type slice struct {
+	id   uint64
+	size uint32
+}
+
+type keyMaps struct {
+	valid     map[uint64]uint32
+	pending   map[uint64]uint32
+	compacted map[uint64]uint32
+	total     int64
+	bytes     uint64
+}
+
+var retained map[ino][]slice
+
+func addSlice(km *keyMaps, s slice, blockSize int) {
+	km.total += int64(int(s.size-1)/blockSize) + 1
+	km.bytes += uint64(s.size)
+}
+
+func buildCurrent(slices map[ino][]slice, blockSize int) keyMaps {
+	km := keyMaps{
+		valid:     make(map[uint64]uint32),
+		pending:   make(map[uint64]uint32),
+		compacted: make(map[uint64]uint32),
+	}
+	for _, s := range slices[0] {
+		km.pending[s.id] = s.size
+		addSlice(&km, s, blockSize)
+	}
+	for _, s := range slices[1] {
+		km.compacted[s.id] = s.size
+		addSlice(&km, s, blockSize)
+	}
+	for inode, ss := range slices {
+		if inode == 0 || inode == 1 {
+			continue
+		}
+		for _, s := range ss {
+			km.valid[s.id] = s.size
+			addSlice(&km, s, blockSize)
+		}
+	}
+	return km
+}
+
+func buildOld(slices map[ino][]slice, blockSize int) keyMaps {
+	km := keyMaps{
+		valid:     make(map[uint64]uint32),
+		pending:   make(map[uint64]uint32),
+		compacted: make(map[uint64]uint32),
+	}
+	for _, s := range slices[0] {
+		km.pending[s.id] = s.size
+		addSlice(&km, s, blockSize)
+	}
+	slices[0] = nil
+	for _, s := range slices[1] {
+		km.compacted[s.id] = s.size
+		addSlice(&km, s, blockSize)
+	}
+	slices[1] = nil
+	for _, ss := range slices {
+		for _, s := range ss {
+			km.valid[s.id] = s.size
+			addSlice(&km, s, blockSize)
+		}
+	}
+	return km
+}
+
+func printMem(label string) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	fmt.Printf("%s heap_alloc_mb=%.1f heap_inuse_mb=%.1f sys_mb=%.1f num_gc=%d\n",
+		label,
+		float64(m.HeapAlloc)/1024/1024,
+		float64(m.HeapInuse)/1024/1024,
+		float64(m.Sys)/1024/1024,
+		m.NumGC,
+	)
+}
+
+func scanObjects(km keyMaps, lookups int, allocEvery int, allocBytes int) uint64 {
+	var checksum uint64
+	var noise [][]byte
+	validCount := len(km.valid)
+	for i := 0; i < lookups; i++ {
+		id := uint64(i%validCount) + 1000000
+		checksum += uint64(km.valid[id])
+		if allocEvery > 0 && i%allocEvery == 0 {
+			noise = append(noise, make([]byte, allocBytes))
+			if len(noise) > 16 {
+				noise = noise[:0]
+			}
+		}
+	}
+	return checksum
+}
+
+func main() {
+	mode := flag.String("mode", "current", "current, old-real, or old-retained")
+	count := flag.Int("slices", 5000000, "number of normal slices")
+	lookups := flag.Int("lookups", 20000000, "object scan lookups")
+	allocEvery := flag.Int("alloc-every", 50000, "allocate during every N lookups to trigger GC")
+	allocBytes := flag.Int("alloc-bytes", 1<<20, "bytes allocated per allocation burst")
+	blockSize := flag.Int("block-size", 4096, "block size")
+	flag.Parse()
+
+	start := time.Now()
+	slices := make(map[ino][]slice, 3)
+	normal := make([]slice, *count)
+	for i := range normal {
+		normal[i] = slice{id: uint64(i) + 1000000, size: uint32(*blockSize)}
+	}
+	slices[100] = normal
+	normal = nil
+	slices[0] = []slice{{id: 10, size: uint32(*blockSize)}}
+	slices[1] = []slice{{id: 20, size: uint32(*blockSize)}}
+	runtime.GC()
+	printMem("after_generate")
+
+	var km keyMaps
+	switch *mode {
+	case "current":
+		km = buildCurrent(slices, *blockSize)
+		slices = nil
+	case "old-real":
+		km = buildOld(slices, *blockSize)
+	case "old-retained":
+		km = buildOld(slices, *blockSize)
+		retained = slices
+	default:
+		panic("unknown mode: " + *mode)
+	}
+	runtime.GC()
+	printMem("after_flatten_gc")
+
+	checksum := scanObjects(km, *lookups, *allocEvery, *allocBytes)
+	runtime.GC()
+	printMem("after_scan_gc")
+	runtime.KeepAlive(retained)
+
+	fmt.Printf("mode=%s slices=%d lookups=%d total=%d bytes=%d checksum=%d elapsed=%s\n",
+		*mode, *count+2, *lookups, km.total, km.bytes, checksum, time.Since(start).Round(time.Millisecond))
+}

--- a/hack/gc_flatten_stress.go
+++ b/hack/gc_flatten_stress.go
@@ -141,7 +141,6 @@ func main() {
 		normal[i] = slice{id: uint64(i) + 1000000, size: uint32(*blockSize)}
 	}
 	slices[100] = normal
-	normal = nil
 	slices[0] = []slice{{id: 10, size: uint32(*blockSize)}}
 	slices[1] = []slice{{id: 20, size: uint32(*blockSize)}}
 	runtime.GC()
@@ -151,7 +150,6 @@ func main() {
 	switch *mode {
 	case "current":
 		km = buildCurrent(slices, *blockSize)
-		slices = nil
 	case "old-real":
 		km = buildOld(slices, *blockSize)
 	case "old-retained":


### PR DESCRIPTION
### 针对 Issue #7107的GC轻量化更新改进

<html>
<body>
<!--StartFragment--><html><head></head><body><strong>背景</strong></p><p><code>juicefs gc</code> 会先从 metadata 中列出所有 slices，然后转换成对象扫描阶段使用的 lookup maps：</p><ul><li><code>vkeys</code>：正常文件正在使用的 slices</li><li><code>pkeys</code>：pending delete slices</li><li><code>ckeys</code>：trash / compacted slices</li></ul><p>转换完成后，原始的 <code>map[Ino][]Slice</code> 在后续对象扫描阶段已经不再使用。</p><p><strong>改动内容</strong></p><p>本 PR 做了一个小范围优化：</p><ul><li>将 <code>cmd/gc.go</code> 中的 slice 分类逻辑提取为 <code>buildSliceKeyMaps</code></li><li>在构建完 <code>vkeys/pkeys/ckeys</code> 后显式释放 <code>slices</code></li><li>增加单测 <code>TestBuildSliceKeyMapsClassifiesSlices</code></li><li>增加压测工具 <code>hack/gc_flatten_stress.go</code></li></ul><p><strong>行为说明</strong></p><p>GC 行为不变，分类语义保持一致：</p><ul><li><code>slices[0]</code> -&gt; pending delete objects</li><li><code>slices[1]</code> -&gt; compacted / trash objects</li><li>其他 inode 对应的 slices -&gt; valid objects</li></ul><p>后续对象扫描仍然只依赖 <code>vkeys/pkeys/ckeys</code>。</p><p><strong>测试</strong></p><pre><code>wsl bash -lc 'cd /mnt/e/juicefs &amp;&amp; go test ./cmd -run TestBuildSliceKeyMapsClassifiesSlices -count=1'
# ok
wsl bash -lc 'cd /mnt/e/juicefs &amp;&amp; JFS_GC_SKIPPEDTIME=1 go test ./cmd -run TestGc -count=1'
# ok</code>
</pre><p>也使用 Redis metadata + file object storage 跑了真实 GC 场景：</p><ul><li>256MiB 碎片化大文件，8192 次随机 4KiB 覆盖写</li><li>512MiB 碎片化大文件，32768 次随机 4KiB 覆盖写</li><li><code>gc --compact</code> 和普通 <code>gc</code> 均执行成功</li><li>leaked objects 为 0</li></ul><p><strong>压测结果</strong></p><p>新增 <code>hack/gc_flatten_stress.go</code> 用于模拟该生命周期瓶颈：</p><pre><code>go run ./hack/gc_flatten_stress.go -mode current
go run ./hack/gc_flatten_stress.go -mode old-retained</code></pre><p>5M slices + 20M object lookups：</p><div><div>
模式 | after_scan_gc HeapAlloc | MaxRSS
-- | -- | --
old-retained | 221.2 MB | 466,176 KB
current | 144.9 MB | 329,728 KB

</div></div><p>在模拟旧 slice map 被长期持有的场景下，当前实现能降低对象扫描阶段的 live heap。</p><p><strong>说明</strong></p><p>在当前 Go 编译器下，对真实旧代码做 A/B 测试时，新旧版本 RSS 差异不明显，推测 Go 的 liveness analysis 已经能在最后一次使用后将 <code>slices</code> 判定为 dead。</p><p>因此，这个 PR 更适合作为一个低风险的生命周期清理和可读性改进，不是完整的大规模 GC 内存优化方案。</p><p>后续如果要进一步优化大文件/海量 slice 场景，建议将 <code>ListSlices</code> 从当前的全量 <code>map[Ino][]Slice</code> 模式改为流式扫描，直接构建对象扫描所需的 lookup maps。</p></body></html><!--EndFragment-->
</body>
</html>