### PR TITLE
fuse: fix stale size=0 in replyAttr TOCTOU race

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -53,17 +53,10 @@ func newFileSystem(conf *vfs.Config, v *vfs.VFS) *fileSystem {
 type setTimeout func(time.Duration)
 
 func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.Attr, set setTimeout) {
+	fs.v.UpdateLength(entry.Inode, entry.Attr) // UpdateLength before ModifiedSince check to avoid TOCTOU race
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
 	} else {
-		// NOTE: UpdateLength must run BEFORE the ModifiedSince check to close a
-		// TOCTOU race: if the writer is already freed when UpdateLength looks it
-		// up, the data commit (modifiedAtNow) must have happened before the free
-		// (commitThread commits via m.Write before freeChunk), so ModifiedSince
-		// below is guaranteed to observe it and force a refresh. With the old
-		// order (check first, merge later), a close() completing in between left
-		// a stale size=0 with neither correction applied.
-		fs.v.UpdateLength(entry.Inode, entry.Attr)
 		refreshed := true
 		if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
 			refreshed = false
@@ -72,9 +65,7 @@ func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.
 			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nattr)
 			if st == 0 {
 				*entry.Attr = nattr
-				// NOTE: merge again: a new writer may have appeared during
-				// GetAttr; length only grows, never regresses.
-				fs.v.UpdateLength(entry.Inode, entry.Attr)
+				fs.v.UpdateLength(entry.Inode, entry.Attr) // Merge again in case write appeared during GetAttr
 			}
 		}
 		if refreshed {

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -57,18 +57,15 @@ func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
 	} else {
-		refreshed := true
 		if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
-			refreshed = false
 			logger.Debugf("refresh attr for %d", entry.Inode)
-			var nattr meta.Attr
-			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nattr)
+			var nAttr meta.Attr
+			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr)
 			if st == 0 {
-				*entry.Attr = nattr
+				*entry.Attr = nAttr
 				fs.v.UpdateLength(entry.Inode, entry.Attr) // Merge again in case write appeared during GetAttr
 			}
-		}
-		if refreshed {
+		} else {
 			set(fs.conf.AttrTimeout)
 		}
 	}

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -55,18 +55,32 @@ type setTimeout func(time.Duration)
 func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.Attr, set setTimeout) {
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
-	} else if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
-		logger.Debugf("refresh attr for %d", entry.Inode)
-		var attr meta.Attr
-		st := fs.v.Meta.GetAttr(ctx, entry.Inode, &attr)
-		if st == 0 {
-			*entry.Attr = attr
+	} else {
+		// NOTE: UpdateLength must run BEFORE the ModifiedSince check to close a
+		// TOCTOU race: if the writer is already freed when UpdateLength looks it
+		// up, the data commit (modifiedAtNow) must have happened before the free
+		// (commitThread commits via m.Write before freeChunk), so ModifiedSince
+		// below is guaranteed to observe it and force a refresh. With the old
+		// order (check first, merge later), a close() completing in between left
+		// a stale size=0 with neither correction applied.
+		fs.v.UpdateLength(entry.Inode, entry.Attr)
+		refreshed := true
+		if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
+			refreshed = false
+			logger.Debugf("refresh attr for %d", entry.Inode)
+			var nattr meta.Attr
+			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nattr)
+			if st == 0 {
+				*entry.Attr = nattr
+				// NOTE: merge again: a new writer may have appeared during
+				// GetAttr; length only grows, never regresses.
+				fs.v.UpdateLength(entry.Inode, entry.Attr)
+			}
+		}
+		if refreshed {
 			set(fs.conf.AttrTimeout)
 		}
-	} else {
-		set(fs.conf.AttrTimeout)
 	}
-	fs.v.UpdateLength(entry.Inode, entry.Attr)
 	attrToStat(entry.Inode, entry.Attr, attr)
 }
 


### PR DESCRIPTION
# Fix: TOCTOU race in `replyAttr` returning stale size=0

## Symptom

`stat`/`fstat` on a freshly-written-and-closed file **intermittently returns `size=0`**, even though the data has been successfully committed and the metadata length has been updated to the real size. The file actually has content, but stat reports it as empty, causing upper-layer applications to misjudge the file as truncated.

## Root cause: TOCTOU race in `replyAttr`

`replyAttr` in `pkg/fuse/fuse.go` translates VFS-layer attrs into the FUSE stat result. The pre-fix code ordered operations as:

```go
func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.Attr, set setTimeout) {
	if vfs.IsSpecialNode(entry.Inode) {
		set(time.Hour)
	} else if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
		// (A) CHECK: was the inode modified since the request started?
		logger.Debugf("refresh attr for %d", entry.Inode)
		var attr meta.Attr
		st := fs.v.Meta.GetAttr(ctx, entry.Inode, &attr)
		if st == 0 {
			*entry.Attr = attr
			set(fs.conf.AttrTimeout)
		}
	} else {
		set(fs.conf.AttrTimeout)
	}
	fs.v.UpdateLength(entry.Inode, entry.Attr)  // (B) MERGE: correct attr.Length with in-writer length
	attrToStat(entry.Inode, entry.Attr, attr)
}
```

The problem: **a time window exists between (A) the `ModifiedSince` check and (B) the `UpdateLength` merge**, and the side effects of a concurrent `close()` straddle this window in a way that defeats both correction mechanisms.

### Close() timing

`VFS.Release` (`pkg/vfs/vfs.go:647`) handles a write handle as:

```go
if f.writer != nil {
    _ = f.writer.Flush(ctx)     // ① wait for commitThread to submit data to meta (m.Write)
    v.invalidateAttr(ino)        // ② mark modifiedAt[ino] = now
}
...
go v.releaseFileHandle(ino, fh) // ③ async: release handle -> h.Close() -> writer.Close -> w.free(f) removes writer from map
```

Where:

- `Flush` (`pkg/vfs/writer.go:386`) holds the lock and waits for `len(f.chunks) == 0`, i.e. for `commitThread` (`pkg/vfs/writer.go:186`) to submit every slice to meta via `m.Write` and `freeChunk`.
- `releaseFileHandle` (`pkg/vfs/handle.go:255`) runs **asynchronously** (launched with `go`), eventually calling `h.Close()` → `writer.Close()` (`pkg/vfs/writer.go:440`) → `f.w.free(f)` (`pkg/vfs/writer.go:542`), which does `delete(w.files, f.inode)` when `refs==0`.

### Race walkthrough

`UpdateLength` (`pkg/vfs/vfs.go:429`) corrects the length as follows:

```go
func (v *VFS) UpdateLength(inode Ino, attr *meta.Attr) {
	if attr.Full && attr.Typ == meta.TypeFile {
		length := v.writer.GetLength(inode)   // look up writer map; returns 0 if writer is gone
		if length > attr.Length {
			attr.Length = length              // overwrite with the larger in-writer length
		}
		v.reader.Truncate(inode, attr.Length)
	}
}
```

Assume a `stat` request arrives while `close()` is in flight:

```
stat request starts (ctx.start = T0)
│
├─ replyAttr enters
│   ├─ (A) ModifiedSince(ino, T0)
│   │     invalidateAttr ② has NOT executed yet → modifiedAt[ino] absent or <= T0
│   │     → returns false → takes the else branch → set(AttrTimeout)
│   │     ⚠ meta length is still stale (size=0, because ① Flush has not finished m.Write)
│   │
├─ ─ ─ ─ ─ window ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
│   meanwhile close() finishes ① Flush (m.Write committed, length=realSize)
│                             finishes ② invalidateAttr (modifiedAt[ino]=now > T0)
│                             finishes ③ releaseFileHandle → writer removed from map
│
├─ (B) UpdateLength(ino, entry.Attr)
│      v.writer.GetLength(ino) → writer already removed by ③ → returns 0
│      0 > attr.Length(0)? → false → no correction
│      ⚠ attr.Length stays 0 (stale meta value; UpdateLength cannot remedy it)
│
└─ attrToStat → returns size=0  ❌
```

**Both correction mechanisms fail simultaneously:**

- (A) `ModifiedSince` is checked before `invalidateAttr` runs → returns false → no meta refresh is triggered (missing the freshly committed length in meta).
- (B) `UpdateLength` runs after the writer has been freed → `GetLength` returns 0 → cannot remedy with the in-writer length.

Result: `attr.Length=0` flows untouched into `attrToStat`, and stat returns size=0.

> Note: this window requires `stat` to enter (A) before `Flush` completes and reach (B) after `releaseFileHandle` completes. Since (B) immediately follows (A) while `releaseFileHandle` is an async goroutine, the window is narrow but real, and is reproducible in production under high-concurrency close/stat workloads.

## The fix

Reorder `replyAttr` so `UpdateLength` runs **before** the `ModifiedSince` check, and runs **again** after the `GetAttr` refresh:

```go
func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.Attr, set setTimeout) {
	if vfs.IsSpecialNode(entry.Inode) {
		set(time.Hour)
	} else {
		fs.v.UpdateLength(entry.Inode, entry.Attr)       // (1) merge in-writer length first
		refreshed := true
		if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
			refreshed = false
			var nattr meta.Attr
			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nattr)
			if st == 0 {
				*entry.Attr = nattr
				fs.v.UpdateLength(entry.Inode, entry.Attr)  // (2) merge again after refresh
			}
		}
		if refreshed {
			set(fs.conf.AttrTimeout)
		}
	}
	attrToStat(entry.Inode, entry.Attr, attr)
}
```

## Why the fix works

After the fix, regardless of which phase `close()` is in, `replyAttr` always obtains the correct length:

**Case 1: close has NOT finished ① Flush (writer still in the map)**

- (1) `UpdateLength`: `writer.GetLength(ino)` returns the real in-writer length → `attr.Length` corrected to realSize ✅
- Even if (A) `ModifiedSince` returns false (meta length still stale at 0), `attr.Length` was already corrected in (1), so the stale meta value is never used.

**Case 2: close has finished ① Flush but not ③ releaseFileHandle (writer still in the map)**

- (1) `UpdateLength`: same as Case 1, `attr.Length` = realSize ✅
- (A) `ModifiedSince`: `invalidateAttr` has run (`modifiedAt[ino]` > `ctx.start`) → returns true → enters the refresh branch
- `GetAttr` fetches the just-committed meta length (realSize) → (2) `UpdateLength` runs again (writer still present, length consistent) ✅

**Case 3: close has finished ① ② ③ (writer removed from the map)**

- (1) `UpdateLength`: `writer.GetLength` returns 0, no correction; but meta length is already realSize (① Flush's m.Write has committed)
- (A) `ModifiedSince`: `invalidateAttr` has run → returns true → enters the refresh branch
- `GetAttr` fetches realSize from meta → `attr.Length` = realSize ✅

**Key invariant (guaranteed by commitThread's implementation):**

> The writer's removal from the map (`w.free(f)`, writer.go:542) happens **after** `commitThread`'s `m.Write` submission (writer.go:208). `commitThread` is in turn synchronized with `Release` via `Flush` waiting for `len(f.chunks)==0` (writer.go:398). Therefore: **once the writer is unreachable, the data must already be committed to meta, and `ModifiedSince` must be true.**

This invariant is the cornerstone of the fix: by moving `UpdateLength` ahead, either the writer is still alive (Cases 1/2, the in-memory length acts as a fallback) or the writer is already gone (Case 3, data is in meta and `ModifiedSince` must trigger a refresh). The two correction paths complement each other and close the window entirely.

## Impact on special inodes

The `IsSpecialNode=true` branch no longer executes the trailing `UpdateLength` (it has been moved into the else branch). Verified that this is **behavior-preserving** for special inodes (controlInode/logInode/StatsInode/ConfigInode):

- These internal nodes have `attr.Typ=TypeFile` and `attr.Full=true` (set by `pkg/vfs/internal.go:96,104`), so they would technically enter `UpdateLength`'s if branch.
- But `writer.GetLength(inode)` returns 0 for them (internal nodes never enter the writer's `files` map), and `reader.Truncate(inode, ...)` is a no-op (`reader.visit` finds `r.files[inode]` empty, so the loop body never runs).
- Thus the old code's `UpdateLength` call on a special inode was effectively a no-op; the new code's explicit skip is semantically equivalent and saves one lock + map lookup.

## Files changed

- `pkg/fuse/fuse.go`: reorder `UpdateLength`/`ModifiedSince` in `replyAttr`, add a second `UpdateLength` after refresh (23 lines added, 9 deleted)
