### PR TITLE
This PR introduces build knobs and a dedicated  target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,15 @@ builds:
       - linux
     goarch:
       - arm64
+  - id: juicefs-linux-riscv64
+    env:
+      - CC=/usr/local/riscv64-linux-musl-cross/bin/riscv64-linux-musl-cc
+    ldflags: -s -w -X github.com/juicedata/juicefs/pkg/version.version={{.Version}} -X github.com/juicedata/juicefs/pkg/version.revision={{.ShortCommit}} -X github.com/juicedata/juicefs/pkg/version.revisionDate={{.Env.REVISIONDATE}} -linkmode external -extldflags '-static'
+    main: .
+    goos:
+      - linux
+    goarch:
+      - riscv64
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ ifdef STATIC
 	export CC
 endif
 
+# RISC-V build knobs (override in command line when needed):
+# make juicefs.riscv64 RISCV64_GORISCV64='rva23u64,zabha,zacas' \
+#     RISCV64_ASM_DEFS='-D HasZvknha -D EnableSmallSizeMemVector'
+RISCV64_CC ?= /usr/local/gcc
+RISCV64_GORISCV64 ?=
+RISCV64_ASM_DEFS ?=
+RISCV64_ASMFLAGS ?= github.com/juicedata/juicefs/...='$(RISCV64_ASM_DEFS)'
+
 juicefs: Makefile cmd/*.go pkg/*/*.go go.*
 	go version
 	go build -gcflags="$(GCFLAGS)" -ldflags="$(LDFLAGS)" -o juicefs .
@@ -67,6 +75,22 @@ juicefs.loongarch: Makefile cmd/*.go pkg/*/*.go go.*
 # Please execute the `brew install FiloSottile/musl-cross/musl-cross` command before using it.
 juicefs.linux:
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=x86_64-linux-musl-gcc CGO_LDFLAGS="-static" go build -gcflags="$(GCFLAGS)" -ldflags="$(LDFLAGS)"  -o juicefs .
+
+# This is cross-compiling RISC-V in a Linux environment on x86_64 (amd64) or aarch64 (arm64) architecture.
+# 1. Install RISC-V musl cross-compile toolchain at /usr/local/riscv64-linux-musl-cross
+#    or override RISCV64_CC to your toolchain path.
+# 2. Run `make juicefs.riscv64` to build the RISC-V binary.
+# 3. Optionally set RISCV64_GORISCV64 for ISA extensions and RISCV64_ASM_DEFS for assembly defines.
+#    Example:
+#      make juicefs.riscv64 RISCV64_GORISCV64='rva23u64,zabha,zacas' \
+#          RISCV64_ASM_DEFS='-D HasZvknha -D EnableSmallSizeMemVector'
+juicefs.riscv64: Makefile cmd/*.go pkg/*/*.go go.*
+	CGO_ENABLED=1 GOARCH=riscv64 GORISCV64="$(RISCV64_GORISCV64)" \
+	CC="$(RISCV64_CC)" \
+	go build -gcflags="$(GCFLAGS)" \
+		-ldflags="$(LDFLAGS)" \
+		-asmflags="$(RISCV64_ASMFLAGS)" \
+		-o juicefs .
 
 /usr/local/include/winfsp:
 	sudo mkdir -p /usr/local/include/winfsp


### PR DESCRIPTION
to enable cross-compilation for RISC-V64 in Linux environments.

Key changes:
- Added configurable variables: RISCV64_CC, RISCV64_GORISCV64, RISCV64_ASM_DEFS, RISCV64_ASMFLAGS
- Documented usage for overriding ISA extensions and assembly defines
- Integrated cross-compile toolchain path support (/usr/local/riscv64-linux-musl-cross by default)
- New Makefile target  for building RISC-V binaries

Developers can now run:
  make juicefs.riscv64 RISCV64_GORISCV64='rva23u64,zabha,zacas'       RISCV64_ASM_DEFS='-D HasZvknha -D EnableSmallSizeMemVector'

to produce RISC-V builds with optional ISA extensions and assembly flags.