### PR TITLE
cmd/config: confirm min client version bumps

### DIFF
--- a/.github/workflows/sdktest.yml
+++ b/.github/workflows/sdktest.yml
@@ -90,7 +90,7 @@ jobs:
           # kerberos test
           sudo cp src/test/resources/kerberos.cfg /tmp/kerberos.cfg
           sudo sh -c "echo "dev.keytab=`base64 /tmp/server.keytab -w 0`" >> /tmp/kerberos.cfg"
-          sudo ../../juicefs config localhost --kerberos-config-file /tmp/kerberos.cfg
+          sudo ../../juicefs config localhost --kerberos-config-file /tmp/kerberos.cfg -y
           sudo mvn test -B -Dtest=io.juicefs.kerberos.KerberosTest
           
           sudo mvn package -B -Dmaven.test.skip=true --quiet -Dmaven.javadoc.skip=true

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -159,25 +159,6 @@ func userConfirmed() bool {
 	return false
 }
 
-func ensureMinClientVersion(format *meta.Format, required string, msg *strings.Builder) bool {
-	current := version.Parse(format.MinClientVersion)
-	target := version.Parse(required)
-	if current != nil && target != nil {
-		if r, err := version.CompareVersions(current, target); err == nil && r >= 0 {
-			return false
-		}
-	}
-	if msg != nil {
-		msg.WriteString("min-client-version: ")
-		msg.WriteString(format.MinClientVersion)
-		msg.WriteString(" -> ")
-		msg.WriteString(required)
-		msg.WriteByte('\n')
-	}
-	format.MinClientVersion = required
-	return true
-}
-
 func config(ctx *cli.Context) error {
 	setup(ctx, 1)
 	removePassword(ctx.Args().Get(0))

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -159,6 +159,19 @@ func userConfirmed() bool {
 	return false
 }
 
+func ensureMinClientVersion(format *meta.Format, required string, msg *strings.Builder) bool {
+	current := version.Parse(format.MinClientVersion)
+	target := version.Parse(required)
+	if current != nil && target != nil {
+		if r, err := version.CompareVersions(current, target); err == nil && r >= 0 {
+			return false
+		}
+	}
+	msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", "min-client-version", format.MinClientVersion, required))
+	format.MinClientVersion = required
+	return true
+}
+
 func config(ctx *cli.Context) error {
 	setup(ctx, 1)
 	removePassword(ctx.Args().Get(0))
@@ -176,12 +189,19 @@ func config(ctx *cli.Context) error {
 	originDirStats := format.DirStats
 	originUGQuota := format.UserGroupQuota
 	var quota, storage, trash, clientVer, tier bool
+	var autoMinClientVersion string
 	var msg strings.Builder
 	encrypted := format.KeyEncrypted
 	var targetTierID uint8
 	var currentTier object.Tier
 	var findTier bool
 	var newTier object.Tier
+	requireMinClientVersion := func(required string) {
+		if ensureMinClientVersion(format, required, &msg) {
+			clientVer = true
+			autoMinClientVersion = format.MinClientVersion
+		}
+	}
 
 	for _, flag := range ctx.LocalFlagNames() {
 		switch flag {
@@ -358,10 +378,8 @@ func config(ctx *cli.Context) error {
 			if enableACL := ctx.Bool(flag); enableACL != format.EnableACL {
 				if enableACL {
 					msg.WriteString(fmt.Sprintf("%s: %v -> %v\n", flag, format.EnableACL, true))
-					msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", "min-client-version", format.MinClientVersion, "1.2.0-A"))
 					format.EnableACL = true
-					format.MinClientVersion = "1.2.0-A"
-					clientVer = true
+					requireMinClientVersion("1.2.0-A")
 				} else {
 					return errors.New("cannot disable acl")
 				}
@@ -370,25 +388,23 @@ func config(ctx *cli.Context) error {
 			if newUrl := ctx.String(flag); newUrl != format.RangerRestUrl {
 				msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", flag, format.RangerRestUrl, newUrl))
 				format.RangerRestUrl = newUrl
-				format.MinClientVersion = "1.3.0-A"
-				clientVer = true
+				requireMinClientVersion("1.3.0-A")
 			}
 		case "ranger-service":
 			if newService := ctx.String(flag); newService != format.RangerService {
 				msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", flag, format.RangerService, newService))
 				format.RangerService = newService
-				format.MinClientVersion = "1.3.0-A"
-				clientVer = true
+				requireMinClientVersion("1.3.0-A")
 			}
 		case "kerberos-config-file":
 			msg.WriteString(fmt.Sprintf("%s: updated\n", flag))
 			format.KerbConf = readKerbConf(ctx.String(flag))
-			format.MinClientVersion = "1.4.0-A"
-			clientVer = true
+			requireMinClientVersion("1.4.0-A")
 		case "tier":
 			if ctx.IsSet("bucket") || ctx.IsSet("access-key") || ctx.IsSet("secret-key") || ctx.IsSet("session-token") {
 				logger.Fatalf("Current tiered storage does not support multi-bucket mode")
 			}
+			var tierChanged bool
 			targetTierID = uint8(ctx.Int(flag))
 			currentTier, findTier = format.Tiers[targetTierID]
 			if !findTier {
@@ -406,6 +422,7 @@ func config(ctx *cli.Context) error {
 				if !findTier || currentTier.Sc != newTier.Sc {
 					msg.WriteString(fmt.Sprintf("set tier %d storage-class: %s\n", targetTierID, newTier.Sc))
 					tier = true
+					tierChanged = true
 				}
 			}
 
@@ -418,10 +435,14 @@ func config(ctx *cli.Context) error {
 				if !findTier || currentTier.Tag != newTier.Tag {
 					msg.WriteString(fmt.Sprintf("set tier %d tag: %s\n", targetTierID, newTier.Tag))
 					tier = true
+					tierChanged = true
 				}
 			}
 			if change {
 				format.Tiers[targetTierID] = newTier
+				if targetTierID != 0 && tierChanged {
+					requireMinClientVersion("1.4.0-A")
+				}
 			} else {
 				logger.Fatalf("missing required flag: --storage-class or --tag")
 			}
@@ -477,11 +498,14 @@ func config(ctx *cli.Context) error {
 			}
 		}
 		if clientVer {
+			confirmClientVer := false
+			if autoMinClientVersion != "" {
+				warn("Clients below version %s will be rejected after modification.", autoMinClientVersion)
+				confirmClientVer = true
+			}
 			if format.CheckVersion() != nil {
 				warn("Clients with the same version of this will be rejected after modification.")
-				if !yes && !userConfirmed() {
-					return fmt.Errorf("Aborted.")
-				}
+				confirmClientVer = true
 			}
 
 			// check all clients
@@ -494,7 +518,11 @@ func config(ctx *cli.Context) error {
 				}
 				if warnMsg != "" {
 					fmt.Println(warnMsg)
+					confirmClientVer = true
 				}
+			}
+			if confirmClientVer && !yes && !userConfirmed() {
+				return fmt.Errorf("Aborted.")
 			}
 		}
 		if tier {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -178,20 +178,6 @@ func ensureMinClientVersion(format *meta.Format, required string, msg *strings.B
 	return true
 }
 
-func higherClientVersion(current, required string) string {
-	if current == "" {
-		return required
-	}
-	cv := version.Parse(current)
-	rv := version.Parse(required)
-	if cv != nil && rv != nil {
-		if r, err := version.CompareVersions(cv, rv); err == nil && r >= 0 {
-			return current
-		}
-	}
-	return required
-}
-
 func config(ctx *cli.Context) error {
 	setup(ctx, 1)
 	removePassword(ctx.Args().Get(0))
@@ -209,16 +195,19 @@ func config(ctx *cli.Context) error {
 	originDirStats := format.DirStats
 	originUGQuota := format.UserGroupQuota
 	var quota, storage, trash, clientVer, tier bool
-	var autoMinClientVersion string
-	var requiredMinClientVersion string
 	var msg strings.Builder
 	encrypted := format.KeyEncrypted
 	var targetTierID uint8
 	var currentTier object.Tier
 	var findTier bool
 	var newTier object.Tier
+
+	requiredMinClientVersion := format.MinClientVersion
 	requireMinClientVersion := func(required string) {
-		requiredMinClientVersion = higherClientVersion(requiredMinClientVersion, required)
+		if mv := maxVersion(requiredMinClientVersion, required); mv != requiredMinClientVersion {
+			requiredMinClientVersion = mv
+			clientVer = true
+		}
 	}
 
 	for _, flag := range ctx.LocalFlagNames() {
@@ -422,7 +411,7 @@ func config(ctx *cli.Context) error {
 			if ctx.IsSet("bucket") || ctx.IsSet("access-key") || ctx.IsSet("secret-key") || ctx.IsSet("session-token") {
 				logger.Fatalf("Current tiered storage does not support multi-bucket mode")
 			}
-			var tierChanged bool
+			requireMinClientVersion("1.4.0-A")
 			targetTierID = uint8(ctx.Int(flag))
 			currentTier, findTier = format.Tiers[targetTierID]
 			if !findTier {
@@ -440,7 +429,6 @@ func config(ctx *cli.Context) error {
 				if !findTier || currentTier.Sc != newTier.Sc {
 					msg.WriteString(fmt.Sprintf("set tier %d storage-class: %s\n", targetTierID, newTier.Sc))
 					tier = true
-					tierChanged = true
 				}
 			}
 
@@ -453,23 +441,25 @@ func config(ctx *cli.Context) error {
 				if !findTier || currentTier.Tag != newTier.Tag {
 					msg.WriteString(fmt.Sprintf("set tier %d tag: %s\n", targetTierID, newTier.Tag))
 					tier = true
-					tierChanged = true
 				}
 			}
 			if change {
 				format.Tiers[targetTierID] = newTier
-				if targetTierID != 0 && tierChanged {
-					requireMinClientVersion("1.4.0-A")
-				}
 			} else {
 				logger.Fatalf("missing required flag: --storage-class or --tag")
 			}
 		}
 	}
-	if requiredMinClientVersion != "" && ensureMinClientVersion(format, requiredMinClientVersion, &msg) {
-		clientVer = true
-		autoMinClientVersion = requiredMinClientVersion
+
+	if clientVer {
+		msg.WriteString("min-client-version: ")
+		msg.WriteString(format.MinClientVersion)
+		msg.WriteString(" -> ")
+		msg.WriteString(requiredMinClientVersion)
+		msg.WriteByte('\n')
+		format.MinClientVersion = requiredMinClientVersion
 	}
+
 	if msg.Len() == 0 {
 		fmt.Println("Nothing changed.")
 		return nil
@@ -521,12 +511,8 @@ func config(ctx *cli.Context) error {
 		}
 		if clientVer {
 			confirmClientVer := false
-			if autoMinClientVersion != "" {
-				warn("Clients below version %s will be rejected after modification.", autoMinClientVersion)
-				confirmClientVer = true
-			}
 			if format.CheckVersion() != nil {
-				warn("Clients with the same version of this will be rejected after modification.")
+				warn("Clients below version %d will be rejected after modification.", format.MinClientVersion)
 				confirmClientVer = true
 			}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -183,12 +183,10 @@ func config(ctx *cli.Context) error {
 	var findTier bool
 	var newTier object.Tier
 
-	requiredMinClientVersion := format.MinClientVersion
+	var requiredMinClientVersion string
 	requireMinClientVersion := func(required string) {
-		if mv := maxVersion(requiredMinClientVersion, required); mv != requiredMinClientVersion {
-			requiredMinClientVersion = mv
-			clientVer = true
-		}
+		requiredMinClientVersion = maxVersion(requiredMinClientVersion, required)
+		clientVer = true
 	}
 
 	for _, flag := range ctx.LocalFlagNames() {
@@ -350,8 +348,7 @@ func config(ctx *cli.Context) error {
 					return fmt.Errorf("Invalid version string: %s", new)
 				}
 				msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", flag, format.MinClientVersion, new))
-				format.MinClientVersion = new
-				clientVer = true
+				requireMinClientVersion(new)
 			}
 		case "max-client-version":
 			if new := ctx.String(flag); new != format.MaxClientVersion {
@@ -432,7 +429,7 @@ func config(ctx *cli.Context) error {
 		}
 	}
 
-	if clientVer {
+	if clientVer && compareVersion(format.MinClientVersion, requiredMinClientVersion) < 0 {
 		msg.WriteString("min-client-version: ")
 		msg.WriteString(format.MinClientVersion)
 		msg.WriteString(" -> ")
@@ -493,7 +490,7 @@ func config(ctx *cli.Context) error {
 		if clientVer {
 			confirmClientVer := false
 			if format.CheckVersion() != nil {
-				warn("Clients below version %d will be rejected after modification.", format.MinClientVersion)
+				warn("Clients below version %s will be rejected after modification.", format.MinClientVersion)
 				confirmClientVer = true
 			}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -186,7 +186,6 @@ func config(ctx *cli.Context) error {
 	var requiredMinClientVersion string
 	requireMinClientVersion := func(required string) {
 		requiredMinClientVersion = maxVersion(requiredMinClientVersion, required)
-		clientVer = true
 	}
 
 	for _, flag := range ctx.LocalFlagNames() {
@@ -429,13 +428,14 @@ func config(ctx *cli.Context) error {
 		}
 	}
 
-	if clientVer && compareVersion(format.MinClientVersion, requiredMinClientVersion) < 0 {
+	if compareVersion(format.MinClientVersion, requiredMinClientVersion) < 0 {
 		msg.WriteString("min-client-version: ")
 		msg.WriteString(format.MinClientVersion)
 		msg.WriteString(" -> ")
 		msg.WriteString(requiredMinClientVersion)
 		msg.WriteByte('\n')
 		format.MinClientVersion = requiredMinClientVersion
+		clientVer = true
 	}
 
 	if msg.Len() == 0 {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -167,9 +167,29 @@ func ensureMinClientVersion(format *meta.Format, required string, msg *strings.B
 			return false
 		}
 	}
-	msg.WriteString(fmt.Sprintf("%s: %s -> %s\n", "min-client-version", format.MinClientVersion, required))
+	if msg != nil {
+		msg.WriteString("min-client-version: ")
+		msg.WriteString(format.MinClientVersion)
+		msg.WriteString(" -> ")
+		msg.WriteString(required)
+		msg.WriteByte('\n')
+	}
 	format.MinClientVersion = required
 	return true
+}
+
+func higherClientVersion(current, required string) string {
+	if current == "" {
+		return required
+	}
+	cv := version.Parse(current)
+	rv := version.Parse(required)
+	if cv != nil && rv != nil {
+		if r, err := version.CompareVersions(cv, rv); err == nil && r >= 0 {
+			return current
+		}
+	}
+	return required
 }
 
 func config(ctx *cli.Context) error {
@@ -190,6 +210,7 @@ func config(ctx *cli.Context) error {
 	originUGQuota := format.UserGroupQuota
 	var quota, storage, trash, clientVer, tier bool
 	var autoMinClientVersion string
+	var requiredMinClientVersion string
 	var msg strings.Builder
 	encrypted := format.KeyEncrypted
 	var targetTierID uint8
@@ -197,10 +218,7 @@ func config(ctx *cli.Context) error {
 	var findTier bool
 	var newTier object.Tier
 	requireMinClientVersion := func(required string) {
-		if ensureMinClientVersion(format, required, &msg) {
-			clientVer = true
-			autoMinClientVersion = format.MinClientVersion
-		}
+		requiredMinClientVersion = higherClientVersion(requiredMinClientVersion, required)
 	}
 
 	for _, flag := range ctx.LocalFlagNames() {
@@ -447,6 +465,10 @@ func config(ctx *cli.Context) error {
 				logger.Fatalf("missing required flag: --storage-class or --tag")
 			}
 		}
+	}
+	if requiredMinClientVersion != "" && ensureMinClientVersion(format, requiredMinClientVersion, &msg) {
+		clientVer = true
+		autoMinClientVersion = requiredMinClientVersion
 	}
 	if msg.Len() == 0 {
 		fmt.Println("Nothing changed.")

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -327,6 +327,37 @@ func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
 	}
 }
 
+func TestConfigFeatureMinClientVersionOverridesExplicitLowerVersion(t *testing.T) {
+	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+	bucketPath := filepath.Join(t.TempDir(), "testBucket")
+	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	out, err := getStdout([]string{"", "config", metaURL, "--enable-acl", "--min-client-version", "1.1.0-A", "--force"})
+	if err != nil {
+		t.Fatalf("config acl with lower min-client-version: %s", err)
+	}
+	if !strings.Contains(string(out), "min-client-version: 1.1.0-A -> 1.2.0-A") {
+		t.Fatalf("missing final min-client-version change: %s", out)
+	}
+
+	data, err := getStdout([]string{"", "config", metaURL})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if !format.EnableACL {
+		t.Fatalf("enable-acl should be true")
+	}
+	if format.MinClientVersion != "1.2.0-A" {
+		t.Fatalf("min-client-version %q != expect 1.2.0-A", format.MinClientVersion)
+	}
+}
+
 func TestConfigKerberosMinClientVersionWithConfirmation(t *testing.T) {
 	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
 	bucketPath := filepath.Join(t.TempDir(), "testBucket")

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -41,6 +42,47 @@ func getStdout(args []string) ([]byte, error) {
 		return nil, err
 	}
 	return os.ReadFile(tmp.Name())
+}
+
+func getStdoutWithInput(args []string, input string) ([]byte, error) {
+	tmpOut, err := os.CreateTemp(os.TempDir(), "jfstest-*")
+	if err != nil {
+		return nil, err
+	}
+	defer tmpOut.Close()
+	defer os.Remove(tmpOut.Name())
+	oldStdout := os.Stdout
+	os.Stdout = tmpOut
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	if input != "" {
+		tmpIn, err := os.CreateTemp(os.TempDir(), "jfstest-input-*")
+		if err != nil {
+			return nil, err
+		}
+		defer tmpIn.Close()
+		defer os.Remove(tmpIn.Name())
+		if _, err = tmpIn.WriteString(input); err != nil {
+			return nil, err
+		}
+		if _, err = tmpIn.Seek(0, 0); err != nil {
+			return nil, err
+		}
+		oldStdin := os.Stdin
+		os.Stdin = tmpIn
+		defer func() {
+			os.Stdin = oldStdin
+		}()
+	}
+
+	err = Main(args)
+	data, readErr := os.ReadFile(tmpOut.Name())
+	if err == nil {
+		err = readErr
+	}
+	return data, err
 }
 
 func TestConfig(t *testing.T) {
@@ -107,5 +149,245 @@ func TestConfig(t *testing.T) {
 	}
 	if format.Bucket != "http://localhost:9000/miniofs2" || format.Storage != "minio" {
 		t.Fatalf("unexpect format: %+v", format)
+	}
+}
+
+func TestConfigTierMinClientVersion(t *testing.T) {
+	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+	bucketPath := filepath.Join(t.TempDir(), "testBucket")
+	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	out, err := getStdout([]string{"", "config", metaURL, "--tier", "1", "--storage-class", "GLACIER", "--force"})
+	if err != nil {
+		t.Fatalf("config tier: %s", err)
+	}
+	if !strings.Contains(string(out), "min-client-version: 1.1.0-A -> 1.4.0-A") {
+		t.Fatalf("min client version change is missing in output: %s", out)
+	}
+
+	data, err := getStdout([]string{"", "config", metaURL})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.MinClientVersion != "1.4.0-A" {
+		t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
+	}
+	if tier := format.Tiers[1]; tier.Sc != "GLACIER" {
+		t.Fatalf("tier 1 storage-class %q != expect GLACIER", tier.Sc)
+	}
+}
+
+func TestConfigTierZeroDoesNotChangeMinClientVersion(t *testing.T) {
+	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+	bucketPath := filepath.Join(t.TempDir(), "testBucket")
+	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	out, err := getStdout([]string{"", "config", metaURL, "--tier", "0", "--storage-class", "STANDARD_IA", "--force"})
+	if err != nil {
+		t.Fatalf("config tier 0: %s", err)
+	}
+	if strings.Contains(string(out), "min-client-version") {
+		t.Fatalf("tier 0 should not change min-client-version: %s", out)
+	}
+
+	data, err := getStdout([]string{"", "config", metaURL})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.MinClientVersion != "1.1.0-A" {
+		t.Fatalf("min-client-version %q != expect 1.1.0-A", format.MinClientVersion)
+	}
+	if tier := format.Tiers[0]; tier.Sc != "STANDARD_IA" {
+		t.Fatalf("tier 0 storage-class %q != expect STANDARD_IA", tier.Sc)
+	}
+}
+
+func TestConfigAutoMinClientVersionRequiresConfirmation(t *testing.T) {
+	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+	bucketPath := filepath.Join(t.TempDir(), "testBucket")
+	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	out, err := getStdoutWithInput([]string{"", "config", metaURL, "--enable-acl"}, "n\n")
+	if err == nil || err.Error() != "Aborted." {
+		t.Fatalf("config should be aborted, got output %q error %v", out, err)
+	}
+	if !strings.Contains(string(out), "Clients below version 1.2.0-A will be rejected after modification.") {
+		t.Fatalf("missing min client version confirmation warning: %s", out)
+	}
+
+	data, err := getStdout([]string{"", "config", metaURL})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.EnableACL {
+		t.Fatalf("enable-acl should not be changed after abort")
+	}
+	if format.MinClientVersion != "1.1.0-A" {
+		t.Fatalf("min-client-version %q != expect 1.1.0-A", format.MinClientVersion)
+	}
+}
+
+func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     func(t *testing.T) []string
+		validate func(t *testing.T, format meta.Format)
+	}{
+		{
+			name: "acl",
+			args: func(t *testing.T) []string {
+				return []string{"--enable-acl"}
+			},
+			validate: func(t *testing.T, format meta.Format) {
+				if !format.EnableACL {
+					t.Fatalf("enable-acl should be true")
+				}
+			},
+		},
+		{
+			name: "ranger",
+			args: func(t *testing.T) []string {
+				return []string{"--ranger-rest-url", "http://localhost:6080"}
+			},
+			validate: func(t *testing.T, format meta.Format) {
+				if format.RangerRestUrl != "http://localhost:6080" {
+					t.Fatalf("ranger-rest-url %q != expect http://localhost:6080", format.RangerRestUrl)
+				}
+			},
+		},
+		{
+			name: "kerberos",
+			args: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), "krb5.conf")
+				if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
+					t.Fatalf("write kerberos config: %s", err)
+				}
+				return []string{"--kerberos-config-file", path}
+			},
+			validate: func(t *testing.T, format meta.Format) {
+				if format.KerbConf != "[libdefaults]\n" {
+					t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
+				}
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+			bucketPath := filepath.Join(t.TempDir(), "testBucket")
+			if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+				t.Fatalf("format: %s", err)
+			}
+			if err := Main([]string{"", "config", metaURL, "--min-client-version", "1.4.0-A", "--force"}); err != nil {
+				t.Fatalf("config min-client-version: %s", err)
+			}
+
+			args := append([]string{"", "config", metaURL}, c.args(t)...)
+			args = append(args, "--force")
+			out, err := getStdout(args)
+			if err != nil {
+				t.Fatalf("config %s: %s", c.name, err)
+			}
+			if strings.Contains(string(out), "min-client-version") {
+				t.Fatalf("min-client-version should not be downgraded: %s", out)
+			}
+
+			data, err := getStdout([]string{"", "config", metaURL})
+			if err != nil {
+				t.Fatalf("getStdout: %s", err)
+			}
+			var format meta.Format
+			if err = json.Unmarshal(data, &format); err != nil {
+				t.Fatalf("json unmarshal: %s", err)
+			}
+			if format.MinClientVersion != "1.4.0-A" {
+				t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
+			}
+			c.validate(t, format)
+		})
+	}
+}
+
+func TestConfigKerberosMinClientVersionWithConfirmation(t *testing.T) {
+	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+	bucketPath := filepath.Join(t.TempDir(), "testBucket")
+	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "krb5.conf")
+	if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
+		t.Fatalf("write kerberos config: %s", err)
+	}
+	out, err := getStdoutWithInput([]string{"", "config", metaURL, "--kerberos-config-file", path}, "y\n")
+	if err != nil {
+		t.Fatalf("config kerberos: %s", err)
+	}
+	if !strings.Contains(string(out), "Clients below version 1.4.0-A will be rejected after modification.") {
+		t.Fatalf("missing min client version confirmation warning: %s", out)
+	}
+	if !strings.Contains(string(out), "min-client-version: 1.1.0-A -> 1.4.0-A") {
+		t.Fatalf("missing min client version change: %s", out)
+	}
+
+	data, err := getStdout([]string{"", "config", metaURL})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.MinClientVersion != "1.4.0-A" {
+		t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
+	}
+	if format.KerbConf != "[libdefaults]\n" {
+		t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
+	}
+}
+
+func TestFormatKerberosMinClientVersion(t *testing.T) {
+	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
+	bucketPath := filepath.Join(t.TempDir(), "testBucket")
+	path := filepath.Join(t.TempDir(), "krb5.conf")
+	if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
+		t.Fatalf("write kerberos config: %s", err)
+	}
+	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, "--kerberos-config-file", path, testVolume}); err != nil {
+		t.Fatalf("format: %s", err)
+	}
+
+	data, err := getStdout([]string{"", "config", metaURL})
+	if err != nil {
+		t.Fatalf("getStdout: %s", err)
+	}
+	var format meta.Format
+	if err = json.Unmarshal(data, &format); err != nil {
+		t.Fatalf("json unmarshal: %s", err)
+	}
+	if format.MinClientVersion != "1.4.0-A" {
+		t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
+	}
+	if format.KerbConf != "[libdefaults]\n" {
+		t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
 	}
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -152,110 +152,43 @@ func TestConfig(t *testing.T) {
 	}
 }
 
-func TestConfigTierMinClientVersion(t *testing.T) {
-	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
-	bucketPath := filepath.Join(t.TempDir(), "testBucket")
-	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
-		t.Fatalf("format: %s", err)
+func TestConfigMinClientVersion(t *testing.T) {
+	writeKerbConf := func(t *testing.T) string {
+		path := filepath.Join(t.TempDir(), "krb5.conf")
+		if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
+			t.Fatalf("write kerberos config: %s", err)
+		}
+		return path
 	}
 
-	out, err := getStdout([]string{"", "config", metaURL, "--tier", "1", "--storage-class", "GLACIER", "--force"})
-	if err != nil {
-		t.Fatalf("config tier: %s", err)
-	}
-	if !strings.Contains(string(out), "min-client-version: 1.1.0-A -> 1.4.0-A") {
-		t.Fatalf("min client version change is missing in output: %s", out)
-	}
-
-	data, err := getStdout([]string{"", "config", metaURL})
-	if err != nil {
-		t.Fatalf("getStdout: %s", err)
-	}
-	var format meta.Format
-	if err = json.Unmarshal(data, &format); err != nil {
-		t.Fatalf("json unmarshal: %s", err)
-	}
-	if format.MinClientVersion != "1.4.0-A" {
-		t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
-	}
-	if tier := format.Tiers[1]; tier.Sc != "GLACIER" {
-		t.Fatalf("tier 1 storage-class %q != expect GLACIER", tier.Sc)
-	}
-}
-
-func TestConfigTierZeroDoesNotChangeMinClientVersion(t *testing.T) {
-	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
-	bucketPath := filepath.Join(t.TempDir(), "testBucket")
-	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
-		t.Fatalf("format: %s", err)
-	}
-
-	out, err := getStdout([]string{"", "config", metaURL, "--tier", "0", "--storage-class", "STANDARD_IA", "--force"})
-	if err != nil {
-		t.Fatalf("config tier 0: %s", err)
-	}
-	if strings.Contains(string(out), "min-client-version") {
-		t.Fatalf("tier 0 should not change min-client-version: %s", out)
-	}
-
-	data, err := getStdout([]string{"", "config", metaURL})
-	if err != nil {
-		t.Fatalf("getStdout: %s", err)
-	}
-	var format meta.Format
-	if err = json.Unmarshal(data, &format); err != nil {
-		t.Fatalf("json unmarshal: %s", err)
-	}
-	if format.MinClientVersion != "1.1.0-A" {
-		t.Fatalf("min-client-version %q != expect 1.1.0-A", format.MinClientVersion)
-	}
-	if tier := format.Tiers[0]; tier.Sc != "STANDARD_IA" {
-		t.Fatalf("tier 0 storage-class %q != expect STANDARD_IA", tier.Sc)
-	}
-}
-
-func TestConfigAutoMinClientVersionRequiresConfirmation(t *testing.T) {
-	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
-	bucketPath := filepath.Join(t.TempDir(), "testBucket")
-	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
-		t.Fatalf("format: %s", err)
-	}
-
-	out, err := getStdoutWithInput([]string{"", "config", metaURL, "--enable-acl"}, "n\n")
-	if err == nil || err.Error() != "Aborted." {
-		t.Fatalf("config should be aborted, got output %q error %v", out, err)
-	}
-	if !strings.Contains(string(out), "Clients below version 1.2.0-A will be rejected after modification.") {
-		t.Fatalf("missing min client version confirmation warning: %s", out)
-	}
-
-	data, err := getStdout([]string{"", "config", metaURL})
-	if err != nil {
-		t.Fatalf("getStdout: %s", err)
-	}
-	var format meta.Format
-	if err = json.Unmarshal(data, &format); err != nil {
-		t.Fatalf("json unmarshal: %s", err)
-	}
-	if format.EnableACL {
-		t.Fatalf("enable-acl should not be changed after abort")
-	}
-	if format.MinClientVersion != "1.1.0-A" {
-		t.Fatalf("min-client-version %q != expect 1.1.0-A", format.MinClientVersion)
-	}
-}
-
-func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
 	cases := []struct {
-		name     string
-		args     func(t *testing.T) []string
-		validate func(t *testing.T, format meta.Format)
+		name       string
+		formatArgs func(t *testing.T) []string // extra flags for the initial format
+		preArgs    []string                    // optional config run before the measured one
+		args       func(t *testing.T) []string // measured config run; nil to only check format result
+		input      string                      // stdin for confirmation prompts
+		wantOut    []string                    // substrings expected in the measured output
+		notWantOut []string                    // substrings that must not appear
+		wantMinVer string
+		validate   func(t *testing.T, format meta.Format)
 	}{
 		{
-			name: "acl",
-			args: func(t *testing.T) []string {
-				return []string{"--enable-acl"}
+			name:       "tier bumps min client version",
+			args:       func(t *testing.T) []string { return []string{"--tier", "1", "--storage-class", "GLACIER", "--force"} },
+			wantOut:    []string{"min-client-version: 1.1.0-A -> 1.4.0-A"},
+			wantMinVer: "1.4.0-A",
+			validate: func(t *testing.T, format meta.Format) {
+				if tier := format.Tiers[1]; tier.Sc != "GLACIER" {
+					t.Fatalf("tier 1 storage-class %q != expect GLACIER", tier.Sc)
+				}
 			},
+		},
+		{
+			name:       "acl does not downgrade",
+			preArgs:    []string{"--min-client-version", "1.4.0-A", "--force"},
+			args:       func(t *testing.T) []string { return []string{"--enable-acl", "--force"} },
+			notWantOut: []string{"min-client-version"},
+			wantMinVer: "1.4.0-A",
 			validate: func(t *testing.T, format meta.Format) {
 				if !format.EnableACL {
 					t.Fatalf("enable-acl should be true")
@@ -263,10 +196,11 @@ func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
 			},
 		},
 		{
-			name: "ranger",
-			args: func(t *testing.T) []string {
-				return []string{"--ranger-rest-url", "http://localhost:6080"}
-			},
+			name:       "ranger does not downgrade",
+			preArgs:    []string{"--min-client-version", "1.4.0-A", "--force"},
+			args:       func(t *testing.T) []string { return []string{"--ranger-rest-url", "http://localhost:6080", "--force"} },
+			notWantOut: []string{"min-client-version"},
+			wantMinVer: "1.4.0-A",
 			validate: func(t *testing.T, format meta.Format) {
 				if format.RangerRestUrl != "http://localhost:6080" {
 					t.Fatalf("ranger-rest-url %q != expect http://localhost:6080", format.RangerRestUrl)
@@ -274,14 +208,46 @@ func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
 			},
 		},
 		{
-			name: "kerberos",
-			args: func(t *testing.T) []string {
-				path := filepath.Join(t.TempDir(), "krb5.conf")
-				if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
-					t.Fatalf("write kerberos config: %s", err)
+			name:       "kerberos does not downgrade",
+			preArgs:    []string{"--min-client-version", "1.4.0-A", "--force"},
+			args:       func(t *testing.T) []string { return []string{"--kerberos-config-file", writeKerbConf(t), "--force"} },
+			notWantOut: []string{"min-client-version"},
+			wantMinVer: "1.4.0-A",
+			validate: func(t *testing.T, format meta.Format) {
+				if format.KerbConf != "[libdefaults]\n" {
+					t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
 				}
-				return []string{"--kerberos-config-file", path}
 			},
+		},
+		{
+			name: "feature overrides explicit lower version",
+			args: func(t *testing.T) []string {
+				return []string{"--enable-acl", "--min-client-version", "1.1.0-A", "--force"}
+			},
+			wantOut:    []string{"min-client-version: 1.1.0-A -> 1.2.0-A"},
+			wantMinVer: "1.2.0-A",
+			validate: func(t *testing.T, format meta.Format) {
+				if !format.EnableACL {
+					t.Fatalf("enable-acl should be true")
+				}
+			},
+		},
+		{
+			name:       "kerberos via config with confirmation input",
+			args:       func(t *testing.T) []string { return []string{"--kerberos-config-file", writeKerbConf(t)} },
+			input:      "y\n",
+			wantOut:    []string{"min-client-version: 1.1.0-A -> 1.4.0-A"},
+			wantMinVer: "1.4.0-A",
+			validate: func(t *testing.T, format meta.Format) {
+				if format.KerbConf != "[libdefaults]\n" {
+					t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
+				}
+			},
+		},
+		{
+			name:       "format with kerberos bumps min client version",
+			formatArgs: func(t *testing.T) []string { return []string{"--kerberos-config-file", writeKerbConf(t)} },
+			wantMinVer: "1.4.0-A",
 			validate: func(t *testing.T, format meta.Format) {
 				if format.KerbConf != "[libdefaults]\n" {
 					t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
@@ -294,21 +260,43 @@ func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
 			bucketPath := filepath.Join(t.TempDir(), "testBucket")
-			if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
+			formatCmd := []string{"", "format", metaURL, "--bucket", bucketPath}
+			if c.formatArgs != nil {
+				formatCmd = append(formatCmd, c.formatArgs(t)...)
+			}
+			formatCmd = append(formatCmd, testVolume)
+			if err := Main(formatCmd); err != nil {
 				t.Fatalf("format: %s", err)
 			}
-			if err := Main([]string{"", "config", metaURL, "--min-client-version", "1.4.0-A", "--force"}); err != nil {
-				t.Fatalf("config min-client-version: %s", err)
+
+			if len(c.preArgs) > 0 {
+				if err := Main(append([]string{"", "config", metaURL}, c.preArgs...)); err != nil {
+					t.Fatalf("pre config: %s", err)
+				}
 			}
 
-			args := append([]string{"", "config", metaURL}, c.args(t)...)
-			args = append(args, "--force")
-			out, err := getStdout(args)
-			if err != nil {
-				t.Fatalf("config %s: %s", c.name, err)
-			}
-			if strings.Contains(string(out), "min-client-version") {
-				t.Fatalf("min-client-version should not be downgraded: %s", out)
+			if c.args != nil {
+				args := append([]string{"", "config", metaURL}, c.args(t)...)
+				var out []byte
+				var err error
+				if c.input != "" {
+					out, err = getStdoutWithInput(args, c.input)
+				} else {
+					out, err = getStdout(args)
+				}
+				if err != nil {
+					t.Fatalf("config: %s", err)
+				}
+				for _, s := range c.wantOut {
+					if !strings.Contains(string(out), s) {
+						t.Fatalf("missing %q in output: %s", s, out)
+					}
+				}
+				for _, s := range c.notWantOut {
+					if strings.Contains(string(out), s) {
+						t.Fatalf("unexpected %q in output: %s", s, out)
+					}
+				}
 			}
 
 			data, err := getStdout([]string{"", "config", metaURL})
@@ -319,106 +307,12 @@ func TestConfigAutoMinClientVersionDoesNotDowngrade(t *testing.T) {
 			if err = json.Unmarshal(data, &format); err != nil {
 				t.Fatalf("json unmarshal: %s", err)
 			}
-			if format.MinClientVersion != "1.4.0-A" {
-				t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
+			if format.MinClientVersion != c.wantMinVer {
+				t.Fatalf("min-client-version %q != expect %q", format.MinClientVersion, c.wantMinVer)
 			}
-			c.validate(t, format)
+			if c.validate != nil {
+				c.validate(t, format)
+			}
 		})
-	}
-}
-
-func TestConfigFeatureMinClientVersionOverridesExplicitLowerVersion(t *testing.T) {
-	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
-	bucketPath := filepath.Join(t.TempDir(), "testBucket")
-	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
-		t.Fatalf("format: %s", err)
-	}
-
-	out, err := getStdout([]string{"", "config", metaURL, "--enable-acl", "--min-client-version", "1.1.0-A", "--force"})
-	if err != nil {
-		t.Fatalf("config acl with lower min-client-version: %s", err)
-	}
-	if !strings.Contains(string(out), "min-client-version: 1.1.0-A -> 1.2.0-A") {
-		t.Fatalf("missing final min-client-version change: %s", out)
-	}
-
-	data, err := getStdout([]string{"", "config", metaURL})
-	if err != nil {
-		t.Fatalf("getStdout: %s", err)
-	}
-	var format meta.Format
-	if err = json.Unmarshal(data, &format); err != nil {
-		t.Fatalf("json unmarshal: %s", err)
-	}
-	if !format.EnableACL {
-		t.Fatalf("enable-acl should be true")
-	}
-	if format.MinClientVersion != "1.2.0-A" {
-		t.Fatalf("min-client-version %q != expect 1.2.0-A", format.MinClientVersion)
-	}
-}
-
-func TestConfigKerberosMinClientVersionWithConfirmation(t *testing.T) {
-	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
-	bucketPath := filepath.Join(t.TempDir(), "testBucket")
-	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, testVolume}); err != nil {
-		t.Fatalf("format: %s", err)
-	}
-
-	path := filepath.Join(t.TempDir(), "krb5.conf")
-	if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
-		t.Fatalf("write kerberos config: %s", err)
-	}
-	out, err := getStdoutWithInput([]string{"", "config", metaURL, "--kerberos-config-file", path}, "y\n")
-	if err != nil {
-		t.Fatalf("config kerberos: %s", err)
-	}
-	if !strings.Contains(string(out), "Clients below version 1.4.0-A will be rejected after modification.") {
-		t.Fatalf("missing min client version confirmation warning: %s", out)
-	}
-	if !strings.Contains(string(out), "min-client-version: 1.1.0-A -> 1.4.0-A") {
-		t.Fatalf("missing min client version change: %s", out)
-	}
-
-	data, err := getStdout([]string{"", "config", metaURL})
-	if err != nil {
-		t.Fatalf("getStdout: %s", err)
-	}
-	var format meta.Format
-	if err = json.Unmarshal(data, &format); err != nil {
-		t.Fatalf("json unmarshal: %s", err)
-	}
-	if format.MinClientVersion != "1.4.0-A" {
-		t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
-	}
-	if format.KerbConf != "[libdefaults]\n" {
-		t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
-	}
-}
-
-func TestFormatKerberosMinClientVersion(t *testing.T) {
-	metaURL := "sqlite3://" + filepath.Join(t.TempDir(), "test.db")
-	bucketPath := filepath.Join(t.TempDir(), "testBucket")
-	path := filepath.Join(t.TempDir(), "krb5.conf")
-	if err := os.WriteFile(path, []byte("[libdefaults]\n"), 0644); err != nil {
-		t.Fatalf("write kerberos config: %s", err)
-	}
-	if err := Main([]string{"", "format", metaURL, "--bucket", bucketPath, "--kerberos-config-file", path, testVolume}); err != nil {
-		t.Fatalf("format: %s", err)
-	}
-
-	data, err := getStdout([]string{"", "config", metaURL})
-	if err != nil {
-		t.Fatalf("getStdout: %s", err)
-	}
-	var format meta.Format
-	if err = json.Unmarshal(data, &format); err != nil {
-		t.Fatalf("json unmarshal: %s", err)
-	}
-	if format.MinClientVersion != "1.4.0-A" {
-		t.Fatalf("min-client-version %q != expect 1.4.0-A", format.MinClientVersion)
-	}
-	if format.KerbConf != "[libdefaults]\n" {
-		t.Fatalf("unexpected kerberos config: %q", format.KerbConf)
 	}
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -509,14 +509,15 @@ func format(c *cli.Context) error {
 			}
 		}
 
+		var minClientVersionMsg strings.Builder
 		if format.EnableACL {
-			format.MinClientVersion = "1.2.0-A"
+			ensureMinClientVersion(format, "1.2.0-A", &minClientVersionMsg)
 		}
 		if format.RangerRestUrl != "" || format.RangerService != "" {
-			format.MinClientVersion = "1.3.0-A"
+			ensureMinClientVersion(format, "1.3.0-A", &minClientVersionMsg)
 		}
 		if format.KerbConf != "" {
-			format.MinClientVersion = "1.4.0-A"
+			ensureMinClientVersion(format, "1.4.0-A", &minClientVersionMsg)
 		}
 
 		if format.AccessKey == "" && os.Getenv("ACCESS_KEY") != "" {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -402,6 +402,19 @@ func readKerbConf(file string) string {
 	return string(data)
 }
 
+func maxVersion(v1, v2 string) string {
+	if v1 == "" {
+		return v2
+	}
+	s1, s2 := version.Parse(v1), version.Parse(v2)
+	if s1 != nil && s2 != nil {
+		if r, err := version.CompareVersions(s1, s2); err == nil && r >= 0 {
+			return v1
+		}
+	}
+	return v2
+}
+
 func format(c *cli.Context) error {
 	setup(c, 2)
 	removePassword(c.Args().Get(0))
@@ -510,13 +523,13 @@ func format(c *cli.Context) error {
 		}
 
 		if format.EnableACL {
-			ensureMinClientVersion(format, "1.2.0-A", nil)
+			format.MinClientVersion = maxVersion(format.MinClientVersion, "1.2.0-A")
 		}
 		if format.RangerRestUrl != "" || format.RangerService != "" {
-			ensureMinClientVersion(format, "1.3.0-A", nil)
+			format.MinClientVersion = maxVersion(format.MinClientVersion, "1.3.0-A")
 		}
 		if format.KerbConf != "" {
-			ensureMinClientVersion(format, "1.4.0-A", nil)
+			format.MinClientVersion = maxVersion(format.MinClientVersion, "1.4.0-A")
 		}
 
 		if format.AccessKey == "" && os.Getenv("ACCESS_KEY") != "" {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -509,15 +509,14 @@ func format(c *cli.Context) error {
 			}
 		}
 
-		var minClientVersionMsg strings.Builder
 		if format.EnableACL {
-			ensureMinClientVersion(format, "1.2.0-A", &minClientVersionMsg)
+			ensureMinClientVersion(format, "1.2.0-A", nil)
 		}
 		if format.RangerRestUrl != "" || format.RangerService != "" {
-			ensureMinClientVersion(format, "1.3.0-A", &minClientVersionMsg)
+			ensureMinClientVersion(format, "1.3.0-A", nil)
 		}
 		if format.KerbConf != "" {
-			ensureMinClientVersion(format, "1.4.0-A", &minClientVersionMsg)
+			ensureMinClientVersion(format, "1.4.0-A", nil)
 		}
 
 		if format.AccessKey == "" && os.Getenv("ACCESS_KEY") != "" {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -402,15 +402,20 @@ func readKerbConf(file string) string {
 	return string(data)
 }
 
-func maxVersion(v1, v2 string) string {
+func compareVersion(v1, v2 string) int {
 	if v1 == "" {
-		return v2
+		return -1
 	}
-	s1, s2 := version.Parse(v1), version.Parse(v2)
-	if s1 != nil && s2 != nil {
-		if r, err := version.CompareVersions(s1, s2); err == nil && r >= 0 {
-			return v1
-		}
+	if v2 == "" {
+		return 1
+	}
+	ret, _ := version.CompareVersions(version.Parse(v1), version.Parse(v2))
+	return ret
+}
+
+func maxVersion(v1, v2 string) string {
+	if compareVersion(v1, v2) >= 0 {
+		return v1
 	}
 	return v2
 }

--- a/pkg/object/checksum_test.go
+++ b/pkg/object/checksum_test.go
@@ -70,8 +70,9 @@ func TestChecksumRead(t *testing.T) {
 
 	// verify failed case
 	for _, contentLength := range lens {
-		content[0] = 'a'
-		reader := verifyChecksum(io.NopCloser(bytes.NewReader(content)), actual, contentLength)
+		corrupted := append([]byte(nil), content...)
+		corrupted[0] ^= 0xff
+		reader := verifyChecksum(io.NopCloser(bytes.NewReader(corrupted)), actual, contentLength)
 		n, err := reader.Read(make([]byte, length))
 		if contentLength == -1 && (err != nil && err != io.EOF || n != length) {
 			t.Fatalf("dont verify checksum when content length is -1")


### PR DESCRIPTION
## Summary
- centralize automatic MinClientVersion bumps for ACL, Ranger, Kerberos, and tier config changes
- prompt for confirmation when a config change will automatically reject older clients

## Tests
- go test ./cmd -run "TestConfig(TierMinClientVersion|TierZeroDoesNotChangeMinClientVersion|AutoMinClientVersionRequiresConfirmation|AutoMinClientVersionDoesNotDowngrade|KerberosMinClientVersionWithConfirmation)$|TestFormatKerberosMinClientVersion$" -count=1
- git diff --check -- cmd/config.go cmd/config_test.go cmd/format.go