### PR TITLE
cmd/sync: Hide sync credentials from worker command arguments

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -551,15 +551,11 @@ func doSync(c *cli.Context) error {
 		logger.Debugf("worker process start")
 	}
 	// Windows support `\` and `/` as its separator, Unix only use `/`
-	srcArg := c.Args().Get(0)
-	dstArg := c.Args().Get(1)
-	srcURL := srcArg
-	dstURL := dstArg
+	srcURL, dstURL := c.Args().Get(0), c.Args().Get(1)
 	if isWorker {
-		srcURL = workerSrcURL
-		dstURL = workerDstURL
+		srcURL, dstURL = workerSrcURL, workerDstURL
 	} else {
-		config.SetClusterStorage(srcArg, dstArg)
+		config.SetClusterStorage(srcURL, dstURL)
 	}
 	removePassword(srcURL, dstURL)
 	if runtime.GOOS == "windows" {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	_ "net/http/pprof"
 	"net/url"
@@ -323,6 +324,10 @@ func clusterFlags() []cli.Flag {
 			Name:  "manager-addr",
 			Usage: "the IP address to communicate with workers",
 		},
+		&cli.BoolFlag{
+			Name:   "worker-config-stdin",
+			Hidden: true,
+		},
 	})
 }
 
@@ -516,7 +521,31 @@ func wrapSyncEncryptedStore(store object.ObjectStorage, keyPath, passphraseEnv, 
 	return object.NewChunkedEncrypted(store, encryptor), nil
 }
 
+func loadClusterWorkerConfig(r io.Reader) (string, string, error) {
+	src, dst, env, err := sync.ReadClusterWorkerConfig(r)
+	if err != nil {
+		return "", "", err
+	}
+	for key, value := range env {
+		if err := os.Setenv(key, value); err != nil {
+			return "", "", fmt.Errorf("set worker environment %q: %s", key, err)
+		}
+	}
+	return src, dst, nil
+}
+
 func doSync(c *cli.Context) error {
+	var workerSrcURL, workerDstURL string
+	if c.Bool("worker-config-stdin") {
+		if c.String("manager") == "" {
+			return fmt.Errorf("worker-config-stdin requires manager")
+		}
+		var err error
+		workerSrcURL, workerDstURL, err = loadClusterWorkerConfig(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("load worker config: %s", err)
+		}
+	}
 	setup(c, 2)
 	if c.IsSet("include") && !c.IsSet("exclude") {
 		logger.Warnf("The include option needs to be used with the exclude option, otherwise the result of the current sync may not match your expectations")
@@ -527,8 +556,14 @@ func doSync(c *cli.Context) error {
 		logger.Debugf("worker process start")
 	}
 	// Windows support `\` and `/` as its separator, Unix only use `/`
-	srcURL := c.Args().Get(0)
-	dstURL := c.Args().Get(1)
+	srcArg := c.Args().Get(0)
+	dstArg := c.Args().Get(1)
+	srcURL := srcArg
+	dstURL := dstArg
+	if c.Bool("worker-config-stdin") {
+		srcURL = workerSrcURL
+		dstURL = workerDstURL
+	}
 	removePassword(srcURL, dstURL)
 	if runtime.GOOS == "windows" {
 		if !strings.Contains(srcURL, "://") {
@@ -541,6 +576,7 @@ func doSync(c *cli.Context) error {
 	if strings.HasSuffix(srcURL, "/") != strings.HasSuffix(dstURL, "/") {
 		logger.Fatalf("SRC and DST should both end with path separator or not!")
 	}
+	config.SetClusterStorage(srcArg, dstArg, srcURL, dstURL)
 	src, err := createSyncStorage(srcURL, config)
 	if err != nil {
 		return err

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -324,10 +324,6 @@ func clusterFlags() []cli.Flag {
 			Name:  "manager-addr",
 			Usage: "the IP address to communicate with workers",
 		},
-		&cli.BoolFlag{
-			Name:   "worker-config-stdin",
-			Hidden: true,
-		},
 	})
 }
 
@@ -535,12 +531,11 @@ func loadClusterWorkerConfig(r io.Reader) (string, string, error) {
 }
 
 func doSync(c *cli.Context) error {
+	isWorker := c.String("manager") != ""
 	var workerSrcURL, workerDstURL string
-	if c.Bool("worker-config-stdin") {
-		if c.String("manager") == "" {
-			return fmt.Errorf("worker-config-stdin requires manager")
-		}
+	if isWorker {
 		var err error
+		// need init before loadClusterWorkerConfig, otherwise the env will not be applied(umask)
 		workerSrcURL, workerDstURL, err = loadClusterWorkerConfig(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("load worker config: %s", err)
@@ -560,9 +555,11 @@ func doSync(c *cli.Context) error {
 	dstArg := c.Args().Get(1)
 	srcURL := srcArg
 	dstURL := dstArg
-	if c.Bool("worker-config-stdin") {
+	if isWorker {
 		srcURL = workerSrcURL
 		dstURL = workerDstURL
+	} else {
+		config.SetClusterStorage(srcArg, dstArg)
 	}
 	removePassword(srcURL, dstURL)
 	if runtime.GOOS == "windows" {
@@ -576,7 +573,6 @@ func doSync(c *cli.Context) error {
 	if strings.HasSuffix(srcURL, "/") != strings.HasSuffix(dstURL, "/") {
 		logger.Fatalf("SRC and DST should both end with path separator or not!")
 	}
-	config.SetClusterStorage(srcArg, dstArg)
 	src, err := createSyncStorage(srcURL, config)
 	if err != nil {
 		return err

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -535,7 +535,7 @@ func doSync(c *cli.Context) error {
 	var workerSrcURL, workerDstURL string
 	if isWorker {
 		var err error
-		// need init before loadClusterWorkerConfig, otherwise the env will not be applied(umask)
+		// need init before NewConfigFromCli, otherwise the env will not be applied(umask)
 		workerSrcURL, workerDstURL, err = loadClusterWorkerConfig(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("load worker config: %s", err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -576,7 +576,7 @@ func doSync(c *cli.Context) error {
 	if strings.HasSuffix(srcURL, "/") != strings.HasSuffix(dstURL, "/") {
 		logger.Fatalf("SRC and DST should both end with path separator or not!")
 	}
-	config.SetClusterStorage(srcArg, dstArg, srcURL, dstURL)
+	config.SetClusterStorage(srcArg, dstArg)
 	src, err := createSyncStorage(srcURL, config)
 	if err != nil {
 		return err

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -119,3 +119,23 @@ func Test_extractToken(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadClusterWorkerConfig(t *testing.T) {
+	t.Setenv("SECRET_KEY", "old-secret")
+	payload := bytes.NewBufferString(`{
+		"source": "oss://test-access-key:test-secret-key@test-bucket.oss.example.com/",
+		"destination": "/tmp/dst/",
+		"env": {"SECRET_KEY": "new-secret"}
+	}`)
+
+	src, dst, err := loadClusterWorkerConfig(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src != "oss://test-access-key:test-secret-key@test-bucket.oss.example.com/" || dst != "/tmp/dst/" {
+		t.Fatalf("unexpected worker storage config: %q -> %q", src, dst)
+	}
+	if got := os.Getenv("SECRET_KEY"); got != "new-secret" {
+		t.Fatalf("worker environment was not restored: %q", got)
+	}
+}

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -22,9 +22,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/juicedata/juicefs/pkg/object"
+	juicesync "github.com/juicedata/juicefs/pkg/sync"
+	"github.com/juicedata/juicefs/pkg/utils"
 )
 
 func TestSync(t *testing.T) {
@@ -137,5 +140,57 @@ func TestLoadClusterWorkerConfig(t *testing.T) {
 	}
 	if got := os.Getenv("SECRET_KEY"); got != "new-secret" {
 		t.Fatalf("worker environment was not restored: %q", got)
+	}
+}
+
+func TestSyncWorkerReadsConfigFromStdinByDefault(t *testing.T) {
+	stdin := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(stdin, []byte("invalid worker config"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	oldStdin := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	err = Main([]string{"juicefs", "sync", "file:///tmp/src", "file:///tmp/dst", "--manager", "127.0.0.1:1"})
+	if err == nil || !strings.Contains(err.Error(), "load worker config") {
+		t.Fatalf("worker should read config from stdin without an extra flag: %v", err)
+	}
+}
+
+func TestSyncWorkerRestoresUmaskBeforeConfigInitialization(t *testing.T) {
+	oldUmask := utils.GetUmask()
+	t.Cleanup(func() { utils.SetUmask(oldUmask) })
+	utils.SetUmask(0022)
+	t.Setenv(juicesync.JFS_UMASK, "")
+
+	stdin := filepath.Join(t.TempDir(), "stdin")
+	payload := `{
+		"source": "invalid://bucket/",
+		"destination": "file:///tmp/dst/",
+		"env": {"JFS_UMASK": "63"}
+	}`
+	if err := os.WriteFile(stdin, []byte(payload), 0600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	oldStdin := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	if err = Main([]string{"juicefs", "sync", "invalid://bucket/", "file:///tmp/dst/", "--manager", "127.0.0.1:1"}); err == nil {
+		t.Fatal("expected unsupported storage error")
+	}
+	if got := utils.GetUmask(); got != 0077 {
+		t.Fatalf("worker umask was not restored before config initialization: %04o", got)
 	}
 }

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -413,7 +413,7 @@ func prepareWorkerCommand(host, address, path string, config *Config) ([]string,
 	if !config.Verbose && !config.Quiet {
 		args = append(args, "-q")
 	}
-	return args, payload, nil
+	return shellescape.EscapeArgs(args), payload, nil
 }
 
 // ReadClusterWorkerConfig reads storage URLs and environment variables from worker stdin.
@@ -468,8 +468,8 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 				return
 			}
 			defer clear(payload)
-			logger.Debugf("launch worker command args: [ssh, %q]", strings.Join(shellescape.EscapeArgs(args), ", "))
-			cmd = exec.Command("ssh", shellescape.EscapeArgs(args)...)
+			logger.Debugf("launch worker command args: [ssh, %q]", strings.Join(args, ", "))
+			cmd = exec.Command("ssh", args...)
 			cmd.Stdin = bytes.NewReader(payload)
 			stderr, err := cmd.StderrPipe()
 			if err != nil {

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -58,6 +58,18 @@ type Stat struct {
 	MultipartUploads map[string]*multipartUploadState `json:"multipart_uploads,omitempty"`
 }
 
+const (
+	clusterWorkerSourceArg      = "cluster-worker-source"
+	clusterWorkerDestinationArg = "cluster-worker-destination"
+	maxClusterWorkerConfigSize  = 16 << 20
+)
+
+type clusterWorkerConfig struct {
+	Source      string            `json:"source"`
+	Destination string            `json:"destination"`
+	Env         map[string]string `json:"env,omitempty"`
+}
+
 var completionMu sync.Mutex
 var completedKeysBuf []string
 var failedKeysBuf []string
@@ -364,6 +376,65 @@ func findSelfPath() (string, error) {
 	return "", fmt.Errorf("can't find path for %s", program)
 }
 
+func prepareWorkerCommand(host, address, path string, config *Config) ([]string, []byte, error) {
+	workerArgs := append([]string(nil), os.Args[1:]...)
+	var foundSource, foundDestination bool
+	for i, arg := range workerArgs {
+		if arg == config.clusterSourceArg {
+			workerArgs[i] = clusterWorkerSourceArg
+			foundSource = true
+		}
+		if arg == config.clusterDestinationArg {
+			workerArgs[i] = clusterWorkerDestinationArg
+			foundDestination = true
+		}
+	}
+	if !foundSource || !foundDestination {
+		return nil, nil, fmt.Errorf("can't locate source or destination in command arguments")
+	}
+
+	payload, err := json.Marshal(clusterWorkerConfig{
+		Source:      config.clusterSource,
+		Destination: config.clusterDestination,
+		Env:         config.Env,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal worker config: %s", err)
+	}
+
+	args := []string{host}
+	// JFS_PAGE_STACK is read during package initialization, before the worker can read stdin.
+	if config.Env["JFS_PAGE_STACK"] != "" {
+		args = append(args, "JFS_PAGE_STACK=1")
+	}
+	args = append(args, path)
+	args = append(args, workerArgs...)
+	args = append(args, "--manager", address, "--worker-config-stdin")
+	if !config.Verbose && !config.Quiet {
+		args = append(args, "-q")
+	}
+	return args, payload, nil
+}
+
+// ReadClusterWorkerConfig reads storage URLs and environment variables from worker stdin.
+func ReadClusterWorkerConfig(r io.Reader) (string, string, map[string]string, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxClusterWorkerConfigSize+1))
+	if err != nil {
+		return "", "", nil, fmt.Errorf("read worker config: %s", err)
+	}
+	if len(data) > maxClusterWorkerConfigSize {
+		return "", "", nil, fmt.Errorf("worker config is too large")
+	}
+	var config clusterWorkerConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return "", "", nil, fmt.Errorf("unmarshal worker config: %s", err)
+	}
+	if config.Source == "" || config.Destination == "" {
+		return "", "", nil, fmt.Errorf("worker config is missing source or destination")
+	}
+	return config.Source, config.Destination, config.Env, nil
+}
+
 func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 	workers := strings.Split(strings.Join(config.Workers, ","), ",")
 	for _, host := range workers {
@@ -391,35 +462,15 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 				return
 			}
 			// launch itself
-			var args = []string{host}
-			// set env
-			var printEnv []string
-			for k, v := range config.Env {
-				args = append(args, fmt.Sprintf("%s=%s", k, v))
-				if strings.Contains(k, "SECRET") ||
-					strings.Contains(k, "TOKEN") ||
-					strings.Contains(k, "PASSWORD") ||
-					strings.Contains(k, "AZURE_STORAGE_CONNECTION_STRING") ||
-					strings.Contains(k, "JFS_RSA_PASSPHRASE") {
-					v = "******"
-				}
-				printEnv = append(printEnv, fmt.Sprintf("%s=%s", k, v))
+			args, payload, err := prepareWorkerCommand(host, address, rpath, config)
+			if err != nil {
+				logger.Errorf("prepare worker command for %q: %s", host, err)
+				return
 			}
-
-			args = append(args, rpath)
-			args = append(args, os.Args[1:]...)
-			args = append(args, "--manager", address)
-			if !config.Verbose && !config.Quiet {
-				args = append(args, "-q")
-			}
-			var argsBk = make([]string, len(args))
-			copy(argsBk, args)
-			for i, s := range printEnv {
-				argsBk[i+1] = s
-			}
-			logger.Debugf("launch worker command args: [ssh, %q]", strings.Join(shellescape.EscapeArgs(argsBk), ", "))
+			defer clear(payload)
+			logger.Debugf("launch worker command args: [ssh, %q]", strings.Join(shellescape.EscapeArgs(args), ", "))
 			cmd = exec.Command("ssh", shellescape.EscapeArgs(args)...)
-			cmd.Stdin = os.Stdin
+			cmd.Stdin = bytes.NewReader(payload)
 			stderr, err := cmd.StderrPipe()
 			if err != nil {
 				logger.Errorf("redirect stderr: %s", err)

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -58,11 +58,7 @@ type Stat struct {
 	MultipartUploads map[string]*multipartUploadState `json:"multipart_uploads,omitempty"`
 }
 
-const (
-	clusterWorkerSourceArg      = "cluster-worker-source"
-	clusterWorkerDestinationArg = "cluster-worker-destination"
-	maxClusterWorkerConfigSize  = 16 << 20
-)
+const maxClusterWorkerConfigSize = 16 << 20
 
 type clusterWorkerConfig struct {
 	Source      string            `json:"source"`
@@ -381,11 +377,11 @@ func prepareWorkerCommand(host, address, path string, config *Config) ([]string,
 	var foundSource, foundDestination bool
 	for i, arg := range workerArgs {
 		if arg == config.clusterSource {
-			workerArgs[i] = clusterWorkerSourceArg
+			workerArgs[i] = utils.RemovePassword(config.clusterSource)
 			foundSource = true
 		}
 		if arg == config.clusterDestination {
-			workerArgs[i] = clusterWorkerDestinationArg
+			workerArgs[i] = utils.RemovePassword(config.clusterDestination)
 			foundDestination = true
 		}
 	}
@@ -402,14 +398,9 @@ func prepareWorkerCommand(host, address, path string, config *Config) ([]string,
 		return nil, nil, fmt.Errorf("marshal worker config: %s", err)
 	}
 
-	args := []string{host}
-	// JFS_PAGE_STACK is read during package initialization, before the worker can read stdin.
-	if config.Env["JFS_PAGE_STACK"] != "" {
-		args = append(args, "JFS_PAGE_STACK=1")
-	}
-	args = append(args, path)
+	args := []string{host, path}
 	args = append(args, workerArgs...)
-	args = append(args, "--manager", address, "--worker-config-stdin")
+	args = append(args, "--manager", address)
 	if !config.Verbose && !config.Quiet {
 		args = append(args, "-q")
 	}

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -380,11 +380,11 @@ func prepareWorkerCommand(host, address, path string, config *Config) ([]string,
 	workerArgs := append([]string(nil), os.Args[1:]...)
 	var foundSource, foundDestination bool
 	for i, arg := range workerArgs {
-		if arg == config.clusterSourceArg {
+		if arg == config.clusterSource {
 			workerArgs[i] = clusterWorkerSourceArg
 			foundSource = true
 		}
-		if arg == config.clusterDestinationArg {
+		if arg == config.clusterDestination {
 			workerArgs[i] = clusterWorkerDestinationArg
 			foundDestination = true
 		}

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -107,6 +107,7 @@ func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
 	os.Args = []string{
 		"/usr/local/bin/juicefs", "sync", src, dst,
 		"--worker", "worker.example.com", "--debug", "--bwlimit", "10",
+		"--start-time", "2026-07-13 07:25:05",
 	}
 	config := &Config{Env: map[string]string{
 		"SECRET_KEY":    "env-secret-key",
@@ -129,6 +130,9 @@ func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
 	}
 	if !strings.Contains(command, "--worker-config-stdin") {
 		t.Fatalf("worker command should enable stdin config: %s", command)
+	}
+	if !strings.Contains(command, `2026-07-13\ 07:25:05`) || strings.Contains(command, `2026-07-13\\\ 07:25:05`) {
+		t.Fatalf("worker command should escape arguments exactly once: %s", command)
 	}
 
 	gotSrc, gotDst, env, err := ReadClusterWorkerConfig(bytes.NewReader(payload))

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -26,7 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oliverisaac/shellescape"
+
 	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juicedata/juicefs/pkg/utils"
 )
 
 type obj struct {
@@ -98,7 +101,7 @@ func TestCluster(t *testing.T) {
 	}
 }
 
-func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
+func TestPrepareWorkerCommandRedactsSecretsInArgs(t *testing.T) {
 	oldArgs := os.Args
 	t.Cleanup(func() { os.Args = oldArgs })
 
@@ -110,8 +113,9 @@ func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
 		"--start-time", "2026-07-13 07:25:05",
 	}
 	config := &Config{Env: map[string]string{
-		"SECRET_KEY":    "env-secret-key",
-		"SESSION_TOKEN": "env-session-token",
+		"SECRET_KEY":     "env-secret-key",
+		"SESSION_TOKEN":  "env-session-token",
+		"JFS_PAGE_STACK": "1",
 	}}
 	config.SetClusterStorage(src, dst)
 
@@ -120,16 +124,25 @@ func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 	command := strings.Join(args, " ")
-	for _, secret := range []string{"test-access-key", "test-secret-key", "test-bucket.oss.example.com", "env-secret-key", "env-session-token"} {
+	for _, secret := range []string{"test-secret-key", "env-secret-key", "env-session-token"} {
 		if strings.Contains(command, secret) {
 			t.Fatalf("worker command leaked %q: %s", secret, command)
 		}
 	}
-	if !strings.Contains(command, clusterWorkerSourceArg) || !strings.Contains(command, clusterWorkerDestinationArg) {
-		t.Fatalf("worker command should use storage placeholders: %s", command)
+	for _, storageURL := range []string{src, dst} {
+		redacted := shellescape.Escape(utils.RemovePassword(storageURL))
+		if !strings.Contains(command, redacted) {
+			t.Fatalf("worker command should use redacted storage URL %q: %s", redacted, command)
+		}
 	}
-	if !strings.Contains(command, "--worker-config-stdin") {
-		t.Fatalf("worker command should enable stdin config: %s", command)
+	if strings.Contains(command, "cluster-worker-source") || strings.Contains(command, "cluster-worker-destination") {
+		t.Fatalf("worker command should not use fixed storage placeholders: %s", command)
+	}
+	if strings.Contains(command, "--worker-config-stdin") {
+		t.Fatalf("worker command should read stdin without an extra flag: %s", command)
+	}
+	if strings.Contains(command, "JFS_PAGE_STACK") {
+		t.Fatalf("worker command should not pass JFS_PAGE_STACK separately: %s", command)
 	}
 	if !strings.Contains(command, `2026-07-13\ 07:25:05`) || strings.Contains(command, `2026-07-13\\\ 07:25:05`) {
 		t.Fatalf("worker command should escape arguments exactly once: %s", command)

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -16,6 +16,7 @@
 package sync
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	_ "net/http/pprof"
@@ -94,6 +95,51 @@ func TestCluster(t *testing.T) {
 	}
 	if _, ok := <-mytodo; ok {
 		t.Fatalf("should end")
+	}
+}
+
+func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	src := "oss://test-access-key:test-secret-key@test-bucket.oss.example.com/"
+	dst := "/tmp/dst/"
+	os.Args = []string{
+		"/usr/local/bin/juicefs", "sync", src, dst,
+		"--worker", "worker.example.com", "--debug", "--bwlimit", "10",
+	}
+	config := &Config{Env: map[string]string{
+		"SECRET_KEY":    "env-secret-key",
+		"SESSION_TOKEN": "env-session-token",
+	}}
+	config.SetClusterStorage(src, dst, src, dst)
+
+	args, payload, err := prepareWorkerCommand("worker.example.com", "10.0.0.1:12345", "/tmp/juicefs", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := strings.Join(args, " ")
+	for _, secret := range []string{"test-access-key", "test-secret-key", "test-bucket.oss.example.com", "env-secret-key", "env-session-token"} {
+		if strings.Contains(command, secret) {
+			t.Fatalf("worker command leaked %q: %s", secret, command)
+		}
+	}
+	if !strings.Contains(command, clusterWorkerSourceArg) || !strings.Contains(command, clusterWorkerDestinationArg) {
+		t.Fatalf("worker command should use storage placeholders: %s", command)
+	}
+	if !strings.Contains(command, "--worker-config-stdin") {
+		t.Fatalf("worker command should enable stdin config: %s", command)
+	}
+
+	gotSrc, gotDst, env, err := ReadClusterWorkerConfig(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSrc != src || gotDst != dst {
+		t.Fatalf("unexpected worker storage config: %q -> %q", gotSrc, gotDst)
+	}
+	if env["SECRET_KEY"] != "env-secret-key" || env["SESSION_TOKEN"] != "env-session-token" {
+		t.Fatalf("unexpected worker environment: %+v", env)
 	}
 }
 

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -112,7 +112,7 @@ func TestPrepareWorkerCommandKeepsCredentialsOutOfArgs(t *testing.T) {
 		"SECRET_KEY":    "env-secret-key",
 		"SESSION_TOKEN": "env-session-token",
 	}}
-	config.SetClusterStorage(src, dst, src, dst)
+	config.SetClusterStorage(src, dst)
 
 	args, payload, err := prepareWorkerCommand("worker.example.com", "10.0.0.1:12345", "/tmp/juicefs", config)
 	if err != nil {

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -82,18 +82,14 @@ type Config struct {
 	concurrentList chan int              `json:"-"`
 	Registerer     prometheus.Registerer `json:"-"`
 
-	clusterSourceArg      string
-	clusterDestinationArg string
-	clusterSource         string
-	clusterDestination    string
+	clusterSource      string
+	clusterDestination string
 }
 
 const JFS_UMASK = "JFS_UMASK"
 
-// SetClusterStorage records the original arguments and resolved storage URLs for worker startup.
-func (c *Config) SetClusterStorage(sourceArg, destinationArg, source, destination string) {
-	c.clusterSourceArg = sourceArg
-	c.clusterDestinationArg = destinationArg
+// SetClusterStorage records the source and destination arguments for worker startup.
+func (c *Config) SetClusterStorage(source, destination string) {
 	c.clusterSource = source
 	c.clusterDestination = destination
 }

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -81,9 +81,22 @@ type Config struct {
 	rules          []rule
 	concurrentList chan int              `json:"-"`
 	Registerer     prometheus.Registerer `json:"-"`
+
+	clusterSourceArg      string
+	clusterDestinationArg string
+	clusterSource         string
+	clusterDestination    string
 }
 
 const JFS_UMASK = "JFS_UMASK"
+
+// SetClusterStorage records the original arguments and resolved storage URLs for worker startup.
+func (c *Config) SetClusterStorage(sourceArg, destinationArg, source, destination string) {
+	c.clusterSourceArg = sourceArg
+	c.clusterDestinationArg = destinationArg
+	c.clusterSource = source
+	c.clusterDestination = destination
+}
 
 func envList() []string {
 	return []string{


### PR DESCRIPTION
## Summary
- Add a stdin-based worker config path for `juicefs sync` cluster workers so source, destination, and env values are passed out of band.
- Replace direct credential-bearing worker args with placeholders in the SSH command, while restoring the real storage config from stdin on the worker side.
- Keep the worker startup flow compatible with `JFS_PAGE_STACK` and preserve existing manager coordination.
- Add tests covering worker command construction, stdin config parsing, and env propagation.

## Testing
- Added unit tests for worker command preparation and config loading.
- Verified the generated worker command omits embedded credentials and uses the stdin config path.