### PR TITLE
object: enhance S3 configuration with default checksum options

### DIFF
--- a/pkg/object/eos.go
+++ b/pkg/object/eos.go
@@ -74,8 +74,8 @@ func newEos(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	if token == "" {
 		token = os.Getenv("EOS_TOKEN")
 	}
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+	cfg, err := config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)
 	}

--- a/pkg/object/minio.go
+++ b/pkg/object/minio.go
@@ -82,10 +82,10 @@ func newMinio(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 	}
 	var cfg aws.Config
 	if accessKey != "" {
-		cfg, err = config.LoadDefaultConfig(ctx,
-			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+		cfg, err = config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	} else {
-		cfg, err = config.LoadDefaultConfig(ctx)
+		cfg, err = config.LoadDefaultConfig(ctx, defaultChecksumOpts()...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)

--- a/pkg/object/oos.go
+++ b/pkg/object/oos.go
@@ -84,8 +84,8 @@ func newOOS(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 	endpoint = uri.Scheme + "://" + uri.Host[len(bucket)+1:]
 	forcePathStyle := !strings.Contains(strings.ToLower(endpoint), "xstore.ctyun.cn")
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+	awsCfg, err := config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)
 	}

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -205,8 +205,8 @@ func newQiniu(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 		region = endpoint[:strings.LastIndex(endpoint, "-")]
 	}
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+	awsCfg, err := config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)
 	}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -399,13 +399,33 @@ func (s *s3client) Restore(ctx context.Context, key string, days int32) error {
 	return err
 }
 
+// defaultChecksumOpts returns AWS SDK load options that set checksum calculation
+// and validation to "when_required" by default. If the user has explicitly set
+// AWS_REQUEST_CHECKSUM_CALCULATION or AWS_RESPONSE_CHECKSUM_VALIDATION, those
+// env vars take precedence and we skip the corresponding programmatic default,
+// because config.WithXxx options have higher priority than environment variables
+// in the AWS SDK v2 resolution order.
+func defaultChecksumOpts() []func(*config.LoadOptions) error {
+	var opts []func(*config.LoadOptions) error
+	if os.Getenv("AWS_REQUEST_CHECKSUM_CALCULATION") == "" {
+		opts = append(opts, config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired))
+	}
+	if os.Getenv("AWS_RESPONSE_CHECKSUM_VALIDATION") == "" {
+		opts = append(opts, config.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired))
+	}
+	return opts
+}
+
 func autoS3Region(bucketName, accessKey, secretKey, token string) (string, error) {
 	var cfg aws.Config
 	var err error
 	if accessKey != "" {
-		cfg, err = config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+		var loadOpts []func(*config.LoadOptions) error
+		loadOpts = append(loadOpts, defaultChecksumOpts()...)
+		loadOpts = append(loadOpts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+		cfg, err = config.LoadDefaultConfig(ctx, loadOpts...)
 	} else {
-		cfg, err = config.LoadDefaultConfig(ctx)
+		cfg, err = config.LoadDefaultConfig(ctx, defaultChecksumOpts()...)
 	}
 	if err != nil {
 		return "", err
@@ -586,15 +606,14 @@ func newS3(endpoint, accessKey, secretKey, token string) (ObjectStorage, error) 
 		})
 	}
 	var cfg aws.Config
+	var loadOpts []func(*config.LoadOptions) error
+	loadOpts = append(loadOpts, defaultChecksumOpts()...)
 	if accessKey == "anonymous" {
-		cfg, err = config.LoadDefaultConfig(ctx,
-			config.WithCredentialsProvider(aws.AnonymousCredentials{}))
+		loadOpts = append(loadOpts, config.WithCredentialsProvider(aws.AnonymousCredentials{}))
 	} else if accessKey != "" {
-		cfg, err = config.LoadDefaultConfig(ctx,
-			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
-	} else {
-		cfg, err = config.LoadDefaultConfig(ctx)
+		loadOpts = append(loadOpts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
 	}
+	cfg, err = config.LoadDefaultConfig(ctx, loadOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/object/scw.go
+++ b/pkg/object/scw.go
@@ -71,8 +71,8 @@ func newScw(endpoint, accessKey, secretKey, token string) (ObjectStorage, error)
 		secretKey = os.Getenv("SCW_SECRET_KEY")
 	}
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+	awsCfg, err := config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)
 	}

--- a/pkg/object/space.go
+++ b/pkg/object/space.go
@@ -61,8 +61,8 @@ func newSpace(endpoint, accessKey, secretKey, token string) (ObjectStorage, erro
 	region := hostParts[1]
 	endpoint = uri.Scheme + "://" + uri.Host[len(bucket)+1:]
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+	awsCfg, err := config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)
 	}

--- a/pkg/object/wasabi.go
+++ b/pkg/object/wasabi.go
@@ -59,8 +59,8 @@ func newWasabi(endpoint, accessKey, secretKey, token string) (ObjectStorage, err
 	region := hostParts[2]
 	endpoint = uri.Scheme + "://" + uri.Host[len(bucket)+1:]
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))
+	awsCfg, err := config.LoadDefaultConfig(ctx, append(defaultChecksumOpts(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, token)))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %s", err)
 	}


### PR DESCRIPTION
## Summary

Backport `561ebeb5` from `main` to `ee-5.4`.

- Default AWS SDK request checksum calculation to `when_required`.
- Default response checksum validation to `when_required`.
- Preserve explicit `AWS_REQUEST_CHECKSUM_CALCULATION` and `AWS_RESPONSE_CHECKSUM_VALIDATION` overrides.

## Why

Avoid unnecessary checksum behavior that can break compatibility with S3-compatible object storage services.

## Validation

- `go test ./pkg/object -count=1`
- `git diff --check origin/ee-5.4..HEAD`

## Notes

Draft backport PR. Do not merge until explicitly approved.
