### PR TITLE
cmd/sync: avoid printing the secret key in logs

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -403,7 +403,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 	uri, token := extractToken(uri)
 	u, err := url.Parse(uri)
 	if err != nil {
-		logger.Fatalf("Can't parse %q: %s", uri, err.Error())
+		logger.Fatalf("Can't parse %q: %s", utils.RemovePassword(uri), utils.RemovePassword(err.Error()))
 	}
 	user := u.User
 	var accessKey, secretKey string
@@ -457,7 +457,7 @@ func createSyncStorage(uri string, conf *sync.Config) (object.ObjectStorage, err
 
 	if conf.Links {
 		if _, ok := store.(object.SupportSymlink); !ok {
-			logger.Warnf("storage %q does not support symlink, ignore it", uri)
+			logger.Warnf("storage %q does not support symlink, ignore it", utils.RemovePassword(uri))
 			conf.Links = false
 		}
 	}


### PR DESCRIPTION
## Summary

Backport `7150bca9` from `main` to `ee-5.4`.

- Redact credentials when reporting invalid sync URIs.
- Redact credentials in unsupported-symlink warnings.

## Why

Prevent object storage secret keys embedded in sync URIs from being written to logs.

## Validation

- `go test ./cmd -run '^$' -count=1`
- `git diff --check origin/ee-5.4..HEAD`

## Notes

Draft backport PR. Do not merge until explicitly approved.
