### PR TITLE
sync: fix limit handling and checkpoint cleanup

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1334,14 +1334,16 @@ func handleExtraObject(tasks chan<- object.Object, dstobj object.Object, config 
 	if checkpointMgr.isCheckpointKey(dstobj.Key()) {
 		return false
 	}
-	incrTotal(1)
-	if !config.DeleteDst || !config.Dirs && dstobj.IsDir() || config.Limit == 0 {
+	if config.Limit == 0 {
+		return true
+	}
+	if !config.DeleteDst || !config.Dirs && dstobj.IsDir() {
 		logger.Debug("Ignore extra object", dstobj.Key())
 		extra.Increment()
 		extraBytes.IncrInt64(dstobj.Size())
 		return false
 	}
-	config.Limit--
+	incrTotal(1)
 	if dstobj.IsDir() {
 		dstDelayDelMu.Lock()
 		dstDelayDel = append(dstDelayDel, dstobj.Key())
@@ -1352,6 +1354,9 @@ func handleExtraObject(tasks chan<- object.Object, dstobj object.Object, config 
 			checkpointMgr.AddPendingKey(prefix, obj)
 		}
 		tasks <- obj
+	}
+	if config.Limit > 0 {
+		config.Limit--
 	}
 	return config.Limit == 0
 }
@@ -1439,13 +1444,6 @@ func produce(tasks chan<- object.Object, srckeys, dstkeys <-chan object.Object, 
 			logger.Debug("Ignore directory ", obj.Key())
 			continue
 		}
-		if config.Limit >= 0 {
-			if config.Limit == 0 {
-				return nil
-			}
-			config.Limit--
-		}
-		incrTotal(1)
 
 		if dstobj != nil && obj.Key() > dstobj.Key() {
 			if handleExtraObject(tasks, dstobj, config, checkpointMgr, prefix) {
@@ -1468,6 +1466,13 @@ func produce(tasks chan<- object.Object, srckeys, dstkeys <-chan object.Object, 
 			}
 		}
 
+		if config.Limit >= 0 {
+			if config.Limit == 0 {
+				return nil
+			}
+			config.Limit--
+		}
+		incrTotal(1)
 		// FIXME: there is a race when source is modified during coping
 		if dstobj == nil || obj.Key() < dstobj.Key() {
 			if config.Existing {
@@ -2244,23 +2249,25 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 			if failed != nil {
 				msg += fmt.Sprintf(", failed: %d", failed.Current())
 			}
-			if total-handled.Current()-extra.Current() > 0 {
-				msg += fmt.Sprintf(", lost: %d", total-handled.Current()-extra.Current())
+			if total-handled.Current() > 0 {
+				msg += fmt.Sprintf(", lost: %d", total-handled.Current())
 			}
 			logger.Info(msg)
 
 			if failed != nil {
-				if n := failed.Current(); n > 0 || total > handled.Current()+extra.Current() {
+				if n := failed.Current(); n > 0 || total > handled.Current() {
 					if checkpointMgr != nil {
 						if e := checkpointMgr.Save(checkpointMgr.checkpoint); e != nil {
 							logger.Warnf("Failed to save checkpoint after failure: %v", e)
 						}
 					}
-					return fmt.Errorf("failed to handle %d objects", n+total-handled.Current()-extra.Current())
+					return fmt.Errorf("failed to handle %d objects", n+total-handled.Current())
 				}
 			}
-			if checkpointMgr != nil {
-				if e := checkpointMgr.DeleteCheckpoint(); e != nil {
+			if checkpointMgr != nil && !config.Dry {
+				if e := try(3, func() error {
+					return checkpointMgr.DeleteCheckpoint()
+				}); e != nil {
 					logger.Warnf("Failed to delete checkpoint after completion: %v", e)
 				}
 			}
@@ -2378,9 +2385,6 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 		}()
 		delWg.Add(1)
 		go func() {
-			if checkpointMgr != nil && config.DeleteDst {
-				delayDelFunc(checkpointMgr.dst, []string{checkpointMgr.checkpointKey})
-			}
 			delayDelFunc(dst, dstDelayDel)
 			delWg.Done()
 		}()

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -620,6 +620,169 @@ func TestLimits(t *testing.T) {
 	}
 }
 
+// Regression test for the shared --limit budget between source processing and
+// destination-extra deletion. The budget is consumed by both deletions and
+// synced source objects; a source object is only counted in total after it
+// passes the limit check, so the run must not report it as "lost".
+func TestSyncLimitDeleteDstBoundary(t *testing.T) {
+	tmpSrc := t.TempDir() + "/"
+	tmpDst := t.TempDir() + "/"
+	src, _ := object.CreateStorage("file", tmpSrc, "", "", "")
+	dst, _ := object.CreateStorage("file", tmpDst, "", "", "")
+
+	// Source has a single new file "a2" that does not exist on the destination.
+	if err := src.Put(ctx, "a2", bytes.NewReader([]byte{})); err != nil {
+		t.Fatalf("put src a2: %s", err)
+	}
+	// Destination has a single extra file "a1" (sorts before "a2") only on dst.
+	if err := dst.Put(ctx, "a1", bytes.NewReader([]byte{})); err != nil {
+		t.Fatalf("put dst a1: %s", err)
+	}
+
+	// With --limit 2 the budget is exactly enough to delete "a1" and copy "a2":
+	// deleting "a1" consumes one unit and syncing "a2" consumes the last one.
+	// The current source object "a2" must still be synced rather than dropped.
+	config := &Config{
+		Threads:     50,
+		Update:      true,
+		Perms:       true,
+		MaxSize:     math.MaxInt64,
+		ListThreads: 1,
+		DeleteDst:   true,
+		Limit:       2,
+	}
+	if err := Sync(src, dst, config); err != nil {
+		t.Fatalf("sync: %s", err)
+	}
+
+	all, err := ListAll(dst, "", "", "", true)
+	if err != nil {
+		t.Fatalf("list all dst: %s", err)
+	}
+	if err := testKeysEqual(all, []string{"", "a2"}); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+}
+
+// Regression test: while deleting an extra dst object consumes part of the
+// --limit budget, the producer must still scan dstkeys to locate the current
+// source object's matching dst. Otherwise the object is treated as missing on
+// dst and gets copied/overwritten, breaking --ignore-existing (and similarly
+// --existing/--update).
+func TestSyncLimitDeleteDstIgnoreExisting(t *testing.T) {
+	tmpSrc := t.TempDir() + "/"
+	tmpDst := t.TempDir() + "/"
+	src, _ := object.CreateStorage("file", tmpSrc, "", "", "")
+	dst, _ := object.CreateStorage("file", tmpDst, "", "", "")
+
+	// Source has "a2" with new content.
+	if err := src.Put(ctx, "a2", bytes.NewReader([]byte("new"))); err != nil {
+		t.Fatalf("put src a2: %s", err)
+	}
+	// Destination has an extra "a1" (sorts before "a2") and an existing "a2"
+	// with different content that --ignore-existing must preserve.
+	if err := dst.Put(ctx, "a1", bytes.NewReader([]byte{})); err != nil {
+		t.Fatalf("put dst a1: %s", err)
+	}
+	if err := dst.Put(ctx, "a2", bytes.NewReader([]byte("old"))); err != nil {
+		t.Fatalf("put dst a2: %s", err)
+	}
+
+	// With --limit 2, deleting "a1" consumes one unit and locating/skipping the
+	// matching "a2" consumes the last one. The current source object "a2"
+	// already exists on dst, so --ignore-existing must skip it rather than
+	// overwrite it.
+	config := &Config{
+		Threads:        50,
+		Perms:          true,
+		MaxSize:        math.MaxInt64,
+		ListThreads:    1,
+		DeleteDst:      true,
+		IgnoreExisting: true,
+		Limit:          2,
+	}
+	if err := Sync(src, dst, config); err != nil {
+		t.Fatalf("sync: %s", err)
+	}
+
+	all, err := ListAll(dst, "", "", "", true)
+	if err != nil {
+		t.Fatalf("list all dst: %s", err)
+	}
+	if err := testKeysEqual(all, []string{"", "a2"}); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+	c, err := dst.Get(ctx, "a2", 0, -1)
+	if err != nil {
+		t.Fatalf("get dst a2: %s", err)
+	}
+	data, _ := io.ReadAll(c)
+	if string(data) != "old" {
+		t.Fatalf("a2 should be preserved by --ignore-existing, got %q", string(data))
+	}
+}
+
+// Regression test for the "leftover dst" branch: a dst object retained from a
+// previous source iteration is deleted as extra for the current source object,
+// consuming part of the --limit budget. The producer must still scan dstkeys to
+// find the current object's matching dst instead of treating it as missing, so
+// that --ignore-existing is honored (the same applies to --existing/--update).
+func TestSyncLimitDeleteDstLeftoverIgnoreExisting(t *testing.T) {
+	tmpSrc := t.TempDir() + "/"
+	tmpDst := t.TempDir() + "/"
+	src, _ := object.CreateStorage("file", tmpSrc, "", "", "")
+	dst, _ := object.CreateStorage("file", tmpDst, "", "", "")
+
+	// Source: "a1" (new on dst) and "a4" (also present on dst).
+	if err := src.Put(ctx, "a1", bytes.NewReader([]byte("a1"))); err != nil {
+		t.Fatalf("put src a1: %s", err)
+	}
+	if err := src.Put(ctx, "a4", bytes.NewReader([]byte("new"))); err != nil {
+		t.Fatalf("put src a4: %s", err)
+	}
+	// Destination: extra "a2" (sorts between a1 and a4) and existing "a4".
+	if err := dst.Put(ctx, "a2", bytes.NewReader([]byte{})); err != nil {
+		t.Fatalf("put dst a2: %s", err)
+	}
+	if err := dst.Put(ctx, "a4", bytes.NewReader([]byte("old"))); err != nil {
+		t.Fatalf("put dst a4: %s", err)
+	}
+
+	// Processing "a1" reads and retains dst "a2" (a2 > a1). When processing
+	// "a4", the retained "a2" is deleted as extra, which consumes one unit of
+	// the shared budget (limit 3 = copy a1 + delete a2 + sync a4). The matching
+	// dst "a4" must still be located so --ignore-existing skips it instead of
+	// overwriting.
+	config := &Config{
+		Threads:        50,
+		Perms:          true,
+		MaxSize:        math.MaxInt64,
+		ListThreads:    1,
+		DeleteDst:      true,
+		IgnoreExisting: true,
+		Limit:          3,
+	}
+	if err := Sync(src, dst, config); err != nil {
+		t.Fatalf("sync: %s", err)
+	}
+
+	all, err := ListAll(dst, "", "", "", true)
+	if err != nil {
+		t.Fatalf("list all dst: %s", err)
+	}
+	if err := testKeysEqual(all, []string{"", "a1", "a4"}); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+	c, err := dst.Get(ctx, "a4", 0, -1)
+	if err != nil {
+		t.Fatalf("get dst a4: %s", err)
+	}
+	data, _ := io.ReadAll(c)
+	if string(data) != "old" {
+		t.Fatalf("a4 should be preserved by --ignore-existing, got %q", string(data))
+	}
+}
+
 func testKeysEqual(objsCh <-chan object.Object, expectedKeys []string) error {
 	var gottenKeys []string
 	for obj := range objsCh {


### PR DESCRIPTION
## Summary

Backport `2a571e9f` from `main` to `ee-5.4`.

- Correct the shared `--limit` budget for source objects and extra destination deletions.
- Fix lost-object accounting.
- Delete completed checkpoints with retries instead of deleting the checkpoint as an extra destination object.

## Why

Keep `--limit`, `--delete-dst`, and checkpoint completion behavior consistent at boundary conditions.

## Validation

- Focused `pkg/sync` limit and delete-destination regression tests.
- `git diff --check origin/ee-5.4..HEAD`

## Notes

Draft backport PR. Do not merge until explicitly approved.
