### PR TITLE
cmd: use dedicated ServeMux instances

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -90,7 +90,8 @@ func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *p
 		logger.Fatalf("metrics format error %q: %v", c.String("metrics"), err)
 	}
 	go metric.UpdateMetrics(registerer)
-	http.Handle("/metrics", promhttp.HandlerFor(
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(
 		registry,
 		promhttp.HandlerOpts{
 			// Opt into OpenMetrics to support exemplars.
@@ -127,7 +128,7 @@ func exposeMetrics(c *cli.Context, registerer prometheus.Registerer, registry *p
 	}
 
 	go func() {
-		if err := http.Serve(ln, nil); err != nil {
+		if err := http.Serve(ln, mux); err != nil {
 			logger.Errorf("Serve for metrics: %s", err)
 		}
 	}()

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -53,6 +53,9 @@ const testVolume = "test"
 
 // gomonkey may encounter the problem of insufficient permissions under mac, please solve it by viewing this link https://github.com/agiledragon/gomonkey/issues/70
 func Test_exposeMetrics(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("gomonkey cannot patch functions on darwin/arm64")
+	}
 	addr := "redis://127.0.0.1:6379/12"
 	client := meta.NewClient(addr, nil)
 	format := &meta.Format{
@@ -97,6 +100,20 @@ func Test_exposeMetrics(t *testing.T) {
 	require.Nil(t, err)
 	require.NotEmpty(t, all)
 	require.Contains(t, string(all), `key1="value1"`)
+
+	pprofURL := url.URL{Scheme: "http", Host: metricsAddr, Path: "/debug/pprof/cmdline"}
+	pprofResp, err := http.Get(pprofURL.String())
+	require.Nil(t, err)
+	pprofBody, err := io.ReadAll(pprofResp.Body)
+	require.Nil(t, err)
+	_ = pprofResp.Body.Close()
+	require.Equal(t, http.StatusNotFound, pprofResp.StatusCode)
+	require.NotContains(t, string(pprofBody), os.Args[0])
+
+	require.NotPanics(t, func() {
+		registerer2, registry2 := wrapRegister(appCtx, "test", "test2")
+		_ = exposeMetrics(appCtx, registerer2, registry2)
+	})
 }
 
 func ResetHttp() {

--- a/pkg/fs/http.go
+++ b/pkg/fs/http.go
@@ -335,7 +335,7 @@ func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.Handler.ServeHTTP(w, r)
 }
 
-func StartHTTPServer(fs *FileSystem, config WebdavConfig) {
+func newWebdavHandler(fs *FileSystem, config WebdavConfig) http.Handler {
 	ctx := meta.NewContext(uint32(os.Getpid()), uint32(utils.GetCurrentUID()), []uint32{uint32(utils.GetCurrentGID())})
 	hfs := &webdavFS{ctx, fs, uint16(utils.GetUmask()), config}
 	srv := &webdav.Handler{
@@ -353,13 +353,19 @@ func StartHTTPServer(fs *FileSystem, config WebdavConfig) {
 	if config.EnableGzip {
 		h = makeGzipHandler(h)
 	}
-	http.Handle("/", h)
+	mux := http.NewServeMux()
+	mux.Handle("/", h)
+	return mux
+}
+
+func StartHTTPServer(fs *FileSystem, config WebdavConfig) {
+	handler := newWebdavHandler(fs, config)
 	logger.Infof("WebDAV listening on %s", config.Addr)
 	var err error
 	if config.CertFile != "" && config.KeyFile != "" {
-		err = http.ListenAndServeTLS(config.Addr, config.CertFile, config.KeyFile, nil)
+		err = http.ListenAndServeTLS(config.Addr, config.CertFile, config.KeyFile, handler)
 	} else {
-		err = http.ListenAndServe(config.Addr, nil)
+		err = http.ListenAndServe(config.Addr, handler)
 	}
 	if err != nil {
 		logger.Fatalf("Error with WebDAV server: %v", err)

--- a/pkg/fs/http_test.go
+++ b/pkg/fs/http_test.go
@@ -20,7 +20,11 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	_ "net/http/pprof"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/juicedata/juicefs/pkg/meta"
@@ -83,5 +87,31 @@ func TestWebdav(t *testing.T) {
 	}
 	if err = aFile.Close(); err != nil {
 		t.Fatalf("webdavFS close file failed: %s", err)
+	}
+}
+
+func TestWebdavNoPprofExposure(t *testing.T) {
+	jfs := createTestFS(t)
+	config := WebdavConfig{Username: "user", Password: "pass"}
+	handler := newWebdavHandler(jfs, config)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	for _, path := range []string{"/", "/debug/pprof/", "/debug/pprof/cmdline", "/metrics"} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %s", path, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		// Without credentials every path must be rejected by Basic Auth,
+		// proving pprof/metrics are not served on a separate unauthenticated route.
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("GET %s: expected 401, got %d", path, resp.StatusCode)
+		}
+		// The process command line (leaked by /debug/pprof/cmdline) must never appear.
+		if strings.Contains(string(body), os.Args[0]) {
+			t.Fatalf("GET %s: response leaked process command line", path)
+		}
 	}
 }

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -231,7 +231,8 @@ func sendStats(addr string, multipartUploads *workerMultipartUploads) {
 }
 
 func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *CheckpointManager) (string, error) {
-	http.HandleFunc("/fetch", func(w http.ResponseWriter, req *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fetch", func(w http.ResponseWriter, req *http.Request) {
 		var objs []object.Object
 		var total int64
 		obj, ok := <-tasks
@@ -273,7 +274,7 @@ func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *Che
 		logger.Debugf("send %d objects(%s) to %s", len(objs), humanize.IBytes(uint64(total)), req.RemoteAddr)
 		_, _ = w.Write(d)
 	})
-	http.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != "POST" {
 			http.Error(w, "POST required", http.StatusBadRequest)
 			return
@@ -339,7 +340,7 @@ func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *Che
 		return "", fmt.Errorf("listen: %s", err)
 	}
 	logger.Infof("Listen at %s", l.Addr())
-	go func() { _ = http.Serve(l, nil) }()
+	go func() { _ = http.Serve(l, mux) }()
 	return l.Addr().String(), nil
 }
 

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -16,8 +16,12 @@
 package sync
 
 import (
+	"io"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/user"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +66,18 @@ func TestCluster(t *testing.T) {
 	addr, err := startManager(&conf, todo, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if resp, err := http.Get("http://" + addr + "/debug/pprof/cmdline"); err != nil {
+		t.Fatalf("get pprof: %s", err)
+	} else {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("manager exposed /debug/pprof: status %d", resp.StatusCode)
+		}
+		if strings.Contains(string(body), os.Args[0]) {
+			t.Fatalf("manager leaked process command line via /debug/pprof/cmdline")
+		}
 	}
 	// sendStats(addr)
 	// worker


### PR DESCRIPTION
## Summary

Backport `a46979cd` from `main` to `ee-5.4`.

- Use dedicated HTTP muxes for metrics, WebDAV, and the sync manager.
- Prevent handlers registered on `http.DefaultServeMux`, such as pprof, from being exposed unintentionally.

## Why

Isolate HTTP endpoints and avoid cross-service handler exposure.

## Validation

- Focused WebDAV and sync cluster tests.
- `cmd` package compile check.
- `git diff --check origin/ee-5.4..HEAD`

## Notes

Draft backport PR. Do not merge until explicitly approved.
