### PR TITLE
utils: show realtime speed in progress bar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/DataDog/zstd v1.5.6
 	github.com/IBM/ibm-cos-sdk-go v1.13.0
+	github.com/VividCortex/ewma v1.2.0
 	github.com/agiledragon/gomonkey/v2 v2.6.0
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.4.1
 	github.com/aliyun/credentials-go v1.4.5
@@ -123,7 +124,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 // indirect
 	github.com/IBM/go-sdk-core/v5 v5.21.2 // indirect
-	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/alecthomas/participle v0.2.1 // indirect
 	github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82 // indirect

--- a/pkg/utils/progress.go
+++ b/pkg/utils/progress.go
@@ -162,8 +162,14 @@ func (p *Progress) AddByteSpinner(name string) *Bar {
 		decor.CurrentKibiByte("% .1f", decor.WCSyncSpaceR),
 		decor.CurrentNoUnit("(%d Bytes)", decor.WCSyncSpaceR),
 	}
-	// FIXME: maybe use EWMA speed
-	decors = append(decors, decor.AverageSpeed(decor.UnitKiB, "  % .1f", decor.WCSyncSpaceR))
+	rt := newRealtimeSpeed()
+	decors = append(decors,
+		// realtime speed with cumulative average in parentheses, e.g.
+		// "52.9 MiB/s (avg 51.0 MiB/s)"; sampled by mpb's render ticker
+		decor.Any(func(s decor.Statistics) string {
+			return rt.update(s.Current, time.Now())
+		}, decor.WCSyncSpaceR),
+	)
 	b := p.Progress.Add(0, newSpinner(),
 		mpb.PrependDecorators(decors...),
 		mpb.BarFillerClearOnComplete(),

--- a/pkg/utils/speed.go
+++ b/pkg/utils/speed.go
@@ -1,0 +1,82 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/VividCortex/ewma"
+	"github.com/vbauerster/mpb/v7/decor"
+)
+
+// speedSampleInterval is the minimum gap between two effective samples. It is
+// slightly larger than mpb's 120ms refresh rate so each sampling window is
+// stable and the reading does not jitter.
+const speedSampleInterval = 1 * time.Second
+
+// realtimeSpeed reports an instantaneous transfer speed (EWMA-smoothed
+// Δbytes/Δt between samples) together with the cumulative average speed since
+// the first sample. It is only ever called by mpb's render loop (serial per
+// bar), so it needs no locking.
+type realtimeSpeed struct {
+	start    time.Time
+	last     int64
+	lastTime time.Time
+	avg      ewma.MovingAverage
+	msg      string
+}
+
+func newRealtimeSpeed() *realtimeSpeed {
+	r := &realtimeSpeed{avg: ewma.NewMovingAverage()}
+	r.msg = r.format(0, 0)
+	return r
+}
+
+// format renders the instantaneous speed with the cumulative average in
+// parentheses, e.g. " 52.9 MiB/s (avg 51.0 MiB/s)".
+func (r *realtimeSpeed) format(inst, avg float64) string {
+	return fmt.Sprintf("% .1f/s (avg % .1f/s)", decor.SizeB1024(int64(inst)), decor.SizeB1024(int64(avg)))
+}
+
+func (r *realtimeSpeed) update(current int64, now time.Time) string {
+	if r.lastTime.IsZero() { // first call: record baseline only
+		r.start = now
+		r.last, r.lastTime = current, now
+		return r.msg
+	}
+	if now.Sub(r.lastTime) < speedSampleInterval { // debounce: reuse last reading
+		return r.msg
+	}
+	dt := now.Sub(r.lastTime).Seconds()
+	delta := current - r.last
+	if delta < 0 { // negative delta (e.g. sync rollback) -> clamp to 0
+		delta = 0
+	}
+	r.avg.Add(float64(delta) / dt)
+	r.last, r.lastTime = current, now
+	var avgSpeed float64
+	if el := now.Sub(r.start).Seconds(); el > 0 {
+		cur := current
+		if cur < 0 {
+			cur = 0
+		}
+		avgSpeed = float64(cur) / el
+	}
+	r.msg = r.format(r.avg.Value(), avgSpeed)
+	return r.msg
+}

--- a/pkg/utils/speed_test.go
+++ b/pkg/utils/speed_test.go
@@ -1,0 +1,81 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// The first effective sample is exact for SimpleEWMA (value starts at 0, so
+// Add(v) sets value=v), which lets us assert the raw bytes/second precisely.
+func TestRealtimeSpeedComputesBytesPerSecond(t *testing.T) {
+	rt := newRealtimeSpeed()
+	base := time.Unix(1600000000, 0)
+	rt.update(0, base)                       // baseline, no sample yet
+	rt.update(1000, base.Add(2*time.Second)) // delta=1000 over 2s -> 500 B/s
+	if got := rt.avg.Value(); got != 500 {
+		t.Fatalf("expected 500 B/s, got %v", got)
+	}
+}
+
+// A second call within speedSampleInterval must be debounced: it returns the
+// cached string and leaves the moving average untouched.
+func TestRealtimeSpeedDebouncesWithinInterval(t *testing.T) {
+	rt := newRealtimeSpeed()
+	base := time.Unix(1600000000, 0)
+	rt.update(0, base)                              // baseline
+	first := rt.update(1000, base.Add(time.Second)) // effective sample -> 1000 B/s
+	if rt.avg.Value() != 1000 {
+		t.Fatalf("setup: expected 1000, got %v", rt.avg.Value())
+	}
+	// only 50ms after the last effective sample (< 300ms) -> debounced
+	second := rt.update(999999, base.Add(time.Second+50*time.Millisecond))
+	if second != first {
+		t.Fatalf("expected debounced msg %q, got %q", first, second)
+	}
+	if rt.avg.Value() != 1000 {
+		t.Fatalf("expected avg unchanged at 1000, got %v", rt.avg.Value())
+	}
+}
+
+// A negative delta (e.g. sync rolls back current via IncrInt64(-n)) must be
+// clamped to 0 so the speed never goes negative. The first sample is exact, so
+// clamped -> 0 while un-clamped would be -500.
+func TestRealtimeSpeedClampsNegativeDelta(t *testing.T) {
+	rt := newRealtimeSpeed()
+	base := time.Unix(1600000000, 0)
+	rt.update(1000, base)                 // baseline last=1000
+	rt.update(500, base.Add(time.Second)) // delta=-500 -> clamp to 0
+	if got := rt.avg.Value(); got != 0 {
+		t.Fatalf("expected clamped 0 B/s, got %v", got)
+	}
+}
+
+// The parenthesised value is the cumulative average since the first sample:
+// current / elapsed. With 600 bytes over 3s total, avg must be 200 B/s.
+func TestRealtimeSpeedAverageSinceStart(t *testing.T) {
+	rt := newRealtimeSpeed()
+	base := time.Unix(1600000000, 0)
+	rt.update(0, base)                             // start
+	rt.update(600, base.Add(time.Second))          // effective sample
+	msg := rt.update(600, base.Add(3*time.Second)) // avg = 600 / 3s = 200 B/s
+	want := rt.format(rt.avg.Value(), 200)
+	if msg != want {
+		t.Fatalf("expected %q, got %q", want, msg)
+	}
+}


### PR DESCRIPTION
## Summary

Backport `eca5788c` from `main` to `ee-5.4`.

- Show EWMA-smoothed realtime throughput in byte progress spinners.
- Keep cumulative average throughput visible alongside realtime speed.

## Why

Make long-running sync and transfer progress easier to observe.

## Validation

- `go test ./pkg/utils -count=1`
- `git diff --check origin/ee-5.4..HEAD`

## Notes

Draft backport PR. Do not merge until explicitly approved.
