### PR TITLE
cmd/sync: handle external links from files-from

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -1021,7 +1021,11 @@ func (fs *FileSystem) doResolve(ctx meta.Context, p string, followLastSymlink bo
 					target = target[len(mp):]
 				} else {
 					fi.name = "file:" + target
-					logger.Errorf("external link: %s -> %s", p, target)
+					linkPath := strings.Join(ss[:i+1], "/")
+					if linkPath == "" {
+						linkPath = "/"
+					}
+					logger.Warnf("external link: %s -> %s (while resolving %s)", linkPath, target, p)
 					return fi, utils.ErrExtlink
 				}
 			} else {

--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -82,6 +82,15 @@ func (f *file) GetTime(t string) time.Time {
 	return f.mtime
 }
 
+func NewSymlink(key, target string) File {
+	return &file{
+		obj{key, int64(len(target)), time.Now(), false, "", ""},
+		"", "",
+		os.ModeSymlink | 0777,
+		true,
+	}
+}
+
 func MarshalObject(o Object) map[string]interface{} {
 	m := make(map[string]interface{})
 	m["key"] = o.Key()

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1893,8 +1893,19 @@ var ignoreFiles int64
 func produceSingleObject(tasks chan<- object.Object, src, dst object.ObjectStorage, key string, config *Config, checkpointMgr *CheckpointManager) error {
 	obj, err := src.Head(ctx, key)
 	if err != nil {
-		logger.Warnf("head %s from %s: %s", key, src, err)
-		return err
+		if config.Links && (errors.Is(err, utils.ErrExtlink) || errors.Is(err, syscall.ENOTSUP) || errors.Is(err, os.ErrNotExist)) {
+			if sl, ok := src.(object.SupportSymlink); ok {
+				if target, e := sl.Readlink(key); e == nil {
+					obj, err = object.NewSymlink(key, target), nil
+				} else {
+					err = fmt.Errorf("readlink %s from %s: %w", key, src, e)
+				}
+			}
+		}
+		if err != nil {
+			logger.Warnf("head %s from %s: %s", key, src, err)
+			return err
+		}
 	}
 	if obj.IsDir() && (!config.Links || !obj.IsSymlink()) {
 		// only `files-from` will hit this case


### PR DESCRIPTION
## Summary

Backport `0f6703c1` from `main` to `ee-5.4`.

- Handle external symbolic links selected through `--files-from`.
- Improve external-link resolution logging.
- Preserve the `ee-5.4` `File.GetTime` API while adding `NewSymlink` during conflict resolution.

## Why

Allow files-from synchronization to represent external links correctly when link copying is enabled.

## Validation

- `go test ./pkg/fs ./pkg/object -run '^$' -count=1`
- `go test ./pkg/sync -count=1`
- `git diff --check origin/ee-5.4..HEAD`

## Notes

Draft backport PR. Do not merge until explicitly approved.
