### PR TITLE
cmd/sync: update multipart upload progress on each read

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -745,9 +745,6 @@ func init() {
 }
 
 func doUploadPart(src, dst object.ObjectStorage, srckey string, off, size int64, key, uploadID string, num int, calChksum bool) (*object.Part, uint32, error) {
-	if limiter != nil {
-		limiter.Wait(size)
-	}
 	start := time.Now()
 	sz := size
 	var part *object.Part
@@ -759,15 +756,16 @@ func doUploadPart(src, dst object.ObjectStorage, srckey string, off, size int64,
 		}
 		defer in.Close()
 		r := &chksumReader{in, 0, calChksum}
+		pr := &withProgress{r}
 		err = utils.ErrNotSUP
 		if obj, ok := dst.(object.SupportUploadPartStream); ok {
-			part, err = obj.UploadPartStream(key, uploadID, num+1, r)
+			part, err = obj.UploadPartStream(key, uploadID, num+1, pr)
 		}
 
 		if errors.Is(err, utils.ErrNotSUP) {
 			data := dynAlloc(int(size))
 			defer dynFree(data)
-			if _, err = io.ReadFull(r, data); err != nil {
+			if _, err = io.ReadFull(pr, data); err != nil {
 				return err
 			}
 			// PartNumber starts from 1
@@ -910,7 +908,6 @@ func doCopyMultiple(src, dst object.ObjectStorage, key string, size int64, mtime
 			parts[num], chksum, copyErr = doCopyRange(src, dst, key, int64(num)*partSize, sz, upload, num, abort, calChksum)
 			chksums[num] = chksumWithSz{chksum, sz}
 			if copyErr == nil {
-				copiedBytes.IncrInt64(sz)
 				if state != nil {
 					uploads.MarkMultipartPart(key, state, parts[num], chksum, calChksum)
 				}


### PR DESCRIPTION
## Summary

Backport `3b0a08d2` from `main` to `ee-5.4`.

- Update multipart upload progress as bytes are read.
- Apply rate limiting and progress accounting through the streaming reader.

## Why

Provide visible progress during individual multipart uploads instead of updating only when a part completes.

## Validation

- `go test ./pkg/sync -count=1`
- `git diff --check origin/ee-5.4..HEAD`

## Review consideration

Please review checkpoint resume semantics carefully: per-read byte accounting can advance before the corresponding multipart part state is persisted.

## Notes

Draft backport PR. Do not merge until explicitly approved.
