### PR TITLE
sync: fail over to local bandwidth limit

### DIFF
--- a/docs/en/guide/sync.md
+++ b/docs/en/guide/sync.md
@@ -319,6 +319,95 @@ parallel-ssh -h hosts.txt -i juicefs mount -d redis://10.10.0.8:6379/1 /jfs-dst 
 juicefs sync --worker host1,host2 /jfs-src /jfs-dst
 ```
 
+### Global traffic control {#global-traffic-control}
+
+`--bwlimit` applies only to a single `juicefs sync` process. When multiple sync processes run concurrently (for example, when using [distributed synchronization](#distributed-sync)), each process enforces its own bandwidth limit independently, so the aggregate bandwidth of all processes may greatly exceed the expected limit.
+
+`--traffic-control-url` solves this by pointing all sync processes to the same centralized traffic-control HTTP server that acts as a shared token-bucket. All processes request bandwidth tokens from the server before transferring data, ensuring that the total throughput across all running instances never exceeds the server-configured rate.
+
+### HTTP API protocol
+
+The sync client and your traffic-control server communicate via a simple JSON-over-HTTP protocol:
+
+| Direction | Method | Path | Body | Description |
+|-----------|--------|------|------|-------------|
+| Request tokens | POST | `<url>` | `{"bytes": N}` | Ask for N bytes of bandwidth. N > 0. |
+| Return unused tokens | POST | `<url>` | `{"bytes": -N}` | Return N bytes of unused tokens to the server. N < 0. |
+
+**Response** (JSON):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `granted` | int64 | Number of bytes actually granted (equal to the requested amount for a blocking server). |
+| `expired` | int64 | Token validity in **milliseconds**. After this window elapses, the client returns any unused tokens, provided it currently has no pending bandwidth demand. |
+
+The client blocks on the POST request until the server responds, so the server's internal token bucket (or any other rate-limiting logic) is what enforces the global limit.
+
+### Reference server implementation
+
+The following is a minimal Go server that implements a global bandwidth limit with an average rate of 3 MB/s and a burst capacity of 10 MB using [`github.com/juju/ratelimit`](https://github.com/juju/ratelimit):
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "log"
+    "net/http"
+
+    "github.com/juju/ratelimit"
+)
+
+var limiter *ratelimit.Bucket
+
+type req struct {
+    // Positive: request tokens. Negative: return unused tokens.
+    Bytes int64 `json:"bytes"`
+}
+type resp struct {
+    Granted int64 `json:"granted"` // bytes granted
+    Expired int64 `json:"expired"` // token validity in milliseconds
+}
+
+func tokenHandler(w http.ResponseWriter, r *http.Request) {
+    body, _ := io.ReadAll(r.Body)
+    var in req
+    json.Unmarshal(body, &in)
+    if in.Bytes > 0 {
+        limiter.Wait(in.Bytes) // blocks until tokens are available
+    }
+    out, _ := json.Marshal(resp{Granted: in.Bytes, Expired: 1000})
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(out)
+}
+
+func main() {
+    // 3 MB/s average rate, 10 MB burst
+    limiter = ratelimit.NewBucketWithRate(3<<20, 10<<20)
+    http.HandleFunc("/token", tokenHandler)
+    fmt.Println("Starting traffic control server on :8080")
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}
+```
+
+### Usage
+
+Start the server on a host reachable by all sync processes, and then pass its token endpoint to each `juicefs sync` call:
+
+```shell
+# Run the traffic control server (once, on any accessible host)
+go run traffic_control_server.go
+
+# Each sync process uses the same URL to share a global bandwidth cap
+juicefs sync --traffic-control-url http://10.0.0.1:8080/token s3://src/ s3://dst/
+```
+
+`--bwlimit` and `--traffic-control-url` can be used together. For each limiter check, sync tries the global traffic-control service first; if the service is unavailable, that check falls back to the local `--bwlimit`. After the service recovers, subsequent checks use the global limit again. Ongoing waits that have already fallen back to `--bwlimit` are not interrupted by recovery. To make the fallback meaningful, set `--bwlimit` to a smaller per-process value than the global cap.
+
+If `--traffic-control-url` is used without `--bwlimit`, there is no local fallback: while the traffic-control service is unavailable, sync transfers without any rate limit (logged as `run without rate limit`), and resumes the global limit once the service recovers.
+
 ## Observation {#observation}
 
 When using `sync` to transfer large files, the progress bar might move slowly or get stuck. If this happens, you can observe the progress using other methods.

--- a/docs/en/reference/command_reference.mdx
+++ b/docs/en/reference/command_reference.mdx
@@ -999,8 +999,8 @@ In which:
 |`--list-depth=1` <VersionAdd>1.1</VersionAdd> |Depth of concurrent `list` operation, default to 1. Read [concurrent `list`](../guide/sync.md#concurrent-list) to learn its usage.|
 |`--no-https`|Do not use HTTPS, default to false.|
 |`--storage-class value` <VersionAdd>1.1</VersionAdd> |the storage class for destination|
-|`--bwlimit=0`|Limit bandwidth in Mbps default to 0 which means unlimited.|
-|`--traffic-control-url value` <VersionAdd>1.4</VersionAdd>|URL of the global traffic control service for coordinating bandwidth across multiple sync instances. The service should expose an HTTP POST endpoint with request body `{"bytes": <requested-bytes>}` and response body `{"granted": <granted-bytes>, "expired": <expire-time-ms>}`.|
+|`--bwlimit=0`|Limit bandwidth in Mbps default to 0 which means unlimited. When used together with `--traffic-control-url`, it acts as a per-process fallback while the global traffic control service is unavailable. Fallback waits already in progress continue under `--bwlimit`, and subsequent waits return to the global limit after recovery. Set it to a smaller value than the global cap to make the fallback meaningful.|
+|`--traffic-control-url value` <VersionAdd>1.4</VersionAdd>|URL of the global traffic control service for coordinating bandwidth across multiple sync instances. The service should expose an HTTP POST endpoint with request body `{"bytes": <requested-bytes>}` and response body `{"granted": <granted-bytes>, "expired": <expire-time-ms>}`. It is tried before `--bwlimit`; if unreachable, current limiter checks fall back to `--bwlimit` (or no limit if unset), and subsequent checks use the global limit again after recovery.|
 
 Usage and API contract for `--traffic-control-url`:
 

--- a/docs/zh_cn/guide/sync.md
+++ b/docs/zh_cn/guide/sync.md
@@ -329,6 +329,95 @@ parallel-ssh -h hosts.txt -i juicefs mount -d redis://10.10.0.8:6379/1 /jfs-dst 
 juicefs sync --worker host1,host2 /jfs-src /jfs-dst
 ```
 
+### 全局流量控制 {#global-traffic-control}
+
+`--bwlimit` 只对单个 `juicefs sync` 进程生效。当多个 sync 进程并发运行（例如使用[分布式同步](#distributed-sync)）时，每个进程各自独立执行限速，所有进程的总带宽之和可能远远超出预期上限。
+
+`--traffic-control-url` 解决了这一问题：将所有 sync 进程都指向同一个中央流量控制 HTTP 服务，每个进程在传输数据前向该服务请求令牌，从而保证所有实例的**总吞吐量**始终不超过服务端配置的速率上限。
+
+### HTTP API 协议
+
+sync 客户端与流量控制服务之间使用简单的 JSON over HTTP 协议通信：
+
+| 方向 | 方法 | 路径 | 请求体 | 说明 |
+|------|------|------|--------|------|
+| 申请令牌 | POST | `<url>` | `{"bytes": N}` | 请求 N 字节的带宽，N > 0 |
+| 归还未用令牌 | POST | `<url>` | `{"bytes": -N}` | 将 N 字节未使用的令牌归还服务端，N < 0 |
+
+**响应体**（JSON）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `granted` | int64 | 实际授予的字节数（阻塞式服务端等于请求量） |
+| `expired` | int64 | 令牌有效期，单位**毫秒**；有效期过后，客户端在当前没有新的带宽需求时会归还未用完的令牌 |
+
+客户端会阻塞在 POST 请求直到服务端响应，因此服务端内部的令牌桶（或其他限速逻辑）即为全局限速的执行者。
+
+### 参考服务端实现
+
+以下是一个最简 Go 服务端示例，使用 [`github.com/juju/ratelimit`](https://github.com/juju/ratelimit) 实现平均 3 MB/s、突发 10 MB 的全局限速：
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "log"
+    "net/http"
+
+    "github.com/juju/ratelimit"
+)
+
+var limiter *ratelimit.Bucket
+
+type req struct {
+    // 正数：申请令牌；负数：归还未用令牌
+    Bytes int64 `json:"bytes"`
+}
+type resp struct {
+    Granted int64 `json:"granted"` // 授予字节数
+    Expired int64 `json:"expired"` // 令牌有效期（毫秒）
+}
+
+func tokenHandler(w http.ResponseWriter, r *http.Request) {
+    body, _ := io.ReadAll(r.Body)
+    var in req
+    json.Unmarshal(body, &in)
+    if in.Bytes > 0 {
+        limiter.Wait(in.Bytes) // 阻塞直到令牌可用
+    }
+    out, _ := json.Marshal(resp{Granted: in.Bytes, Expired: 1000})
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(out)
+}
+
+func main() {
+    // 平均 3 MB/s，突发上限 10 MB
+    limiter = ratelimit.NewBucketWithRate(3<<20, 10<<20)
+    http.HandleFunc("/token", tokenHandler)
+    fmt.Println("流量控制服务已启动，监听 :8080")
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}
+```
+
+### 使用方法
+
+在所有 sync 进程可以访问到的主机上启动服务端，然后在每次 `juicefs sync` 调用时传入令牌端点地址：
+
+```shell
+# 在任意可访问的主机上启动流量控制服务（只需启动一次）
+go run traffic_control_server.go
+
+# 每个 sync 进程使用相同的 URL，共享全局带宽上限
+juicefs sync --traffic-control-url http://10.0.0.1:8080/token s3://src/ s3://dst/
+```
+
+`--bwlimit` 与 `--traffic-control-url` 可以同时使用。每次限速检查都会优先尝试全局流量控制服务；如果服务不可用，本次检查回退到本地 `--bwlimit`。服务恢复后，后续检查重新使用全局限流；已经进入本地 `--bwlimit` 等待的请求不会因恢复而被中断切换。为了让回退真正起到限速作用，应将 `--bwlimit`（单进程上限）设置得比全局上限更小一些。
+
+如果只设置了 `--traffic-control-url` 而没有设置 `--bwlimit`，则没有本地兜底：在流量控制服务不可用期间，sync 会以**不限速**的方式传输（对应日志 `run without rate limit`），待服务恢复后再切回全局限流。
+
 ## 观测和监控 {#observation}
 
 简单来说，用 `sync` 命令拷贝大文件时，进度条可能会迟迟不更新，如果担心命令未能正常工作，可以用其他手段对传输情况进行观测。

--- a/docs/zh_cn/reference/command_reference.mdx
+++ b/docs/zh_cn/reference/command_reference.mdx
@@ -994,8 +994,8 @@ juicefs sync --include='a1/b1' --exclude='a*' --include='b2' --exclude='b?' s3:/
 |`--list-depth=1` <VersionAdd>1.1</VersionAdd>|并发 `list` 目录深度，默认为 1。阅读[并发 `list`](../guide/sync.md#concurrent-list)以了解如何使用。|
 |`--no-https`|不要使用 HTTPS，默认为 false。|
 |`--storage-class value` <VersionAdd>1.1</VersionAdd>|目标端的新建文件的存储类型。|
-|`--bwlimit=0`|限制最大带宽，单位 Mbps，默认为 0 表示不限制。|
-|`--traffic-control-url value` <VersionAdd>1.4</VersionAdd>|全局流量控制服务的 URL，用于在多个 sync 实例间协调带宽。服务需提供 HTTP POST 接口，请求体 `{"bytes": <请求字节数>}`，响应体 `{"granted": <允许字节数>, "expired": <过期时间（毫秒）>}`。|
+|`--bwlimit=0`|限制最大带宽，单位 Mbps，默认为 0 表示不限制。与 `--traffic-control-url` 同时使用时，它作为单进程的兜底限流：全局流量控制服务不可用时，本次限速检查会回退到它；服务恢复后，后续检查重新使用全局限流，已进入本地等待的请求不会被中断切换。建议将其设置得比全局上限更小，才能让兜底真正起到限速作用。|
+|`--traffic-control-url value` <VersionAdd>1.4</VersionAdd>|全局流量控制服务的 URL，用于在多个 sync 实例间协调带宽。服务需提供 HTTP POST 接口，请求体 `{"bytes": <请求字节数>}`，响应体 `{"granted": <允许字节数>, "expired": <过期时间（毫秒）>}`。它会优先于 `--bwlimit` 尝试；不可达时当前限速检查会回退到 `--bwlimit`（未设置则不限速），服务恢复后后续检查重新使用全局限流。|
 
 `--traffic-control-url` 使用方法与接口定义：
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -79,12 +79,15 @@ type mixedLimiter struct {
 }
 
 func (l *mixedLimiter) Wait(count int64) {
-	if l.local != nil {
-		l.local.Wait(count)
+	if l.global != nil && l.global.healthy.Load() {
+		if l.global.wait(count) {
+			return
+		}
 	}
-	if l.global != nil {
-		l.global.wait(count)
+	if l.local == nil {
+		return
 	}
+	l.local.Wait(count)
 }
 
 type globalLimit struct {
@@ -94,7 +97,10 @@ type globalLimit struct {
 	need    int64
 	waiters []*sync.Cond
 
-	address string
+	address   string
+	localBW   int64
+	healthy   atomic.Bool
+	lastProbe time.Time
 }
 type req struct {
 	// Positive numbers indicate a request, negative numbers indicate a payback.
@@ -106,7 +112,17 @@ type resp struct {
 	Expired int64 `json:"expired"` // Millisecond
 }
 
-func (l *globalLimit) request(ask int64) (int64, int64, error) {
+func (l *globalLimit) request(ask int64) (granted int64, expired int64, err error) {
+	defer func() {
+		ok := err == nil
+		if prev := l.healthy.Swap(ok); prev && !ok {
+			if l.localBW > 0 {
+				logger.Warnf("traffic control %s is unavailable, switch to local bwlimit %s", l.address, utils.Mbps(l.localBW))
+			} else {
+				logger.Warnf("traffic control %s is unavailable, run without rate limit", l.address)
+			}
+		}
+	}()
 	r := req{Bytes: ask}
 	data, err := json.Marshal(r)
 	if err != nil {
@@ -118,7 +134,10 @@ func (l *globalLimit) request(ask int64) (int64, int64, error) {
 		if result != nil {
 			status = http.StatusText(result.StatusCode)
 		}
-		logger.Errorf("request traffic control %s failed: %s, http status: %s", l.address, err, status)
+		logger.Warnf("request traffic control %s failed: %s, http status: %s", l.address, err, status)
+		if err == nil {
+			err = fmt.Errorf("http status: %s", status)
+		}
 		return 0, 0, err
 	}
 	defer result.Body.Close()
@@ -127,18 +146,21 @@ func (l *globalLimit) request(ask int64) (int64, int64, error) {
 		return 0, 0, err
 	}
 	res := resp{}
-	if err := json.Unmarshal(content, &res); err != nil {
+	if err = json.Unmarshal(content, &res); err != nil {
 		return 0, 0, err
 	}
 	return res.Granted, res.Expired, nil
 }
 
-func (l *globalLimit) wait(bytes int64) {
+func (l *globalLimit) wait(bytes int64) bool {
 	l.Lock()
 	defer l.Unlock()
 	if bytes <= 0 || l.balance >= bytes && len(l.waiters) == 0 {
 		l.balance -= bytes
-		return
+		return true
+	}
+	if !l.healthy.Load() {
+		return false
 	}
 	l.need += bytes
 
@@ -148,33 +170,55 @@ func (l *globalLimit) wait(bytes int64) {
 		me.Wait()
 	}
 
-	if l.balance < bytes {
-		// request credit for other waiters together
-		ask := l.need - l.balance
-		if ask >= bytes*10 {
-			// don't wait for too long
-			ask = bytes * 10
-		}
-		l.Unlock()
-		granted, expire, err := l.request(ask)
-		l.Lock()
-		if err == nil {
-			l.balance += granted
-			l.due = time.Now().Add(time.Millisecond * time.Duration(expire))
-			logger.Debugf("grant %d from %s until %s", granted, l.address, l.due)
-		}
+	ok := l.balance >= bytes || l.requestMoreLocked(bytes)
+	if ok {
+		l.balance -= bytes
 	}
-
-	l.balance -= bytes
 	l.need -= bytes
 	l.waiters = l.waiters[1:]
 	if len(l.waiters) > 0 {
 		l.waiters[0].Signal()
 	}
+	return ok
+}
+
+func (l *globalLimit) requestMoreLocked(bytes int64) bool {
+	if !l.healthy.Load() {
+		return false
+	}
+	// request credit for other waiters together
+	ask := l.need - l.balance
+	if ask >= bytes*10 {
+		// don't wait for too long
+		ask = bytes * 10
+	}
+	l.Unlock()
+	granted, expire, err := l.request(ask)
+	l.Lock()
+	if err != nil {
+		return false
+	}
+	l.balance += granted
+	l.due = time.Now().Add(time.Millisecond * time.Duration(expire))
+	logger.Debugf("grant %d from %s until %s", granted, l.address, l.due)
+	return true
 }
 
 func (l *globalLimit) checkBalance() {
 	now := time.Now()
+	if !l.healthy.Load() {
+		if time.Since(l.lastProbe) >= time.Second {
+			l.lastProbe = now
+			if _, _, err := l.request(0); err == nil {
+				if l.localBW > 0 {
+					logger.Infof("traffic control %s recovered, switch back to global limit from local bwlimit %s", l.address, utils.Mbps(l.localBW))
+				} else {
+					logger.Infof("traffic control %s recovered, switch back to global limit", l.address)
+				}
+			}
+		}
+		return
+	}
 	l.Lock()
 	if l.balance > 0 && l.need == 0 && l.due.Before(now) {
 		payback := l.balance
@@ -2143,7 +2187,8 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 	}
 	var gLimit *globalLimit
 	if config.TrafficControlURL != "" {
-		gLimit = &globalLimit{address: config.TrafficControlURL}
+		gLimit = &globalLimit{address: config.TrafficControlURL, localBW: config.BWLimit}
+		gLimit.healthy.Store(true)
 		go func() {
 			for {
 				time.Sleep(time.Millisecond * 10)

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -19,16 +19,21 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/juicedata/juicefs/pkg/object"
+	"github.com/juju/ratelimit"
 )
 
 func collectAll(c <-chan object.Object) []string {
@@ -996,5 +1001,134 @@ func TestSyncEncryptLargeFile(t *testing.T) {
 	got, _ := io.ReadAll(r)
 	if !bytes.Equal(got, largeData) {
 		t.Fatalf("decrypted large file mismatch: got %d bytes, want %d", len(got), len(largeData))
+	}
+}
+
+// TestMixedLimiterFailover verifies that the global traffic control takes
+// precedence, falls back to the local bwlimit when the global service is
+// unavailable, and switches back to the global limit once it recovers.
+func TestMixedLimiterFailover(t *testing.T) {
+	var up atomic.Bool
+	up.Store(true)
+	var granted atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !up.Load() {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var in req
+		_ = json.Unmarshal(body, &in)
+		if in.Bytes > 0 {
+			granted.Add(in.Bytes)
+		}
+		out, _ := json.Marshal(resp{Granted: in.Bytes, Expired: 1000})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(out)
+	}))
+	defer srv.Close()
+
+	gLimit := &globalLimit{address: srv.URL}
+	gLimit.healthy.Store(true)
+	// a tiny local limit as fallback
+	bps := float64(1e6)
+	local := ratelimit.NewBucketWithRate(bps, int64(bps))
+	l := &mixedLimiter{global: gLimit, local: local}
+
+	// while healthy, the global service should be used
+	l.Wait(1024)
+	if granted.Load() == 0 {
+		t.Fatalf("expected global service to be used while healthy")
+	}
+	if !gLimit.healthy.Load() {
+		t.Fatalf("expected global limit to stay healthy")
+	}
+
+	// take the service down: the next Wait should mark it unhealthy and fall back
+	up.Store(false)
+	before := granted.Load()
+	l.Wait(1 << 20) // exhausts remaining balance and triggers a failing request
+	if gLimit.healthy.Load() {
+		t.Fatalf("expected global limit to become unhealthy after failure")
+	}
+	// subsequent waits must not increase granted (global is skipped)
+	l.Wait(1024)
+	if granted.Load() != before {
+		t.Fatalf("expected global service to be skipped while unhealthy")
+	}
+
+	// bring the service back and probe for recovery
+	up.Store(true)
+	gLimit.lastProbe = time.Time{} // allow immediate probe
+	gLimit.checkBalance()
+	if !gLimit.healthy.Load() {
+		t.Fatalf("expected global limit to recover after service is back")
+	}
+}
+
+// TestGlobalLimitDrainWaitersOnFailure verifies that when the traffic-control
+// service becomes unavailable, the waiters already queued behind the head do
+// NOT each issue their own failing request. Only the first waiter that detects
+// the failure hits the (dead) service; the rest drain immediately and fall
+// back to the local bwlimit.
+func TestGlobalLimitDrainWaitersOnFailure(t *testing.T) {
+	var down atomic.Bool
+	var downReqs atomic.Int64
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if down.Load() {
+			downReqs.Add(1)
+			<-release // simulate an unresponsive/hung service
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var in req
+		_ = json.Unmarshal(body, &in)
+		out, _ := json.Marshal(resp{Granted: in.Bytes, Expired: 1000})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(out)
+	}))
+	defer srv.Close()
+
+	g := &globalLimit{address: srv.URL}
+	g.healthy.Store(true)
+
+	down.Store(true)
+	const n = 5
+	results := make(chan bool, n)
+	for i := 0; i < n; i++ {
+		go func() { results <- g.wait(1 << 20) }()
+	}
+
+	// wait until all goroutines are queued: the head is hung in request() while
+	// the others block as waiters behind it.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		g.Lock()
+		nw := len(g.waiters)
+		g.Unlock()
+		if nw == n {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waiters did not queue up in time, got %d/%d", nw, n)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// release the hung request so the head fails and the queue drains.
+	close(release)
+	for i := 0; i < n; i++ {
+		if ok := <-results; ok {
+			t.Fatalf("expected wait to fall back (return false) while service is down")
+		}
+	}
+
+	if got := downReqs.Load(); got != 1 {
+		t.Fatalf("expected only 1 request to the down service, got %d", got)
+	}
+	if g.healthy.Load() {
+		t.Fatalf("expected global limit to be marked unhealthy")
 	}
 }


### PR DESCRIPTION
## Summary

Backport `107fbb90` from `main` to `ee-5.4`.

- Prefer global traffic control while the service is healthy.
- Fall back to local `--bwlimit` when the service is unavailable.
- Probe for recovery and switch subsequent waits back to global control.
- Add the corresponding English and Chinese traffic-control documentation.

## Why

Avoid blocking sync indefinitely when the global traffic-control service is temporarily unavailable.

## Validation

- `go test -race ./pkg/sync -run '^(TestMixedLimiterFailover|TestGlobalLimitDrainWaitersOnFailure)$' -count=1`
- `git diff --check origin/ee-5.4..HEAD`

## Behavior note

Without a local `--bwlimit`, sync runs without a rate limit while the global service is unavailable.

## Notes

Draft backport PR. Do not merge until explicitly approved.
