### PR TITLE
object/oss: fix missing crc protection for OSS objects

### DIFF
--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -144,7 +144,7 @@ func (o *ossClient) Put(ctx context.Context, key string, in io.Reader, getters .
 	}
 	if ins, ok := in.(io.ReadSeeker); ok {
 		req.Metadata = make(map[string]string)
-		req.Metadata[oss.HeaderOssMetaPrefix+checksumAlgr] = generateChecksum(ins)
+		req.Metadata[checksumAlgr] = generateChecksum(ins)
 	}
 	var reqId string
 	result, err := o.client.PutObject(ctx, req)


### PR DESCRIPTION
OSS SDK automatically adds `X-Oss-Meta-` prefix to metadata keys. Passing `HeaderOssMetaPrefix` explicitly duplicated the prefix, so a full-object read could not find the checksum and might return data without crc protection.