### PR TITLE
object/oss: fix missing crc protection for OSS objects (#7275)

### DIFF
--- a/pkg/object/oss.go
+++ b/pkg/object/oss.go
@@ -139,7 +139,7 @@ func (o *ossClient) Put(key string, in io.Reader, getters ...AttrGetter) error {
 	}
 	if ins, ok := in.(io.ReadSeeker); ok {
 		req.Metadata = make(map[string]string)
-		req.Metadata[oss.HeaderOssMetaPrefix+checksumAlgr] = generateChecksum(ins)
+		req.Metadata[checksumAlgr] = generateChecksum(ins)
 	}
 	var reqId string
 	result, err := o.client.PutObject(ctx, req)


### PR DESCRIPTION
(cherry picked from commit a84508bffa2403fd192939be0e8438fe4f709ddd)