### PR TITLE
fuse: make size merge and modified check atomic

### DIFF
--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -55,9 +55,7 @@ func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
 	} else if entry.Attr.Typ == meta.TypeFile && fs.v.MergeWriterLength(entry.Inode, entry.Attr, ctx.start) {
-		// Modified since the request started: the merged size may still be changing,
-		// so refresh from meta and leave the timeout at 0 to keep the kernel from
-		// caching a possibly-stale size.
+		// Size may still be changing; refresh from meta and skip attr cache.
 		logger.Debugf("refresh attr for %d", entry.Inode)
 		var nAttr meta.Attr
 		if fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr) == 0 {

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
-
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juicedata/juicefs/pkg/vfs"
@@ -53,21 +52,20 @@ func newFileSystem(conf *vfs.Config, v *vfs.VFS) *fileSystem {
 type setTimeout func(time.Duration)
 
 func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.Attr, set setTimeout) {
-	fs.v.UpdateLength(entry.Inode, entry.Attr) // UpdateLength before ModifiedSince check to avoid TOCTOU race
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
-	} else {
-		if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
-			logger.Debugf("refresh attr for %d", entry.Inode)
-			var nAttr meta.Attr
-			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr)
-			if st == 0 {
-				*entry.Attr = nAttr
-				fs.v.UpdateLength(entry.Inode, entry.Attr) // Merge again in case write appeared during GetAttr
-			}
-		} else {
-			set(fs.conf.AttrTimeout)
+	} else if entry.Attr.Typ == meta.TypeFile && fs.v.MergeWriterLength(entry.Inode, entry.Attr, ctx.start) {
+		// Modified since the request started: the merged size may still be changing,
+		// so refresh from meta and leave the timeout at 0 to keep the kernel from
+		// caching a possibly-stale size.
+		logger.Debugf("refresh attr for %d", entry.Inode)
+		var nAttr meta.Attr
+		if fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr) == 0 {
+			*entry.Attr = nAttr
+			fs.v.MergeWriterLength(entry.Inode, entry.Attr, ctx.start)
 		}
+	} else {
+		set(fs.conf.AttrTimeout)
 	}
 	attrToStat(entry.Inode, entry.Attr, attr)
 }

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -22,19 +22,23 @@ package fuse
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/gofrs/flock"
 	"github.com/google/uuid"
+	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/hanwen/go-fuse/v2/posixtest"
 	"github.com/juicedata/juicefs/pkg/chunk"
 	"github.com/juicedata/juicefs/pkg/meta"
@@ -42,6 +46,106 @@ import (
 	"github.com/juicedata/juicefs/pkg/vfs"
 	"github.com/pkg/xattr"
 )
+
+type mockAttrMeta struct {
+	meta.Meta
+	attr meta.Attr
+}
+
+func (m *mockAttrMeta) GetAttr(ctx meta.Context, inode meta.Ino, attr *meta.Attr) syscall.Errno {
+	*attr = m.attr
+	return 0
+}
+
+// mockAttrDataWriter only needs GetLength; the rest just satisfies DataWriter.
+type mockAttrDataWriter struct {
+	length uint64
+}
+
+func (w *mockAttrDataWriter) Open(inode vfs.Ino, fleng uint64, tierID uint8) vfs.FileWriter {
+	return nil
+}
+func (w *mockAttrDataWriter) Flush(ctx meta.Context, inode vfs.Ino) syscall.Errno { return 0 }
+func (w *mockAttrDataWriter) GetLength(inode vfs.Ino) uint64                      { return w.length }
+func (w *mockAttrDataWriter) Truncate(inode vfs.Ino, length uint64)               {}
+func (w *mockAttrDataWriter) UpdateMtime(inode vfs.Ino, mtime time.Time)          {}
+func (w *mockAttrDataWriter) FlushAll() error                                     { return nil }
+
+// mockAttrDataReader records Truncate calls; the rest just satisfies DataReader.
+type mockAttrDataReader struct {
+	truncated []uint64
+}
+
+func (r *mockAttrDataReader) Open(inode vfs.Ino, length uint64) vfs.FileReader { return nil }
+func (r *mockAttrDataReader) Truncate(inode vfs.Ino, length uint64) {
+	r.truncated = append(r.truncated, length)
+}
+func (r *mockAttrDataReader) Invalidate(inode vfs.Ino, off, length uint64) {}
+
+func setVFSField(t *testing.T, v *vfs.VFS, name string, value interface{}) {
+	t.Helper()
+	field := reflect.ValueOf(v).Elem().FieldByName(name)
+	if !field.IsValid() {
+		t.Fatalf("VFS.%s does not exist", name)
+	}
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+func newReplyAttrMockFS(t *testing.T, ino meta.Ino, start time.Time, metaLength, writerLength uint64) (*fileSystem, *mockAttrDataReader) {
+	t.Helper()
+	reader := &mockAttrDataReader{}
+	v := &vfs.VFS{Meta: &mockAttrMeta{attr: meta.Attr{Full: true, Typ: meta.TypeFile, Nlink: 1, Length: metaLength}}}
+	setVFSField(t, v, "reader", reader)
+	setVFSField(t, v, "writer", &mockAttrDataWriter{length: writerLength})
+	setVFSField(t, v, "modifiedAt", map[vfs.Ino]time.Time{ino: start.Add(time.Millisecond)})
+	return newFileSystem(&vfs.Config{AttrTimeout: time.Second}, v), reader
+}
+
+func TestReplyAttrSkipsCacheForConcurrentModification(t *testing.T) {
+	ino := meta.Ino(2)
+	start := time.Now()
+	fs, _ := newReplyAttrMockFS(t, ino, start, 0, 0)
+	entry := &meta.Entry{Inode: ino, Attr: &meta.Attr{Full: true, Typ: meta.TypeFile, Nlink: 1, Length: 0}}
+	ctx := &fuseContext{Context: context.Background(), start: start, header: &fuse.InHeader{}}
+	var attr fuse.Attr
+	timeoutSet := false
+
+	fs.replyAttr(ctx, entry, &attr, func(time.Duration) { timeoutSet = true })
+
+	if timeoutSet {
+		t.Fatalf("replyAttr cached an attr that was modified after request start")
+	}
+}
+
+func TestReplyAttrDoesNotTruncateReaderWithStaleLength(t *testing.T) {
+	ino := meta.Ino(2)
+	start := time.Now()
+	fs, reader := newReplyAttrMockFS(t, ino, start, 0, 0)
+	entry := &meta.Entry{Inode: ino, Attr: &meta.Attr{Full: true, Typ: meta.TypeFile, Nlink: 1, Length: 0}}
+	ctx := &fuseContext{Context: context.Background(), start: start, header: &fuse.InHeader{}}
+	var attr fuse.Attr
+
+	fs.replyAttr(ctx, entry, &attr, func(time.Duration) {})
+
+	if len(reader.truncated) != 0 {
+		t.Fatalf("replyAttr truncated reader with stale attr length: %v", reader.truncated)
+	}
+}
+
+func TestReplyAttrMergesWriterLengthWhenModified(t *testing.T) {
+	ino := meta.Ino(2)
+	start := time.Now()
+	fs, _ := newReplyAttrMockFS(t, ino, start, 0, 100)
+	entry := &meta.Entry{Inode: ino, Attr: &meta.Attr{Full: true, Typ: meta.TypeFile, Nlink: 1, Length: 0}}
+	ctx := &fuseContext{Context: context.Background(), start: start, header: &fuse.InHeader{}}
+	var attr fuse.Attr
+
+	fs.replyAttr(ctx, entry, &attr, func(time.Duration) {})
+
+	if entry.Attr.Length != 100 {
+		t.Fatalf("replyAttr dropped buffered writer length: got %d, want 100", entry.Attr.Length)
+	}
+}
 
 func format(url string) {
 	m := meta.NewClient(url, nil)

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -426,17 +426,17 @@ func (v *VFS) Opendir(ctx Context, ino Ino, flags uint32) (fh uint64, err syscal
 	return
 }
 
-// mergeLength merges writer length and syncs reader length.
-func (v *VFS) mergeLength(inode Ino, attr *meta.Attr) {
+// mergeWriterLen merges the in-memory writer length into attr.Length.
+func (v *VFS) mergeWriterLen(inode Ino, attr *meta.Attr) {
 	if length := v.writer.GetLength(inode); length > attr.Length {
 		attr.Length = length
 	}
-	v.reader.Truncate(inode, attr.Length)
 }
 
 func (v *VFS) UpdateLength(inode Ino, attr *meta.Attr) {
 	if attr.Full && attr.Typ == meta.TypeFile {
-		v.mergeLength(inode, attr)
+		v.mergeWriterLen(inode, attr)
+		v.reader.Truncate(inode, attr.Length)
 	}
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -426,13 +426,17 @@ func (v *VFS) Opendir(ctx Context, ino Ino, flags uint32) (fh uint64, err syscal
 	return
 }
 
+// mergeLength merges writer length and syncs reader length.
+func (v *VFS) mergeLength(inode Ino, attr *meta.Attr) {
+	if length := v.writer.GetLength(inode); length > attr.Length {
+		attr.Length = length
+	}
+	v.reader.Truncate(inode, attr.Length)
+}
+
 func (v *VFS) UpdateLength(inode Ino, attr *meta.Attr) {
 	if attr.Full && attr.Typ == meta.TypeFile {
-		length := v.writer.GetLength(inode)
-		if length > attr.Length {
-			attr.Length = length
-		}
-		v.reader.Truncate(inode, attr.Length)
+		v.mergeLength(inode, attr)
 	}
 }
 

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -564,6 +564,25 @@ func (w *dataWriter) GetLength(inode Ino) uint64 {
 	return 0
 }
 
+// MergeWriterLength merges the in-memory writer length into attr.Length, syncs the
+// reader length, and reports whether ino was modified since start, doing it all
+// atomically under modM.
+//
+// A writer is freed only after invalidateAttr (which also takes modM) runs on the
+// close path, so within this critical section either the writer is still alive and
+// its length is authoritative, or modifiedAt is already recorded. Therefore a
+// "not modified" result guarantees the merged length is trustworthy and cacheable,
+// while a "modified" result tells the caller not to cache the (possibly stale) size.
+func (v *VFS) MergeWriterLength(ino Ino, attr *meta.Attr, start time.Time) (modified bool) {
+	v.modM.Lock()
+	defer v.modM.Unlock()
+	if t, ok := v.modifiedAt[ino]; ok && t.After(start) {
+		modified = true
+	}
+	v.mergeLength(ino, attr)
+	return
+}
+
 func (w *dataWriter) Truncate(inode Ino, len uint64) {
 	f := w.find(inode)
 	if f != nil {

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -564,15 +564,9 @@ func (w *dataWriter) GetLength(inode Ino) uint64 {
 	return 0
 }
 
-// MergeWriterLength merges the in-memory writer length into attr.Length, syncs the
-// reader length, and reports whether ino was modified since start, doing it all
-// atomically under modM.
-//
-// A writer is freed only after invalidateAttr (which also takes modM) runs on the
-// close path, so within this critical section either the writer is still alive and
-// its length is authoritative, or modifiedAt is already recorded. Therefore a
-// "not modified" result guarantees the merged length is trustworthy and cacheable,
-// while a "modified" result tells the caller not to cache the (possibly stale) size.
+// MergeWriterLength merges the in-memory writer length into attr.Length and reports
+// whether ino was modified since start. Returns true if the size may be stale and
+// should not be cached. Runs atomically under modM.
 func (v *VFS) MergeWriterLength(ino Ino, attr *meta.Attr, start time.Time) (modified bool) {
 	v.modM.Lock()
 	defer v.modM.Unlock()

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -567,14 +567,25 @@ func (w *dataWriter) GetLength(inode Ino) uint64 {
 // MergeWriterLength merges the in-memory writer length into attr.Length and reports
 // whether ino was modified since start. Returns true if the size may be stale and
 // should not be cached. Runs atomically under modM.
-func (v *VFS) MergeWriterLength(ino Ino, attr *meta.Attr, start time.Time) (modified bool) {
+//
+// The writer length is always merged so the reported size never drops below data
+// that is buffered but not yet in meta. The reader length is only synced when the
+// size is trustworthy (not modified since start): a stale attr could otherwise
+// re-expand a reader that a concurrent truncate just shrank.
+func (v *VFS) MergeWriterLength(ino Ino, attr *meta.Attr, start time.Time) bool {
 	v.modM.Lock()
 	defer v.modM.Unlock()
+	modified := false
 	if t, ok := v.modifiedAt[ino]; ok && t.After(start) {
 		modified = true
 	}
-	v.mergeLength(ino, attr)
-	return
+	if attr.Full && attr.Typ == meta.TypeFile {
+		v.mergeWriterLen(ino, attr)
+		if !modified {
+			v.reader.Truncate(ino, attr.Length)
+		}
+	}
+	return modified
 }
 
 func (w *dataWriter) Truncate(inode Ino, len uint64) {

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -842,12 +842,12 @@ func (j *juice) Readdir(path string,
 		for _, e := range entries {
 			name := string(e.Name)
 			if full {
-				if j.vfs.ModifiedSince(e.Inode, readAt) {
+				if j.vfs.MergeWriterLength(e.Inode, e.Attr, readAt) {
 					if e2, err := j.vfs.GetAttr(ctx, e.Inode, 0); err == 0 {
 						e.Attr = e2.Attr
+						j.vfs.MergeWriterLength(e.Inode, e.Attr, readAt)
 					}
 				}
-				j.vfs.UpdateLength(e.Inode, e.Attr)
 				j.attrToStat(e.Inode, e.Attr, &st)
 				ok = fill(name, &st, 0)
 			} else {


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/7271

Introduce VFS.MergeWriterLength to atomically combine modified-since detection with writer-length merge (and reader length sync) under modM.
Use it in FUSE replyAttr and WinFSP readdir-plus stat fill, including re-merge after GetAttr refresh, to avoid stale size caching and split-check TOCTOU races.
Also refactor UpdateLength to reuse a shared mergeLength helper.

增加vfs.MergeWriterLength，用于在modLock 下原子化的将 上次修改时间检测和 writer.length合并结合。
在fuse.replyAttr和 winfsp的 readdir-plus中使用 这个功能，可以解决之前遇到的一系列竞态问题，详细case如下：


case1: (Initial stale size issue)  
t0: Process p1 calls write to write 100 bytes, then calls close(). Inside close(), it needs to wait for commitThread.  
t1: Process p2 calls stat, first invoking meta.GetAttr() and obtaining a size of 0 (since commitThread has not yet completed).  
t2: Process p2 calls MergeWriterLength, retrieving the correct writer.Length for merging. Due to the lock, close() will wait until this operation completes before releasing the writer.  
Conclusion: ✅ 
case2:

t0: Process p1 calls write to write 100 bytes, then calls close(). Inside close(), it needs to wait for commitThread.  
t1: Process p2 calls stat, first invoking meta.GetAttr() and obtaining size 0 (because commitThread has not yet completed).  
t2: Process p1 completes the commit and releases the writer.  
t3: Process p2 calls mergeWriterLength, detects that modifiedTime has changed, and triggers a second m.GetAttr().  
Conclusion: ✅ 
case3:  

t0: Process p2 calls stat first, invoking meta.GetAttr() to get size 0.  
t1: Process p1 calls write to write 100 bytes, then close(), waiting for commitThread.  
t2: Process p2 calls MergeWriterLength, obtaining the correct writer.Length for merging. Since a lock is held, close() will wait until this operation completes before releasing the writer.  
Conclusion: ✅ 

case4:
t0: Process p2 first calls stat, invoking meta.GetAttr() to obtain a size of 0.  
t1: Process p2 calls MergeWriterLength; the size remains 0.  
t2: Process p1 begins writing 100 bytes and completes all close operations.  
t3: Process p2 returns result 0 to the kernel, which is still an outdated value.  
The correctness of this case is guaranteed by the kernel. If the write occurs after the stat, the kernel can recognize it as stale via attr_version and will not cache it.  
Conclusion: ✅


case1:（最初的stale size问题）
t0: p1 进程调用write 写入100字节，然后调用close() ,close内部需要等待commitThread
t1: p2 进程调用stat，先调用meta.GetAttr() 得到size 0 (因为commitThread还未完成)
t2: p2 进程调用MergeWriterLength，拿到正确的writer.Length进行merge。因为加了锁，此时close会等待这里完成才释放writer
结论：✅

case2: 
t0: p1 进程调用write 写入100字节，然后调用close() ,close内部需要等待commitThread
t1: p2 进程调用stat，先调用meta.GetAttr() 得到size 0 (因为commitThread还未完成)
t2: p1 进程 commit完成，释放writer
t3: p2 调用mergeWriterLength，发现modifiedTime被更改，触发二次m.GetAttr()。
结论：✅

case3：
t0: p2进程 先stat，调用meta.GetAttr() 拿到size 0
t1: p1 进程调用write写入100字节，然后close() 等待commitThread
t2: p2 进程调用MergeWriterLength，拿到正确的writer.Length进行merge。因为加了锁，此时close会等待这里完成才释放writer
结论：✅

case4:
t0: p2进程 先stat，调用meta.GetAttr() 拿到size 0
t1: p2 进程调用MergeWriterLength，size依然是0
t2: p1 进程开始write 100字节 ，并完成所有close操作。
t3: p2 返回结果 0 给内核，依然是过期的结果。
这个case的正确性由内核保证，如果write发生在stat以后，kernel可以通过attr_version识别出这是一个过期的结果，不会缓存
结论：✅


