### PR TITLE
 fs: When a symlink is found with doResolve(), the subsequent path needs to be concatenated.

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -1031,12 +1031,18 @@ func (fs *FileSystem) doResolve(ctx meta.Context, p string, followLastSymlink bo
 			} else {
 				target = path.Join(strings.Join(ss[:i], "/"), target)
 			}
-			fi, err = fs.doResolve(ctx, target, followLastSymlink, visited)
-			if err != 0 {
-				return
+			hasRemaining := false
+			for _, comp := range ss[i+1:] {
+				if comp != "" {
+					target = target + "/" + comp
+					hasRemaining = true
+				}
 			}
-			inode = fi.Inode()
-			attr = fi.attr
+			fi, err = fs.doResolve(ctx, target, followLastSymlink, visited)
+			if err == 0 && fi != nil && !hasRemaining {
+				fi.name = name
+			}
+			return
 		}
 		fi.name = name
 		parent = inode

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -55,9 +55,7 @@ func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
 	} else if entry.Attr.Typ == meta.TypeFile && fs.v.MergeWriterLength(entry.Inode, entry.Attr, ctx.start) {
-		// Modified since the request started: the merged size may still be changing,
-		// so refresh from meta and leave the timeout at 0 to keep the kernel from
-		// caching a possibly-stale size.
+		// Size may still be changing; refresh from meta and skip attr cache.
 		logger.Debugf("refresh attr for %d", entry.Inode)
 		var nAttr meta.Attr
 		if fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr) == 0 {

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
-
 	"github.com/juicedata/juicefs/pkg/meta"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/juicedata/juicefs/pkg/vfs"
@@ -53,21 +52,20 @@ func newFileSystem(conf *vfs.Config, v *vfs.VFS) *fileSystem {
 type setTimeout func(time.Duration)
 
 func (fs *fileSystem) replyAttr(ctx *fuseContext, entry *meta.Entry, attr *fuse.Attr, set setTimeout) {
-	fs.v.UpdateLength(entry.Inode, entry.Attr) // UpdateLength before ModifiedSince check to avoid TOCTOU race
 	if vfs.IsSpecialNode(entry.Inode) {
 		set(time.Hour)
-	} else {
-		if entry.Attr.Typ == meta.TypeFile && fs.v.ModifiedSince(entry.Inode, ctx.start) {
-			logger.Debugf("refresh attr for %d", entry.Inode)
-			var nAttr meta.Attr
-			st := fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr)
-			if st == 0 {
-				*entry.Attr = nAttr
-				fs.v.UpdateLength(entry.Inode, entry.Attr) // Merge again in case write appeared during GetAttr
-			}
-		} else {
-			set(fs.conf.AttrTimeout)
+	} else if entry.Attr.Typ == meta.TypeFile && fs.v.MergeWriterLength(entry.Inode, entry.Attr, ctx.start) {
+		// Modified since the request started: the merged size may still be changing,
+		// so refresh from meta and leave the timeout at 0 to keep the kernel from
+		// caching a possibly-stale size.
+		logger.Debugf("refresh attr for %d", entry.Inode)
+		var nAttr meta.Attr
+		if fs.v.Meta.GetAttr(ctx, entry.Inode, &nAttr) == 0 {
+			*entry.Attr = nAttr
+			fs.v.MergeWriterLength(entry.Inode, entry.Attr, ctx.start)
 		}
+	} else {
+		set(fs.conf.AttrTimeout)
 	}
 	attrToStat(entry.Inode, entry.Attr, attr)
 }

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -426,13 +426,17 @@ func (v *VFS) Opendir(ctx Context, ino Ino, flags uint32) (fh uint64, err syscal
 	return
 }
 
+// mergeLength merges writer length and syncs reader length.
+func (v *VFS) mergeLength(inode Ino, attr *meta.Attr) {
+	if length := v.writer.GetLength(inode); length > attr.Length {
+		attr.Length = length
+	}
+	v.reader.Truncate(inode, attr.Length)
+}
+
 func (v *VFS) UpdateLength(inode Ino, attr *meta.Attr) {
 	if attr.Full && attr.Typ == meta.TypeFile {
-		length := v.writer.GetLength(inode)
-		if length > attr.Length {
-			attr.Length = length
-		}
-		v.reader.Truncate(inode, attr.Length)
+		v.mergeLength(inode, attr)
 	}
 }
 

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -564,6 +564,25 @@ func (w *dataWriter) GetLength(inode Ino) uint64 {
 	return 0
 }
 
+// MergeWriterLength merges the in-memory writer length into attr.Length, syncs the
+// reader length, and reports whether ino was modified since start, doing it all
+// atomically under modM.
+//
+// A writer is freed only after invalidateAttr (which also takes modM) runs on the
+// close path, so within this critical section either the writer is still alive and
+// its length is authoritative, or modifiedAt is already recorded. Therefore a
+// "not modified" result guarantees the merged length is trustworthy and cacheable,
+// while a "modified" result tells the caller not to cache the (possibly stale) size.
+func (v *VFS) MergeWriterLength(ino Ino, attr *meta.Attr, start time.Time) (modified bool) {
+	v.modM.Lock()
+	defer v.modM.Unlock()
+	if t, ok := v.modifiedAt[ino]; ok && t.After(start) {
+		modified = true
+	}
+	v.mergeLength(ino, attr)
+	return
+}
+
 func (w *dataWriter) Truncate(inode Ino, len uint64) {
 	f := w.find(inode)
 	if f != nil {

--- a/pkg/vfs/writer.go
+++ b/pkg/vfs/writer.go
@@ -564,15 +564,9 @@ func (w *dataWriter) GetLength(inode Ino) uint64 {
 	return 0
 }
 
-// MergeWriterLength merges the in-memory writer length into attr.Length, syncs the
-// reader length, and reports whether ino was modified since start, doing it all
-// atomically under modM.
-//
-// A writer is freed only after invalidateAttr (which also takes modM) runs on the
-// close path, so within this critical section either the writer is still alive and
-// its length is authoritative, or modifiedAt is already recorded. Therefore a
-// "not modified" result guarantees the merged length is trustworthy and cacheable,
-// while a "modified" result tells the caller not to cache the (possibly stale) size.
+// MergeWriterLength merges the in-memory writer length into attr.Length and reports
+// whether ino was modified since start. Returns true if the size may be stale and
+// should not be cached. Runs atomically under modM.
 func (v *VFS) MergeWriterLength(ino Ino, attr *meta.Attr, start time.Time) (modified bool) {
 	v.modM.Lock()
 	defer v.modM.Unlock()

--- a/pkg/winfsp/winfs.go
+++ b/pkg/winfsp/winfs.go
@@ -842,12 +842,12 @@ func (j *juice) Readdir(path string,
 		for _, e := range entries {
 			name := string(e.Name)
 			if full {
-				if j.vfs.ModifiedSince(e.Inode, readAt) {
+				if j.vfs.MergeWriterLength(e.Inode, e.Attr, readAt) {
 					if e2, err := j.vfs.GetAttr(ctx, e.Inode, 0); err == 0 {
 						e.Attr = e2.Attr
+						j.vfs.MergeWriterLength(e.Inode, e.Attr, readAt)
 					}
 				}
-				j.vfs.UpdateLength(e.Inode, e.Attr)
 				j.attrToStat(e.Inode, e.Attr, &st)
 				ok = fill(name, &st, 0)
 			} else {

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -133,6 +133,7 @@ const (
 	ENOTEMPTY = -0x27
 	ENODATA   = -0x3d
 	ENOTSUP   = -0x5f
+	ELOOP     = -0x28
 )
 
 func errno(err error) int32 {
@@ -178,6 +179,8 @@ func errno(err error) int32 {
 		return ENODATA
 	case syscall.ENOTSUP:
 		return ENOTSUP
+	case syscall.ELOOP:
+		return ELOOP
 	default:
 		logger.Warnf("unknown errno %d: %s", eno, err)
 		return -int32(eno)


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/7295