### PR TITLE
meta: add sync option for badger metadata engine

### DIFF
--- a/docs/en/reference/how_to_set_up_metadata_engine.md
+++ b/docs/en/reference/how_to_set_up_metadata_engine.md
@@ -190,6 +190,16 @@ When being used as the metadata storage engine for JuiceFS, KeyDB functions the 
 
 When using BadgerDB as the JuiceFS metadata storage engine, use `badger://` to specify the database path.
 
+You can append query options to the Badger metadata URL:
+
+- `sync=true|false`: controls whether Badger enables sync-on-commit (`SyncWrites`). Default is `false` for better write performance.
+
+For example:
+
+```shell
+juicefs format badger://$HOME/badger-data?sync=true myjfs
+```
+
 #### Create a file system
 
 You only need to create a file system for use, and there is no need to create a BadgerDB database in advance.

--- a/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
+++ b/docs/zh_cn/reference/how_to_set_up_metadata_engine.md
@@ -177,6 +177,16 @@ KeyDB 的 Active Replication 功能是异步复制的，可能会导致一致性
 
 使用 BadgerDB 作为 JuiceFS 元数据存储引擎时，使用 `badger://` 协议头指定数据库路径。
 
+可以在 Badger 元数据 URL 中追加 query 参数：
+
+- `sync=true|false`：控制 Badger 是否开启提交时同步（`SyncWrites`），默认值是 `false`，以获得更好的写入性能。
+
+例如：
+
+```shell
+juicefs format badger://$HOME/badger-data?sync=true myjfs
+```
+
 #### 创建文件系统
 
 无需提前创建 BadgerDB 数据库，直接创建文件系统即可：

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -265,7 +265,7 @@ func newBadgerClient(addr string) (tkvClient, error) {
 		}
 		syncValue := strings.ToLower(query.Get("sync"))
 		switch syncValue {
-		case "", "false":
+		case "false":
 			opt.SyncWrites = false
 		case "true":
 			opt.SyncWrites = true

--- a/pkg/meta/tkv_badger.go
+++ b/pkg/meta/tkv_badger.go
@@ -22,8 +22,10 @@ package meta
 import (
 	"bytes"
 	"context"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -254,7 +256,24 @@ func (c *badgerClient) close() error {
 func (c *badgerClient) gc() {}
 
 func newBadgerClient(addr string) (tkvClient, error) {
-	opt := badger.DefaultOptions(addr)
+	dataPath, queryStr, _ := strings.Cut(addr, "?")
+	opt := badger.DefaultOptions(dataPath)
+	if queryStr != "" {
+		query, err := url.ParseQuery(queryStr)
+		if err != nil {
+			return nil, err
+		}
+		syncValue := strings.ToLower(query.Get("sync"))
+		switch syncValue {
+		case "", "false":
+			opt.SyncWrites = false
+		case "true":
+			opt.SyncWrites = true
+		default:
+			logger.Warnf("invalid badger sync option %q, fallback to false", syncValue)
+			opt.SyncWrites = false
+		}
+	}
 	opt.Logger = utils.GetLogger("badger")
 	opt.MetricsEnabled = false
 	client, err := badger.Open(opt)

--- a/pkg/meta/tkv_test.go
+++ b/pkg/meta/tkv_test.go
@@ -369,6 +369,39 @@ func TestBadgerSimpleTxnReadOnly(t *testing.T) {
 	}
 }
 
+func TestBadgerSyncOption(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name     string
+		addr     string
+		expected bool
+	}{
+		{name: "default false", addr: root + "/default", expected: false},
+		{name: "sync true", addr: root + "/true?sync=true", expected: true},
+		{name: "sync false", addr: root + "/false?sync=false", expected: false},
+		{name: "sync invalid 1", addr: root + "/invalid1?sync=1", expected: false},
+		{name: "sync invalid 0", addr: root + "/invalid0?sync=0", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := newBadgerClient(tt.addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.close()
+
+			bc, ok := client.(*badgerClient)
+			if !ok {
+				t.Fatalf("unexpected client type %T", client)
+			}
+			if got := bc.client.Opts().SyncWrites; got != tt.expected {
+				t.Fatalf("sync option mismatch: got %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestBadgerDeleteTxnTooBig(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- add `sync` query option for Badger metadata URL (`badger://...?...`)
- map `sync=true|false` to Badger `SyncWrites` (default: false)
- treat invalid values (including `sync=1|0`) as false and log a warning
- add Badger tests for default/true/false/invalid values
- update Badger metadata docs in English and Chinese

## Testing
- `go test ./pkg/meta -run 'TestBadger(SyncOption|Client|KV|ScanKeysOnlyNilValues|SimpleTxnReadOnly|DeleteTxnTooBig)$'`

## Notes
- `make test.meta.core` requires Redis in this environment and fails at `TestRedisClient` when `127.0.0.1:6379` is unavailable.

Closes #7249
