### PR TITLE
test: sync paths in bundles after directory rename

### DIFF
--- a/.github/scripts/hypo/fs.py
+++ b/.github/scripts/hypo/fs.py
@@ -136,6 +136,26 @@ class JuicefsMachine(RuleBasedStateMachine):
         else:
             return rule in self.INCLUDE_RULES
 
+    def _update_paths_after_rename(self, old_path, new_path):
+        if not old_path:
+            return
+
+        old_prefix = old_path + os.sep
+        new_prefix = new_path + os.sep
+
+        for name in ('files', 'folders', 'entry_with_acl'):
+            bundle = self.bundles.get(name, [])
+            for i, entry in enumerate(bundle):
+                if isinstance(entry, str) and entry.startswith(old_prefix):
+                    bundle[i] = new_prefix + entry[len(old_prefix):]
+
+        xattr_bundle = self.bundles.get('xattrs', [])
+        for i, entry in enumerate(xattr_bundle):
+            if (isinstance(entry, tuple) and len(entry) == 2
+                    and isinstance(entry[0], str)
+                    and entry[0].startswith(old_prefix)):
+                xattr_bundle[i] = (new_prefix + entry[0][len(old_prefix):], entry[1])
+
     @rule(
         entry = Entries,
         user = st.sampled_from(SUDO_USERS)
@@ -356,7 +376,9 @@ class JuicefsMachine(RuleBasedStateMachine):
         if isinstance(result1, Exception):
             return entry
         else:
-            return os.path.join(parent, new_entry_name)
+            new_path = os.path.join(parent, new_entry_name)
+            self._update_paths_after_rename(entry, new_path)
+            return new_path
         
 
     @rule( target=Files, entry = Files.filter(lambda x: x != multiple()),


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/7315

When a directory is successfully renamed, recursively update paths in other
Bundles (Files, entry_with_acl, Xattrs) to maintain consistency with the
actual filesystem state.

Add _update_paths_after_rename() helper that:
- Walks all path-based bundles and updates entries with old_path prefix
- Handles both string paths and tuple-based xattrs  
- Protects root path from unintended rewrites