### PR TITLE
ci: use distro fusermount3 for unprivileged tests

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,6 +16,20 @@ runs:
         go-version: 'oldstable'
         cache: true
 
+    - name: Use distro fusermount3
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        fusermount_bin=/usr/bin/fusermount3
+        if [[ ! -x "$fusermount_bin" || ! -u "$fusermount_bin" || "$(stat -c %u "$fusermount_bin")" != "0" ]]; then
+          echo "::error::$fusermount_bin must be an executable setuid-root helper"
+          exit 1
+        fi
+        helper_dir="$RUNNER_TEMP/juicefs-fuse-bin"
+        mkdir -p "$helper_dir"
+        ln -sf "$fusermount_bin" "$helper_dir/fusermount3"
+        echo "$helper_dir" >> "$GITHUB_PATH"
+
     - name: Change go version for root user
       shell: bash
       run: |

--- a/.github/workflows/rmfiles.yml
+++ b/.github/workflows/rmfiles.yml
@@ -7,12 +7,14 @@ on:
       - 'release-**'
     paths:
       - '**/rmfiles.yml'
+      - '.github/actions/build/action.yml'
   pull_request:
     branches:
       - 'main'
       - 'release-**'
     paths:
       - '**/rmfiles.yml'
+      - '.github/actions/build/action.yml'
   schedule:
     - cron:  '0 20 * * *'
   workflow_dispatch:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -18,16 +18,18 @@ on:
     branches:
       - 'main'
       - 'release-*'
-    paths-ignore:
-      - '.autocorrectrc'
-      - '.markdownlint-cli2.jsonc'
-      - 'package*.json'
-      - 'docs/**'
-      - '**.md'
-      - '.github/**'
-      - '!.github/workflows/unittests.yml'
-      - '**.java'
-      - '**/pom.xml'
+    paths:
+      - '**'
+      - '!.autocorrectrc'
+      - '!.markdownlint-cli2.jsonc'
+      - '!package*.json'
+      - '!docs/**'
+      - '!**.md'
+      - '!.github/**'
+      - '.github/actions/build/action.yml'
+      - '.github/workflows/unittests.yml'
+      - '!**.java'
+      - '!**/pom.xml'
   workflow_dispatch:
     inputs:
       debug:


### PR DESCRIPTION
## What changed

- Prefer the distro-provided setuid-root `fusermount3` in the shared Linux build action.
- Validate that `/usr/bin/fusermount3` is executable, owned by root, and has the setuid bit before exposing it through a targeted PATH shim.
- Run `unittests` and `rmr-test` when the shared build action changes.
- Correct the pull-request path filter in `unittests.yml` so selected CI files can be re-included.

## Why

The updated `ubuntu-22.04` runner image places `/usr/local/bin/fusermount3` before the distro helper in PATH. That binary is not setuid-root, so unprivileged FUSE mounts fail with `Operation not permitted`. This affected both `pkg/fuse`'s `TestFUSE` and CI workflows that invoke `juicefs mount` without sudo.

The fix keeps JuiceFS running as the normal runner user and changes only which `fusermount3` helper is resolved.

## Validation

- YAML parsing for all modified CI files
- `actionlint` for the modified workflows
- `git diff --check`

The updated workflow triggers cover both `test.pkg` and `rmr-test` on this PR.