### PR TITLE
meta: redis session heartbeats collapse at scale due to global-key WATCH contention

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -279,6 +279,7 @@ type baseMeta struct {
 	txlocks      [nlocks]sync.Mutex // Pessimistic locks to reduce conflict
 	subTrash     internalNode
 	sid          uint64
+	sessionJSON  atomic.Value // []byte
 	nextTxnId    uint64
 	of           *openfiles
 	removedFiles map[Ino]bool
@@ -761,7 +762,15 @@ func (m *baseMeta) newSessionInfo() []byte {
 	if err != nil {
 		panic(err) // marshal SessionInfo should never fail
 	}
+	m.sessionJSON.Store(buf) // keep session info unchanged throughout its lifecycle
 	return buf
+}
+
+func (m *baseMeta) currentSessionInfo() []byte {
+	if data := m.sessionJSON.Load(); data != nil {
+		return data.([]byte)
+	}
+	return m.newSessionInfo()
 }
 
 func (m *baseMeta) NewSession(record bool) error {

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -574,6 +574,19 @@ func testMetaClient(t *testing.T, m Meta) {
 	if base.sid != ses[0].Sid {
 		t.Fatalf("my sid %d != registered sid %d", base.sid, ses[0].Sid)
 	}
+	if err = base.en.doCleanStaleSession(base.sid); err != nil {
+		t.Fatalf("clean session: %s", err)
+	}
+	if err = base.en.doRefreshSession(); err != nil {
+		t.Fatalf("refresh session: %s", err)
+	}
+	restored, err := m.GetSession(base.sid, false)
+	if err != nil {
+		t.Fatalf("get restored session: %s", err)
+	}
+	if !reflect.DeepEqual(ses[0].SessionInfo, restored.SessionInfo) { // session should remain unchanged even after rejoining
+		t.Fatalf("restored session info changed: %+v != %+v", restored.SessionInfo, ses[0].SessionInfo)
+	}
 	go m.CleanStaleSessions(Background())
 
 	var parent, inode, dummyInode Ino

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -90,12 +90,11 @@ import (
 
 type redisMeta struct {
 	*baseMeta
-	rdb         redis.UniversalClient
-	prefix      string
-	shaLookup   string // The SHA returned by Redis for the loaded `scriptLookup`
-	shaResolve  string // The SHA returned by Redis for the loaded `scriptResolve`
-	cache       *redisCache
-	sessionJSON atomic.Value // []byte
+	rdb        redis.UniversalClient
+	prefix     string
+	shaLookup  string // The SHA returned by Redis for the loaded `scriptLookup`
+	shaResolve string // The SHA returned by Redis for the loaded `scriptResolve`
+	cache      *redisCache
 }
 
 var _ Meta = (*redisMeta)(nil)
@@ -446,7 +445,6 @@ func (m *redisMeta) doNewSession(sinfo []byte, update bool) error {
 	ctx := Background()
 	ssid := strconv.FormatUint(m.sid, 10)
 	expire := m.expireTime()
-	m.sessionJSON.Store(sinfo)
 	_, err := m.rdb.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 		pipe.ZAdd(ctx, m.allSessions(), redis.Z{Score: float64(expire), Member: ssid})
 		pipe.HSet(ctx, m.sessionInfos(), ssid, sinfo)
@@ -470,15 +468,6 @@ func (m *redisMeta) doNewSession(sinfo []byte, update bool) error {
 		go m.cleanupLegacies()
 	}
 	return nil
-}
-
-func (m *redisMeta) cachedSessionJSON() []byte {
-	if data := m.sessionJSON.Load(); data != nil {
-		return data.([]byte)
-	}
-	data := m.newSessionInfo()
-	m.sessionJSON.Store(data)
-	return data
 }
 
 func (m *redisMeta) getCounter(name string) (int64, error) {
@@ -3032,7 +3021,7 @@ func (m *redisMeta) doRefreshSession() error {
 	expire := m.expireTime()
 	var created *redis.BoolCmd
 	_, err := m.rdb.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-		created = pipe.HSetNX(ctx, m.sessionInfos(), ssid, m.cachedSessionJSON())
+		created = pipe.HSetNX(ctx, m.sessionInfos(), ssid, m.currentSessionInfo())
 		pipe.ZAdd(ctx, m.allSessions(), redis.Z{
 			Score:  float64(expire),
 			Member: ssid,

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -90,11 +90,12 @@ import (
 
 type redisMeta struct {
 	*baseMeta
-	rdb        redis.UniversalClient
-	prefix     string
-	shaLookup  string // The SHA returned by Redis for the loaded `scriptLookup`
-	shaResolve string // The SHA returned by Redis for the loaded `scriptResolve`
-	cache      *redisCache
+	rdb         redis.UniversalClient
+	prefix      string
+	shaLookup   string // The SHA returned by Redis for the loaded `scriptLookup`
+	shaResolve  string // The SHA returned by Redis for the loaded `scriptResolve`
+	cache       *redisCache
+	sessionJSON atomic.Value // []byte
 }
 
 var _ Meta = (*redisMeta)(nil)
@@ -445,15 +446,13 @@ func (m *redisMeta) doNewSession(sinfo []byte, update bool) error {
 	ctx := Background()
 	ssid := strconv.FormatUint(m.sid, 10)
 	expire := m.expireTime()
-	err := m.txn(ctx, func(tx *redis.Tx) error {
-		_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-			pipe.ZAdd(ctx, m.allSessions(), redis.Z{Score: float64(expire), Member: ssid})
-			pipe.HSet(ctx, m.sessionInfos(), ssid, sinfo)
-			m.genLog(ctx, pipe, time.Now(), "NEWSESSION(%d,%d,%s)", m.sid, expire, logEncode(sinfo))
-			return nil
-		})
-		return err
-	}, m.allSessions(), m.sessionInfos())
+	m.sessionJSON.Store(sinfo)
+	_, err := m.rdb.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.ZAdd(ctx, m.allSessions(), redis.Z{Score: float64(expire), Member: ssid})
+		pipe.HSet(ctx, m.sessionInfos(), ssid, sinfo)
+		m.genLog(ctx, pipe, time.Now(), "NEWSESSION(%d,%d,%s)", m.sid, expire, logEncode(sinfo))
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("new session %d: %s", m.sid, err)
 	}
@@ -471,6 +470,15 @@ func (m *redisMeta) doNewSession(sinfo []byte, update bool) error {
 		go m.cleanupLegacies()
 	}
 	return nil
+}
+
+func (m *redisMeta) cachedSessionJSON() []byte {
+	if data := m.sessionJSON.Load(); data != nil {
+		return data.([]byte)
+	}
+	data := m.newSessionInfo()
+	m.sessionJSON.Store(data)
+	return data
 }
 
 func (m *redisMeta) getCounter(name string) (int64, error) {
@@ -2968,15 +2976,12 @@ func (m *redisMeta) doCleanStaleSession(sid uint64) error {
 		return fmt.Errorf("failed to clean up sid %d", sid)
 	} else {
 		var removed *redis.IntCmd
-		if err := m.txn(ctx, func(tx *redis.Tx) error {
-			_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-				pipe.HDel(ctx, m.sessionInfos(), ssid)
-				removed = pipe.ZRem(ctx, m.allSessions(), ssid)
-				m.genLog(ctx, pipe, time.Now(), "CLEANSESSION(%d)", sid)
-				return nil
-			})
-			return err
-		}, m.sessionInfos(), m.allSessions()); err != nil {
+		if _, err := m.rdb.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.HDel(ctx, m.sessionInfos(), ssid)
+			removed = pipe.ZRem(ctx, m.allSessions(), ssid)
+			m.genLog(ctx, pipe, time.Now(), "CLEANSESSION(%d)", sid)
+			return nil
+		}); err != nil {
 			return err
 		}
 		if n, err := removed.Result(); err != nil {
@@ -3025,26 +3030,19 @@ func (m *redisMeta) doRefreshSession() error {
 	ctx := Background()
 	ssid := strconv.FormatUint(m.sid, 10)
 	expire := m.expireTime()
-	return m.txn(ctx, func(tx *redis.Tx) error {
-		ok, err := tx.HExists(ctx, m.sessionInfos(), ssid).Result()
-		if err != nil {
-			return err
-		}
-		if !ok {
-			logger.Warnf("Session %d was stale and cleaned up, but now it comes back again", m.sid)
-		}
-		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-			if !ok {
-				pipe.HSet(ctx, m.sessionInfos(), ssid, m.newSessionInfo())
-			}
-			pipe.ZAdd(ctx, m.allSessions(), redis.Z{
-				Score:  float64(expire),
-				Member: ssid,
-			})
-			return nil
+	var created *redis.BoolCmd
+	_, err := m.rdb.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		created = pipe.HSetNX(ctx, m.sessionInfos(), ssid, m.cachedSessionJSON())
+		pipe.ZAdd(ctx, m.allSessions(), redis.Z{
+			Score:  float64(expire),
+			Member: ssid,
 		})
-		return err
-	}, m.sessionInfos(), m.allSessions())
+		return nil
+	})
+	if err == nil && created.Val() {
+		logger.Warnf("Session %d was stale and cleaned up, but now I'm back again", m.sid)
+	}
+	return err
 }
 
 func (m *redisMeta) doDeleteSustainedInode(sid uint64, inode Ino) error {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -3252,7 +3252,7 @@ func (m *dbMeta) doRefreshSession() error {
 		n, err := ses.Cols("Expire").Update(&session2{Expire: m.expireTime()}, &session2{Sid: m.sid})
 		if err == nil && n == 0 {
 			logger.Warnf("Session %d was stale and cleaned up, but now it comes back again", m.sid)
-			err = mustInsert(ses, &session2{m.sid, m.expireTime(), m.newSessionInfo()})
+			err = mustInsert(ses, &session2{m.sid, m.expireTime(), m.currentSessionInfo()})
 		}
 		return err
 	})

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -669,7 +669,7 @@ func (m *kvMeta) doRefreshSession() error {
 		buf := tx.get(m.sessionKey(m.sid))
 		if buf == nil {
 			logger.Warnf("Session %d was stale and cleaned up, but now it comes back again", m.sid)
-			tx.set(m.sessionInfoKey(m.sid), m.newSessionInfo())
+			tx.set(m.sessionInfoKey(m.sid), m.currentSessionInfo())
 		}
 		expire := m.expireTime()
 		tx.set(m.sessionKey(m.sid), m.packInt64(expire))


### PR DESCRIPTION
`doRefreshSession` watches global `sessionInfos` and `allSessions` keys, which means a heartbeat from any client invalidates transactions of all other clients, even though they update different session IDs.

At scale, this becomes a transaction invalidation storm. We observed session refresh transactions repeatedly reaching the 50-retry limit:

```
2026/07/30 19:44:00.195884 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:00.732924 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:01.269866 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:01.797462 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:02.330039 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:02.782794 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:03.307708 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:03.776121 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:04.207680 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:04.790227 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:05.385755 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:06.033308 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:06.638188 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:07.290222 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:07.975963 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:08.497598 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:09.241273 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:09.809947 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:10.434062 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:11.062381 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:11.860897 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:12.604286 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:13.472067 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:14.404429 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:15.127014 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:16.014441 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:16.662308 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:17.442114 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:18.679593 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:19.637181 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:20.572941 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:21.769437 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:23.135296 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:24.448483 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:25.899586 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:26.900691 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:27.951598 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:29.763394 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:30.838200 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:32.424532 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:33.640350 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:34.883344 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:37.136074 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:39.237223 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:40.012325 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:40.764745 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:42.233019 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:43.046817 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:45.091411 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:46.998655 juicefs[3364728] <WARNING>: Session 13343 was stale and cleaned up, but now it comes back again [doRefreshSession@redis.go:3038]
2026/07/30 19:44:47.962378 juicefs[3364728] <WARNING>: Already tried 50 times, returning: redis: transaction failed [txn@redis.go:1199]
```

High frequent retries eventually exhaust Redis connections, making new JuiceFS clients unable to connect at all. I suggest not to apply `WATCH` indiscriminately.