### PR TITLE
meta/redis: fix stale F_RDLCK not released by session cleanup

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -1370,6 +1370,28 @@ func testLocks(t *testing.T, m Meta) {
 	if st := m.Flock(ctx, inode, o1, syscall.F_UNLCK, false); st != 0 {
 		t.Fatalf("flock unlock: %s", st)
 	}
+
+	// Regression: a BSD read-lock must be registered in the per-session index
+	// (locked$<sid>) exactly like a write-lock. Otherwise stale-session cleanup
+	// and GetSession(detail) cannot see it, so a read-lock left behind by a
+	// crashed holder is never released and blocks every future write-lock on
+	// the same inode with EAGAIN forever.
+	if st := m.Flock(ctx, inode, o1, syscall.F_RDLCK, false); st != 0 {
+		t.Fatalf("flock rlock: %s", st)
+	}
+	if r, ok := m.(*redisMeta); ok {
+		ms, err := r.rdb.SMembers(context.Background(), r.lockedKey(r.sid)).Result()
+		if err != nil {
+			t.Fatalf("SMembers %s: %s", r.lockedKey(r.sid), err)
+		}
+		if len(ms) != 1 {
+			t.Fatalf("read-lock not registered in session index: got %d entries, want 1", len(ms))
+		}
+	}
+	if st := m.Flock(ctx, inode, o1, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("flock unlock: %s", st)
+	}
+
 	if r, ok := m.(*redisMeta); ok {
 		ms, err := r.rdb.SMembers(context.Background(), r.lockedKey(r.sid)).Result()
 		if err != nil {
@@ -6167,4 +6189,69 @@ func newFuseDefaultCtx(uid, primaryGid uint32) *fuseDefaultCtx {
 		uid:     uid,
 		gid:     primaryGid,
 	}
+}
+
+// TestRedisStaleReadLockCleanup is a regression test for the gateway outage:
+// a read-lock whose holder crashed (no F_UNLCK) used to survive stale-session
+// cleanup, because F_RDLCK never added the inode to locked$<sid>, which is the
+// only thing doCleanStaleSession scans. The orphan R then made every F_WRLCK
+// on the same inode return EAGAIN forever. This test reproduces the crash +
+// cleanup + a fresh write-lock.
+func TestRedisStaleReadLockCleanup(t *testing.T) {
+	if os.Getenv("SKIP_NON_CORE") == "true" {
+		t.Skipf("skip non-core test")
+	}
+	m, err := newRedisMeta("redis", "127.0.0.1:6379/10", testConfig())
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
+	}
+	if err := m.Reset(); err != nil {
+		t.Fatalf("reset meta: %s", err)
+	}
+	if err := m.Init(testFormat(), false); err != nil {
+		t.Fatalf("init meta: %s", err)
+	}
+	if err := m.NewSession(true); err != nil {
+		t.Fatalf("new session: %s", err)
+	}
+	defer m.CloseSession() // err ignored: cleanup below already removed the session
+
+	r, ok := m.(*redisMeta)
+	if !ok {
+		t.Fatal("not a redisMeta")
+	}
+
+	ctx := Background()
+	var inode Ino
+	var attr = &Attr{}
+	if st := m.Create(ctx, 1, "f_stale_rlock", 0644, 0, 0, &inode, attr); st != 0 {
+		t.Fatalf("create f: %s", st)
+	}
+	defer m.Unlink(ctx, 1, "f_stale_rlock")
+
+	owner := uint64(0xF000000000000001)
+	if st := m.Flock(ctx, inode, owner, syscall.F_RDLCK, false); st != 0 {
+		t.Fatalf("flock rlock: %s", st)
+	}
+
+	// Simulate a crash: the holder dies without F_UNLCK. A surviving cleaner
+	// (any live client) eventually runs cleanup for this sid.
+	sid := r.sid
+	if err := r.doCleanStaleSession(sid); err != nil {
+		t.Fatalf("doCleanStaleSession: %s", err)
+	}
+
+	// (a) the orphan read-lock field must be gone from lockf$<inode>
+	if fields, err := r.rdb.HGetAll(ctx, r.flockKey(inode)).Result(); err != nil {
+		t.Fatalf("HGetAll %s: %s", r.flockKey(inode), err)
+	} else if len(fields) != 0 {
+		t.Fatalf("orphan read-lock survived stale-session cleanup: %v", fields)
+	}
+
+	// (b) the operational symptom: a fresh write-lock on the same inode must
+	// succeed now (previously it looped on EAGAIN against the dead R).
+	if st := m.Flock(ctx, inode, owner+1, syscall.F_WRLCK, false); st != 0 {
+		t.Fatalf("write-lock after cleanup should succeed, got %s", st)
+	}
+	_ = m.Flock(ctx, inode, owner+1, syscall.F_UNLCK, false)
 }

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -6255,3 +6255,167 @@ func TestRedisStaleReadLockCleanup(t *testing.T) {
 	}
 	_ = m.Flock(ctx, inode, owner+1, syscall.F_UNLCK, false)
 }
+
+// TestRedisLockIndexRelease covers the release side of the locked$<sid> index:
+// the index entry must be dropped as soon as no owner of the session holds a
+// lock on the inode, and must NOT be dropped while at least one owner does —
+// regardless of locks held by other sessions on the same inode.
+func TestRedisLockIndexRelease(t *testing.T) {
+	if os.Getenv("SKIP_NON_CORE") == "true" {
+		t.Skipf("skip non-core test")
+	}
+	m1, err := newRedisMeta("redis", "127.0.0.1:6379/10", testConfig())
+	if err != nil {
+		t.Fatalf("create meta1: %s", err)
+	}
+	if err := m1.Reset(); err != nil {
+		t.Fatalf("reset meta1: %s", err)
+	}
+	if err := m1.Init(testFormat(), false); err != nil {
+		t.Fatalf("init meta1: %s", err)
+	}
+	if err := m1.NewSession(true); err != nil {
+		t.Fatalf("new session1: %s", err)
+	}
+	defer m1.CloseSession()
+
+	m2, err := newRedisMeta("redis", "127.0.0.1:6379/10", testConfig())
+	if err != nil {
+		t.Fatalf("create meta2: %s", err)
+	}
+	if _, err := m2.Load(true); err != nil {
+		t.Fatalf("load meta2: %s", err)
+	}
+	if err := m2.NewSession(true); err != nil {
+		t.Fatalf("new session2: %s", err)
+	}
+	defer m2.CloseSession()
+
+	r1, ok := m1.(*redisMeta)
+	if !ok {
+		t.Fatal("meta1 is not redisMeta")
+	}
+	r2, ok := m2.(*redisMeta)
+	if !ok {
+		t.Fatal("meta2 is not redisMeta")
+	}
+	ctx := Background()
+	var inode Ino
+	var attr = &Attr{}
+	if st := m1.Create(ctx, 1, "f_lockidx", 0644, 0, 0, &inode, attr); st != 0 {
+		t.Fatalf("create f: %s", st)
+	}
+	defer m1.Unlink(ctx, 1, "f_lockidx")
+
+	lockedLists := func(r *redisMeta, ino Ino) bool {
+		ms, err := r.rdb.SMembers(ctx, r.lockedKey(r.sid)).Result()
+		if err != nil {
+			t.Fatalf("SMembers %s: %s", r.lockedKey(r.sid), err)
+		}
+		for _, k := range ms {
+			if k == r.flockKey(ino) || k == r.plockKey(ino) {
+				return true
+			}
+		}
+		return false
+	}
+	fieldsOf := func(r *redisMeta, key string) map[string]string {
+		fields, err := r.rdb.HGetAll(ctx, key).Result()
+		if err != nil {
+			t.Fatalf("HGetAll %s: %s", key, err)
+		}
+		return fields
+	}
+
+	// BSD flock: two sessions share a read-lock; releasing in session1 must
+	// drop session1's index entry even though the hash is not globally empty
+	// (this is the leak the reviewer pointed at), and keep session2's lock.
+	if st := m1.Flock(ctx, inode, 1, syscall.F_RDLCK, false); st != 0 {
+		t.Fatalf("session1 rlock: %s", st)
+	}
+	if st := m2.Flock(ctx, inode, 1, syscall.F_RDLCK, false); st != 0 {
+		t.Fatalf("session2 rlock: %s", st)
+	}
+	if st := m1.Flock(ctx, inode, 1, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("session1 unlock: %s", st)
+	}
+	if lockedLists(r1, inode) {
+		t.Fatalf("locked$%d still lists flock inode after the session released its last owner", r1.sid)
+	}
+	if fields := fieldsOf(r2, r2.flockKey(inode)); len(fields) != 1 {
+		t.Fatalf("session2 flock must survive session1 unlock, got %v", fields)
+	}
+	if st := m2.Flock(ctx, inode, 1, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("session2 unlock: %s", st)
+	}
+	if lockedLists(r2, inode) {
+		t.Fatalf("locked$%d still lists flock inode", r2.sid)
+	}
+	if fields := fieldsOf(r1, r1.flockKey(inode)); len(fields) != 0 {
+		t.Fatalf("flock hash not empty: %v", fields)
+	}
+
+	// Same session, two owners: the index entry must survive until the last
+	// owner of the session releases.
+	if st := m1.Flock(ctx, inode, 1, syscall.F_RDLCK, false); st != 0 {
+		t.Fatalf("rlock owner1: %s", st)
+	}
+	if st := m1.Flock(ctx, inode, 2, syscall.F_RDLCK, false); st != 0 {
+		t.Fatalf("rlock owner2: %s", st)
+	}
+	if st := m1.Flock(ctx, inode, 1, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("unlock owner1: %s", st)
+	}
+	if !lockedLists(r1, inode) {
+		t.Fatalf("locked$%d lost the flock inode while owner2 still holds it", r1.sid)
+	}
+	if st := m1.Flock(ctx, inode, 2, syscall.F_UNLCK, false); st != 0 {
+		t.Fatalf("unlock owner2: %s", st)
+	}
+	if lockedLists(r1, inode) {
+		t.Fatalf("locked$%d still lists flock inode after last owner released", r1.sid)
+	}
+
+	// POSIX locks: shared read ranges from two sessions; same leak, same fix.
+	if st := m1.Setlk(ctx, inode, 1, false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("session1 plock: %s", st)
+	}
+	if st := m2.Setlk(ctx, inode, 1, false, syscall.F_RDLCK, 0, 0xFFFF, 2); st != 0 {
+		t.Fatalf("session2 plock: %s", st)
+	}
+	if st := m1.Setlk(ctx, inode, 1, false, syscall.F_UNLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("session1 punlock: %s", st)
+	}
+	if lockedLists(r1, inode) {
+		t.Fatalf("locked$%d still lists plock inode after the session released its last owner", r1.sid)
+	}
+	if fields := fieldsOf(r2, r2.plockKey(inode)); len(fields) != 1 {
+		t.Fatalf("session2 plock must survive session1 unlock, got %v", fields)
+	}
+	if st := m2.Setlk(ctx, inode, 1, false, syscall.F_UNLCK, 0, 0xFFFF, 2); st != 0 {
+		t.Fatalf("session2 punlock: %s", st)
+	}
+	if lockedLists(r2, inode) {
+		t.Fatalf("locked$%d still lists plock inode", r2.sid)
+	}
+
+	// Same session, two plock owners: entry survives until the last owner.
+	if st := m1.Setlk(ctx, inode, 1, false, syscall.F_RDLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("plock owner1: %s", st)
+	}
+	if st := m1.Setlk(ctx, inode, 2, false, syscall.F_RDLCK, 0x10000, 0x20000, 2); st != 0 {
+		t.Fatalf("plock owner2: %s", st)
+	}
+	if st := m1.Setlk(ctx, inode, 1, false, syscall.F_UNLCK, 0, 0xFFFF, 1); st != 0 {
+		t.Fatalf("punlock owner1: %s", st)
+	}
+	if !lockedLists(r1, inode) {
+		t.Fatalf("locked$%d lost the plock inode while owner2 still holds it", r1.sid)
+	}
+	if st := m1.Setlk(ctx, inode, 2, false, syscall.F_UNLCK, 0x10000, 0x20000, 2); st != 0 {
+		t.Fatalf("punlock owner2: %s", st)
+	}
+	if lockedLists(r1, inode) {
+		t.Fatalf("locked$%d still lists plock inode after last owner released", r1.sid)
+	}
+}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -6198,9 +6198,6 @@ func newFuseDefaultCtx(uid, primaryGid uint32) *fuseDefaultCtx {
 // on the same inode return EAGAIN forever. This test reproduces the crash +
 // cleanup + a fresh write-lock.
 func TestRedisStaleReadLockCleanup(t *testing.T) {
-	if os.Getenv("SKIP_NON_CORE") == "true" {
-		t.Skipf("skip non-core test")
-	}
 	m, err := newRedisMeta("redis", "127.0.0.1:6379/10", testConfig())
 	if err != nil {
 		t.Fatalf("create meta: %s", err)
@@ -6261,9 +6258,6 @@ func TestRedisStaleReadLockCleanup(t *testing.T) {
 // lock on the inode, and must NOT be dropped while at least one owner does —
 // regardless of locks held by other sessions on the same inode.
 func TestRedisLockIndexRelease(t *testing.T) {
-	if os.Getenv("SKIP_NON_CORE") == "true" {
-		t.Skipf("skip non-core test")
-	}
 	m1, err := newRedisMeta("redis", "127.0.0.1:6379/10", testConfig())
 	if err != nil {
 		t.Fatalf("create meta1: %s", err)

--- a/pkg/meta/redis_lock.go
+++ b/pkg/meta/redis_lock.go
@@ -29,6 +29,20 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// lastLockOfSession reports whether no field in the lock hash other than lkey
+// belongs to this session. It decides when the locked$<sid> index entry must
+// be dropped on release: locks held by other sessions on the same inode must
+// neither keep our index entry alive nor be removed by us.
+func (r *redisMeta) lastLockOfSession(lkeys []string, lkey string) bool {
+	prefix := strconv.FormatUint(r.sid, 10) + "_"
+	for _, k := range lkeys {
+		if k != lkey && strings.HasPrefix(k, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
 func (r *redisMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, block bool) syscall.Errno {
 	ikey := r.flockKey(inode)
 	lkey := r.ownerKey(owner)
@@ -41,7 +55,7 @@ func (r *redisMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, bl
 			}
 			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 				pipe.HDel(ctx, ikey, lkey)
-				if len(lkeys) == 1 && lkeys[0] == lkey {
+				if r.lastLockOfSession(lkeys, lkey) {
 					pipe.SRem(ctx, r.lockedKey(r.sid), ikey)
 				}
 				r.genLog(ctx, pipe, time.Now(), "FLOCK(%d,%d,U)", inode, owner)
@@ -165,7 +179,7 @@ func (r *redisMeta) Setlk(ctx Context, inode Ino, owner uint64, block bool, ltyp
 				_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 					if len(ls) == 0 {
 						pipe.HDel(ctx, ikey, lkey)
-						if len(lkeys) == 1 && lkeys[0] == lkey {
+						if r.lastLockOfSession(lkeys, lkey) {
 							pipe.SRem(ctx, r.lockedKey(r.sid), ikey)
 						}
 					} else {

--- a/pkg/meta/redis_lock.go
+++ b/pkg/meta/redis_lock.go
@@ -29,10 +29,6 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// lastLockOfSession reports whether no field in the lock hash other than lkey
-// belongs to this session. It decides when the locked$<sid> index entry must
-// be dropped on release: locks held by other sessions on the same inode must
-// neither keep our index entry alive nor be removed by us.
 func (r *redisMeta) lastLockOfSession(lkeys []string, lkey string) bool {
 	prefix := strconv.FormatUint(r.sid, 10) + "_"
 	for _, k := range lkeys {

--- a/pkg/meta/redis_lock.go
+++ b/pkg/meta/redis_lock.go
@@ -66,6 +66,7 @@ func (r *redisMeta) Flock(ctx Context, inode Ino, owner uint64, ltype uint32, bl
 				}
 				_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 					pipe.HSet(ctx, ikey, lkey, "R")
+					pipe.SAdd(ctx, r.lockedKey(r.sid), ikey)
 					r.genLog(ctx, pipe, time.Now(), "FLOCK(%d,%d,R)", inode, owner)
 					return nil
 				})


### PR DESCRIPTION
# Fix: register BSD read-locks (`F_RDLCK`) in the `locked$` index so stale-session cleanup can release them

## Summary

`redisMeta.Flock` writes the lock field into `lockf$<inode>` for **both** read and write locks, but adds the reverse-index entry `SAdd(locked$<sid>, lockf$<inode>)` **only** in the `F_WRLCK` branch — the `F_RDLCK` branch is missing it.

Since `doCleanStaleSession` frees a dead session's locks by iterating **only** `locked$<sid>` (there is no sid-prefix scan of `lockf*` anywhere in the cleanup path), a read-lock whose holder dies without a clean `F_UNLCK` is **never released**: the field stays in `lockf$<inode>` forever while the session itself is removed from `sessionInfos`/`allSessions` as if nothing were wrong. Any later `F_WRLCK` on the same inode then returns `EAGAIN` indefinitely.

This PR adds the missing `SAdd` to the read branch, making it symmetric with the write branch and consistent with the index contract documented at the top of `redis.go` (`locked$sid -> { lockf$inode or lockp$inode }`, with no write-only qualifier). The cleanup code is correct and untouched; the index was simply never populated for reads.

> **TL;DR** — a one-line omission in the read-lock path makes dead sessions' shared locks uncleanable, permanently blocking exclusive locks on the same inode.

## How it was discovered

The bug was triggered in production by **MinIO gateway** on JuiceFS. MinIO's `NewNSLock(MinioMetaBucket, MinioMetaLockFile)` takes a BSD read-lock (`F_RDLCK`) on the `.sys.minio` metadata file through the JuiceFS FUSE layer. On every unclean shutdown of the gateway (e.g., `SIGKILL` in Kubernetes), the read-lock field remained in `lockf$<inode>` forever while the session itself was removed from `allSessions` by stale-session cleanup. Subsequent MinIO gateway restarts then failed to acquire the exclusive lock on `.sys.minio`, spinning on `EAGAIN` indefinitely. The only recovery was a manual `HDEL lockf$<inode> <sid>_<owner>`.

Every orphaned field observed in production was of type `R`, never `W` — exactly what this asymmetry predicts.

## Why it stayed hidden

`meta.Flock(..., F_RDLCK, ...)` is rarely exercised upstream (FUSE mostly sees `LOCK_EX`; record locks go through `Setlk`/`lockp$`), so a "dead shared-lock gets released" case was likely never covered. It becomes fatal for any real `F_RDLCK` consumer — we hit it through the JuiceFS-backed MinIO gateway that maps shared namespace locks to `F_RDLCK` on the `.sys.minio` metadata file, where the omission reproduces on essentially every unclean shutdown.

## Symptoms (after an unclean shutdown, e.g. `SIGKILL` in k8s)

- `<sid>_<owner>: R` remains in `lockf$<inode>` (standard `ownerKey` format).
- `locked$<sid>` is **empty**; `sessionInfos`/`allSessions` no longer contain the sid (session "cleaned").
- A new process needing the exclusive lock spins forever: `get write lock timed out ino:<inode>` / `trying to acquire lock`, because `F_WRLCK` sees the orphaned `R` via `HGetAll` and refuses (`len(owners) > 0 → EAGAIN`), and nothing will ever remove it.
- Only recovery is a manual `HDEL lockf$<inode> <sid>_<owner>`.

## Root cause & fix

```diff
 if ltype == F_RDLCK {
     for _, v := range owners {
         if v == "W" {
             return syscall.EAGAIN
         }
     }
     _, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
         pipe.HSet(ctx, ikey, lkey, "R")
+        pipe.SAdd(ctx, r.lockedKey(r.sid), ikey)
         return nil
     })
     return err
 }
```

The `SAdd` sits in the same `TxPipelined` / under the same `WATCH(ikey)` as the `HSet`, so the field write and the index registration stay atomic — exactly as in the write branch.

We confirmed the cleanup side is innocent: had `doCleanStaleSession(<sid>)` ever run while `locked$<sid>` contained the inode, then with `fail == false` (required for the session to have been removed) it would have `HDel`'d the matched field. The field's survival proves the inode was never indexed for that read-lock — i.e. the defect is on the acquisition side.

## Safety

- **Idempotent** — repeated `F_RDLCK` on the same `(sid, inode)` adds no duplicate members; no unbounded growth of `locked$`.
- **Atomic** with the field write (same pipeline/`WATCH`); a concurrent mutation aborts and retries, as today.
- **Cleanup now frees R** — `doCleanStaleSession` sees the inode, the sid-prefix filter matches the field, `HDel` releases it; `juicefs status` also starts reporting live read-locks correctly as a side benefit.
- **Readers of `locked$` are type-agnostic** — the known consumers either delete fields by sid prefix regardless of type (`doCleanStaleSession`, correct for `R`) or only display them (`getSession`); a grep of `lockedKey` / `F_*LCK` in `pkg/meta` found no consumer assuming write-only entries (a maintainer's confirmation for any non-OSS paths would be appreciated).
- **One benign side effect:** in a shared scenario (A and B both hold `R`), A's normal `RUnlock` sees `len(lkeys) > 1` and skips `SRem`, leaving a transient stale `locked$A → ikey` pointer. It is harmless — it self-clears when A dies (`doCleanStaleSession` runs the trailing `SRem` even with an empty field list), and stale pointers of this kind already occur on the write path today. `F_UNLCK` is left unchanged to keep the fix minimal.

## Not retroactive (operational note)

The fix only registers read-locks taken **after** the patched binary runs; fields orphaned by previous versions are in no `locked$` set and won't be reclaimed by cleanup even after upgrade. Affected clusters need a one-time reconciliation that scans `lockf*`/`lockp*` directly and `HDEL`s fields whose sid is absent from `sessionInfos`/`allSessions` (safe — live holders are never touched). This is intentionally out of scope here; happy to contribute it as a follow-up.

## Testing

Two regression tests, both fail without the fix and pass with it:

### Test 1 — R-lock registration in `testLocks` (`pkg/meta/base_test.go`)

Inserted into the existing flock sequence in `testLocks`: take `F_RDLCK` on a clean inode → verify `SMembers(locked$<sid>)` returns exactly 1 entry → unlock → verify `locked$` is empty again. This catches the root cause (missing `SAdd`) and also serves as an indicator for `db`/`kv` backends if they share the same asymmetry.

```go
// Regression: a BSD read-lock must be registered in the per-session index
// (locked$<sid>) exactly like a write-lock. Otherwise stale-session cleanup
// and GetSession(detail) cannot see it, so a read-lock left behind by a
// crashed holder is never released and blocks every future write-lock on
// the same inode with EAGAIN forever.
if st := m.Flock(ctx, inode, o1, syscall.F_RDLCK, false); st != 0 {
    t.Fatalf("flock rlock: %s", st)
}
if r, ok := m.(*redisMeta); ok {
    ms, err := r.rdb.SMembers(context.Background(), r.lockedKey(r.sid)).Result()
    if err != nil {
        t.Fatalf("SMembers %s: %s", r.lockedKey(r.sid), err)
    }
    if len(ms) != 1 {
        t.Fatalf("read-lock not registered in session index: got %d entries, want 1", len(ms))
    }
}
if st := m.Flock(ctx, inode, o1, syscall.F_UNLCK, false); st != 0 {
    t.Fatalf("flock unlock: %s", st)
}
```

### Test 2 — `TestRedisStaleReadLockCleanup` (`pkg/meta/base_test.go`)

End-to-end reproduction of the operational scenario: session A takes `F_RDLCK` and "crashes" without `F_UNLCK`; `doCleanStaleSession` runs for its sid; assert (a) orphan field is gone from `lockf$<inode>` and (b) a fresh `F_WRLCK` on the same inode succeeds. Without the fix, (a) fails with `orphan read-lock survived stale-session cleanup: map[1_F000000000000001:R]`.

```go
func TestRedisStaleReadLockCleanup(t *testing.T) {
    // ... setup redis meta, create file ...
    if st := m.Flock(ctx, inode, owner, syscall.F_RDLCK, false); st != 0 {
        t.Fatalf("flock rlock: %s", st)
    }
    // Simulate crash — cleanup without F_UNLCK
    sid := r.sid
    if err := r.doCleanStaleSession(sid); err != nil {
        t.Fatalf("doCleanStaleSession: %s", err)
    }
    // (a) orphan field must be gone
    if fields, err := r.rdb.HGetAll(ctx, r.flockKey(inode)).Result(); err != nil {
        t.Fatalf("HGetAll %s: %s", r.flockKey(inode), err)
    } else if len(fields) != 0 {
        t.Fatalf("orphan read-lock survived stale-session cleanup: %v", fields)
    }
    // (b) fresh write-lock must succeed
    if st := m.Flock(ctx, inode, owner+1, syscall.F_WRLCK, false); st != 0 {
        t.Fatalf("write-lock after cleanup should succeed, got %s", st)
    }
}
```

## Out of scope

Built-in reconciler for pre-existing orphans; tightening `F_UNLCK` to drop the index entry by "no fields left for this sid"; gateway-side self-healing on lock-acquisition timeout. Listed for context only.

---

We believe this is a long-dormant omission in a rarely exercised branch, not a deliberate design choice. Happy to adjust the test or fold in any follow-up — just let us know.
