### PR TITLE
cache: avoid selecting store twice in exist

### DIFF
--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -1310,7 +1310,7 @@ func (m *cacheManager) exist(key string) (string, bool) {
 		return "", false
 	}
 	loc := store.dir
-	existed, err := m.getStore(key).exist(key)
+	existed, err := store.exist(key)
 	if err == errNotCached {
 		legacy := m.getStoreLegacy(key)
 		if legacy != store && legacy != nil {


### PR DESCRIPTION
This PR fixes a potential nil pointer panic and inconsistent result in `cacheManager.exist`.

The function previously selected the primary cache store twice:

```go
store := m.getStore(key)
if store == nil {
    return "", false
}
loc := store.dir
existed, err := m.getStore(key).exist(key)
```
This ensures that:
- The nil check applies to the store that is actually used.
- The returned location matches the queried store.
- No additional lock or synchronization is added.
The existing legacy store fallback behavior remains unchanged.