### PR TITLE
cache: fix data races in cached store.

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -365,16 +365,17 @@ func (store *cachedStore) upload(ctx context.Context, key string, block *Page, s
 		buf.Acquire()
 	}
 	defer buf.Release()
+	n, err := store.compressor.Compress(buf.Data, block.Data)
+	if err != nil {
+		block.Release()
+		return fmt.Errorf("Compress block key %s: %s", key, err)
+	}
+	buf.Data = buf.Data[:n]
 	if sync && (blen < store.conf.BlockSize || store.conf.CacheLargeWrite) {
 		// block will be freed after written into disk
 		store.bcache.cache(key, block, false, false)
 	}
-	n, err := store.compressor.Compress(buf.Data, block.Data)
 	block.Release()
-	if err != nil {
-		return fmt.Errorf("Compress block key %s: %s", key, err)
-	}
-	buf.Data = buf.Data[:n]
 
 	try, max := 0, 3
 	if sync {

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -92,7 +92,7 @@ type cacheStore struct {
 	keys      KeyIndex
 	scanned   bool
 	stageFull bool
-	rawFull   bool
+	rawFull   atomic.Bool
 	checksum  string // checksum level
 	uploader  func(key, path string, force bool) bool
 
@@ -354,16 +354,18 @@ func (cache *cacheStore) checkFreeSpace() {
 	for cache.available() {
 		usage := cache.curFreeRatio()
 		cache.stageFull = cache.isFull(usage, true)
-		cache.rawFull = cache.isFull(usage, false)
-		if cache.rawFull && cache.keys.name() != EvictionNone {
+		rawFull := cache.isFull(usage, false)
+		cache.rawFull.Store(rawFull)
+		if rawFull && cache.keys.name() != EvictionNone {
 			logger.Tracef("Cleanup cache when check free space (%s): free ratio (%d%%), space usage (%d%%), inodes usage (%d%%)", cache.dir, int(cache.freeRatio*100), int(usage.br*100), int(usage.fr*100))
 			cache.Lock()
 			cache.cleanupFull()
 			cache.Unlock()
 			usage = cache.curFreeRatio()
-			cache.rawFull = cache.isFull(usage, false)
+			rawFull = cache.isFull(usage, false)
+			cache.rawFull.Store(rawFull)
 		}
-		if cache.rawFull {
+		if rawFull {
 			cache.uploadStaging()
 		}
 		time.Sleep(time.Second)
@@ -445,7 +447,7 @@ func (cache *cacheStore) cache(key string, p *Page, force, dropCache bool) {
 	if !cache.enabled() {
 		return
 	}
-	if cache.rawFull && cache.keys.name() == EvictionNone {
+	if cache.rawFull.Load() && cache.keys.name() == EvictionNone {
 		logger.Debugf("Caching directory is full (%s), drop %s (%d bytes)", cache.dir, key, len(p.Data))
 		cache.m.cacheDrops.Add(1)
 		return

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -521,9 +521,7 @@ func TestUnknownInodeStatsShouldNotMarkCacheAsRawFull(t *testing.T) {
 		s := newCacheStore(m, conf.CacheDir, 1<<30, conf.CacheItems, 1, &conf, nil)
 
 		require.Never(t, func() bool {
-			s.Lock()
-			defer s.Unlock()
-			return s.rawFull
+			return s.rawFull.Load()
 		}, 1500*time.Millisecond, 100*time.Millisecond)
 	})
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes two data races in the chunk cache implementation.

### Race 1: concurrent access to `Page.Data`

In `cachedStore.upload()`, the block was published to the asynchronous disk cache before compression completed:

```go
store.bcache.cache(key, block, false, false)
n, err := store.compressor.Compress(buf.Data, block.Data)
buf.Data = buf.Data[:n]
```

When using the no-op compressor, `buf` and `block` reference the same `Page`. The disk cache goroutine could therefore read `Page.Data` while the upload goroutine was modifying its contents or slice header.

`Page.Acquire()` only extends the lifetime of the page and does not synchronize concurrent access to its data.

#### Fix

Complete compression and update `buf.Data` before publishing the block to the disk cache:

```go
n, err := store.compressor.Compress(buf.Data, block.Data)
if err != nil {
    block.Release()
    return fmt.Errorf("Compress block key %s: %s", key, err)
}
buf.Data = buf.Data[:n]

if sync && (blen < store.conf.BlockSize || store.conf.CacheLargeWrite) {
    store.bcache.cache(key, block, false, false)
}
block.Release()
```

This ensures the page becomes immutable before another goroutine can access it.

### Race 2: concurrent access to `rawFull`

`cacheStore.checkFreeSpace()` periodically updated `rawFull`, while `cacheStore.cache()` read it concurrently without synchronization:

```text
cacheStore.checkFreeSpace -> rawFull write
cacheStore.cache          -> rawFull read
```

#### Fix

Change `rawFull` to `atomic.Bool` and use `Store()` and `Load()` for concurrent access.

A local variable is used during each free-space checking iteration to avoid unnecessary atomic reads:

```go
rawFull := cache.isFull(usage, false)
cache.rawFull.Store(rawFull)
```

The cache path reads the published state with:

```go
if cache.rawFull.Load() && cache.keys.name() == EvictionNone {
    // Drop the cache request.
}
```

This fixes the race without adding mutex contention to the frequently executed cache path.

## Test

```bash
MOCKEY_CHECK_GCFLAGS=false \
go test -race -run '^TestStoreDefault$' -count=1 ./pkg/chunk
```

Result:

```text
ok github.com/juicedata/juicefs/pkg/chunk
```