### PR TITLE
meta: speedup trash cleanup by parallel directory deletion

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -3184,7 +3184,7 @@ func (m *baseMeta) CleanupTrashBefore(ctx Context, edge time.Time, increProgress
 		}()
 	}
 
-	concurrent := make(chan int, 10)
+	concurrent := make(chan int, backgroundDeleteThreads)
 	for len(entries) > 0 {
 		if ctx.Canceled() {
 			return errno(ctx.Err())

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1838,7 +1838,9 @@ func (m *baseMeta) Rmdir(ctx Context, parent Ino, name string, skipCheckTrash ..
 			m.parentMu.Unlock()
 		}
 		m.updateDirStat(ctx, parent, 0, -align4K(0), -1)
-		m.updateDirQuota(ctx, parent, -align4K(0), -1)
+		if !parent.IsTrash() {
+			m.updateDirQuota(ctx, parent, -align4K(0), -1)
+		}
 	}
 	return st
 }
@@ -3182,7 +3184,7 @@ func (m *baseMeta) CleanupTrashBefore(ctx Context, edge time.Time, increProgress
 		}()
 	}
 
-	concurrent := make(chan int, 1) // no effect for flatterned trash dirs
+	concurrent := make(chan int, 10)
 	for len(entries) > 0 {
 		if ctx.Canceled() {
 			return errno(ctx.Err())

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -121,6 +121,8 @@ const TrashInode Ino = 0x7FFFFFFF10000000 // larger than vfs.minInternalNode
 
 const RmrDefaultThreads = 50
 
+const backgroundDeleteThreads = 10
+
 func (i Ino) String() string {
 	return strconv.FormatUint(uint64(i), 10)
 }
@@ -529,7 +531,7 @@ type Meta interface {
 	OnReload(func(new *Format))
 
 	HandleQuota(ctx Context, cmd uint8, qkey string, qtype uint32, quotas map[string]*Quota, strict, repair bool, create bool) error
-	//Triggers a global user group quota scan
+	// Triggers a global user group quota scan
 	ScanUserGroupUsage(ctx Context) error
 
 	// Dump the tree under root, which may be modified by checkRoot

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -5723,7 +5723,7 @@ func (m *redisMeta) doCleanupDetachedNode(ctx Context, ino Ino) syscall.Errno {
 	if err != nil || exists == 0 {
 		return errno(err)
 	}
-	rmConcurrent := make(chan int, 10)
+	rmConcurrent := make(chan int, backgroundDeleteThreads)
 	if eno := m.emptyDir(ctx, ino, true, nil, rmConcurrent); eno != 0 {
 		return eno
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -5697,7 +5697,7 @@ func (m *dbMeta) doCleanupDetachedNode(ctx Context, ino Ino) syscall.Errno {
 	if err != nil || !exist {
 		return errno(err)
 	}
-	rmConcurrent := make(chan int, 10)
+	rmConcurrent := make(chan int, backgroundDeleteThreads)
 	if eno := m.emptyDir(ctx, ino, true, nil, rmConcurrent); eno != 0 {
 		return eno
 	}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1117,6 +1117,9 @@ func (m *kvMeta) txn(ctx Context, f func(tx *kvTxn) error, inodes ...Ino) error 
 			return syscall.EINTR
 		}
 		err := m.client.txn(ctx, f, i)
+		if err != nil && ctx.Canceled() {
+			return context.Canceled // preserve cancellation so `errno` do not print a full error stack
+		}
 		if eno, ok := err.(syscall.Errno); ok && eno == 0 {
 			err = nil
 		}
@@ -2026,6 +2029,10 @@ func (m *kvMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, oldAttr *Attr, skipCheckTrash ...bool) syscall.Errno {
 	var trash Ino
 	var attr Attr
+	parentLocks := []Ino{parent}
+	if parent.IsTrash() {
+		parentLocks = nil // trash parent attributes are not updated, so sibling removals are independent.
+	}
 	if !(len(skipCheckTrash) == 1 && skipCheckTrash[0]) {
 		if st := m.checkTrash(parent, &trash); st != 0 {
 			return st
@@ -2121,7 +2128,7 @@ func (m *kvMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, oldA
 		}
 		m.genLog(tx, now, "RMDIR(%d,%s,%d):%d", parent, logEncode2(name), trash, inode)
 		return nil
-	}, parent)
+	}, parentLocks...)
 	if err == nil {
 		if trash == 0 {
 			m.updateStats(-align4K(0), -1)

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1117,9 +1117,6 @@ func (m *kvMeta) txn(ctx Context, f func(tx *kvTxn) error, inodes ...Ino) error 
 			return syscall.EINTR
 		}
 		err := m.client.txn(ctx, f, i)
-		if err != nil && ctx.Canceled() {
-			return context.Canceled // preserve cancellation so `errno` do not print a full error stack
-		}
 		if eno, ok := err.(syscall.Errno); ok && eno == 0 {
 			err = nil
 		}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -4542,7 +4542,7 @@ func (m *kvMeta) doCleanupDetachedNode(ctx Context, ino Ino) syscall.Errno {
 	if err != nil || buf == nil {
 		return errno(err)
 	}
-	rmConcurrent := make(chan int, 10)
+	rmConcurrent := make(chan int, backgroundDeleteThreads)
 	if eno := m.emptyDir(ctx, ino, true, nil, rmConcurrent); eno != 0 {
 		return eno
 	}

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -139,7 +139,7 @@ func errno(err error) syscall.Errno {
 	if err == nil {
 		return 0
 	}
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return syscall.EINTR
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
@@ -303,6 +303,7 @@ func (m *baseMeta) emptyDir(ctx Context, inode Ino, skipCheckTrash bool, count *
 			return st
 		}
 		var wg sync.WaitGroup
+		var statusOnce sync.Once
 		var status syscall.Errno
 		var nonDirEntries []*Entry
 		for i, e := range entries {
@@ -314,13 +315,14 @@ func (m *baseMeta) emptyDir(ctx Context, inode Ino, skipCheckTrash bool, count *
 						defer wg.Done()
 						st := m.emptyEntry(ctx, inode, name, child, skipCheckTrash, count, concurrent)
 						if st != 0 && st != syscall.ENOENT {
-							status = st
+							statusOnce.Do(func() { status = st })
 						}
 						<-concurrent
 					}(e.Inode, string(e.Name))
 				default:
 					if st := m.emptyEntry(ctx, inode, string(e.Name), e.Inode, skipCheckTrash, count, concurrent); st != 0 && st != syscall.ENOENT {
 						ctx.Cancel()
+						wg.Wait()
 						return st
 					}
 				}
@@ -328,6 +330,7 @@ func (m *baseMeta) emptyDir(ctx Context, inode Ino, skipCheckTrash bool, count *
 				nonDirEntries = append(nonDirEntries, e)
 			}
 			if ctx.Canceled() {
+				wg.Wait()
 				return syscall.EINTR
 			}
 			entries[i] = nil // release memory

--- a/pkg/meta/utils.go
+++ b/pkg/meta/utils.go
@@ -139,7 +139,7 @@ func errno(err error) syscall.Errno {
 	if err == nil {
 		return 0
 	}
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), context.Canceled.Error()) { // TiKV stringifies context cancellation in some error paths
 		return syscall.EINTR
 	}
 	if errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
`BatchUnlink` has greatly improved trash cleanup. However, it only applies to file entries. Directories are still deleted sequentially, so trash buckets with many directories are still slow.

This PR optimizes directory cleanup by:

- deleting trash directories concurrently with 10 workers, as many other cleanup routines do;
- removing transaction slot lock for trash parents, because deleting sibling entries in the trash does not update parent attributes and can safely run in parallel;
- skipping unnecessary quota updates for trash parents;

For one of our internal volume used to stores many GitHub repositories, the trash contains a very large number of files and directories:

- With parallel directory deletion: about 600 entries/s and no txn conflicts.
<img width="840" height="84" alt="image" src="https://github.com/user-attachments/assets/5b6e6e70-8f1f-4295-a31d-2335f3df317f" />

- With the previous serial directory deletion: about 130 entries/s.
<img width="1326" height="84" alt="image" src="https://github.com/user-attachments/assets/b30cd61b-ca1b-4346-9fc6-42567e005686" />

As a longer-term optimization, it's better to support a dedicated `BatchRmdir` api.
