### PR TITLE
meta: fix volume usage stats leak in trash creation

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -3042,7 +3042,9 @@ func (m *baseMeta) checkTrash(parent Ino, trash *Ino) syscall.Errno {
 	if st == syscall.ENOENT {
 		attr := Attr{Typ: TypeDirectory, Nlink: 2, Length: 4 << 10, Parent: TrashInode, Full: true}
 		st = m.en.doMknod(Background(), TrashInode, name, TypeDirectory, 0555, 0, "", trash, &attr)
-		m.en.updateStats(align4K(0), 1)
+		if st == 0 {
+			m.en.updateStats(align4K(0), 1)
+		}
 	}
 
 	m.Lock()


### PR DESCRIPTION
After clearing a volume, we found its usage stats does not return to zero. This is one of the stats leaks.