### PR TITLE
build: fix Java SDK cross-build and release failure handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,12 @@ jobs:
 
       - name: Build SDK
         run: |
-          make -C sdk/java package-all && sudo chown -R $USER sdk/java/target
-          echo "JUICEFS_VERSION=$(mvn -f sdk/java/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+          set -e
+          make -C sdk/java package-all
+          sudo chown -R "$USER" sdk/java/target
+          JUICEFS_VERSION=$(mvn -f sdk/java/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          test -s "sdk/java/target/juicefs-hadoop-${JUICEFS_VERSION}.jar"
+          echo "JUICEFS_VERSION=${JUICEFS_VERSION}" >> "$GITHUB_ENV"
 
       - name: Upload SDK
         uses: softprops/action-gh-release@v1

--- a/sdk/java/Makefile
+++ b/sdk/java/Makefile
@@ -33,7 +33,7 @@ libjfs-all: libjfs.so
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/src/github.com/juicedata/juicefs/sdk/java/libjfs \
 		--entrypoint=/bin/bash \
-		juicedata/golang-cross:latest \
+		juicedata/golang-cross:v1.25.7-0 \
 		-c 'make mac win linux-arm64 mac-arm64'
 
 libjfs.so:


### PR DESCRIPTION
fix #7370

The root `Makefile` was pinned to `golang-cross:v1.25.7-0` for 1.4, but
`sdk/java/Makefile` was left on `latest`, which still ships go 1.21.9.

`release-1.4` needs the same change.
