### PR TITLE
meta: fix races on the format

### DIFF
--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -273,7 +273,9 @@ type baseMeta struct {
 	sync.Mutex
 	addr string
 	conf *Config
-	fmt  *Format
+	// fmt is reloaded in the background while other goroutines read it, so it is
+	// only ever accessed through getFormat/setFormat
+	fmt atomic.Pointer[Format]
 
 	root         Ino
 	txlocks      [nlocks]sync.Mutex // Pessimistic locks to reduce conflict
@@ -728,9 +730,7 @@ func (m *baseMeta) Load(checkVersion bool) (*Format, error) {
 	if format.Tiers == nil {
 		format.Tiers = object.NewTiers(format.StorageClass)
 	}
-	m.Lock()
-	m.fmt = format
-	m.Unlock()
+	m.setFormat(format)
 	return format, nil
 }
 
@@ -819,7 +819,7 @@ func (m *baseMeta) NewSession(record bool) error {
 		go m.cleanupSlices(ctx)
 		go m.cleanupTrash(ctx)
 		go m.symlinks.clean(ctx, &m.sessWG)
-		if m.fmt.ChangeLog {
+		if m.getFormat().ChangeLog {
 			m.sessWG.Add(1)
 			go m.cleanupChangelog(ctx)
 		}
@@ -1102,8 +1102,9 @@ func parseChangelogTime(entry string) (time.Time, error) {
 func (m *baseMeta) cleanupChangelog(ctx Context) {
 	defer m.sessWG.Done()
 	for {
-		maxAge := time.Duration(m.fmt.ChangeLogMaxAge) * time.Second
-		maxLines := m.fmt.ChangeLogMaxLines
+		format := m.getFormat()
+		maxAge := time.Duration(format.ChangeLogMaxAge) * time.Second
+		maxLines := format.ChangeLogMaxLines
 		interval := 5 * time.Minute
 		select {
 		case <-ctx.Done():
@@ -2774,9 +2775,11 @@ func (m *baseMeta) resolve(ctx Context, dpath string, inode *Ino, create bool) s
 }
 
 func (m *baseMeta) getFormat() *Format {
-	m.Lock()
-	defer m.Unlock()
-	return m.fmt
+	return m.fmt.Load()
+}
+
+func (m *baseMeta) setFormat(format *Format) {
+	m.fmt.Store(format)
 }
 
 func (m *baseMeta) GetFormat() Format {
@@ -3228,7 +3231,7 @@ func (m *baseMeta) scanTrashFiles(ctx Context, scan trashFileScan) error {
 			logger.Warnf("bad entry as a subTrash: %s", entry.Name)
 			continue
 		}
-		if m.fmt.DirStats {
+		if m.getFormat().DirStats {
 			ds, st := m.GetDirStat(ctx, entry.Inode)
 			if st == 0 && ds != nil {
 				if _, err := scan(entry.Inode, uint64(ds.length), ts, ds.inodes); err != nil {

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -4416,9 +4416,9 @@ func TestQuotaEdgeCases(t *testing.T) {
 	m.groupQuotas = make(map[uint64]*Quota)
 	m.quotaMu = sync.RWMutex{}
 
-	m.fmt = &Format{
+	m.setFormat(&Format{
 		UserGroupQuota: true,
-	}
+	})
 
 	fileOwnerUid := uint32(1001)
 	fileOwnerGid := uint32(2001)
@@ -4476,9 +4476,9 @@ func TestCheckQuotaFileOwner(t *testing.T) {
 	m.groupQuotas = make(map[uint64]*Quota)
 	m.quotaMu = sync.RWMutex{}
 
-	m.fmt = &Format{
+	m.setFormat(&Format{
 		UserGroupQuota: true,
-	}
+	})
 
 	fileOwnerUid := uint32(1001)
 	fileOwnerGid := uint32(2001)

--- a/pkg/meta/dump.go
+++ b/pkg/meta/dump.go
@@ -385,9 +385,7 @@ func (m *baseMeta) loadDumpedQuotas(ctx Context, dm *DumpedMeta) {
 
 	if len(dm.UserQuotas) > 0 || len(dm.GroupQuotas) > 0 {
 		format := dm.Setting
-		m.Lock()
-		m.fmt = &format
-		m.Unlock()
+		m.setFormat(&format)
 		if err := m.ScanUserGroupUsage(ctx); err != nil {
 			logger.Warnf("rebuild user/group quota usage failed: %v", err)
 		}

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -317,7 +317,7 @@ func (m *redisMeta) NewSession(record bool) error {
 
 func (m *redisMeta) doDeleteSlice(id uint64, size uint32) error {
 	ctx := Background()
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		return m.rdb.HDel(ctx, m.sliceRefs(), m.sliceKey(id, size)).Err()
 	}
 	_, err := m.rdb.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
@@ -395,7 +395,7 @@ func (m *redisMeta) doInit(format *Format, force bool) error {
 	if err = m.rdb.Set(ctx, m.setting(), data, 0).Err(); err != nil {
 		return err
 	}
-	m.fmt = format
+	m.setFormat(format)
 	if body != nil {
 		return nil
 	}
@@ -486,7 +486,7 @@ func (m *redisMeta) incrCounter(name string, value int64) (int64, error) {
 
 	var v int64
 	var err error
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		v, err = m.rdb.IncrBy(Background(), key, value).Result()
 	} else {
 		_, err = m.rdb.TxPipelined(Background(), func(pipe redis.Pipeliner) error {
@@ -1603,7 +1603,7 @@ func (m *redisMeta) txnLastLog() string {
 }
 
 func (m *redisMeta) genLog(ctx Context, pipe redis.Pipeliner, ts time.Time, op string, args ...any) {
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		return
 	}
 	op = fmt.Sprintf(op, args...)
@@ -5173,9 +5173,7 @@ func (m *redisMeta) LoadMeta(r io.Reader) (err error) {
 	if err != nil {
 		return err
 	}
-	m.Lock()
-	m.fmt = &dm.Setting
-	m.Unlock()
+	m.setFormat(&dm.Setting)
 	if err = m.loadDumpedACLs(ctx); err != nil {
 		return err
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -670,7 +670,7 @@ func (m *dbMeta) doInit(format *Format, force bool) error {
 		return fmt.Errorf("json: %s", err)
 	}
 
-	m.fmt = format
+	m.setFormat(format)
 	n := &node{
 		Type:   TypeDirectory,
 		Nlink:  2,
@@ -1076,7 +1076,7 @@ func (m *dbMeta) batchUpdateChunkRefs(s *xorm.Session, chunkRefDeltas map[uint64
 }
 
 func (m *dbMeta) genLog(ctx Context, s *xorm.Session, ns int64, op string, args ...any) {
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		return
 	}
 	op = fmt.Sprintf(op, args...)
@@ -5254,9 +5254,7 @@ func (m *dbMeta) LoadMeta(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	m.Lock()
-	m.fmt = &dm.Setting
-	m.Unlock()
+	m.setFormat(&dm.Setting)
 	if err = m.loadDumpedACLs(Background()); err != nil {
 		return err
 	}

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -137,7 +137,7 @@ func (m *kvMeta) Name() string {
 }
 
 func (m *kvMeta) doDeleteSlice(id uint64, size uint32) error {
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		return m.deleteKeys(m.sliceKey(id, size))
 	}
 	return m.txn(Background(), func(tx *kvTxn) error {
@@ -563,7 +563,7 @@ func (m *kvMeta) doInit(format *Format, force bool) error {
 		return fmt.Errorf("json: %s", err)
 	}
 
-	m.fmt = format
+	m.setFormat(format)
 	ts := time.Now().Unix()
 	attr := &Attr{
 		Typ:    TypeDirectory,
@@ -643,7 +643,7 @@ func (m *kvMeta) doFlushStats() {
 }
 
 func (m *kvMeta) doNewSession(sinfo []byte, update bool) error {
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		if err := m.setValue(m.sessionKey(m.sid), m.packInt64(m.expireTime())); err != nil {
 			return fmt.Errorf("new session: %s", err)
 		}
@@ -751,7 +751,7 @@ func (m *kvMeta) doCleanStaleSession(sid uint64) error {
 	if fail {
 		return fmt.Errorf("failed to clean up sid %d", sid)
 	} else {
-		if !m.fmt.ChangeLog {
+		if !m.getFormat().ChangeLog {
 			return m.deleteKeys(m.sessionKey(sid), m.legacySessionKey(sid), m.sessionInfoKey(sid))
 		}
 		return m.txn(ctx, func(tx *kvTxn) error {
@@ -909,7 +909,7 @@ func (m *kvMeta) ListSessions() ([]*Session, error) {
 }
 
 func (m *kvMeta) genLog(tx *kvTxn, ts time.Time, op string, args ...any) {
-	if !m.fmt.ChangeLog {
+	if !m.getFormat().ChangeLog {
 		return
 	}
 	id := tx.id()
@@ -4358,9 +4358,7 @@ func (m *kvMeta) LoadMeta(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	m.Lock()
-	m.fmt = &dm.Setting
-	m.Unlock()
+	m.setFormat(&dm.Setting)
 
 	if err = m.loadDumpedACLs(Background()); err != nil {
 		return err


### PR DESCRIPTION
`baseMeta.fmt` is replaced whenever the format is reloaded, while other goroutines read it concurrently. `Load()` took the `baseMeta` mutex around the write, but `doInit()` did not take it at all and none of the readers did either, so the locking never actually excluded anything. The race detector reports it on every engine, e.g. `doInit()` writing the pointer against a background compaction goroutine reading `fmt.ChangeLog` through `deleteSlice()`.

Store it as an `atomic.Pointer` and route every access through `getFormat`/`setFormat`. An atomic load rather than the mutex because `genLog` reads the format inside every mutating transaction, and `baseMeta`'s mutex also covers session handling and quotas. Changing the field type makes the compiler point at each of the remaining accesses.

`cleanupChangelog` read `ChangeLogMaxAge` and `ChangeLogMaxLines` as two separate loads; take one snapshot so the pair stays consistent across a reload.

### Split out

The delete-slice channel fix this PR used to carry (`startDeleteSliceTasks` guarding `dslices` with the `baseMeta` mutex while `stopDeleteSliceTasks` and `deleteSlice` guard it with `dSliceMu`) moved to its own PR, as asked in review. It does not depend on this one, and the two can land in either order. Until both are in, a `-race` run still reports the other pair on each branch.

### Not covered here

The atomic pointer protects the pointer, not the pointee. Two call sites still mutate a `Format` after it has been published, so they remain racy against readers of those fields. Both predate this change and sit on separate paths, so they are left for a follow-up:

- `handleQuotaSet` (`pkg/meta/quota.go`) takes the published format from `getFormat()` and writes `DirStats` / `UserGroupQuota` into it before handing it to `doInit`.
- The reload loop invokes the `OnReload` callbacks with the same pointer `Load` has just stored, and the callback registered in `cmd/mount.go` writes `Bucket`, `Storage` and `Tiers` into it on every reload.

Both fix the same way, by patching a copy and then publishing it, which builds on the `setFormat` introduced here.
