### PR TITLE
build: isolate Go linker flags from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ REVISION := $(shell git rev-parse --short HEAD 2>/dev/null)
 REVISIONDATE := $(shell git log -1 --pretty=format:'%cd' --date short 2>/dev/null)
 PKG := github.com/juicedata/juicefs/pkg/version
 GCFLAGS =
+LDFLAGS =
 BUILD ?= release
 ifneq ($(strip $(REVISION)),) # Use git clone
 	LDFLAGS += -X $(PKG).revision=$(REVISION) \


### PR DESCRIPTION
## What does this PR do?

  Fixes builds in packaging environments that export native linker flags through `LDFLAGS`, such as Arch/AUR, RPM, Debian, Gentoo, Nix, and Buildroot.

  The Makefile only appended to `LDFLAGS`, causing environment values such as `-Wl,-O1` to be passed to Go's linker through `go
  build -ldflags`. Go's linker does not recognize these compiler-driver flags and fails with:

 ```text
  flag provided but not defined: -Wl,-O1
```
  This PR initializes LDFLAGS alongside GCFLAGS, ensuring that JuiceFS Go linker flags start from a known-empty value.

fix: https://github.com/juicedata/juicefs/issues/7373