### PR TITLE
cache: skip invisible blocks during warmup

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -82,16 +82,17 @@ func (s *rSlice) index(off int) int {
 	return off / s.store.conf.BlockSize
 }
 
-func (s *rSlice) keys() []string {
-	if s.length <= 0 {
-		return nil
+func (s *rSlice) blockRange(offset, length uint32) (int, int, uint64, error) {
+	if uint64(offset) > uint64(s.length) || uint64(length) > uint64(s.length)-uint64(offset) {
+		return 0, -1, 0, fmt.Errorf("invalid range [%d,%d) for slice %d with size %d", offset, uint64(offset)+uint64(length), s.id, s.length)
 	}
-	lastIndx := (s.length - 1) / s.store.conf.BlockSize
-	keys := make([]string, lastIndx+1)
-	for i := 0; i <= lastIndx; i++ {
-		keys[i] = s.key(i)
+	if length == 0 {
+		return 0, -1, 0, nil
 	}
-	return keys
+	first := int(offset) / s.store.conf.BlockSize
+	last := int(uint64(offset)+uint64(length)-1) / s.store.conf.BlockSize
+	bytes := uint64(last-first)*uint64(s.store.conf.BlockSize) + uint64(s.blockSize(last))
+	return first, last, bytes, nil
 }
 
 func (s *rSlice) ReadAt(ctx context.Context, page *Page, off int) (n int, err error) {
@@ -1174,11 +1175,15 @@ func (store *cachedStore) Remove(id uint64, length int) error {
 	return r.Remove()
 }
 
-func (store *cachedStore) FillCache(id uint64, length uint32) error {
-	r := sliceForRead(id, int(length), store)
-	keys := r.keys()
+func (store *cachedStore) FillCache(id uint64, size, offset, length uint32) (uint64, error) {
+	r := sliceForRead(id, int(size), store)
+	first, last, bytes, rangeErr := r.blockRange(offset, length)
+	if rangeErr != nil {
+		return 0, rangeErr
+	}
 	var err error
-	for _, k := range keys {
+	for i := first; i <= last; i++ {
+		k := r.key(i)
 		if _, existed := store.bcache.exist(k); existed { // already cached
 			continue
 		}
@@ -1194,30 +1199,36 @@ func (store *cachedStore) FillCache(id uint64, length uint32) error {
 		}
 		p.Release()
 	}
-	return err
+	return bytes, err
 }
 
-func (store *cachedStore) EvictCache(id uint64, length uint32) error {
-	r := sliceForRead(id, int(length), store)
-	keys := r.keys()
-	for _, k := range keys {
-		store.bcache.remove(k, false)
+func (store *cachedStore) EvictCache(id uint64, size, offset, length uint32) (uint64, error) {
+	r := sliceForRead(id, int(size), store)
+	first, last, bytes, err := r.blockRange(offset, length)
+	if err != nil {
+		return 0, err
 	}
-	return nil
+	for i := first; i <= last; i++ {
+		store.bcache.remove(r.key(i), false)
+	}
+	return bytes, nil
 }
 
-func (store *cachedStore) CheckCache(id uint64, length uint32, handler func(exists bool, loc string, size int)) error {
-	r := sliceForRead(id, int(length), store)
-	keys := r.keys()
+func (store *cachedStore) CheckCache(id uint64, size, offset, length uint32, handler func(exists bool, loc string, size int)) (uint64, error) {
+	r := sliceForRead(id, int(size), store)
+	first, last, bytes, err := r.blockRange(offset, length)
+	if err != nil {
+		return 0, err
+	}
 	var loc string
 	var existed bool
-	for i, k := range keys {
-		loc, existed = store.bcache.exist(k)
+	for i := first; i <= last; i++ {
+		loc, existed = store.bcache.exist(r.key(i))
 		if handler != nil {
 			handler(existed, loc, r.blockSize(i))
 		}
 	}
-	return nil
+	return bytes, nil
 }
 
 func (store *cachedStore) UsedMemory() int64 {

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -212,10 +212,7 @@ func TestForceUpload(t *testing.T) {
 	store := NewCachedStore(blob, config, nil)
 	cleanCache := func() {
 		rSlice := sliceForRead(1, 1024, store.(*cachedStore))
-		keys := rSlice.keys()
-		for _, k := range keys {
-			store.(*cachedStore).bcache.remove(k, true)
-		}
+		store.(*cachedStore).bcache.remove(rSlice.key(0), true)
 	}
 	readSlice := func(id uint64, length int) error {
 		p := NewPage(make([]byte, length))
@@ -300,10 +297,10 @@ func TestFillCache(t *testing.T) {
 	if cnt, used := bcache.stats(); cnt != 1 || used != 1024+4096 { // only chunk 10 cached
 		t.Fatalf("cache cnt %d used %d, expect cnt 1 used 5120", cnt, used)
 	}
-	if err := store.FillCache(10, 1024); err != nil {
+	if _, err := store.FillCache(10, 1024, 0, 1024); err != nil {
 		t.Fatalf("fill cache 10 1024: %s", err)
 	}
-	if err := store.FillCache(11, uint32(bsize)); err != nil {
+	if _, err := store.FillCache(11, uint32(bsize), 0, uint32(bsize)); err != nil {
 		t.Fatalf("fill cache 11 %d: %s", bsize, err)
 	}
 	time.Sleep(time.Second)
@@ -319,17 +316,17 @@ func TestFillCache(t *testing.T) {
 		}
 	}
 	// check
-	err := store.CheckCache(10, 1024, handler)
+	_, err := store.CheckCache(10, 1024, 0, 1024, handler)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(0), missBytes)
 
 	missBytes = 0
-	err = store.CheckCache(11, uint32(bsize), handler)
+	_, err = store.CheckCache(11, uint32(bsize), 0, uint32(bsize), handler)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(0), missBytes)
 
 	// evict slice 11
-	err = store.EvictCache(11, uint32(bsize))
+	_, err = store.EvictCache(11, uint32(bsize), 0, uint32(bsize))
 	assert.Nil(t, err)
 
 	// stat
@@ -339,9 +336,88 @@ func TestFillCache(t *testing.T) {
 
 	// check again
 	missBytes = 0
-	err = store.CheckCache(11, uint32(bsize), handler)
+	_, err = store.CheckCache(11, uint32(bsize), 0, uint32(bsize), handler)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(bsize), missBytes)
+}
+
+func TestCacheBlockRange(t *testing.T) {
+	conf := defaultConf
+	bsize := conf.BlockSize
+	store := &cachedStore{conf: conf}
+	r := sliceForRead(1, bsize*5/2, store)
+	tests := []struct {
+		name    string
+		offset  uint32
+		length  uint32
+		first   int
+		last    int
+		bytes   uint64
+		wantErr bool
+	}{
+		{"full slice", 0, uint32(bsize * 5 / 2), 0, 2, uint64(bsize * 5 / 2), false},
+		{"first byte", 0, 1, 0, 0, uint64(bsize), false},
+		{"exact block", uint32(bsize), uint32(bsize), 1, 1, uint64(bsize), false},
+		{"cross boundary", uint32(bsize - 1), 2, 0, 1, uint64(bsize * 2), false},
+		{"short last block", uint32(bsize * 2), uint32(bsize / 2), 2, 2, uint64(bsize / 2), false},
+		{"empty at end", uint32(bsize * 5 / 2), 0, 0, -1, 0, false},
+		{"offset beyond end", uint32(bsize*5/2 + 1), 0, 0, 0, 0, true},
+		{"range beyond end", uint32(bsize * 2), uint32(bsize), 0, 0, 0, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			first, last, bytes, err := r.blockRange(test.offset, test.length)
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.first, first)
+			assert.Equal(t, test.last, last)
+			assert.Equal(t, test.bytes, bytes)
+		})
+	}
+}
+
+func TestCacheVisibleBlocks(t *testing.T) {
+	mem, _ := object.CreateStorage("mem", "", "", "", "")
+	conf := defaultConf
+	conf.CacheDir = "memory"
+	conf.CacheSize = 10 << 20
+	store := NewCachedStore(mem, conf, nil)
+	bsize := conf.BlockSize
+	size := bsize * 5 / 2
+	if err := forgetSlice(store, 12, size); err != nil {
+		t.Fatalf("forge slice: %s", err)
+	}
+	defer store.Remove(12, size)
+
+	if _, err := store.EvictCache(12, uint32(size), 0, uint32(size)); err != nil {
+		t.Fatalf("evict full slice: %s", err)
+	}
+	bytes, err := store.FillCache(12, uint32(size), uint32(bsize), uint32(bsize))
+	if err != nil {
+		t.Fatalf("fill visible block: %s", err)
+	}
+	assert.Equal(t, uint64(bsize), bytes)
+
+	check := func(offset, length uint32) bool {
+		t.Helper()
+		var cached bool
+		_, err := store.CheckCache(12, uint32(size), offset, length, func(exists bool, _ string, _ int) {
+			cached = exists
+		})
+		assert.NoError(t, err)
+		return cached
+	}
+	assert.False(t, check(0, uint32(bsize)))
+	assert.True(t, check(uint32(bsize), uint32(bsize)))
+	assert.False(t, check(uint32(bsize*2), uint32(bsize/2)))
+
+	bytes, err = store.EvictCache(12, uint32(size), uint32(bsize), uint32(bsize))
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(bsize), bytes)
+	assert.False(t, check(uint32(bsize), uint32(bsize)))
 }
 
 func BenchmarkCachedRead(b *testing.B) {

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -41,9 +41,9 @@ type ChunkStore interface {
 	NewReader(id uint64, length int) Reader
 	NewWriter(id uint64, tierID uint8) Writer
 	Remove(id uint64, length int) error
-	FillCache(id uint64, length uint32) error
-	EvictCache(id uint64, length uint32) error
-	CheckCache(id uint64, length uint32, handler func(exists bool, loc string, size int)) error
+	FillCache(id uint64, size, offset, length uint32) (uint64, error)
+	EvictCache(id uint64, size, offset, length uint32) (uint64, error)
+	CheckCache(id uint64, size, offset, length uint32, handler func(exists bool, loc string, size int)) (uint64, error)
 	UsedMemory() int64
 	UpdateLimit(upload, download int64)
 	BlobStorage() object.ObjectStorage

--- a/pkg/vfs/context_cancellation_test.go
+++ b/pkg/vfs/context_cancellation_test.go
@@ -44,10 +44,14 @@ type blockingChunkStore struct {
 func (s *blockingChunkStore) NewReader(id uint64, length int) chunk.Reader   { return s.reader }
 func (s *blockingChunkStore) NewWriter(id uint64, tierID uint8) chunk.Writer { return nil }
 func (s *blockingChunkStore) Remove(id uint64, length int) error             { return nil }
-func (s *blockingChunkStore) FillCache(id uint64, length uint32) error       { return nil }
-func (s *blockingChunkStore) EvictCache(id uint64, length uint32) error      { return nil }
-func (s *blockingChunkStore) CheckCache(id uint64, length uint32, handler func(bool, string, int)) error {
-	return nil
+func (s *blockingChunkStore) FillCache(id uint64, size, offset, length uint32) (uint64, error) {
+	return 0, nil
+}
+func (s *blockingChunkStore) EvictCache(id uint64, size, offset, length uint32) (uint64, error) {
+	return 0, nil
+}
+func (s *blockingChunkStore) CheckCache(id uint64, size, offset, length uint32, handler func(bool, string, int)) (uint64, error) {
+	return 0, nil
 }
 func (s *blockingChunkStore) UsedMemory() int64                  { return 0 }
 func (s *blockingChunkStore) UpdateLimit(upload, download int64) {}

--- a/pkg/vfs/fill.go
+++ b/pkg/vfs/fill.go
@@ -89,8 +89,8 @@ func (c *CacheFiller) cacheFile(ctx meta.Context, action CacheAction, resp *Cach
 		var handler sliceHandler
 		switch action {
 		case WarmupCache:
-			handler = func(s meta.Slice) error {
-				return c.store.FillCache(s.Id, s.Size)
+			handler = func(s meta.Slice) (uint64, error) {
+				return c.store.FillCache(s.Id, s.Size, s.Off, s.Len)
 			}
 
 			if c.conf.Meta.OpenCache > 0 {
@@ -100,8 +100,8 @@ func (c *CacheFiller) cacheFile(ctx meta.Context, action CacheAction, resp *Cach
 				_ = c.meta.Close(ctx, f.ino)
 			}
 		case EvictCache:
-			handler = func(s meta.Slice) error {
-				return c.store.EvictCache(s.Id, s.Size)
+			handler = func(s meta.Slice) (uint64, error) {
+				return c.store.EvictCache(s.Id, s.Size, s.Off, s.Len)
 			}
 		case CheckCache:
 			blockHandler := func(exists bool, loc string, size int) {
@@ -113,8 +113,8 @@ func (c *CacheFiller) cacheFile(ctx meta.Context, action CacheAction, resp *Cach
 					atomic.AddUint64(&resp.MissBytes, uint64(size))
 				}
 			}
-			handler = func(s meta.Slice) error {
-				return c.store.CheckCache(s.Id, s.Size, blockHandler)
+			handler = func(s meta.Slice) (uint64, error) {
+				return c.store.CheckCache(s.Id, s.Size, s.Off, s.Len, blockHandler)
 			}
 		}
 
@@ -288,7 +288,7 @@ type sliceIterator struct {
 	slices         []meta.Slice
 }
 
-type sliceHandler func(s meta.Slice) error
+type sliceHandler func(s meta.Slice) (uint64, error)
 
 func (iter *sliceIterator) hasNext() bool {
 	if iter.err != nil {
@@ -336,7 +336,6 @@ func (iter *sliceIterator) Iterate(handler sliceHandler, concurrent chan token) 
 			continue
 		}
 		atomic.AddUint64(&iter.stat.SliceCount, 1)
-		atomic.AddUint64(&iter.stat.TotalBytes, uint64(s.Size))
 
 		select {
 		case concurrent <- token{}:
@@ -346,12 +345,16 @@ func (iter *sliceIterator) Iterate(handler sliceHandler, concurrent chan token) 
 					<-concurrent
 					wg.Done()
 				}()
-				if err := handler(s); err != nil {
+				bytes, err := handler(s)
+				atomic.AddUint64(&iter.stat.TotalBytes, bytes)
+				if err != nil {
 					iter.err = fmt.Errorf("inode %d slice %d : %w", iter.ino, s.Id, err)
 				}
 			}()
 		default:
-			if err := handler(s); err != nil {
+			bytes, err := handler(s)
+			atomic.AddUint64(&iter.stat.TotalBytes, bytes)
+			if err != nil {
 				iter.err = fmt.Errorf("inode %d slice %d : %w", iter.ino, s.Id, err)
 			}
 		}

--- a/pkg/vfs/fill_test.go
+++ b/pkg/vfs/fill_test.go
@@ -19,9 +19,37 @@ package vfs
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/juicedata/juicefs/pkg/chunk"
 	"github.com/juicedata/juicefs/pkg/meta"
 )
+
+type cacheCall struct {
+	action               CacheAction
+	id                   uint64
+	size, offset, length uint32
+}
+
+type recordingChunkStore struct {
+	chunk.ChunkStore
+	calls chan cacheCall
+}
+
+func (s *recordingChunkStore) FillCache(id uint64, size, offset, length uint32) (uint64, error) {
+	s.calls <- cacheCall{WarmupCache, id, size, offset, length}
+	return 4096, nil
+}
+
+func (s *recordingChunkStore) EvictCache(id uint64, size, offset, length uint32) (uint64, error) {
+	s.calls <- cacheCall{EvictCache, id, size, offset, length}
+	return 4096, nil
+}
+
+func (s *recordingChunkStore) CheckCache(id uint64, size, offset, length uint32, handler func(bool, string, int)) (uint64, error) {
+	s.calls <- cacheCall{CheckCache, id, size, offset, length}
+	return 4096, nil
+}
 
 func TestFill(t *testing.T) {
 	v, _ := createTestVFS(nil, "")
@@ -46,4 +74,32 @@ func TestFill(t *testing.T) {
 	}
 	// bad cases
 	v.cacheFiller.Cache(meta.Background(), WarmupCache, []string{"/test/file", "/sym2", "/sym3", "/.stats", "/not_exists"}, 2, nil)
+}
+
+func TestCacheFillerUsesVisibleSliceRange(t *testing.T) {
+	v, _ := createTestVFS(nil, "")
+	ctx := meta.Background()
+	var inode meta.Ino
+	var attr meta.Attr
+	if st := v.Meta.Create(ctx, meta.RootInode, "partial", 0644, 0, 0, &inode, &attr); st != 0 {
+		t.Fatalf("create file: %s", st)
+	}
+	slice := meta.Slice{Id: 123, Size: 8 << 20, Off: 3 << 20, Len: 2 << 20}
+	if st := v.Meta.Write(ctx, inode, 0, 0, slice, time.Now()); st != 0 {
+		t.Fatalf("write slice: %s", st)
+	}
+
+	store := &recordingChunkStore{ChunkStore: v.Store, calls: make(chan cacheCall, 3)}
+	v.cacheFiller.store = store
+	for _, action := range []CacheAction{WarmupCache, EvictCache, CheckCache} {
+		resp := &CacheResponse{Locations: make(map[string]uint64)}
+		v.cacheFiller.Cache(ctx, action, []string{"/partial"}, 1, resp)
+		call := <-store.calls
+		if call.action != action || call.id != slice.Id || call.size != slice.Size || call.offset != slice.Off || call.length != slice.Len {
+			t.Fatalf("unexpected cache call: %+v", call)
+		}
+		if resp.TotalBytes != 4096 {
+			t.Fatalf("total bytes: %d, want 4096", resp.TotalBytes)
+		}
+	}
 }


### PR DESCRIPTION
## What does this PR do?

  Skip fully invisible blocks when running cache warmup operations, including:

  - `juicefs warmup`
  - `juicefs warmup --check`
  - `juicefs warmup --evict`

  Metadata returns the visible part of each slice through `Slice.Off` and `Slice.Len`. Previously, the cache operations only
  received the slice ID and full size, causing all blocks of a partially visible slice to be processed.

  This PR passes the visible slice range to the chunk store and only processes cache blocks overlapping `[offset, offset +
  length)`.

  A partially visible block is still processed in full because cache blocks are the minimum cache unit.

related issue: https://github.com/juicedata/juicefs/issues/7374