### PR TITLE
meta/redis: batch load quotas to reduce round trips

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -4478,6 +4478,95 @@ func (m *redisMeta) doDelQuota(ctx Context, qtype uint32, key uint64) error {
 	return err
 }
 
+const quotaLoadBatchSize = 1000
+
+type quotaLoadEntry struct {
+	key        string
+	id         uint64
+	usedInodes int64
+	usedSpace  *redis.StringCmd
+	quota      *redis.StringCmd
+}
+
+func (m *redisMeta) loadQuotaBatch(ctx Context, config *quotaKeys, name string, keys []string, quotas map[uint64]*Quota) error {
+	if len(keys)%2 != 0 {
+		return fmt.Errorf("invalid HSCAN result for %s quotas: odd number of fields", name)
+	}
+
+	entries := make([]quotaLoadEntry, 0, len(keys)/2)
+	for i := 0; i < len(keys); i += 2 {
+		key := keys[i]
+		id, err := strconv.ParseUint(key, 10, 64)
+		if err != nil {
+			logger.Errorf("invalid key in %s: %s", name, key)
+			continue
+		}
+		usedInodes, err := strconv.ParseInt(keys[i+1], 10, 64)
+		if err != nil {
+			logger.Errorf("invalid usedInodes for %s %s: %s", name, key, keys[i+1])
+			continue
+		}
+		entries = append(entries, quotaLoadEntry{
+			key:        key,
+			id:         id,
+			usedInodes: usedInodes,
+		})
+	}
+
+	for start := 0; start < len(entries); start += quotaLoadBatchSize {
+		end := start + quotaLoadBatchSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		if err := m.loadQuotaEntries(ctx, config, name, entries[start:end], quotas); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// loadQuotaEntries fetches used space and limits for a batch of entries in one
+// pipeline round trip, keeping the per-entry semantics of doLoadQuotas.
+func (m *redisMeta) loadQuotaEntries(ctx Context, config *quotaKeys, name string, batch []quotaLoadEntry, quotas map[uint64]*Quota) error {
+	_, err := m.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for i := range batch {
+			batch[i].usedSpace = pipe.HGet(ctx, config.usedSpaceKey, batch[i].key)
+			batch[i].quota = pipe.HGet(ctx, config.quotaKey, batch[i].key)
+		}
+		return nil
+	})
+	if err != nil && err != redis.Nil {
+		return err
+	}
+
+	for i := range batch {
+		entry := &batch[i]
+		usedSpace, err := entry.usedSpace.Int64()
+		if err != nil && err != redis.Nil {
+			return err
+		}
+
+		var maxSpace, maxInodes int64 = -1, -1
+		if buf, err := entry.quota.Bytes(); err == nil {
+			if len(buf) != 16 {
+				logger.Errorf("invalid quota value for %s %s: len=%d", name, entry.key, len(buf))
+				continue
+			}
+			maxSpace, maxInodes = m.parseQuota(buf)
+		} else if err != redis.Nil {
+			return err
+		}
+
+		quotas[entry.id] = &Quota{
+			MaxSpace:   maxSpace,
+			MaxInodes:  maxInodes,
+			UsedSpace:  usedSpace,
+			UsedInodes: entry.usedInodes,
+		}
+	}
+	return nil
+}
+
 func (m *redisMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Quota, map[uint64]*Quota, error) {
 	format := m.getFormat()
 	dirQuotas := make(map[uint64]*Quota)
@@ -4505,43 +4594,7 @@ func (m *redisMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Qu
 			return nil, nil, nil, fmt.Errorf("failed to load %s quotas: %w", qt.name, err)
 		}
 		if err := m.hscan(ctx, config.usedInodesKey, func(keys []string) error {
-			for i := 0; i < len(keys); i += 2 {
-				key := keys[i]
-				id, err := strconv.ParseUint(key, 10, 64)
-				if err != nil {
-					logger.Errorf("invalid key in %s: %s", qt.name, key)
-					continue
-				}
-				usedInodes, err := strconv.ParseInt(keys[i+1], 10, 64)
-				if err != nil {
-					logger.Errorf("invalid usedInodes for %s %s: %s", qt.name, key, keys[i+1])
-					continue
-				}
-
-				usedSpace, err := m.rdb.HGet(ctx, config.usedSpaceKey, key).Int64()
-				if err != nil && err != redis.Nil {
-					return err
-				}
-
-				var maxSpace, maxInodes int64 = -1, -1
-				if buf, err := m.rdb.HGet(ctx, config.quotaKey, key).Bytes(); err == nil {
-					if len(buf) != 16 {
-						logger.Errorf("invalid quota value for %s %s: len=%d", qt.name, key, len(buf))
-						continue
-					}
-					maxSpace, maxInodes = m.parseQuota(buf)
-				} else if err != redis.Nil {
-					return err
-				}
-
-				qt.quotas[id] = &Quota{
-					MaxSpace:   maxSpace,
-					MaxInodes:  maxInodes,
-					UsedSpace:  usedSpace,
-					UsedInodes: usedInodes,
-				}
-			}
-			return nil
+			return m.loadQuotaBatch(ctx, config, qt.name, keys, qt.quotas)
 		}); err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/meta/redis_quota_test.go
+++ b/pkg/meta/redis_quota_test.go
@@ -1,0 +1,145 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package meta
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisLoadQuotas(t *testing.T) {
+	m := newTestRedisMeta(t, 7)
+	ctx := Background()
+	config, err := m.getQuotaKeys(DirQuotaType)
+	require.NoError(t, err)
+
+	_, err = m.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for id := uint64(1); id <= quotaLoadBatchSize+1; id++ {
+			key := strconv.FormatUint(id, 10)
+			pipe.HSet(ctx, config.usedInodesKey, key, id*2)
+			pipe.HSet(ctx, config.usedSpaceKey, key, id*10)
+			pipe.HSet(ctx, config.quotaKey, key, m.packQuota(int64(id*100), int64(id*3)))
+		}
+		// entry with usedInodes only: usedSpace and quota are missing
+		pipe.HSet(ctx, config.usedInodesKey, strconv.FormatUint(quotaLoadBatchSize+2, 10), 7)
+		// entry with an invalid quota value (not 16 bytes): must be skipped
+		pipe.HSet(ctx, config.usedInodesKey, strconv.FormatUint(quotaLoadBatchSize+3, 10), 8)
+		pipe.HSet(ctx, config.usedSpaceKey, strconv.FormatUint(quotaLoadBatchSize+3, 10), 80)
+		pipe.HSet(ctx, config.quotaKey, strconv.FormatUint(quotaLoadBatchSize+3, 10), "bad")
+		// garbage field: invalid key and usedInodes, both must be skipped
+		pipe.HSet(ctx, config.usedInodesKey, "not-a-key", "garbage")
+		return nil
+	})
+	require.NoError(t, err)
+
+	dirQuotas, userQuotas, groupQuotas, err := m.doLoadQuotas(ctx)
+	require.NoError(t, err)
+	require.Empty(t, userQuotas)
+	require.Empty(t, groupQuotas)
+	require.Len(t, dirQuotas, quotaLoadBatchSize+2)
+
+	first := dirQuotas[1]
+	require.NotNil(t, first)
+	require.EqualValues(t, 100, first.MaxSpace)
+	require.EqualValues(t, 3, first.MaxInodes)
+	require.EqualValues(t, 10, first.UsedSpace)
+	require.EqualValues(t, 2, first.UsedInodes)
+
+	last := dirQuotas[quotaLoadBatchSize+1]
+	require.NotNil(t, last)
+	require.EqualValues(t, (quotaLoadBatchSize+1)*100, last.MaxSpace)
+	require.EqualValues(t, (quotaLoadBatchSize+1)*3, last.MaxInodes)
+	require.EqualValues(t, (quotaLoadBatchSize+1)*10, last.UsedSpace)
+	require.EqualValues(t, (quotaLoadBatchSize+1)*2, last.UsedInodes)
+
+	missing := dirQuotas[quotaLoadBatchSize+2]
+	require.NotNil(t, missing)
+	require.EqualValues(t, -1, missing.MaxSpace)
+	require.EqualValues(t, -1, missing.MaxInodes)
+	require.EqualValues(t, 0, missing.UsedSpace)
+	require.EqualValues(t, 7, missing.UsedInodes)
+
+	require.Nil(t, dirQuotas[quotaLoadBatchSize+3])
+}
+
+func TestRedisLoadUGQuotas(t *testing.T) {
+	m := newTestRedisMeta(t, 8)
+	m.getBase().getFormat().UserGroupQuota = true
+	ctx := Background()
+
+	dirConfig, err := m.getQuotaKeys(DirQuotaType)
+	require.NoError(t, err)
+	userConfig, err := m.getQuotaKeys(UserQuotaType)
+	require.NoError(t, err)
+	groupConfig, err := m.getQuotaKeys(GroupQuotaType)
+	require.NoError(t, err)
+
+	_, err = m.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.HSet(ctx, dirConfig.usedInodesKey, "10", 2)
+		pipe.HSet(ctx, dirConfig.usedSpaceKey, "10", 20)
+		pipe.HSet(ctx, dirConfig.quotaKey, "10", m.packQuota(200, 4))
+		pipe.HSet(ctx, userConfig.usedInodesKey, "100", 5)
+		pipe.HSet(ctx, userConfig.usedSpaceKey, "100", 500)
+		pipe.HSet(ctx, userConfig.quotaKey, "100", m.packQuota(1000, 10))
+		pipe.HSet(ctx, groupConfig.usedInodesKey, "200", 6)
+		pipe.HSet(ctx, groupConfig.usedSpaceKey, "200", 600)
+		pipe.HSet(ctx, groupConfig.quotaKey, "200", m.packQuota(2000, 20))
+		return nil
+	})
+	require.NoError(t, err)
+
+	dirQuotas, userQuotas, groupQuotas, err := m.doLoadQuotas(ctx)
+	require.NoError(t, err)
+	require.Len(t, dirQuotas, 1)
+	require.Len(t, userQuotas, 1)
+	require.Len(t, groupQuotas, 1)
+
+	dir := dirQuotas[10]
+	require.NotNil(t, dir)
+	require.EqualValues(t, 200, dir.MaxSpace)
+	require.EqualValues(t, 4, dir.MaxInodes)
+	require.EqualValues(t, 20, dir.UsedSpace)
+	require.EqualValues(t, 2, dir.UsedInodes)
+
+	user := userQuotas[100]
+	require.NotNil(t, user)
+	require.EqualValues(t, 1000, user.MaxSpace)
+	require.EqualValues(t, 10, user.MaxInodes)
+	require.EqualValues(t, 500, user.UsedSpace)
+	require.EqualValues(t, 5, user.UsedInodes)
+
+	group := groupQuotas[200]
+	require.NotNil(t, group)
+	require.EqualValues(t, 2000, group.MaxSpace)
+	require.EqualValues(t, 20, group.MaxInodes)
+	require.EqualValues(t, 600, group.UsedSpace)
+	require.EqualValues(t, 6, group.UsedInodes)
+}
+
+func TestRedisLoadQuotasOddHScan(t *testing.T) {
+	m := newTestRedisMeta(t, 9)
+	config, err := m.getQuotaKeys(DirQuotaType)
+	require.NoError(t, err)
+
+	quotas := make(map[uint64]*Quota)
+	err = m.loadQuotaBatch(Background(), config, "dir", []string{"1", "2", "3"}, quotas)
+	require.Error(t, err)
+	require.Empty(t, quotas)
+}


### PR DESCRIPTION
Closes #7388

## Problem

`redisMeta.doLoadQuotas` issues two serialized HGET round trips per quota entry (`HGET usedSpaceKey` + `HGET quotaKey`), driven by the HSCAN over `usedInodesKey`. With N dir/user/group quotas this is 2N round trips, executed at mount time (`loadQuotas`), on every `juicefs quota list`, and during user/group quota check/repair. Large volumes (tens of thousands of quota entries) mount slowly and `quota list` blocks on the same N+1 pattern. The TKV engine already batches quota key fetches (#7171).

## Change

- `loadQuotaBatch`: parses HSCAN pairs into entries (skipping unparseable keys/`usedInodes` as before).
- `loadQuotaEntries`: fetches `usedSpace`/`quota` for 1000 entries in one `Pipelined` round trip, then applies per-entry handling identical to the previous loop:
  - missing keys (`redis.Nil`) → `UsedSpace=0`, `MaxSpace=-1`, `MaxInodes=-1`
  - invalid quota values (not 16 bytes) are skipped with a log, as before
- Guards a latent out-of-range panic: the previous loop indexed `keys[i+1]` without checking for an odd-length HSCAN result; the new code returns an error instead.

## Tests

`pkg/meta/redis_quota_test.go` (new):

- batch boundary: 1001 entries across two pipelines, values verified
- missing `usedSpace`/`quota` keys (redis.Nil path)
- invalid quota value and garbage fields skipped
- user/group quota types loaded through the same path
- odd-length HSCAN result → error, empty result

Verified against a real Redis (`databases 32`): `go test ./pkg/meta -run TestRedisLoad -count=1 -v` passes.