### PR TITLE
cmd/sync: fix delayed deletes in checkpoint

### DIFF
--- a/pkg/sync/checkpoint.go
+++ b/pkg/sync/checkpoint.go
@@ -276,26 +276,25 @@ func (m *CheckpointManager) Save(ckpt *Checkpoint) error {
 		m.statsUpdater(&ckpt.Stats)
 	}
 
+	ckpt.Lock()
 	ckpt.UpdatedAt = time.Now()
-
-	ckpt.RLock()
 	prefixCount := len(ckpt.PrefixState)
 	for _, state := range ckpt.PrefixState {
 		state.RLock()
 	}
 	m.multipartUploadStore.RLock()
-	data, err := json.Marshal(ckpt)
-	m.multipartUploadStore.RUnlock()
-	for _, state := range ckpt.PrefixState {
-		state.RUnlock()
-	}
 	srcDelayDelMu.Lock()
 	ckpt.SrcDelayDel = append([]string(nil), srcDelayDel...)
 	srcDelayDelMu.Unlock()
 	dstDelayDelMu.Lock()
 	ckpt.DstDelayDel = append([]string(nil), dstDelayDel...)
 	dstDelayDelMu.Unlock()
-	ckpt.RUnlock()
+	data, err := json.Marshal(ckpt)
+	m.multipartUploadStore.RUnlock()
+	for _, state := range ckpt.PrefixState {
+		state.RUnlock()
+	}
+	ckpt.Unlock()
 
 	if err != nil {
 		return fmt.Errorf("failed to marshal checkpoint: %w", err)

--- a/pkg/sync/checkpoint_test.go
+++ b/pkg/sync/checkpoint_test.go
@@ -105,6 +105,54 @@ func TestCheckpointManagerSaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestCheckpointManagerSaveDelayDeletes(t *testing.T) {
+	srcStore, _ := object.CreateStorage("mem", "delay-delete-src", "", "", "")
+	store, _ := object.CreateStorage("mem", "delay-delete-dst", "", "", "")
+
+	srcDelayDelMu.Lock()
+	savedSrcDelayDel := srcDelayDel
+	srcDelayDel = []string{"src-dir-a"}
+	srcDelayDelMu.Unlock()
+	dstDelayDelMu.Lock()
+	savedDstDelayDel := dstDelayDel
+	dstDelayDel = []string{"dst-dir-a"}
+	dstDelayDelMu.Unlock()
+	t.Cleanup(func() {
+		srcDelayDelMu.Lock()
+		srcDelayDel = savedSrcDelayDel
+		srcDelayDelMu.Unlock()
+		dstDelayDelMu.Lock()
+		dstDelayDel = savedDstDelayDel
+		dstDelayDelMu.Unlock()
+	})
+
+	manager := NewCheckpointManager(srcStore, store, nil)
+	if err := manager.Save(manager.checkpoint); err != nil {
+		t.Fatalf("save initial checkpoint: %v", err)
+	}
+
+	srcDelayDelMu.Lock()
+	srcDelayDel = append(srcDelayDel, "src-dir-b")
+	srcDelayDelMu.Unlock()
+	dstDelayDelMu.Lock()
+	dstDelayDel = append(dstDelayDel, "dst-dir-b")
+	dstDelayDelMu.Unlock()
+	if err := manager.Save(manager.checkpoint); err != nil {
+		t.Fatalf("save final checkpoint: %v", err)
+	}
+
+	loaded, err := NewCheckpointManager(srcStore, store, nil).Load()
+	if err != nil {
+		t.Fatalf("load checkpoint: %v", err)
+	}
+	if !reflect.DeepEqual(loaded.SrcDelayDel, []string{"src-dir-a", "src-dir-b"}) {
+		t.Fatalf("unexpected source delayed deletes: %v", loaded.SrcDelayDel)
+	}
+	if !reflect.DeepEqual(loaded.DstDelayDel, []string{"dst-dir-a", "dst-dir-b"}) {
+		t.Fatalf("unexpected destination delayed deletes: %v", loaded.DstDelayDel)
+	}
+}
+
 func TestCheckpointManagerPrefixStateLifecycle(t *testing.T) {
 	srcStore, _ := object.CreateStorage("mem", "src", "", "", "")
 	store, _ := object.CreateStorage("mem", "", "", "", "")

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1536,12 +1536,12 @@ func produce(tasks chan<- object.Object, srckeys, dstkeys <-chan object.Object, 
 				sendTask(withSize(obj, markChecksum))
 			} else if config.DeleteSrc {
 				if obj.IsDir() {
-					if checkpointMgr != nil {
-						checkpointMgr.UpdateLastListedKey(prefix, obj)
-					}
 					srcDelayDelMu.Lock()
 					srcDelayDel = append(srcDelayDel, obj.Key())
 					srcDelayDelMu.Unlock()
+					if checkpointMgr != nil {
+						checkpointMgr.UpdateLastListedKey(prefix, obj)
+					}
 				} else {
 					sendTask(withSize(obj, markDeleteSrc))
 				}


### PR DESCRIPTION
## Why

`CheckpointManager.Save` previously marshaled the checkpoint before copying the latest `srcDelayDel` and `dstDelayDel` lists into it. As a result, the persisted lists always lagged one save cycle behind.

When a checkpoint-enabled sync using deletion options was interrupted, the final signal-triggered save could omit directories discovered since the previous save. Because the listing cursor had already advanced past those directories, they could not be rediscovered after resuming and were silently left undeleted.

Fixes #7392