### PR TITLE
object: reuse encrypted data across put retries

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -375,6 +375,7 @@ func (store *cachedStore) upload(ctx context.Context, key string, block *Page, s
 		return fmt.Errorf("Compress block key %s: %s", key, err)
 	}
 	buf.Data = buf.Data[:n]
+	ctx = object.WithPutRequest(ctx)
 
 	try, max := 0, 3
 	if sync {

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -395,6 +395,54 @@ type dStore struct {
 	cnt int32
 }
 
+type retryEncryptor struct {
+	calls atomic.Int32
+}
+
+func (e *retryEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	e.calls.Add(1)
+	return append([]byte("encrypted:"), plaintext...), nil
+}
+
+func (e *retryEncryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	return bytes.TrimPrefix(ciphertext, []byte("encrypted:")), nil
+}
+
+type retryOnceStore struct {
+	object.ObjectStorage
+	puts atomic.Int32
+}
+
+func (s *retryOnceStore) Put(_ context.Context, _ string, in io.Reader, _ ...object.AttrGetter) error {
+	if _, err := io.Copy(io.Discard, in); err != nil {
+		return err
+	}
+	if s.puts.Add(1) == 1 {
+		return errors.New("temporary put failure")
+	}
+	return nil
+}
+
+type storageWrapper struct {
+	object.ObjectStorage
+}
+
+func TestUploadEncryptedRetry(t *testing.T) {
+	base, err := object.CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	backend := &retryOnceStore{ObjectStorage: base}
+	enc := &retryEncryptor{}
+	storage := &storageWrapper{ObjectStorage: object.NewEncrypted(backend, enc)}
+	conf := defaultConf
+	conf.CacheDir = "memory"
+	store := NewCachedStore(storage, conf, nil).(*cachedStore)
+
+	block := NewPage([]byte("block data"))
+	require.NoError(t, store.upload(context.Background(), "key", block, nil))
+	require.Equal(t, int32(2), backend.puts.Load())
+	require.Equal(t, int32(1), enc.calls.Load())
+}
+
 func (s *dStore) Get(ctx context.Context, key string, off, limit int64, getters ...object.AttrGetter) (io.ReadCloser, error) {
 	atomic.AddInt32(&s.cnt, 1)
 	return nil, errors.New("not found")

--- a/pkg/object/encrypt.go
+++ b/pkg/object/encrypt.go
@@ -348,12 +348,23 @@ func (e *encrypted) Get(ctx context.Context, key string, off, limit int64, gette
 	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
-func (e *encrypted) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) error {
+func (e *encrypted) encrypt(in io.Reader) ([]byte, error) {
 	plain, err := io.ReadAll(in)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	ciphertext, err := e.enc.Encrypt(plain)
+	return e.enc.Encrypt(plain)
+}
+
+func (e *encrypted) ciphertextForPut(ctx context.Context, key string, in io.Reader) ([]byte, error) {
+	if state, ok := ctx.Value(putRequestKey).(*putRequestState); ok {
+		return state.ciphertextFor(e, key, in)
+	}
+	return e.encrypt(in)
+}
+
+func (e *encrypted) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) error {
+	ciphertext, err := e.ciphertextForPut(ctx, key, in)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/put_retry.go
+++ b/pkg/object/put_retry.go
@@ -1,0 +1,79 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+)
+
+type putRequestContextKey struct{}
+
+var putRequestKey = &putRequestContextKey{}
+
+type preparedCiphertext struct {
+	key        string
+	ciphertext []byte
+}
+
+type putRequestState struct {
+	mu       sync.Mutex
+	prepared map[*encrypted]preparedCiphertext
+}
+
+type putRequestContext struct {
+	context.Context
+	state putRequestState
+}
+
+func (c *putRequestContext) Value(key any) any {
+	if requestKey, ok := key.(*putRequestContextKey); ok && requestKey == putRequestKey {
+		return &c.state
+	}
+	return c.Context.Value(key)
+}
+
+// WithPutRequest marks repeated Put calls as attempts for the same object payload.
+// The returned context must not be reused for another logical Put request.
+func WithPutRequest(ctx context.Context) context.Context {
+	if ctx == nil {
+		panic("cannot create context from nil parent")
+	}
+	return &putRequestContext{Context: ctx}
+}
+
+func (s *putRequestState) ciphertextFor(e *encrypted, key string, in io.Reader) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if prepared, ok := s.prepared[e]; ok {
+		if key != prepared.key {
+			return nil, fmt.Errorf("put request key mismatch: %q != %q", key, prepared.key)
+		}
+		return prepared.ciphertext, nil
+	}
+	ciphertext, err := e.encrypt(in)
+	if err != nil {
+		return nil, err
+	}
+	if s.prepared == nil {
+		s.prepared = make(map[*encrypted]preparedCiphertext)
+	}
+	s.prepared[e] = preparedCiphertext{key: key, ciphertext: ciphertext}
+	return ciphertext, nil
+}

--- a/pkg/object/put_retry_test.go
+++ b/pkg/object/put_retry_test.go
@@ -1,0 +1,202 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/require"
+)
+
+type countingEncryptor struct {
+	Encryptor
+	calls atomic.Int32
+}
+
+func (e *countingEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	e.calls.Add(1)
+	return e.Encryptor.Encrypt(plaintext)
+}
+
+type failOnceEncryptor struct {
+	Encryptor
+	calls atomic.Int32
+}
+
+func (e *failOnceEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	if e.calls.Add(1) == 1 {
+		return nil, errors.New("temporary encrypt failure")
+	}
+	return e.Encryptor.Encrypt(plaintext)
+}
+
+type retryPutStorage struct {
+	ObjectStorage
+	failures int
+	puts     atomic.Int32
+
+	mu      sync.Mutex
+	bodies  [][]byte
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *retryPutStorage) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) error {
+	body, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	put := s.puts.Add(1)
+	s.mu.Lock()
+	s.bodies = append(s.bodies, body)
+	s.mu.Unlock()
+	if put == 1 && s.started != nil {
+		close(s.started)
+		<-s.release
+	}
+	if int(put) <= s.failures {
+		return errors.New("temporary put failure")
+	}
+	return s.ObjectStorage.Put(ctx, key, bytes.NewReader(body), getters...)
+}
+
+func TestEncryptedPutRetry(t *testing.T) {
+	ctx := WithPutRequest(context.Background())
+	base, err := CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	storage := &retryPutStorage{ObjectStorage: base, failures: 2}
+	dc, err := NewDataEncryptor(NewRSAEncryptor(rsaKey), AES256GCM_RSA)
+	require.NoError(t, err)
+	enc := &countingEncryptor{Encryptor: dc}
+	store := WithPrefix(NewEncrypted(storage, enc), "prefix/")
+	want := []byte("same plaintext for every attempt")
+
+	for i := 0; i < 3; i++ {
+		err = store.Put(ctx, "key", bytes.NewReader(want))
+		if i < 2 {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	require.Equal(t, int32(1), enc.calls.Load())
+	storage.mu.Lock()
+	require.Len(t, storage.bodies, 3)
+	require.Equal(t, storage.bodies[0], storage.bodies[1])
+	require.Equal(t, storage.bodies[0], storage.bodies[2])
+	ciphertext := storage.bodies[2]
+	storage.mu.Unlock()
+	plain, err := dc.Decrypt(ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, want, plain)
+}
+
+func TestPutRequestContext(t *testing.T) {
+	type contextKey struct{}
+	parent, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey{}, "value"))
+	ctx := WithPutRequest(parent)
+
+	require.Equal(t, "value", ctx.Value(contextKey{}))
+	cancel()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.Panics(t, func() { WithPutRequest(nil) })
+}
+
+func TestEncryptedPut(t *testing.T) {
+	base, err := CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	dc, err := NewDataEncryptor(NewRSAEncryptor(rsaKey), AES256GCM_RSA)
+	require.NoError(t, err)
+	enc := &countingEncryptor{Encryptor: dc}
+	store := NewEncrypted(base, enc)
+
+	for i := 0; i < 2; i++ {
+		require.NoError(t, store.Put(context.Background(), "key", bytes.NewReader([]byte("payload"))))
+	}
+	require.Equal(t, int32(2), enc.calls.Load())
+
+	readErr := errors.New("read failure")
+	require.ErrorIs(t, store.Put(context.Background(), "key", iotest.ErrReader(readErr)), readErr)
+	require.Equal(t, int32(2), enc.calls.Load())
+}
+
+func TestEncryptedPutPrepareRetry(t *testing.T) {
+	ctx := WithPutRequest(context.Background())
+	base, err := CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	dc, err := NewDataEncryptor(NewRSAEncryptor(rsaKey), AES256GCM_RSA)
+	require.NoError(t, err)
+	enc := &failOnceEncryptor{Encryptor: dc}
+	store := NewEncrypted(base, enc)
+
+	require.Error(t, store.Put(ctx, "key", bytes.NewReader([]byte("payload"))))
+	require.NoError(t, store.Put(ctx, "key", bytes.NewReader([]byte("payload"))))
+	require.Equal(t, int32(2), enc.calls.Load())
+}
+
+func TestPutRequestKey(t *testing.T) {
+	ctx := WithPutRequest(context.Background())
+	base, err := CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	dc, err := NewDataEncryptor(NewRSAEncryptor(rsaKey), AES256GCM_RSA)
+	require.NoError(t, err)
+	store := NewEncrypted(base, dc)
+
+	require.NoError(t, store.Put(ctx, "key", bytes.NewReader([]byte("payload"))))
+	err = store.Put(ctx, "other", bytes.NewReader([]byte("payload")))
+	require.ErrorContains(t, err, "put request key mismatch")
+	_, err = base.Head(context.Background(), "other")
+	require.Error(t, err)
+}
+
+func TestEncryptedPutConcurrent(t *testing.T) {
+	ctx := WithPutRequest(context.Background())
+	base, err := CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	storage := &retryPutStorage{
+		ObjectStorage: base,
+		started:       make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	dc, err := NewDataEncryptor(NewRSAEncryptor(rsaKey), AES256GCM_RSA)
+	require.NoError(t, err)
+	enc := &countingEncryptor{Encryptor: dc}
+	store := NewEncrypted(storage, enc)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- store.Put(ctx, "key", bytes.NewReader([]byte("payload")))
+	}()
+	<-storage.started
+	require.NoError(t, store.Put(ctx, "key", bytes.NewReader([]byte("payload"))))
+	close(storage.release)
+	require.NoError(t, <-firstDone)
+
+	require.Equal(t, int32(1), enc.calls.Load())
+	storage.mu.Lock()
+	defer storage.mu.Unlock()
+	require.Len(t, storage.bodies, 2)
+	require.Equal(t, storage.bodies[0], storage.bodies[1])
+}


### PR DESCRIPTION
## 1.Why and Backgroud?
`cachedStore.upload` retries failed object uploads by calling `ObjectStorage.Put` again. For encrypted storage, each attempt previously reread and re-encrypted the same data block, generating a new data key, nonce, and ciphertext. This introduced unnecessary CPU and memory overhead, especially when timed-out attempts overlapped with subsequent retries.

related issue: https://github.com/juicedata/juicefs/issues/7325

## 2.How to fix?
This change creates a request-scoped context shared by all attempts of one logical Put. `encrypted.Put` encrypts the payload once and reuses the prepared ciphertext for subsequent attempts, with synchronization for overlapping retries and isolation between different encryption instances. Regular Put calls without this context keep their existing behavior, and storage wrappers require no additional interfaces as long as they propagate the context.