### PR TITLE
meta: stop mutating the published format, publish it only once stored

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -503,7 +503,7 @@ func format(c *cli.Context) error {
 				format.KerbConf = readKerbConf(c.String(flag))
 			}
 		}
-	} else if strings.HasPrefix(err.Error(), "database is not formatted") {
+	} else if errors.Is(err, meta.ErrNotFormatted) {
 		create = true
 		format = &meta.Format{
 			Name:             name,

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1202,7 +1203,14 @@ func (fs *FileSystem) HandleQuota(ctx meta.Context, key string, cmd uint8, capac
 		if strings.HasPrefix(_err.Error(), "no quota for inode") {
 			return qs, 0
 		}
-		err = syscall.EINVAL
+		// keep the errno the meta layer reported (EIO for a failed store), so a
+		// transient failure is not read as a permanently bad request
+		var eno syscall.Errno
+		if errors.As(_err, &eno) {
+			err = eno
+		} else {
+			err = syscall.EINVAL
+		}
 	}
 	return
 }

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -276,6 +276,9 @@ type baseMeta struct {
 	// fmt is reloaded in the background while other goroutines read it, so it is
 	// only ever accessed through getFormat/setFormat
 	fmt atomic.Pointer[Format]
+	// serializes the load-modify-store sequences that update the stored format,
+	// so two of them cannot drop each other's change
+	fmtMu sync.Mutex
 
 	root         Ino
 	txlocks      [nlocks]sync.Mutex // Pessimistic locks to reduce conflict
@@ -1032,6 +1035,21 @@ func (m *baseMeta) FlushSession() {
 
 func (m *baseMeta) Init(format *Format, force bool) error {
 	return m.en.doInit(format, force)
+}
+
+// enableFormatFlag turns a feature flag on in the stored format. It starts from
+// a fresh copy of what the volume holds rather than the published one, which
+// may carry the overrides this client was started with, and the lock keeps a
+// concurrent call from storing a format without the flag the other just set.
+func (m *baseMeta) enableFormatFlag(set func(*Format)) error {
+	m.fmtMu.Lock()
+	defer m.fmtMu.Unlock()
+	format, err := m.loadFormat(false)
+	if err != nil {
+		return err
+	}
+	set(format)
+	return m.Init(format, false)
 }
 
 func (m *baseMeta) cleanupDeletedFiles(ctx Context) {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -710,10 +710,13 @@ func (r *baseMeta) newMsg(mid uint32, args ...interface{}) error {
 	return fmt.Errorf("message %d is not supported", mid)
 }
 
+// ErrNotFormatted is returned when the volume holds no format yet.
+var ErrNotFormatted = errors.New("database is not formatted, please run `juicefs format ...` first")
+
 func (m *baseMeta) Load(checkVersion bool) (*Format, error) {
 	body, err := m.en.doLoad()
 	if err == nil && len(body) == 0 {
-		err = fmt.Errorf("database is not formatted, please run `juicefs format ...` first")
+		err = ErrNotFormatted
 	}
 	if err != nil {
 		return nil, err
@@ -913,7 +916,7 @@ func (m *baseMeta) refresh(ctx Context) {
 
 		old := m.getFormat()
 		if format, err := m.Load(false); err != nil {
-			if strings.HasPrefix(err.Error(), "database is not formatted") {
+			if errors.Is(err, ErrNotFormatted) {
 				logger.Errorf("reload setting: %s", err)
 				os.Exit(UmountCode)
 			}

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1033,8 +1033,15 @@ func (m *baseMeta) FlushSession() {
 	logger.Infof("flush session %d:", m.sid)
 }
 
+// Init stores the format and publishes it once the engine has committed it, so
+// a caller that gets an error back is never left with a format the volume never
+// received, whichever engine is in use.
 func (m *baseMeta) Init(format *Format, force bool) error {
-	return m.en.doInit(format, force)
+	if err := m.en.doInit(format, force); err != nil {
+		return err
+	}
+	m.setFormat(format)
+	return nil
 }
 
 // enableFormatFlag turns a feature flag on in the stored format. It starts from

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -2835,7 +2835,7 @@ func (m *baseMeta) setFormat(format *Format) {
 }
 
 func (m *baseMeta) GetFormat() Format {
-	return *m.getFormat()
+	return *m.getFormat().Clone()
 }
 
 func (m *baseMeta) CompactAll(ctx Context, threads int, bar *utils.Bar) syscall.Errno {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -713,7 +713,9 @@ func (r *baseMeta) newMsg(mid uint32, args ...interface{}) error {
 // ErrNotFormatted is returned when the volume holds no format yet.
 var ErrNotFormatted = errors.New("database is not formatted, please run `juicefs format ...` first")
 
-func (m *baseMeta) Load(checkVersion bool) (*Format, error) {
+// loadFormat reads the stored format without publishing it, so a caller can
+// finish preparing it before other goroutines can observe it.
+func (m *baseMeta) loadFormat(checkVersion bool) (*Format, error) {
 	body, err := m.en.doLoad()
 	if err == nil && len(body) == 0 {
 		err = ErrNotFormatted
@@ -732,6 +734,14 @@ func (m *baseMeta) Load(checkVersion bool) (*Format, error) {
 	}
 	if format.Tiers == nil {
 		format.Tiers = object.NewTiers(format.StorageClass)
+	}
+	return format, nil
+}
+
+func (m *baseMeta) Load(checkVersion bool) (*Format, error) {
+	format, err := m.loadFormat(checkVersion)
+	if err != nil {
+		return nil, err
 	}
 	m.setFormat(format)
 	return format, nil
@@ -892,6 +902,40 @@ func (m *baseMeta) OnReload(fn func(f *Format)) {
 
 const UmountCode = 11
 
+func (m *baseMeta) reloadFormat() {
+	old := m.getFormat()
+	format, err := m.loadFormat(false)
+	if err != nil {
+		if errors.Is(err, ErrNotFormatted) {
+			logger.Errorf("reload setting: %s", err)
+			os.Exit(UmountCode)
+		}
+		logger.Warnf("reload setting: %s", err)
+		return
+	}
+	if format.MetaVersion > MaxVersion {
+		logger.Errorf("incompatible metadata version %d > max version %d", format.MetaVersion, MaxVersion)
+		os.Exit(UmountCode)
+	}
+	if format.UUID != old.UUID {
+		logger.Errorf("UUID changed from %s to %s", old.UUID, format.UUID)
+		os.Exit(UmountCode)
+	}
+	if reflect.DeepEqual(format, old) {
+		return
+	}
+	m.msgCallbacks.Lock()
+	cbs := m.reloadCb
+	m.msgCallbacks.Unlock()
+	// the callbacks patch the format (the mount overrides it with the options
+	// given on the command line); run them before publishing it, so readers
+	// never see it change under them
+	for _, cb := range cbs {
+		cb(format)
+	}
+	m.setFormat(format)
+}
+
 func (m *baseMeta) refresh(ctx Context) {
 	for {
 		if ctx.Canceled() {
@@ -914,27 +958,7 @@ func (m *baseMeta) refresh(ctx Context) {
 		}
 		m.sesMu.Unlock()
 
-		old := m.getFormat()
-		if format, err := m.Load(false); err != nil {
-			if errors.Is(err, ErrNotFormatted) {
-				logger.Errorf("reload setting: %s", err)
-				os.Exit(UmountCode)
-			}
-			logger.Warnf("reload setting: %s", err)
-		} else if format.MetaVersion > MaxVersion {
-			logger.Errorf("incompatible metadata version %d > max version %d", format.MetaVersion, MaxVersion)
-			os.Exit(UmountCode)
-		} else if format.UUID != old.UUID {
-			logger.Errorf("UUID changed from %s to %s", old.UUID, format.UUID)
-			os.Exit(UmountCode)
-		} else if !reflect.DeepEqual(format, old) {
-			m.msgCallbacks.Lock()
-			cbs := m.reloadCb
-			m.msgCallbacks.Unlock()
-			for _, cb := range cbs {
-				cb(format)
-			}
-		}
+		m.reloadFormat()
 
 		if v, err := m.en.getCounter(usedSpace); err == nil {
 			atomic.StoreInt64(&m.usedSpace, v)

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -4439,6 +4439,56 @@ func testAtime(t *testing.T, m Meta) {
 	}
 }
 
+// memkv seeds every client from settingPath and writes the setting back to it,
+// so a test must neither inherit one nor leave one behind.
+func newTestMemKV(t *testing.T, name string, format *Format) Meta {
+	t.Helper()
+	_ = os.Remove(settingPath)
+	t.Cleanup(func() { _ = os.Remove(settingPath) })
+	m, err := newKVMeta("memkv", name, testConfig())
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
+	}
+	if err := m.Init(format, false); err != nil {
+		t.Fatalf("init: %s", err)
+	}
+	return m
+}
+
+// The Format published by setFormat is shared with every reader that calls
+// getFormat, so a change has to be published as a new value: mutating the live
+// one races with those readers. The atomic pointer guards the pointer, not the
+// struct it points at.
+func TestPublishedFormatIsNotMutated(t *testing.T) {
+	t.Run("reload callbacks", func(t *testing.T) {
+		m := newTestMemKV(t, "test-format-reload", testFormat())
+		base := m.getBase()
+		// leave the published format differing from the stored one, so the
+		// reload counts as a change and runs the callbacks
+		stale := *base.getFormat()
+		stale.Bucket = "stale"
+		base.setFormat(&stale)
+
+		var called, live bool
+		base.OnReload(func(f *Format) {
+			called = true
+			live = base.getFormat() == f
+			f.Bucket = "patched"
+		})
+		base.reloadFormat()
+
+		if !called {
+			t.Fatalf("reload callback was not called")
+		}
+		if live {
+			t.Fatalf("reload published the format before the callbacks patched it")
+		}
+		if got := base.getFormat().Bucket; got != "patched" {
+			t.Fatalf("the callback's patch was not published: Bucket=%q", got)
+		}
+	})
+}
+
 // TestQuotaEdgeCases
 func TestQuotaEdgeCases(t *testing.T) {
 	m := &baseMeta{}

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -4548,6 +4548,10 @@ func TestQuotaSetFailsWhenFormatUpdateFails(t *testing.T) {
 	if err == nil {
 		t.Fatalf("handleQuotaSet returned no error although DirStats could not be enabled")
 	}
+	// a failed store is not a bad request: the caller has to be able to retry
+	if !errors.Is(err, syscall.EIO) {
+		t.Fatalf("handleQuotaSet did not report the failed store as EIO: %v", err)
+	}
 }
 
 // TestQuotaEdgeCases

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	aclAPI "github.com/juicedata/juicefs/pkg/acl"
+	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -4517,6 +4518,19 @@ func TestPublishedFormatIsNotMutated(t *testing.T) {
 		}
 		if !stored.DirStats {
 			t.Fatalf("handleQuotaSet did not store DirStats")
+		}
+	})
+
+	// Tiers is a map, so a copy sharing it would let a caller patching its own
+	// copy (the .config handler does) write into the format every reader shares
+	t.Run("tiers are copied", func(t *testing.T) {
+		m := newTestMemKV(t, "test-format-tiers", &Format{Name: "test", Tiers: object.NewTiers("standard")})
+		base := m.getBase()
+
+		f := m.GetFormat()
+		f.Tiers[0] = object.Tier{ID: 0, Sc: "patched"}
+		if got := base.getFormat().Tiers[0].Sc; got == "patched" {
+			t.Fatalf("GetFormat shares Tiers with the published format: Sc=%q", got)
 		}
 	})
 

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -4588,6 +4588,31 @@ func TestPublishedFormatIsNotMutated(t *testing.T) {
 		}
 	})
 
+	t.Run("status", func(t *testing.T) {
+		m := newTestMemKV(t, "test-format-status", &Format{Name: "test", SecretKey: "secret"})
+		base := m.getBase()
+		// the reload callbacks patch the live format; Status must not republish
+		// the stored one over their patches
+		published := base.getFormat()
+		published.Bucket = "patched"
+
+		sections := &Sections{}
+		if err := Status(context.Background(), m, false, sections); err != nil {
+			t.Fatalf("status: %s", err)
+		}
+		// only the reported copy may be scrubbed, not the format every reader
+		// shares: a later doInit would persist the scrubbed secrets
+		if got := base.getFormat().SecretKey; got != "secret" {
+			t.Fatalf("Status removed the secret from the published format: SecretKey=%q", got)
+		}
+		if sections.Setting.SecretKey != "removed" {
+			t.Fatalf("Status reported the secret: SecretKey=%q", sections.Setting.SecretKey)
+		}
+		if got := base.getFormat().Bucket; got != "patched" {
+			t.Fatalf("Status republished the stored format over the live one: Bucket=%q", got)
+		}
+	})
+
 	t.Run("reload callbacks", func(t *testing.T) {
 		m := newTestMemKV(t, "test-format-reload", testFormat())
 		base := m.getBase()

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -4460,6 +4460,51 @@ func newTestMemKV(t *testing.T, name string, format *Format) Meta {
 // one races with those readers. The atomic pointer guards the pointer, not the
 // struct it points at.
 func TestPublishedFormatIsNotMutated(t *testing.T) {
+	t.Run("quota set", func(t *testing.T) {
+		m := newTestMemKV(t, "test-format-quota", &Format{Name: "test"})
+		base := m.getBase()
+		published := base.getFormat()
+		if published.DirStats {
+			t.Fatalf("DirStats has to start disabled for this test")
+		}
+
+		// quotas holds no entry for dpath, so handleQuotaSet returns right
+		// after turning DirStats on, which is the part under test
+		if err := base.handleQuotaSet(Background(), DirQuotaType, 0, "/d", map[string]*Quota{}, false); err != nil {
+			t.Fatalf("handleQuotaSet: %s", err)
+		}
+		if published.DirStats {
+			t.Fatalf("handleQuotaSet turned DirStats on in the published format")
+		}
+		if !base.getFormat().DirStats {
+			t.Fatalf("handleQuotaSet did not publish the updated format")
+		}
+	})
+
+	// the flag has to be stored on top of what the volume holds: the published
+	// format may carry the overrides this client was started with
+	t.Run("quota set keeps the local overrides local", func(t *testing.T) {
+		m := newTestMemKV(t, "test-format-override", &Format{Name: "test"})
+		base := m.getBase()
+		patched := *base.getFormat()
+		patched.Bucket = "local-override"
+		base.setFormat(&patched)
+
+		if err := base.handleQuotaSet(Background(), DirQuotaType, 0, "/d", map[string]*Quota{}, false); err != nil {
+			t.Fatalf("handleQuotaSet: %s", err)
+		}
+		stored, err := base.loadFormat(false)
+		if err != nil {
+			t.Fatalf("load format: %s", err)
+		}
+		if stored.Bucket == "local-override" {
+			t.Fatalf("handleQuotaSet stored this client's override in the volume")
+		}
+		if !stored.DirStats {
+			t.Fatalf("handleQuotaSet did not store DirStats")
+		}
+	})
+
 	t.Run("reload callbacks", func(t *testing.T) {
 		m := newTestMemKV(t, "test-format-reload", testFormat())
 		base := m.getBase()
@@ -4487,6 +4532,22 @@ func TestPublishedFormatIsNotMutated(t *testing.T) {
 			t.Fatalf("the callback's patch was not published: Bucket=%q", got)
 		}
 	})
+}
+
+// A quota whose format update failed would be created but never accounted:
+// updateDirQuota gives up as soon as it sees DirStats disabled.
+func TestQuotaSetFailsWhenFormatUpdateFails(t *testing.T) {
+	m := newTestMemKV(t, "test-quota-init-error", &Format{Name: "test"})
+	kv := m.(*kvMeta)
+	// corrupt the stored setting, so the doInit that turns DirStats on fails
+	if err := kv.setValue(kv.fmtKey("setting"), []byte("not json")); err != nil {
+		t.Fatalf("corrupt setting: %s", err)
+	}
+
+	err := m.getBase().handleQuotaSet(Background(), DirQuotaType, 0, "/d", map[string]*Quota{}, false)
+	if err == nil {
+		t.Fatalf("handleQuotaSet returned no error although DirStats could not be enabled")
+	}
 }
 
 // TestQuotaEdgeCases

--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"reflect"
 	"runtime"
 	"sort"
@@ -4455,6 +4456,20 @@ func newTestMemKV(t *testing.T, name string, format *Format) Meta {
 	return m
 }
 
+// A client whose writes fail: doInit gets past the initial read, which goes
+// through simpleTxn, and then fails where the setting would be stored.
+type failWriteClient struct {
+	tkvClient
+	fail bool
+}
+
+func (c *failWriteClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) error {
+	if c.fail {
+		return fmt.Errorf("injected write failure")
+	}
+	return c.tkvClient.txn(ctx, f, retry)
+}
+
 // The Format published by setFormat is shared with every reader that calls
 // getFormat, so a change has to be published as a new value: mutating the live
 // one races with those readers. The atomic pointer guards the pointer, not the
@@ -4502,6 +4517,60 @@ func TestPublishedFormatIsNotMutated(t *testing.T) {
 		}
 		if !stored.DirStats {
 			t.Fatalf("handleQuotaSet did not store DirStats")
+		}
+	})
+
+	// Init publishes the format only after the engine stored it, so a failed
+	// one must not leave this client running on a format the volume never got.
+	t.Run("failed init", func(t *testing.T) {
+		m := newTestMemKV(t, "test-format-doinit", &Format{Name: "test"})
+		kv := m.(*kvMeta)
+		if kv.getFormat().Capacity != 0 {
+			t.Fatalf("Capacity has to start at 0 for this test")
+		}
+
+		client := &failWriteClient{tkvClient: kv.client}
+		kv.client = client
+		client.fail = true
+
+		// Capacity avoids the branches that clean up dir stats or quotas, so
+		// the first write doInit attempts is the setting itself
+		newFormat := *kv.getFormat()
+		newFormat.Capacity = 1 << 30
+		if err := kv.Init(&newFormat, false); err == nil {
+			t.Fatalf("Init returned no error although the setting could not be stored")
+		}
+		if got := kv.getFormat().Capacity; got != 0 {
+			t.Fatalf("Init published the format although storing it failed: Capacity=%d", got)
+		}
+	})
+
+	// the same invariant on the SQL engine: its doInit writes through txn,
+	// which refuses to run on a read-only client, while the read it does first
+	// goes through simpleTxn and still succeeds
+	t.Run("failed init (sql)", func(t *testing.T) {
+		m, err := newSQLMeta("sqlite3", path.Join(t.TempDir(), "jfs-format.db"), testConfig())
+		if err != nil {
+			t.Fatalf("create meta: %s", err)
+		}
+		if err := m.Init(&Format{Name: "test"}, false); err != nil {
+			t.Fatalf("init: %s", err)
+		}
+		db := m.(*dbMeta)
+		if db.getFormat().Capacity != 0 {
+			t.Fatalf("Capacity has to start at 0 for this test")
+		}
+
+		db.conf.ReadOnly = true
+		defer func() { db.conf.ReadOnly = false }()
+
+		newFormat := *db.getFormat()
+		newFormat.Capacity = 1 << 30
+		if err := db.Init(&newFormat, false); err == nil {
+			t.Fatalf("Init returned no error although the setting could not be stored")
+		}
+		if got := db.getFormat().Capacity; got != 0 {
+			t.Fatalf("Init published the format although storing it failed: Capacity=%d", got)
 		}
 	})
 

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -112,6 +112,19 @@ type Format struct {
 	KerbConf string `json:",omitempty"`
 }
 
+// Clone returns a deep copy: the published format is read by other goroutines,
+// so a copy still sharing Tiers would let a patch write into the live map.
+func (f *Format) Clone() *Format {
+	c := *f
+	if f.Tiers != nil {
+		c.Tiers = make(object.Tiers, len(f.Tiers))
+		for id, t := range f.Tiers {
+			c.Tiers[id] = t
+		}
+	}
+	return &c
+}
+
 func (f *Format) update(old *Format, force bool) error {
 	if force {
 		logger.Warnf("Existing volume will be overwrited: %s", old)

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -624,30 +624,19 @@ func (m *baseMeta) handleQuotaSet(ctx Context, qtype uint32, key uint64, dpath s
 	switch qtype {
 	case DirQuotaType:
 		if !format.DirStats {
-			format.DirStats = true
-			err := m.en.doInit(format, false)
-			if err != nil {
-				logger.Warnf("init dir stats: %s", err)
+			// give up if the flag cannot be stored: the quota would be created
+			// but never accounted, as updateDirQuota skips a volume without it.
+			// EIO, so the caller retries instead of reading it as a bad request
+			if err := m.enableFormatFlag(func(f *Format) { f.DirStats = true }); err != nil {
+				return fmt.Errorf("init dir stats: %s (%w)", err, syscall.EIO)
 			}
 		}
 		quota = quotas[dpath]
-	case UserQuotaType:
+	case UserQuotaType, GroupQuotaType:
 		if !format.UserGroupQuota {
-			format.UserGroupQuota = true
 			scan = true
-			err := m.en.doInit(format, false)
-			if err != nil {
-				logger.Warnf("init user group quota: %s", err)
-			}
-		}
-		quota = quotas[fmt.Sprintf("%d", key)]
-	case GroupQuotaType:
-		if !format.UserGroupQuota {
-			format.UserGroupQuota = true
-			scan = true
-			err := m.en.doInit(format, false)
-			if err != nil {
-				logger.Warnf("init user group quota: %s", err)
+			if err := m.enableFormatFlag(func(f *Format) { f.UserGroupQuota = true }); err != nil {
+				return fmt.Errorf("init user group quota: %s (%w)", err, syscall.EIO)
 			}
 		}
 		quota = quotas[fmt.Sprintf("%d", key)]

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -395,7 +395,6 @@ func (m *redisMeta) doInit(format *Format, force bool) error {
 	if err = m.rdb.Set(ctx, m.setting(), data, 0).Err(); err != nil {
 		return err
 	}
-	m.setFormat(format)
 	if body != nil {
 		return nil
 	}

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -670,7 +670,6 @@ func (m *dbMeta) doInit(format *Format, force bool) error {
 		return fmt.Errorf("json: %s", err)
 	}
 
-	m.setFormat(format)
 	n := &node{
 		Type:   TypeDirectory,
 		Nlink:  2,

--- a/pkg/meta/status.go
+++ b/pkg/meta/status.go
@@ -49,10 +49,22 @@ type Sections struct {
 
 // Status retrieves the status of the filesystem
 func Status(ctx context.Context, m Meta, trash bool, sections *Sections) error {
-	format, err := m.Load(true)
+	base := m.getBase()
+	stored, err := base.loadFormat(true)
 	if err != nil {
 		return fmt.Errorf("load setting: %v", err)
 	}
+	// publishing here would drop the patches the reload callbacks applied to
+	// the live format, and the next reload would find it unchanged and not run
+	// them again; a client that has none yet (the status command makes a fresh
+	// one) needs it published for StatFS below
+	if base.getFormat() == nil {
+		base.setFormat(stored)
+	}
+	// only the reported copy may be scrubbed: stripping the secrets from the
+	// format every reader shares would race with them, and a later store would
+	// write the placeholders into the volume
+	format := stored.Clone()
 	format.RemoveSecret()
 
 	sessions, err := m.ListSessions()

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -563,7 +563,6 @@ func (m *kvMeta) doInit(format *Format, force bool) error {
 		return fmt.Errorf("json: %s", err)
 	}
 
-	m.setFormat(format)
 	ts := time.Now().Unix()
 	attr := &Attr{
 		Typ:    TypeDirectory,


### PR DESCRIPTION
Follow-up to #7378, which stored `baseMeta.fmt` as an `atomic.Pointer`. That guards the pointer, not the struct it points at, and several call sites still wrote into the format every reader shares.

The reload path published too early: `Load` published the format before `refresh` handed it to the reload callbacks, and the mount's callback writes the command line overrides (`Bucket`, `Storage`, `Tiers`, `UploadLimit`) into it on every heartbeat. The parsing is split out of `Load` as `loadFormat`, and `reloadFormat` runs the callbacks while the format is still private, publishing it once they are done. The window where readers saw the stored values before the overrides were applied is gone too.

`Status` (`pkg/meta/status.go`) called `Load`, which publishes the format, and then `RemoveSecret` on that same pointer, replacing `SecretKey`, `SessionToken` and `EncryptKey` with `removed` for every reader of the volume. From a long lived client (the Java SDK calls `Status` on a mounted session) a later quota set would store the placeholders in the volume setting for good. Publishing there also dropped the patches the reload callbacks had applied, and because the next reload then finds the stored format unchanged and skips the callbacks, the client kept running without its own overrides until the stored format changed. It now reads through `loadFormat`, which does not publish, and scrubs a copy, so only the reported `Sections` carries the placeholders.

`handleQuotaSet` (`pkg/meta/quota.go`) turned `DirStats` or `UserGroupQuota` on in the format it had just read from `getFormat()`, then passed that same pointer on to be stored. On a mount or an SDK client that format is the one the reload callbacks have patched, so the bucket and the limits of a single client went into the volume setting for every other client. Two such calls also raced: each started from the same format, so whichever stored last dropped the flag the other had set, and both reported success. It now loads the stored format, sets the flag on that, and holds a lock across the load and the store.

`GetFormat` returns the format by value, which reads as a private copy, but `Tiers` is a map so the copy keeps pointing at the live one. Reading `.config` on a mount takes such a copy and hands it to the mount's patcher, which writes `Tiers[0]` straight back into the map the published format owns, while the heartbeat walks it in `reflect.DeepEqual`. That is a concurrent map read and write, which takes the process down rather than just racing. `Format.Clone` copies the map, and `GetFormat` hands that out.

Three related changes fell out of this.

`handleQuotaSet` only warned when the `doInit` enabling those flags failed, and created the quota anyway. Since the flag is no longer forced on locally, `updateDirQuota` sees it disabled and returns immediately, so the quota exists but is never accounted or enforced while the command reports success. It returns the error now, carrying `EIO`, and `fs.FileSystem.HandleQuota` passes that errno through instead of turning everything it does not recognise into `EINVAL`, so a metadata store that was briefly unreachable no longer reaches a Java caller as an invalid request.

Publishing moved out of the engines into `Init`. Each engine picked its own moment: redis between storing the setting and creating the root inode of a fresh volume, the SQL and KV engines before the transaction that stores it. A caller that got an error back could therefore be left running on a format the volume never received, and whether that happened depended on the engine. `Init` publishes once `doInit` reports success, so the engines only store and a fourth one cannot get the ordering wrong.

`ErrNotFormatted` replaces the message prefix that three places matched on with a string compare. Rewording that message would have quietly turned the reload's `os.Exit(UmountCode)` into a warning, leaving a mount running against a volume that no longer exists, with nothing failing to build.

### Tests

`TestPublishedFormatIsNotMutated` covers the invariant in seven subtests (quota set, quota set keeps the local overrides local, tiers are copied, failed init, failed init (sql), status, reload callbacks), and `TestQuotaSetFailsWhenFormatUpdateFails` covers the error propagation. Each case was run against the code without its fix first and fails there, for example:

```
base_test.go:4533: GetFormat shares Tiers with the published format: Sc="patched"
base_test.go:4517: handleQuotaSet stored this client's override in the volume
base_test.go:4612: Status republished the stored format over the live one: Bucket=""
base_test.go:4661: handleQuotaSet did not report the failed store as EIO
```

The KV `failed init` case injects the failure through a `tkvClient` wrapper that fails `txn` but not `simpleTxn`, so `doInit` gets past its initial read and fails exactly where the setting would be stored. It changes `Capacity` rather than a flag, because enabling `DirStats` or `UserGroupQuota` runs a cleanup transaction that would fail earlier and hide the case under test. The SQL case gets the same reads pass, writes fail split from a read only client, since `dbMeta.txn` refuses to run while the initial read still goes through `simpleTxn`. That case fails with the `setFormat` call `sql.go` used to have before its transaction.