### PR TITLE
meta/redis: batch load quotas to reduce round trips

### DIFF
--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3973,7 +3973,10 @@ func (m *redisMeta) hscan(ctx context.Context, key string, f func([]string) erro
 func (m *redisMeta) hscanToMap(ctx context.Context, key string) (map[string]string, error) {
 	result := make(map[string]string)
 	err := m.hscan(ctx, key, func(keys []string) error {
-		for i := 0; i+1 < len(keys); i += 2 {
+		if len(keys)%2 != 0 {
+			return fmt.Errorf("invalid HSCAN response for %s: odd number of elements: %d", key, len(keys))
+		}
+		for i := 0; i < len(keys); i += 2 {
 			result[keys[i]] = keys[i+1]
 		}
 		return nil

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3970,6 +3970,20 @@ func (m *redisMeta) hscan(ctx context.Context, key string, f func([]string) erro
 	return nil
 }
 
+func (m *redisMeta) hscanToMap(ctx context.Context, key string) (map[string]string, error) {
+	result := make(map[string]string)
+	err := m.hscan(ctx, key, func(keys []string) error {
+		for i := 0; i+1 < len(keys); i += 2 {
+			result[keys[i]] = keys[i+1]
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (m *redisMeta) ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno {
 	logger.Debugf("start cleanup...")
 	m.cleanupLeakedInodes(opt.Delete)
@@ -4504,46 +4518,55 @@ func (m *redisMeta) doLoadQuotas(ctx Context) (map[uint64]*Quota, map[uint64]*Qu
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to load %s quotas: %w", qt.name, err)
 		}
-		if err := m.hscan(ctx, config.usedInodesKey, func(keys []string) error {
-			for i := 0; i < len(keys); i += 2 {
-				key := keys[i]
-				id, err := strconv.ParseUint(key, 10, 64)
-				if err != nil {
-					logger.Errorf("invalid key in %s: %s", qt.name, key)
+
+		usedInodesMap, err := m.hscanToMap(ctx, config.usedInodesKey)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		usedSpaceMap, err := m.hscanToMap(ctx, config.usedSpaceKey)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		quotaMap, err := m.hscanToMap(ctx, config.quotaKey)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		for key, usedInodesStr := range usedInodesMap {
+			id, err := strconv.ParseUint(key, 10, 64)
+			if err != nil {
+				logger.Errorf("invalid key in %s: %s", qt.name, key)
+				continue
+			}
+			usedInodes, err := strconv.ParseInt(usedInodesStr, 10, 64)
+			if err != nil {
+				logger.Errorf("invalid usedInodes for %s %s: %s", qt.name, key, usedInodesStr)
+				continue
+			}
+
+			var usedSpace int64
+			if v, ok := usedSpaceMap[key]; ok {
+				if usedSpace, err = strconv.ParseInt(v, 10, 64); err != nil {
+					logger.Errorf("invalid usedSpace for %s %s: %s", qt.name, key, v)
 					continue
-				}
-				usedInodes, err := strconv.ParseInt(keys[i+1], 10, 64)
-				if err != nil {
-					logger.Errorf("invalid usedInodes for %s %s: %s", qt.name, key, keys[i+1])
-					continue
-				}
-
-				usedSpace, err := m.rdb.HGet(ctx, config.usedSpaceKey, key).Int64()
-				if err != nil && err != redis.Nil {
-					return err
-				}
-
-				var maxSpace, maxInodes int64 = -1, -1
-				if buf, err := m.rdb.HGet(ctx, config.quotaKey, key).Bytes(); err == nil {
-					if len(buf) != 16 {
-						logger.Errorf("invalid quota value for %s %s: len=%d", qt.name, key, len(buf))
-						continue
-					}
-					maxSpace, maxInodes = m.parseQuota(buf)
-				} else if err != redis.Nil {
-					return err
-				}
-
-				qt.quotas[id] = &Quota{
-					MaxSpace:   maxSpace,
-					MaxInodes:  maxInodes,
-					UsedSpace:  usedSpace,
-					UsedInodes: usedInodes,
 				}
 			}
-			return nil
-		}); err != nil {
-			return nil, nil, nil, err
+
+			var maxSpace, maxInodes int64 = -1, -1
+			if v, ok := quotaMap[key]; ok {
+				if len(v) != 16 {
+					logger.Errorf("invalid quota value for %s %s: len=%d", qt.name, key, len(v))
+					continue
+				}
+				maxSpace, maxInodes = m.parseQuota([]byte(v))
+			}
+
+			qt.quotas[id] = &Quota{
+				MaxSpace:   maxSpace,
+				MaxInodes:  maxInodes,
+				UsedSpace:  usedSpace,
+				UsedInodes: usedInodes,
+			}
 		}
 	}
 

--- a/pkg/meta/redis_batchclone_test.go
+++ b/pkg/meta/redis_batchclone_test.go
@@ -17,6 +17,7 @@
 package meta
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"syscall"
@@ -605,4 +606,59 @@ func TestRedisBatchClonePartialFailureLeavesState(t *testing.T) {
 		t.Fatalf("expected partial writes after failed BatchClone, got usedDelta=%d inodeDelta=%d", usedDelta, inodeDelta)
 	}
 	t.Logf("failed BatchClone left state: status=%s leakedIno=%d usedDelta=%d inodeDelta=%d", st, leakedIno, usedDelta, inodeDelta)
+}
+
+func TestRedisHscanToMap(t *testing.T) {
+	m := newTestRedisMeta(t, 13)
+	ctx := Background()
+
+	// empty hash returns an empty map
+	got, err := m.hscanToMap(ctx, "jfs_hscan_empty")
+	if err != nil {
+		t.Fatalf("hscanToMap empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+
+	// small hash returns all fields
+	small := "jfs_hscan_small"
+	if err := m.rdb.Del(ctx, small).Err(); err != nil {
+		t.Fatalf("del %s: %v", small, err)
+	}
+	want := map[string]string{"a": "1", "b": "2", "c": "3"}
+	if err := m.rdb.HSet(ctx, small, want).Err(); err != nil {
+		t.Fatalf("hset %s: %v", small, err)
+	}
+	got, err = m.hscanToMap(ctx, small)
+	if err != nil {
+		t.Fatalf("hscanToMap small: %v", err)
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("small hash mismatch: want %v got %v", want, got)
+	}
+
+	// large hash spanning multiple HSCAN batches
+	large := "jfs_hscan_large"
+	if err := m.rdb.Del(ctx, large).Err(); err != nil {
+		t.Fatalf("del %s: %v", large, err)
+	}
+	wantLarge := make(map[string]string, 20000)
+	pairs := make([]interface{}, 0, 40000)
+	for i := 0; i < 20000; i++ {
+		f := fmt.Sprintf("field-%d", i)
+		v := fmt.Sprintf("value-%d", i)
+		wantLarge[f] = v
+		pairs = append(pairs, f, v)
+	}
+	if err := m.rdb.HSet(ctx, large, pairs...).Err(); err != nil {
+		t.Fatalf("hset %s: %v", large, err)
+	}
+	got, err = m.hscanToMap(ctx, large)
+	if err != nil {
+		t.Fatalf("hscanToMap large: %v", err)
+	}
+	if !reflect.DeepEqual(wantLarge, got) {
+		t.Fatalf("large hash mismatch: want %d entries got %d entries", len(wantLarge), len(got))
+	}
 }


### PR DESCRIPTION
close https://github.com/juicedata/juicefs/issues/7388

Load quota usage and limits via three HSCAN operations followed by local join, instead of two serialized HGETs per entry. Improves mount and quota list latency on large quota volumes.