### PR TITLE
vfs: align ioctl flag permissions with the kernel

### DIFF
--- a/docs/en/security/trash.md
+++ b/docs/en/security/trash.md
@@ -123,6 +123,8 @@ It is possible to skip the trash and permanently delete files directly. The 's' 
 
 You will need to enable the mount option `--enable-ioctl` to allow adjusting file attributes using `chattr`.
 
+JuiceFS follows the permission rules the Linux kernel applies to `chattr`: you must own a file to change its attributes, and while the 's' flag only requires ownership, the 'i' (immutable) and 'a' (append-only) flags can only be set or cleared by root.
+
 ## Trash and slices {#gc}
 
 Apart from user deleted files, there's another type of data which also resides in Trash, which isn't directly visible from the `.trash` directory, they are stale slices created by file edits and overwrites. Read more in [How JuiceFS stores files](../introduction/architecture.md#how-juicefs-store-files). To sum up, if applications constantly delete or overwrite files, object storage usage will exceed file system usage.

--- a/docs/zh_cn/security/trash.md
+++ b/docs/zh_cn/security/trash.md
@@ -135,6 +135,8 @@ juicefs rmr .trash/2022-11-30-10/
 
 需要在挂载时启用`--enable-ioctl`选项，才能使用 chattr 命令修改文件属性。
 
+JuiceFS 遵循 Linux 内核对 chattr 的权限规则：只有文件属主才能修改其属性；其中's'属性属主即可设置，而'i'（immutable）和'a'（append-only）属性只有 root 才能设置或清除。
+
 ## 回收站和文件碎片 {#gc}
 
 在回收站里，除了因用户操作而产生的文件，还存在另一类对用户不可见的数据——覆写产生的文件碎片。关于文件碎片是怎么产生的，可以详细阅读[「JuiceFS 如何存储文件」](../introduction/architecture.md#how-juicefs-store-files)。总而言之，如果应用经常删除文件或者频繁覆盖写文件，会导致对象存储使用量远大于文件系统用量。

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -347,31 +347,39 @@ func (v *VFS) Ioctl(ctx Context, ino Ino, cmd uint32, arg uint64, bufIn, bufOut 
 		} else {
 			return syscall.EINVAL
 		}
+		var flags uint8
 		if (iflag & FS_SECRM_FL) != 0 {
-			attr.Flags |= meta.FlagSkipTrash
+			flags |= meta.FlagSkipTrash
 		}
 		if (iflag & FS_IMMUTABLE_FL) != 0 {
-			attr.Flags |= meta.FlagImmutable
+			flags |= meta.FlagImmutable
 		}
 		if (iflag & FS_APPEND_FL) != 0 {
-			attr.Flags |= meta.FlagAppend
-		}
-		if ctx.CheckPermission() && ctx.Uid() != 0 {
-			// chattr sends the whole resulting mask, so clearing a protected flag
-			// arrives as a missing bit rather than a set one; compare against the
-			// current flags to catch both directions.
-			const protected = meta.FlagSkipTrash | meta.FlagImmutable | meta.FlagAppend
-			var cur = &Attr{}
-			if err = v.Meta.GetAttr(ctx, ino, cur); err != 0 {
-				return err
-			}
-			if (cur.Flags^attr.Flags)&protected != 0 {
-				return syscall.EPERM
-			}
+			flags |= meta.FlagAppend
 		}
 		if iflag &= ^uint64(FS_SECRM_FL | FS_IMMUTABLE_FL | FS_APPEND_FL); iflag != 0 {
 			return syscall.ENOTSUP
 		}
+		// The flags this ioctl maps; the Windows attributes are left untouched.
+		const mapped = meta.FlagSkipTrash | meta.FlagImmutable | meta.FlagAppend
+		// Only these two need a privileged caller, matching CAP_LINUX_IMMUTABLE.
+		const privileged = meta.FlagImmutable | meta.FlagAppend
+		var cur = &Attr{}
+		if err = v.Meta.GetAttr(ctx, ino, cur); err != 0 {
+			return err
+		}
+		// Kernels older than 5.13, and any kernel handed FS_IOC_SETFLAGS_32, pass
+		// the request through without looking at it, so the checks the kernel runs
+		// in vfs_fileattr_set() have to be repeated here.
+		if ctx.Uid() != 0 {
+			if ctx.Uid() != cur.Uid { // inode_owner_or_capable()
+				return syscall.EPERM
+			}
+			if (cur.Flags^flags)&privileged != 0 {
+				return syscall.EPERM
+			}
+		}
+		attr.Flags = cur.Flags&^mapped | flags
 		return v.Meta.SetAttr(ctx, ino, meta.SetAttrFlag, 0, attr)
 	} else {
 		if err = v.Meta.GetAttr(ctx, ino, attr); err != 0 {

--- a/pkg/vfs/vfs_unix.go
+++ b/pkg/vfs/vfs_unix.go
@@ -347,9 +347,6 @@ func (v *VFS) Ioctl(ctx Context, ino Ino, cmd uint32, arg uint64, bufIn, bufOut 
 		} else {
 			return syscall.EINVAL
 		}
-		if ctx.CheckPermission() && ctx.Uid() != 0 && iflag&(FS_SECRM_FL|FS_IMMUTABLE_FL|FS_APPEND_FL) != 0 {
-			return syscall.EPERM
-		}
 		if (iflag & FS_SECRM_FL) != 0 {
 			attr.Flags |= meta.FlagSkipTrash
 		}
@@ -358,6 +355,19 @@ func (v *VFS) Ioctl(ctx Context, ino Ino, cmd uint32, arg uint64, bufIn, bufOut 
 		}
 		if (iflag & FS_APPEND_FL) != 0 {
 			attr.Flags |= meta.FlagAppend
+		}
+		if ctx.CheckPermission() && ctx.Uid() != 0 {
+			// chattr sends the whole resulting mask, so clearing a protected flag
+			// arrives as a missing bit rather than a set one; compare against the
+			// current flags to catch both directions.
+			const protected = meta.FlagSkipTrash | meta.FlagImmutable | meta.FlagAppend
+			var cur = &Attr{}
+			if err = v.Meta.GetAttr(ctx, ino, cur); err != 0 {
+				return err
+			}
+			if (cur.Flags^attr.Flags)&protected != 0 {
+				return syscall.EPERM
+			}
 		}
 		if iflag &= ^uint64(FS_SECRM_FL | FS_IMMUTABLE_FL | FS_APPEND_FL); iflag != 0 {
 			return syscall.ENOTSUP

--- a/pkg/vfs/vfs_unix_test.go
+++ b/pkg/vfs/vfs_unix_test.go
@@ -30,8 +30,10 @@ import (
 const (
 	testIocSetFlags = 0x40086602
 	testIocGetFlags = 0x80086601
+	testSecrmFl     = 0x00000001
 	testImmutableFl = 0x00000010
 	testAppendFl    = 0x00000020
+	testNodumpFl    = 0x00000040
 )
 
 func testSetFlags(v *VFS, ctx Context, ino Ino, iflag uint64) syscall.Errno {
@@ -49,15 +51,31 @@ func testGetFlags(t *testing.T, v *VFS, ctx Context, ino Ino) uint64 {
 	return utils.NativeEndian.Uint64(bufOut)
 }
 
-// Changing the immutable or append-only flag requires root, in either direction.
-// chattr sends the full resulting flag mask, so clearing a protected flag arrives
-// as a missing bit rather than a set one; guarding only the incoming bits let a
-// non-root owner clear the flag and then modify the file. This mirrors the kernel's
-// fileattr_set_prepare(), which gates on the delta between old and new flags.
+func testMetaFlags(t *testing.T, v *VFS, ino Ino) uint8 {
+	t.Helper()
+	var attr Attr
+	if e := v.Meta.GetAttr(meta.Background(), ino, &attr); e != 0 {
+		t.Fatalf("get attr: %s", e)
+	}
+	return attr.Flags
+}
+
+// FS_IOC_SETFLAGS carries the whole resulting flag mask rather than a delta, and
+// on kernels older than 5.13 -- or whenever FS_IOC_SETFLAGS_32 is used -- it is
+// handed to the filesystem without the kernel checking it at all. So the rules
+// vfs_fileattr_set() applies have to be reproduced here:
+//
+//	immutable/append : only root may change them, in either direction
+//	skip-trash       : the owner may change it, like the kernel does for FS_SECRM_FL
+//	any flag         : the caller must own the file
+//
+// Flags that this ioctl does not map, such as the Windows attributes, must be
+// left alone.
 func TestIoctlSetFlagsPermission(t *testing.T) {
 	v, _ := createTestVFS(nil, "")
 	rootCtx := NewLogContext(meta.NewContext(1, 0, []uint32{0}))
 	userCtx := NewLogContext(meta.NewContext(10, 1, []uint32{2, 3}))
+	otherCtx := NewLogContext(meta.NewContext(11, 4, []uint32{5}))
 
 	// owned by the unprivileged user, so only the flag rules can protect it
 	newFile := func(name string) Ino {
@@ -72,48 +90,119 @@ func TestIoctlSetFlagsPermission(t *testing.T) {
 		return fe.Inode
 	}
 
-	for _, c := range []struct {
-		name string
-		flag uint64
-	}{
-		{"immutable", testImmutableFl},
-		{"append", testAppendFl},
-	} {
-		ino := newFile(c.name)
+	t.Run("privileged flags need root", func(t *testing.T) {
+		for _, c := range []struct {
+			name string
+			flag uint64
+		}{
+			{"immutable", testImmutableFl},
+			{"append", testAppendFl},
+		} {
+			ino := newFile(c.name)
 
-		// a non-root user cannot raise a protected flag
-		if e := testSetFlags(v, userCtx, ino, c.flag); e != syscall.EPERM {
-			t.Fatalf("non-root setting %s should be EPERM, got %s", c.name, e)
+			// a non-root user cannot raise a protected flag
+			if e := testSetFlags(v, userCtx, ino, c.flag); e != syscall.EPERM {
+				t.Fatalf("non-root setting %s should be EPERM, got %s", c.name, e)
+			}
+			if e := testSetFlags(v, rootCtx, ino, c.flag); e != 0 {
+				t.Fatalf("root should be able to set %s: %s", c.name, e)
+			}
+			if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag == 0 {
+				t.Fatalf("%s flag was not set: %x", c.name, flags)
+			}
+
+			// the regression: clearing sends a mask without the protected bit
+			if e := testSetFlags(v, userCtx, ino, 0); e != syscall.EPERM {
+				t.Fatalf("non-root clearing %s should be EPERM, got %s", c.name, e)
+			}
+			if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag == 0 {
+				t.Fatalf("%s flag was cleared by a non-root user: %x", c.name, flags)
+			}
+
+			// a write that does not change any protected flag is not privileged,
+			// matching fileattr_set_prepare()
+			if e := testSetFlags(v, userCtx, ino, c.flag); e != 0 {
+				t.Fatalf("non-root no-op write of %s should be allowed, got %s", c.name, e)
+			}
+
+			if e := testSetFlags(v, rootCtx, ino, 0); e != 0 {
+				t.Fatalf("root should be able to clear %s: %s", c.name, e)
+			}
+			if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag != 0 {
+				t.Fatalf("%s flag should be cleared: %x", c.name, flags)
+			}
+			if e := testSetFlags(v, userCtx, ino, 0); e != 0 {
+				t.Fatalf("non-root no-op write on unflagged file should be allowed, got %s", e)
+			}
 		}
-		if e := testSetFlags(v, rootCtx, ino, c.flag); e != 0 {
-			t.Fatalf("root should be able to set %s: %s", c.name, e)
+	})
+
+	// the kernel only gates APPEND and IMMUTABLE on CAP_LINUX_IMMUTABLE, so an
+	// owner is free to toggle skip-trash on their own files
+	t.Run("skip-trash needs no privilege", func(t *testing.T) {
+		ino := newFile("skip-trash")
+
+		if e := testSetFlags(v, userCtx, ino, testSecrmFl); e != 0 {
+			t.Fatalf("owner should be able to set skip-trash: %s", e)
 		}
-		if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag == 0 {
-			t.Fatalf("%s flag was not set: %x", c.name, flags)
+		if flags := testGetFlags(t, v, userCtx, ino); flags&testSecrmFl == 0 {
+			t.Fatalf("skip-trash flag was not set: %x", flags)
+		}
+		if e := testSetFlags(v, userCtx, ino, 0); e != 0 {
+			t.Fatalf("owner should be able to clear skip-trash: %s", e)
+		}
+		if flags := testGetFlags(t, v, userCtx, ino); flags&testSecrmFl != 0 {
+			t.Fatalf("skip-trash flag should be cleared: %x", flags)
+		}
+	})
+
+	// inode_owner_or_capable(): a non-owner may not touch the flags at all, not
+	// even the ones that need no privilege, and not even when nothing changes
+	t.Run("non-owner is rejected", func(t *testing.T) {
+		ino := newFile("non-owner")
+
+		if e := testSetFlags(v, otherCtx, ino, 0); e != syscall.EPERM {
+			t.Fatalf("non-owner no-op write should be EPERM, got %s", e)
+		}
+		if e := testSetFlags(v, otherCtx, ino, testSecrmFl); e != syscall.EPERM {
+			t.Fatalf("non-owner setting skip-trash should be EPERM, got %s", e)
+		}
+		if e := testSetFlags(v, otherCtx, ino, testImmutableFl); e != syscall.EPERM {
+			t.Fatalf("non-owner setting immutable should be EPERM, got %s", e)
+		}
+		if flags := testGetFlags(t, v, rootCtx, ino); flags != 0 {
+			t.Fatalf("flags should be untouched: %x", flags)
+		}
+	})
+
+	// FS_IOC_SETFLAGS does not carry the Windows attributes, so a client that
+	// cannot see them must not drop them
+	t.Run("keeps unmapped flags", func(t *testing.T) {
+		ino := newFile("unmapped")
+		hidden := &Attr{Flags: meta.FlagWindowsHidden | meta.FlagWindowsArchive}
+		if e := v.Meta.SetAttr(rootCtx, ino, meta.SetAttrFlag, 0, hidden); e != 0 {
+			t.Fatalf("set windows attributes: %s", e)
 		}
 
-		// the regression: clearing sends a mask without the protected bit
-		if e := testSetFlags(v, userCtx, ino, 0); e != syscall.EPERM {
-			t.Fatalf("non-root clearing %s should be EPERM, got %s", c.name, e)
+		if e := testSetFlags(v, rootCtx, ino, testImmutableFl); e != 0 {
+			t.Fatalf("root should be able to set immutable: %s", e)
 		}
-		if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag == 0 {
-			t.Fatalf("%s flag was cleared by a non-root user: %x", c.name, flags)
-		}
-
-		// a write that does not change any protected flag is not privileged,
-		// matching fileattr_set_prepare()
-		if e := testSetFlags(v, userCtx, ino, c.flag); e != 0 {
-			t.Fatalf("non-root no-op write of %s should be allowed, got %s", c.name, e)
+		if flags := testMetaFlags(t, v, ino); flags != meta.FlagWindowsHidden|meta.FlagWindowsArchive|meta.FlagImmutable {
+			t.Fatalf("windows attributes were dropped: %x", flags)
 		}
 
 		if e := testSetFlags(v, rootCtx, ino, 0); e != 0 {
-			t.Fatalf("root should be able to clear %s: %s", c.name, e)
+			t.Fatalf("root should be able to clear immutable: %s", e)
 		}
-		if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag != 0 {
-			t.Fatalf("%s flag should be cleared: %x", c.name, flags)
+		if flags := testMetaFlags(t, v, ino); flags != meta.FlagWindowsHidden|meta.FlagWindowsArchive {
+			t.Fatalf("windows attributes were dropped: %x", flags)
 		}
-		if e := testSetFlags(v, userCtx, ino, 0); e != 0 {
-			t.Fatalf("non-root no-op write on unflagged file should be allowed, got %s", e)
+	})
+
+	t.Run("unsupported flags are rejected", func(t *testing.T) {
+		ino := newFile("unsupported")
+		if e := testSetFlags(v, rootCtx, ino, testNodumpFl); e != syscall.ENOTSUP {
+			t.Fatalf("unsupported flag should be ENOTSUP, got %s", e)
 		}
-	}
+	})
 }

--- a/pkg/vfs/vfs_unix_test.go
+++ b/pkg/vfs/vfs_unix_test.go
@@ -1,0 +1,119 @@
+//go:build !windows
+// +build !windows
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vfs
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/utils"
+)
+
+const (
+	testIocSetFlags = 0x40086602
+	testIocGetFlags = 0x80086601
+	testImmutableFl = 0x00000010
+	testAppendFl    = 0x00000020
+)
+
+func testSetFlags(v *VFS, ctx Context, ino Ino, iflag uint64) syscall.Errno {
+	bufIn := make([]byte, 8)
+	utils.NativeEndian.PutUint64(bufIn, iflag)
+	return v.Ioctl(ctx, ino, testIocSetFlags, 0, bufIn, nil)
+}
+
+func testGetFlags(t *testing.T, v *VFS, ctx Context, ino Ino) uint64 {
+	t.Helper()
+	bufOut := make([]byte, 8)
+	if e := v.Ioctl(ctx, ino, testIocGetFlags, 0, nil, bufOut); e != 0 {
+		t.Fatalf("get flags: %s", e)
+	}
+	return utils.NativeEndian.Uint64(bufOut)
+}
+
+// Changing the immutable or append-only flag requires root, in either direction.
+// chattr sends the full resulting flag mask, so clearing a protected flag arrives
+// as a missing bit rather than a set one; guarding only the incoming bits let a
+// non-root owner clear the flag and then modify the file. This mirrors the kernel's
+// fileattr_set_prepare(), which gates on the delta between old and new flags.
+func TestIoctlSetFlagsPermission(t *testing.T) {
+	v, _ := createTestVFS(nil, "")
+	rootCtx := NewLogContext(meta.NewContext(1, 0, []uint32{0}))
+	userCtx := NewLogContext(meta.NewContext(10, 1, []uint32{2, 3}))
+
+	// owned by the unprivileged user, so only the flag rules can protect it
+	newFile := func(name string) Ino {
+		t.Helper()
+		fe, e := v.Mknod(rootCtx, 1, name, 0666|syscall.S_IFREG, 0, 0)
+		if e != 0 {
+			t.Fatalf("mknod %s: %s", name, e)
+		}
+		if _, e := v.SetAttr(rootCtx, fe.Inode, meta.SetAttrUID|meta.SetAttrGID, 0, 0, 1, 2, 0, 0, 0, 0, 0); e != 0 {
+			t.Fatalf("chown %s: %s", name, e)
+		}
+		return fe.Inode
+	}
+
+	for _, c := range []struct {
+		name string
+		flag uint64
+	}{
+		{"immutable", testImmutableFl},
+		{"append", testAppendFl},
+	} {
+		ino := newFile(c.name)
+
+		// a non-root user cannot raise a protected flag
+		if e := testSetFlags(v, userCtx, ino, c.flag); e != syscall.EPERM {
+			t.Fatalf("non-root setting %s should be EPERM, got %s", c.name, e)
+		}
+		if e := testSetFlags(v, rootCtx, ino, c.flag); e != 0 {
+			t.Fatalf("root should be able to set %s: %s", c.name, e)
+		}
+		if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag == 0 {
+			t.Fatalf("%s flag was not set: %x", c.name, flags)
+		}
+
+		// the regression: clearing sends a mask without the protected bit
+		if e := testSetFlags(v, userCtx, ino, 0); e != syscall.EPERM {
+			t.Fatalf("non-root clearing %s should be EPERM, got %s", c.name, e)
+		}
+		if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag == 0 {
+			t.Fatalf("%s flag was cleared by a non-root user: %x", c.name, flags)
+		}
+
+		// a write that does not change any protected flag is not privileged,
+		// matching fileattr_set_prepare()
+		if e := testSetFlags(v, userCtx, ino, c.flag); e != 0 {
+			t.Fatalf("non-root no-op write of %s should be allowed, got %s", c.name, e)
+		}
+
+		if e := testSetFlags(v, rootCtx, ino, 0); e != 0 {
+			t.Fatalf("root should be able to clear %s: %s", c.name, e)
+		}
+		if flags := testGetFlags(t, v, rootCtx, ino); flags&c.flag != 0 {
+			t.Fatalf("%s flag should be cleared: %x", c.name, flags)
+		}
+		if e := testSetFlags(v, userCtx, ino, 0); e != 0 {
+			t.Fatalf("non-root no-op write on unflagged file should be allowed, got %s", e)
+		}
+	}
+}

--- a/pkg/vfs/vfs_windows.go
+++ b/pkg/vfs/vfs_windows.go
@@ -35,8 +35,15 @@ func (v *VFS) ChFlags(ctx Context, ino Ino, flags uint8) (err syscall.Errno) {
 		return
 	}
 
-	err = syscall.EINVAL
-	var attr = &Attr{Flags: flags}
+	// The attributes a Windows client can express. The POSIX-only flags
+	// (append-only, skip-trash) are absent from the mask it sends, so they have to
+	// survive a change of the Windows attributes.
+	const mapped = meta.FlagImmutable | meta.FlagWindowsHidden | meta.FlagWindowsSystem | meta.FlagWindowsArchive
+	var cur = &Attr{}
+	if err = v.Meta.GetAttr(ctx, ino, cur); err != 0 {
+		return
+	}
+	var attr = &Attr{Flags: cur.Flags&^mapped | flags&mapped}
 
 	if ctx.CheckPermission() {
 		if err = v.Meta.CheckSetAttr(ctx, ino, meta.SetAttrFlag, *attr); err != 0 {


### PR DESCRIPTION
`FS_IOC_SETFLAGS` carries the whole resulting flag mask, so clearing a protected flag arrives as a missing bit rather than a set one. The guard only rejected a non-root caller whose incoming mask contained `FS_SECRM_FL`, `FS_IMMUTABLE_FL` or `FS_APPEND_FL`, which caught `chattr +i` but not `chattr -i`: a user who could reach a file root had made immutable was able to clear the flag and then modify or delete it.

Compare the requested flags with the current ones and refuse a non-root caller when a protected bit changes in either direction, which is what the kernel does in `fileattr_set_prepare()`. A write that leaves every protected flag as it was stays unprivileged, so re-applying a flag that is already set no longer fails.

Windows is unaffected: `FILE_ATTRIBUTE_READONLY` goes through `ChFlags` in vfs_windows.go, not this `ioctl`.