### PR TITLE
ci: add release distribution check workflow

### DIFF
--- a/.github/scripts/check_release_distributions.py
+++ b/.github/scripts/check_release_distributions.py
@@ -17,6 +17,15 @@ from typing import Any
 
 STABLE_TAG_RE = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
 BASE_VERSION_RE = re.compile(r"(?<![0-9])(?P<version>[0-9]+\.[0-9]+\.[0-9]+)(?![0-9])")
+CHECKSUM_RE = re.compile(r"^(?P<checksum>[0-9a-fA-F]{64})[ \t]+\*?(?P<filename>\S+)$")
+CDN_CLIENT_ARTIFACT_SUFFIXES = (
+    "linux-amd64.tar.gz",
+    "linux-arm64.tar.gz",
+    "darwin-amd64.tar.gz",
+    "darwin-arm64.tar.gz",
+    "windows-amd64.tar.gz",
+    "windows-amd64.zip",
+)
 UTC = dt.timezone.utc
 
 
@@ -105,15 +114,21 @@ class HttpClient:
         *,
         headers: dict[str, str] | None = None,
         method: str = "GET",
+        read_limit: int | None = None,
     ) -> bytes:
+        if read_limit is not None and read_limit < 0:
+            raise CheckError("read limit must not be negative")
         request_headers = {**self.default_headers, **(headers or {})}
         request = urllib.request.Request(url, headers=request_headers, method=method)
         last_error: Exception | None = None
         for attempt in range(self.retries):
             try:
                 with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                    return response.read()
-            except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+                    content = response.read() if read_limit is None else response.read(read_limit)
+                    if read_limit and not content:
+                        raise CheckError(f"empty response from {url}")
+                    return content
+            except (OSError, urllib.error.URLError, urllib.error.HTTPError, CheckError) as exc:
                 last_error = exc
                 if attempt + 1 < self.retries:
                     time.sleep(2**attempt)
@@ -136,6 +151,9 @@ class HttpClient:
             self.request(url, method="HEAD")
         except CheckError:
             self.request(url, headers={"Range": "bytes=0-0"})
+
+    def probe_download(self, url: str) -> None:
+        self.request(url, headers={"Range": "bytes=0-0"}, read_limit=1)
 
 
 def github_latest_release(
@@ -261,6 +279,21 @@ def aggregate_versions(
     )
 
 
+def parse_checksums(checksum_text: str) -> tuple[dict[str, str], list[int]]:
+    checksums: dict[str, str] = {}
+    invalid_lines: list[int] = []
+    for line_number, raw_line in enumerate(checksum_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = CHECKSUM_RE.fullmatch(line)
+        if not match or match.group("filename") in checksums:
+            invalid_lines.append(line_number)
+            continue
+        checksums[match.group("filename")] = match.group("checksum").lower()
+    return checksums, invalid_lines
+
+
 def check_cdn(
     client: HttpClient,
     expected: str,
@@ -269,27 +302,48 @@ def check_cdn(
     base_url = "https://d.juicefs.com/juicefs/releases"
     latest = client.get_text(f"{base_url}/latest-version.txt").strip()
     checksum_text = client.get_text(f"{base_url}/download/v{expected}/checksums.txt")
+    required_assets = [
+        f"juicefs-{expected}-{suffix}" for suffix in CDN_CLIENT_ARTIFACT_SUFFIXES
+    ]
     assets = release_payload.get("assets")
     if not isinstance(assets, list):
         return CheckResult("CDN", "invalid", expected, latest or "unknown", "release assets are missing")
-    prefix = f"juicefs-{expected}-"
-    expected_assets = [
-        asset.get("name")
+    release_assets = {
+        asset["name"]
         for asset in assets
-        if isinstance(asset, dict)
-        and isinstance(asset.get("name"), str)
-        and asset["name"].startswith(prefix)
-        and asset["name"].endswith((".tar.gz", ".zip"))
-    ]
-    if not expected_assets:
-        return CheckResult("CDN", "invalid", expected, latest or "unknown", "no client archives in GitHub release")
-    missing_checksums = [name for name in expected_assets if name not in checksum_text]
-    for name in expected_assets:
-        client.probe(f"{base_url}/download/v{expected}/{name}")
-    details = [f"{len(expected_assets)} client archives are reachable"]
+        if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+    }
+    missing_release_assets = [name for name in required_assets if name not in release_assets]
+    checksums, invalid_checksum_lines = parse_checksums(checksum_text)
+    missing_checksums = [name for name in required_assets if name not in checksums]
+    download_failures: list[str] = []
+    for name in required_assets:
+        try:
+            client.probe_download(f"{base_url}/download/v{expected}/{name}")
+        except CheckError:
+            download_failures.append(name)
+    passed_downloads = len(required_assets) - len(download_failures)
+    details = [f"{passed_downloads}/{len(required_assets)} ranged GET download probes passed"]
+    if download_failures:
+        details.append("failed download probes: " + ", ".join(download_failures))
+    if missing_release_assets:
+        details.append("missing release assets: " + ", ".join(missing_release_assets))
     if missing_checksums:
-        details.append("missing checksums: " + ", ".join(missing_checksums))
-    status = "current" if latest == expected and not missing_checksums else "stale"
+        details.append("missing or invalid checksums: " + ", ".join(missing_checksums))
+    if invalid_checksum_lines:
+        lines = ", ".join(str(line) for line in invalid_checksum_lines)
+        details.append(f"invalid checksum lines: {lines}")
+    if download_failures:
+        status = "unavailable"
+    elif (
+        latest == expected
+        and not missing_release_assets
+        and not missing_checksums
+        and not invalid_checksum_lines
+    ):
+        status = "current"
+    else:
+        status = "stale"
     return CheckResult("CDN", status, expected, latest or "unknown", "; ".join(details))
 
 

--- a/.github/scripts/check_release_distributions.py
+++ b/.github/scripts/check_release_distributions.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections.abc import Callable
+from typing import Any
+
+
+STABLE_TAG_RE = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
+BASE_VERSION_RE = re.compile(r"(?<![0-9])(?P<version>[0-9]+\.[0-9]+\.[0-9]+)(?![0-9])")
+UTC = dt.timezone.utc
+
+
+class CheckError(RuntimeError):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class ReleaseInfo:
+    release_id: int
+    tag: str
+    version: str
+    published_at: dt.datetime
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckResult:
+    channel: str
+    status: str
+    expected: str
+    actual: str
+    detail: str = ""
+
+
+def parse_datetime(value: str) -> dt.datetime:
+    if not isinstance(value, str):
+        raise CheckError(f"invalid timestamp: {value!r}")
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CheckError(f"invalid timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise CheckError(f"timestamp must include a timezone: {value!r}")
+    return parsed.astimezone(UTC)
+
+
+def parse_latest_release(payload: dict[str, Any]) -> ReleaseInfo:
+    if payload.get("draft"):
+        raise CheckError("GitHub latest release is a draft")
+    if payload.get("prerelease"):
+        raise CheckError("GitHub latest release is a prerelease")
+    tag = payload.get("tag_name")
+    match = STABLE_TAG_RE.fullmatch(tag or "")
+    if not match:
+        raise CheckError(f"GitHub latest release has an invalid stable tag: {tag!r}")
+    release_id = payload.get("id")
+    if not isinstance(release_id, int):
+        raise CheckError("GitHub latest release has no numeric id")
+    return ReleaseInfo(
+        release_id=release_id,
+        tag=tag,
+        version=match.group("version"),
+        published_at=parse_datetime(payload.get("published_at")),
+    )
+
+
+def extract_base_version(value: str) -> str | None:
+    match = BASE_VERSION_RE.search(value or "")
+    return match.group("version") if match else None
+
+
+def version_status(expected: str, actual: str) -> str:
+    return "current" if extract_base_version(actual) == expected else "stale"
+
+
+def grace_expired(
+    published_at: dt.datetime,
+    grace_hours: int,
+    now: dt.datetime | None = None,
+) -> bool:
+    if grace_hours < 0:
+        raise CheckError("grace hours must not be negative")
+    current = (now or dt.datetime.now(UTC)).astimezone(UTC)
+    return current >= published_at + dt.timedelta(hours=grace_hours)
+
+
+class HttpClient:
+    def __init__(self, timeout: int = 20, retries: int = 3):
+        self.timeout = timeout
+        self.retries = retries
+        self.default_headers = {"User-Agent": "juicefs-release-distribution-check"}
+
+    def request(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        method: str = "GET",
+    ) -> bytes:
+        request_headers = {**self.default_headers, **(headers or {})}
+        request = urllib.request.Request(url, headers=request_headers, method=method)
+        last_error: Exception | None = None
+        for attempt in range(self.retries):
+            try:
+                with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                    return response.read()
+            except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+                last_error = exc
+                if attempt + 1 < self.retries:
+                    time.sleep(2**attempt)
+        raise CheckError(f"request failed after {self.retries} attempts: {url}: {last_error}")
+
+    def get_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
+        try:
+            return json.loads(self.request(url, headers=headers))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise CheckError(f"invalid JSON response from {url}") from exc
+
+    def get_text(self, url: str, headers: dict[str, str] | None = None) -> str:
+        try:
+            return self.request(url, headers=headers).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CheckError(f"invalid UTF-8 response from {url}") from exc
+
+    def probe(self, url: str) -> None:
+        try:
+            self.request(url, method="HEAD")
+        except CheckError:
+            self.request(url, headers={"Range": "bytes=0-0"})
+
+
+def github_latest_release(
+    client: HttpClient,
+    repository: str,
+    token: str = "",
+) -> tuple[ReleaseInfo, dict[str, Any]]:
+    url = f"https://api.github.com/repos/{repository}/releases/latest"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    payload = client.get_json(
+        url,
+        headers=headers,
+    )
+    if not isinstance(payload, dict):
+        raise CheckError("GitHub latest release response is not an object")
+    return parse_latest_release(payload), payload
+
+
+def run_channel(
+    channel: str,
+    expected: str,
+    checker: Callable[[], CheckResult],
+) -> CheckResult:
+    try:
+        return checker()
+    except CheckError as exc:
+        return CheckResult(channel, "unavailable", expected, "unknown", str(exc))
+    except Exception as exc:  # Keep one broken parser from hiding all other channels.
+        return CheckResult(channel, "invalid", expected, "unknown", str(exc))
+
+
+def should_fail(results: list[CheckResult], expired: bool) -> bool:
+    if any(result.status == "invalid" for result in results):
+        return True
+    return expired and any(result.status in {"stale", "unavailable"} for result in results)
+
+
+def append_github_output(path: str, values: dict[str, str]) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as output:
+        for key, value in values.items():
+            if "\n" in value:
+                raise CheckError(f"GitHub output {key} must be a single line")
+            output.write(f"{key}={value}\n")
+
+
+def append_summary(path: str, content: str) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as summary:
+        summary.write(content.rstrip() + "\n")
+
+
+def result_icon(result: CheckResult, expired: bool) -> str:
+    if result.status == "current":
+        return "✅"
+    if result.status == "invalid" or expired:
+        return "❌"
+    return "⚠️"
+
+
+def render_results_summary(
+    release: ReleaseInfo,
+    trigger_tag: str,
+    grace_hours: int,
+    expired: bool,
+    results: list[CheckResult],
+) -> str:
+    trigger = trigger_tag or "schedule/manual"
+    lines = [
+        "## JuiceFS release distribution check",
+        "",
+        f"- Trigger release: `{trigger}`",
+        f"- Target latest release: `{release.tag}` (GitHub release `{release.release_id}`)",
+        f"- Published at: `{release.published_at.isoformat()}`",
+        f"- Grace period: `{grace_hours}h` ({'expired' if expired else 'active'})",
+        "",
+        "| Channel | Status | Expected | Actual | Detail |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for result in results:
+        detail = result.detail.replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| {result.channel} | {result_icon(result, expired)} {result.status} "
+            f"| `{result.expected}` | `{result.actual}` | {detail} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def aggregate_versions(
+    channel: str,
+    expected: str,
+    versions: dict[str, str],
+    detail: str = "",
+) -> CheckResult:
+    if not versions:
+        return CheckResult(channel, "invalid", expected, "unknown", "no stable packages found")
+    mismatches = {
+        name: version
+        for name, version in versions.items()
+        if extract_base_version(version) != expected
+    }
+    actual = ", ".join(f"{name}={version}" for name, version in sorted(versions.items()))
+    if len(actual) > 300:
+        actual = f"{len(versions) - len(mismatches)}/{len(versions)} current"
+    if mismatches:
+        mismatch_detail = ", ".join(
+            f"{name}={version}" for name, version in sorted(mismatches.items())
+        )
+        detail = "; ".join(filter(None, [detail, f"mismatches: {mismatch_detail}"]))
+    return CheckResult(
+        channel,
+        "stale" if mismatches else "current",
+        expected,
+        actual,
+        detail,
+    )
+
+
+def check_cdn(
+    client: HttpClient,
+    expected: str,
+    release_payload: dict[str, Any],
+) -> CheckResult:
+    base_url = "https://d.juicefs.com/juicefs/releases"
+    latest = client.get_text(f"{base_url}/latest-version.txt").strip()
+    checksum_text = client.get_text(f"{base_url}/download/v{expected}/checksums.txt")
+    assets = release_payload.get("assets")
+    if not isinstance(assets, list):
+        return CheckResult("CDN", "invalid", expected, latest or "unknown", "release assets are missing")
+    prefix = f"juicefs-{expected}-"
+    expected_assets = [
+        asset.get("name")
+        for asset in assets
+        if isinstance(asset, dict)
+        and isinstance(asset.get("name"), str)
+        and asset["name"].startswith(prefix)
+        and asset["name"].endswith((".tar.gz", ".zip"))
+    ]
+    if not expected_assets:
+        return CheckResult("CDN", "invalid", expected, latest or "unknown", "no client archives in GitHub release")
+    missing_checksums = [name for name in expected_assets if name not in checksum_text]
+    for name in expected_assets:
+        client.probe(f"{base_url}/download/v{expected}/{name}")
+    details = [f"{len(expected_assets)} client archives are reachable"]
+    if missing_checksums:
+        details.append("missing checksums: " + ", ".join(missing_checksums))
+    status = "current" if latest == expected and not missing_checksums else "stale"
+    return CheckResult("CDN", status, expected, latest or "unknown", "; ".join(details))
+
+
+def check_homebrew(client: HttpClient, expected: str) -> CheckResult:
+    payload = client.get_json("https://formulae.brew.sh/api/formula/juicefs.json")
+    try:
+        actual = payload["versions"]["stable"]
+    except (KeyError, TypeError) as exc:
+        raise CheckError("Homebrew formula has no stable version") from exc
+    return CheckResult("Homebrew", version_status(expected, actual), expected, actual)
+
+
+def check_ppa(client: HttpClient, expected: str) -> CheckResult:
+    versions: dict[str, str] = {}
+    supported_series: dict[str, bool] = {}
+    for ppa in ("ppa", "arm64"):
+        url = (
+            f"https://api.launchpad.net/1.0/~juicefs/+archive/ubuntu/{ppa}"
+            "?ws.op=getPublishedSources&exact_match=true&source_name=juicefs"
+            "&status=Published&order_by_date=true"
+        )
+        payload = client.get_json(url)
+        entries = payload.get("entries") if isinstance(payload, dict) else None
+        if not isinstance(entries, list):
+            raise CheckError(f"Launchpad {ppa} response has no entries")
+        latest_by_series: dict[str, dict[str, Any]] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            series_url = entry.get("distro_series_link")
+            if not isinstance(series_url, str):
+                continue
+            latest_by_series.setdefault(series_url, entry)
+        for series_url, entry in latest_by_series.items():
+            if series_url not in supported_series:
+                series = client.get_json(series_url)
+                supported_series[series_url] = (
+                    bool(series.get("supported")) if isinstance(series, dict) else False
+                )
+            if not supported_series[series_url]:
+                continue
+            series_name = series_url.rstrip("/").rsplit("/", 1)[-1]
+            version = entry.get("source_package_version")
+            if not isinstance(version, str):
+                raise CheckError(f"Launchpad {ppa}/{series_name} has no source version")
+            versions[f"{ppa}/{series_name}"] = version
+    return aggregate_versions("Ubuntu PPA", expected, versions, "supported Ubuntu series only")
+
+
+def check_copr(client: HttpClient, expected: str) -> CheckResult:
+    payload = client.get_json(
+        "https://copr.fedorainfracloud.org/api_3/monitor?ownername=juicedata&projectname=juicefs"
+    )
+    packages = payload.get("packages") if isinstance(payload, dict) else None
+    package = next(
+        (item for item in packages or [] if isinstance(item, dict) and item.get("name") == "juicefs"),
+        None,
+    )
+    if not package or not isinstance(package.get("chroots"), dict):
+        raise CheckError("Copr monitor has no juicefs chroots")
+    versions: dict[str, str] = {}
+    failed: list[str] = []
+    for name, build in package["chroots"].items():
+        if not isinstance(build, dict):
+            failed.append(f"{name}=invalid")
+            continue
+        if build.get("state") != "succeeded":
+            failed.append(f"{name}={build.get('state', 'unknown')}")
+        versions[name] = str(build.get("pkg_version", "unknown"))
+    result = aggregate_versions("Fedora Copr", expected, versions)
+    if failed:
+        return dataclasses.replace(
+            result,
+            status="stale",
+            detail="failed chroots: " + ", ".join(sorted(failed)),
+        )
+    return result
+
+
+def check_snap(client: HttpClient, expected: str) -> CheckResult:
+    payload = client.get_json(
+        "https://api.snapcraft.io/v2/snaps/info/juicefs",
+        headers={"Snap-Device-Series": "16"},
+    )
+    channel_map = payload.get("channel-map") if isinstance(payload, dict) else None
+    versions: dict[str, str] = {}
+    for item in channel_map or []:
+        if not isinstance(item, dict) or not isinstance(item.get("channel"), dict):
+            continue
+        channel = item["channel"]
+        if channel.get("track") != "latest" or channel.get("risk") != "stable":
+            continue
+        architecture = str(channel.get("architecture", "unknown"))
+        versions[architecture] = str(item.get("version", "unknown"))
+    return aggregate_versions("Snap stable", expected, versions)
+
+
+def check_aur(client: HttpClient, expected: str) -> CheckResult:
+    payload = client.get_json(
+        "https://aur.archlinux.org/rpc/v5/info?arg[]=juicefs&arg[]=juicefs-bin"
+    )
+    results = payload.get("results") if isinstance(payload, dict) else None
+    versions = {
+        item["Name"]: item["Version"]
+        for item in results or []
+        if isinstance(item, dict)
+        and item.get("Name") in {"juicefs", "juicefs-bin"}
+        and isinstance(item.get("Version"), str)
+    }
+    missing = {"juicefs", "juicefs-bin"} - set(versions)
+    if missing:
+        return CheckResult("AUR stable", "invalid", expected, "unknown", "missing: " + ", ".join(sorted(missing)))
+    return aggregate_versions("AUR stable", expected, versions, "juicefs-git excluded")
+
+
+def check_scoop(client: HttpClient, expected: str) -> CheckResult:
+    payload = client.get_json(
+        "https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket/juicefs.json"
+    )
+    if not isinstance(payload, dict):
+        raise CheckError("Scoop manifest is not an object")
+    actual = str(payload.get("version", "unknown"))
+    architecture = payload.get("architecture")
+    entry = architecture.get("64bit") if isinstance(architecture, dict) else None
+    url = entry.get("url") if isinstance(entry, dict) else None
+    checksum = entry.get("hash") if isinstance(entry, dict) else None
+    if not isinstance(url, str) or not isinstance(checksum, str) or not checksum:
+        return CheckResult("Scoop", "invalid", expected, actual, "64-bit URL or hash is missing")
+    status = version_status(expected, actual)
+    if f"/v{expected}/" not in url:
+        status = "stale"
+    client.probe(url)
+    return CheckResult("Scoop", status, expected, actual, "manifest URL and hash present")
+
+
+def check_docker(client: HttpClient, expected: str) -> CheckResult:
+    tags = [f"ce-v{expected}", "latest"]
+    states: dict[str, str] = {}
+    for tag in tags:
+        payload = client.get_json(
+            f"https://hub.docker.com/v2/repositories/juicedata/mount/tags/{tag}"
+        )
+        state = payload.get("tag_status") if isinstance(payload, dict) else None
+        states[tag] = str(state or "unknown")
+    stale = {tag: state for tag, state in states.items() if state != "active"}
+    return CheckResult(
+        "Docker Hub",
+        "stale" if stale else "current",
+        expected,
+        ", ".join(f"{tag}={state}" for tag, state in states.items()),
+        "binary versions are checked by docker smoke tests",
+    )
+
+
+def check_maven(client: HttpClient, expected: str) -> CheckResult:
+    base_url = "https://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop"
+    metadata = client.get_text(f"{base_url}/maven-metadata.xml")
+    try:
+        root = ET.fromstring(metadata)
+    except ET.ParseError as exc:
+        raise CheckError("Maven metadata is invalid XML") from exc
+    latest = root.findtext("./versioning/latest") or "unknown"
+    release = root.findtext("./versioning/release") or "unknown"
+    versions = {item.text for item in root.findall("./versioning/versions/version") if item.text}
+    status = "current" if latest == expected and release == expected and expected in versions else "stale"
+    if expected in versions:
+        client.probe(f"{base_url}/{expected}/juicefs-hadoop-{expected}.pom")
+        client.probe(f"{base_url}/{expected}/juicefs-hadoop-{expected}.jar")
+    return CheckResult(
+        "Maven Central",
+        status,
+        expected,
+        f"latest={latest}, release={release}",
+        "POM and JAR checked" if expected in versions else "target version is absent",
+    )
+
+
+def perform_checks(
+    client: HttpClient,
+    release: ReleaseInfo,
+    release_payload: dict[str, Any],
+) -> list[CheckResult]:
+    expected = release.version
+    checkers: list[tuple[str, Callable[[], CheckResult]]] = [
+        ("CDN", lambda: check_cdn(client, expected, release_payload)),
+        ("Homebrew", lambda: check_homebrew(client, expected)),
+        ("Ubuntu PPA", lambda: check_ppa(client, expected)),
+        ("Fedora Copr", lambda: check_copr(client, expected)),
+        ("Snap stable", lambda: check_snap(client, expected)),
+        ("AUR stable", lambda: check_aur(client, expected)),
+        ("Scoop", lambda: check_scoop(client, expected)),
+        ("Docker Hub", lambda: check_docker(client, expected)),
+        ("Maven Central", lambda: check_maven(client, expected)),
+    ]
+    return [run_channel(name, expected, checker) for name, checker in checkers]
+
+
+def check_command(args: argparse.Namespace) -> int:
+    client = HttpClient()
+    try:
+        release, release_payload = github_latest_release(
+            client,
+            args.repository,
+            token=os.environ.get("GITHUB_TOKEN", ""),
+        )
+    except CheckError as exc:
+        append_summary(args.summary, f"## JuiceFS release distribution check\n\n❌ {exc}")
+        print(exc, file=sys.stderr)
+        return 1
+    expired = grace_expired(release.published_at, args.grace_hours)
+    append_github_output(
+        args.github_output,
+        {
+            "target_version": release.version,
+            "target_tag": release.tag,
+            "release_id": str(release.release_id),
+            "published_at": release.published_at.isoformat(),
+            "grace_expired": str(expired).lower(),
+        },
+    )
+    results = perform_checks(client, release, release_payload)
+    summary = render_results_summary(
+        release,
+        args.trigger_tag,
+        args.grace_hours,
+        expired,
+        results,
+    )
+    append_summary(args.summary, summary)
+    print(summary)
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as output:
+            json.dump(
+                {
+                    "release": dataclasses.asdict(release),
+                    "trigger_tag": args.trigger_tag,
+                    "grace_expired": expired,
+                    "results": [dataclasses.asdict(result) for result in results],
+                },
+                output,
+                default=str,
+                indent=2,
+            )
+    return 1 if should_fail(results, expired) else 0
+
+
+def resolve_command(args: argparse.Namespace) -> int:
+    client = HttpClient()
+    try:
+        release, _ = github_latest_release(
+            client,
+            args.repository,
+            token=os.environ.get("GITHUB_TOKEN", ""),
+        )
+    except CheckError as exc:
+        append_summary(args.summary, f"## JuiceFS latest release\n\n❌ {exc}")
+        print(exc, file=sys.stderr)
+        return 1
+    append_github_output(
+        args.github_output,
+        {
+            "target_version": release.version,
+            "target_tag": release.tag,
+            "release_id": str(release.release_id),
+            "published_at": release.published_at.isoformat(),
+        },
+    )
+    trigger = args.trigger_tag or "schedule/manual"
+    append_summary(
+        args.summary,
+        "\n".join(
+            [
+                "## JuiceFS latest release",
+                "",
+                f"- Trigger release: `{trigger}`",
+                f"- Target latest release: `{release.tag}` (GitHub release `{release.release_id}`)",
+            ]
+        ),
+    )
+    print(f"trigger={trigger}, target={release.tag}, release_id={release.release_id}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check JuiceFS release distribution versions")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="check all official stable distribution channels")
+    check.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "juicedata/juicefs"))
+    check.add_argument("--trigger-tag", default="")
+    check.add_argument("--grace-hours", type=int, default=24)
+    check.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    check.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    check.add_argument("--json-output", default="")
+
+    resolve = subparsers.add_parser("resolve", help="resolve GitHub's explicitly marked latest release")
+    resolve.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "juicedata/juicefs"))
+    resolve.add_argument("--trigger-tag", default="")
+    resolve.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    resolve.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+
+    verify = subparsers.add_parser("verify-version", help="verify one installed binary version")
+    verify.add_argument("--channel", required=True)
+    verify.add_argument("--expected", required=True)
+    verify.add_argument("--actual-file", required=True)
+    verify.add_argument("--command-status", type=int, default=0)
+    verify.add_argument("--published-at", required=True)
+    verify.add_argument("--grace-hours", type=int, default=24)
+    verify.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+
+    return parser
+
+
+def verify_version_command(args: argparse.Namespace) -> int:
+    published_at = parse_datetime(args.published_at)
+    expired = grace_expired(published_at, args.grace_hours)
+    try:
+        with open(args.actual_file, encoding="utf-8", errors="replace") as actual_file:
+            actual_output = actual_file.read().strip()
+    except OSError as exc:
+        actual_output = str(exc)
+        args.command_status = args.command_status or 1
+    if args.command_status:
+        result = CheckResult(
+            args.channel,
+            "unavailable",
+            args.expected,
+            "unknown",
+            f"command exited with {args.command_status}: {actual_output[-500:]}",
+        )
+    else:
+        actual_version = extract_base_version(actual_output) or "unknown"
+        status = version_status(args.expected, actual_output)
+        result = CheckResult(args.channel, status, args.expected, actual_version)
+    icon = result_icon(result, expired)
+    append_summary(
+        args.summary,
+        "\n".join(
+            [
+                f"## {args.channel}",
+                "",
+                "| Status | Expected | Actual | Detail |",
+                "| --- | --- | --- | --- |",
+                f"| {icon} {result.status} | `{result.expected}` | `{result.actual}` | {result.detail} |",
+            ]
+        ),
+    )
+    return 1 if should_fail([result], expired) else 0
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.command == "check":
+        return check_command(args)
+    if args.command == "resolve":
+        return resolve_command(args)
+    if args.command == "verify-version":
+        return verify_version_command(args)
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_release_distributions.py
+++ b/.github/scripts/check_release_distributions.py
@@ -9,6 +9,7 @@ import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
@@ -62,18 +63,18 @@ def parse_datetime(value: str) -> dt.datetime:
     return parsed.astimezone(UTC)
 
 
-def parse_latest_release(payload: dict[str, Any]) -> ReleaseInfo:
+def parse_latest_release(payload: dict[str, Any], label: str = "GitHub latest release") -> ReleaseInfo:
     if payload.get("draft"):
-        raise CheckError("GitHub latest release is a draft")
+        raise CheckError(f"{label} is a draft")
     if payload.get("prerelease"):
-        raise CheckError("GitHub latest release is a prerelease")
+        raise CheckError(f"{label} is a prerelease")
     tag = payload.get("tag_name")
     match = STABLE_TAG_RE.fullmatch(tag or "")
     if not match:
-        raise CheckError(f"GitHub latest release has an invalid stable tag: {tag!r}")
+        raise CheckError(f"{label} has an invalid stable tag: {tag!r}")
     release_id = payload.get("id")
     if not isinstance(release_id, int):
-        raise CheckError("GitHub latest release has no numeric id")
+        raise CheckError(f"{label} has no numeric id")
     return ReleaseInfo(
         release_id=release_id,
         tag=tag,
@@ -161,7 +162,38 @@ def github_latest_release(
     repository: str,
     token: str = "",
 ) -> tuple[ReleaseInfo, dict[str, Any]]:
-    url = f"https://api.github.com/repos/{repository}/releases/latest"
+    return github_release_request(client, repository, "latest", "GitHub latest release", token)
+
+
+def github_release_by_tag(
+    client: HttpClient,
+    repository: str,
+    tag: str,
+    token: str = "",
+) -> tuple[ReleaseInfo, dict[str, Any]]:
+    tag_path = urllib.parse.quote(tag, safe="")
+    return github_release_request(client, repository, f"tags/{tag_path}", f"GitHub release {tag}", token)
+
+
+def github_target_release(
+    client: HttpClient,
+    repository: str,
+    trigger_tag: str = "",
+    token: str = "",
+) -> tuple[ReleaseInfo, dict[str, Any]]:
+    if trigger_tag:
+        return github_release_by_tag(client, repository, trigger_tag, token)
+    return github_latest_release(client, repository, token)
+
+
+def github_release_request(
+    client: HttpClient,
+    repository: str,
+    path: str,
+    label: str,
+    token: str = "",
+) -> tuple[ReleaseInfo, dict[str, Any]]:
+    url = f"https://api.github.com/repos/{repository}/releases/{path}"
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
@@ -173,8 +205,8 @@ def github_latest_release(
         headers=headers,
     )
     if not isinstance(payload, dict):
-        raise CheckError("GitHub latest release response is not an object")
-    return parse_latest_release(payload), payload
+        raise CheckError(f"{label} response is not an object")
+    return parse_latest_release(payload, label), payload
 
 
 def run_channel(
@@ -233,7 +265,7 @@ def render_results_summary(
         "## JuiceFS release distribution check",
         "",
         f"- Trigger release: `{trigger}`",
-        f"- Target latest release: `{release.tag}` (GitHub release `{release.release_id}`)",
+        f"- Target release: `{release.tag}` (GitHub release `{release.release_id}`)",
         f"- Published at: `{release.published_at.isoformat()}`",
         f"- Grace period: `{grace_hours}h` ({'expired' if expired else 'active'})",
         "",
@@ -544,9 +576,10 @@ def perform_checks(
 def check_command(args: argparse.Namespace) -> int:
     client = HttpClient()
     try:
-        release, release_payload = github_latest_release(
+        release, release_payload = github_target_release(
             client,
             args.repository,
+            args.trigger_tag,
             token=os.environ.get("GITHUB_TOKEN", ""),
         )
     except CheckError as exc:
@@ -593,13 +626,14 @@ def check_command(args: argparse.Namespace) -> int:
 def resolve_command(args: argparse.Namespace) -> int:
     client = HttpClient()
     try:
-        release, _ = github_latest_release(
+        release, _ = github_target_release(
             client,
             args.repository,
+            args.trigger_tag,
             token=os.environ.get("GITHUB_TOKEN", ""),
         )
     except CheckError as exc:
-        append_summary(args.summary, f"## JuiceFS latest release\n\n❌ {exc}")
+        append_summary(args.summary, f"## JuiceFS target release\n\n❌ {exc}")
         print(exc, file=sys.stderr)
         return 1
     append_github_output(
@@ -616,10 +650,10 @@ def resolve_command(args: argparse.Namespace) -> int:
         args.summary,
         "\n".join(
             [
-                "## JuiceFS latest release",
+                "## JuiceFS target release",
                 "",
                 f"- Trigger release: `{trigger}`",
-                f"- Target latest release: `{release.tag}` (GitHub release `{release.release_id}`)",
+                f"- Target release: `{release.tag}` (GitHub release `{release.release_id}`)",
             ]
         ),
     )

--- a/.github/scripts/check_release_distributions_test.py
+++ b/.github/scripts/check_release_distributions_test.py
@@ -10,12 +10,24 @@ from unittest import mock
 import check_release_distributions as checker
 
 
+CDN_ASSETS = [
+    "juicefs-1.4.1-linux-amd64.tar.gz",
+    "juicefs-1.4.1-linux-arm64.tar.gz",
+    "juicefs-1.4.1-darwin-amd64.tar.gz",
+    "juicefs-1.4.1-darwin-arm64.tar.gz",
+    "juicefs-1.4.1-windows-amd64.tar.gz",
+    "juicefs-1.4.1-windows-amd64.zip",
+]
+
+
 class FakeClient:
-    def __init__(self, *, json_values=None, text_values=None, fail=False):
+    def __init__(self, *, json_values=None, text_values=None, fail=False, download_error=False):
         self.json_values = json_values or {}
         self.text_values = text_values or {}
         self.fail = fail
+        self.download_error = download_error
         self.urls = []
+        self.download_urls = []
 
     def _lookup(self, values, url):
         if self.fail:
@@ -37,6 +49,12 @@ class FakeClient:
         self.urls.append(url)
         if self.fail:
             raise checker.CheckError("network unavailable")
+
+    def probe_download(self, url):
+        self.urls.append(url)
+        self.download_urls.append(url)
+        if self.fail or self.download_error:
+            raise checker.CheckError("download unavailable")
 
 
 class ReleaseResolutionTest(unittest.TestCase):
@@ -157,6 +175,49 @@ class ReleaseResolutionTest(unittest.TestCase):
                 checker.parse_latest_release(payload)
 
 
+class HttpClientTest(unittest.TestCase):
+    def test_download_probe_uses_range_get_and_reads_only_one_byte(self):
+        requests = []
+        read_sizes = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def read(self, size=-1):
+                read_sizes.append(size)
+                return b"x"
+
+        def urlopen(request, timeout):
+            requests.append(request)
+            return Response()
+
+        with mock.patch.object(checker.urllib.request, "urlopen", urlopen):
+            checker.HttpClient(retries=1).probe_download("https://cdn.example/client.tar.gz")
+
+        self.assertEqual("GET", requests[0].get_method())
+        self.assertEqual("bytes=0-0", requests[0].get_header("Range"))
+        self.assertEqual([1], read_sizes)
+
+    def test_download_probe_rejects_an_empty_response(self):
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def read(self, size=-1):
+                return b""
+
+        with mock.patch.object(checker.urllib.request, "urlopen", lambda request, timeout: Response()):
+            with self.assertRaises(checker.CheckError):
+                checker.HttpClient(retries=1).probe_download("https://cdn.example/empty.tar.gz")
+
+
 class VersionTest(unittest.TestCase):
     def test_package_and_binary_revisions_use_the_base_version(self):
         current = [
@@ -232,11 +293,9 @@ class VerifyVersionCommandTest(unittest.TestCase):
 class ChannelFixtureTest(unittest.TestCase):
     expected = "1.4.1"
     release_payload = {
-        "assets": [
-            {"name": "checksums.txt"},
-            {"name": "juicefs-1.4.1-linux-amd64.tar.gz"},
-            {"name": "juicefs-hadoop-1.4.1.jar"},
-        ]
+        "assets": [{"name": "checksums.txt"}]
+        + [{"name": name} for name in CDN_ASSETS]
+        + [{"name": "juicefs-hadoop-1.4.1.jar"}]
     }
 
     def assert_current_and_stale(self, build):
@@ -245,21 +304,64 @@ class ChannelFixtureTest(unittest.TestCase):
         self.assertEqual("stale", stale.status)
 
     def test_cdn_current_and_stale(self):
-        def build():
-            common = {"checksums.txt": "hash  juicefs-1.4.1-linux-amd64.tar.gz\n"}
-            current = checker.check_cdn(
-                FakeClient(text_values={"latest-version.txt": "1.4.1\n", **common}),
-                self.expected,
-                self.release_payload,
-            )
-            stale = checker.check_cdn(
-                FakeClient(text_values={"latest-version.txt": "1.3.3\n", **common}),
-                self.expected,
-                self.release_payload,
-            )
-            return current, stale
+        checksums = "".join(f"{'a' * 64}  {name}\n" for name in CDN_ASSETS)
+        current_client = FakeClient(
+            text_values={"latest-version.txt": "1.4.1\n", "checksums.txt": checksums}
+        )
+        stale_client = FakeClient(
+            text_values={"latest-version.txt": "1.3.3\n", "checksums.txt": checksums}
+        )
 
-        self.assert_current_and_stale(build)
+        current = checker.check_cdn(current_client, self.expected, self.release_payload)
+        stale = checker.check_cdn(stale_client, self.expected, self.release_payload)
+
+        self.assertEqual("current", current.status)
+        self.assertEqual("stale", stale.status)
+        self.assertEqual(6, len(current_client.download_urls))
+        self.assertIn("6/6 ranged GET", current.detail)
+
+    def test_cdn_requires_every_fixed_client_asset(self):
+        checksums = "".join(f"{'a' * 64}  {name}\n" for name in CDN_ASSETS)
+        payload = {"assets": [{"name": name} for name in CDN_ASSETS[:-1]]}
+        result = checker.check_cdn(
+            FakeClient(text_values={"latest-version.txt": "1.4.1", "checksums.txt": checksums}),
+            self.expected,
+            payload,
+        )
+
+        self.assertEqual("stale", result.status)
+        self.assertIn(CDN_ASSETS[-1], result.detail)
+
+    def test_cdn_rejects_missing_or_invalid_checksums(self):
+        checksums = "".join(
+            ("not-a-sha" if index == 0 else "a" * 64) + f"  {name}\n"
+            for index, name in enumerate(CDN_ASSETS[:-1])
+        )
+        result = checker.check_cdn(
+            FakeClient(text_values={"latest-version.txt": "1.4.1", "checksums.txt": checksums}),
+            self.expected,
+            self.release_payload,
+        )
+
+        self.assertEqual("stale", result.status)
+        self.assertIn(CDN_ASSETS[0], result.detail)
+        self.assertIn(CDN_ASSETS[-1], result.detail)
+
+    def test_cdn_download_failure_is_unavailable(self):
+        checksums = "".join(f"{'a' * 64}  {name}\n" for name in CDN_ASSETS)
+        client = FakeClient(
+            text_values={"latest-version.txt": "1.4.1", "checksums.txt": checksums},
+            download_error=True,
+        )
+        result = checker.run_channel(
+            "CDN",
+            self.expected,
+            lambda: checker.check_cdn(client, self.expected, self.release_payload),
+        )
+
+        self.assertEqual("unavailable", result.status)
+        self.assertIn("0/6 ranged GET", result.detail)
+        self.assertIn(CDN_ASSETS[0], result.detail)
 
     def test_homebrew_current_and_stale(self):
         self.assert_current_and_stale(

--- a/.github/scripts/check_release_distributions_test.py
+++ b/.github/scripts/check_release_distributions_test.py
@@ -79,6 +79,28 @@ class ReleaseResolutionTest(unittest.TestCase):
             client.urls,
         )
 
+    def test_release_event_uses_the_trigger_release_tag(self):
+        client = FakeClient(
+            json_values={
+                "/releases/tags/v1.3.4": {
+                    "id": 410000001,
+                    "tag_name": "v1.3.4",
+                    "published_at": "2026-08-19T06:00:00Z",
+                    "draft": False,
+                    "prerelease": False,
+                }
+            }
+        )
+
+        release, _ = checker.github_target_release(client, "juicedata/juicefs", "v1.3.4")
+
+        self.assertEqual("v1.3.4", release.tag)
+        self.assertEqual("1.3.4", release.version)
+        self.assertEqual(
+            ["https://api.github.com/repos/juicedata/juicefs/releases/tags/v1.3.4"],
+            client.urls,
+        )
+
     def test_github_token_is_scoped_to_the_latest_release_request(self):
         requests = []
 
@@ -113,7 +135,40 @@ class ReleaseResolutionTest(unittest.TestCase):
         self.assertEqual("Bearer dummy-token", requests[0].get_header("Authorization"))
         self.assertIsNone(requests[1].get_header("Authorization"))
 
-    def test_resolve_command_exports_the_explicit_latest_release(self):
+    def test_resolve_command_exports_the_trigger_release(self):
+        payload = {
+            "id": 410000001,
+            "tag_name": "v1.3.4",
+            "published_at": "2026-08-19T06:00:00Z",
+            "draft": False,
+            "prerelease": False,
+        }
+        original_client = checker.HttpClient
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir, "output.txt")
+            summary_path = Path(temp_dir, "summary.md")
+            checker.HttpClient = lambda: FakeClient(json_values={"/releases/tags/v1.3.4": payload})
+            try:
+                result = checker.resolve_command(
+                    Namespace(
+                        repository="juicedata/juicefs",
+                        trigger_tag="v1.3.4",
+                        github_output=str(output_path),
+                        summary=str(summary_path),
+                    )
+                )
+            finally:
+                checker.HttpClient = original_client
+
+            self.assertEqual(0, result)
+            outputs = output_path.read_text(encoding="utf-8")
+            self.assertIn("target_version=1.3.4", outputs)
+            self.assertIn("release_id=410000001", outputs)
+            summary = summary_path.read_text(encoding="utf-8")
+            self.assertIn("Trigger release: `v1.3.4`", summary)
+            self.assertIn("Target release: `v1.3.4`", summary)
+
+    def test_resolve_command_exports_the_latest_release_without_trigger(self):
         payload = {
             "id": 362269109,
             "tag_name": "v1.4.1",
@@ -130,7 +185,7 @@ class ReleaseResolutionTest(unittest.TestCase):
                 result = checker.resolve_command(
                     Namespace(
                         repository="juicedata/juicefs",
-                        trigger_tag="v1.3.3",
+                        trigger_tag="",
                         github_output=str(output_path),
                         summary=str(summary_path),
                     )
@@ -141,29 +196,9 @@ class ReleaseResolutionTest(unittest.TestCase):
             self.assertEqual(0, result)
             outputs = output_path.read_text(encoding="utf-8")
             self.assertIn("target_version=1.4.1", outputs)
-            self.assertIn("release_id=362269109", outputs)
             summary = summary_path.read_text(encoding="utf-8")
-            self.assertIn("Trigger release: `v1.3.3`", summary)
-            self.assertIn("Target latest release: `v1.4.1`", summary)
-
-    def test_latest_release_is_not_replaced_by_later_trigger(self):
-        latest = checker.parse_latest_release(
-            {
-                "id": 362269109,
-                "tag_name": "v1.4.1",
-                "published_at": "2026-07-30T08:03:19Z",
-                "draft": False,
-                "prerelease": False,
-            }
-        )
-
-        self.assertEqual("v1.4.1", latest.tag)
-        self.assertEqual("1.4.1", latest.version)
-        self.assertLess(
-            latest.published_at,
-            checker.parse_datetime("2026-08-07T09:12:29Z"),
-            "the later v1.3.3 trigger must not become the target release",
-        )
+            self.assertIn("Trigger release: `schedule/manual`", summary)
+            self.assertIn("Target release: `v1.4.1`", summary)
 
     def test_invalid_latest_release_is_rejected(self):
         cases = [
@@ -241,7 +276,7 @@ class GracePeriodTest(unittest.TestCase):
     def setUp(self):
         self.published = checker.parse_datetime("2026-07-30T08:03:19Z")
 
-    def test_grace_uses_latest_release_publication_time(self):
+    def test_grace_uses_target_release_publication_time(self):
         self.assertFalse(
             checker.grace_expired(
                 self.published,
@@ -256,10 +291,6 @@ class GracePeriodTest(unittest.TestCase):
                 checker.parse_datetime("2026-07-31T08:03:19Z"),
             )
         )
-
-    def test_later_maintenance_release_does_not_reset_grace(self):
-        later_v133 = checker.parse_datetime("2026-08-07T09:12:29Z")
-        self.assertTrue(checker.grace_expired(self.published, 24, later_v133))
 
     def test_stale_and_unavailable_fail_only_after_grace(self):
         results = [checker.CheckResult("test", "stale", "1.4.1", "1.3.3")]

--- a/.github/scripts/check_release_distributions_test.py
+++ b/.github/scripts/check_release_distributions_test.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+
+import datetime as dt
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
+
+import check_release_distributions as checker
+
+
+class FakeClient:
+    def __init__(self, *, json_values=None, text_values=None, fail=False):
+        self.json_values = json_values or {}
+        self.text_values = text_values or {}
+        self.fail = fail
+        self.urls = []
+
+    def _lookup(self, values, url):
+        if self.fail:
+            raise checker.CheckError("network unavailable")
+        for marker, value in values.items():
+            if marker in url:
+                return value
+        raise checker.CheckError(f"unexpected URL: {url}")
+
+    def get_json(self, url, headers=None):
+        self.urls.append(url)
+        return self._lookup(self.json_values, url)
+
+    def get_text(self, url, headers=None):
+        self.urls.append(url)
+        return self._lookup(self.text_values, url)
+
+    def probe(self, url):
+        self.urls.append(url)
+        if self.fail:
+            raise checker.CheckError("network unavailable")
+
+
+class ReleaseResolutionTest(unittest.TestCase):
+    def test_resolver_calls_the_explicit_latest_release_endpoint(self):
+        client = FakeClient(
+            json_values={
+                "/releases/latest": {
+                    "id": 362269109,
+                    "tag_name": "v1.4.1",
+                    "published_at": "2026-07-30T08:03:19Z",
+                    "draft": False,
+                    "prerelease": False,
+                }
+            }
+        )
+
+        release, _ = checker.github_latest_release(client, "juicedata/juicefs")
+
+        self.assertEqual("v1.4.1", release.tag)
+        self.assertEqual(
+            ["https://api.github.com/repos/juicedata/juicefs/releases/latest"],
+            client.urls,
+        )
+
+    def test_github_token_is_scoped_to_the_latest_release_request(self):
+        requests = []
+
+        class Response:
+            def __init__(self, body):
+                self.body = body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def read(self):
+                return self.body
+
+        def urlopen(request, timeout):
+            requests.append(request)
+            if request.full_url.endswith("/releases/latest"):
+                return Response(
+                    b'{"id": 362269109, "tag_name": "v1.4.1", '
+                    b'"published_at": "2026-07-30T08:03:19Z", '
+                    b'"draft": false, "prerelease": false}'
+                )
+            return Response(b'{"versions": {"stable": "1.4.1"}}')
+
+        client = checker.HttpClient(retries=1)
+        with mock.patch.object(checker.urllib.request, "urlopen", urlopen):
+            checker.github_latest_release(client, "juicedata/juicefs", token="dummy-token")
+            checker.check_homebrew(client, "1.4.1")
+
+        self.assertEqual("Bearer dummy-token", requests[0].get_header("Authorization"))
+        self.assertIsNone(requests[1].get_header("Authorization"))
+
+    def test_resolve_command_exports_the_explicit_latest_release(self):
+        payload = {
+            "id": 362269109,
+            "tag_name": "v1.4.1",
+            "published_at": "2026-07-30T08:03:19Z",
+            "draft": False,
+            "prerelease": False,
+        }
+        original_client = checker.HttpClient
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir, "output.txt")
+            summary_path = Path(temp_dir, "summary.md")
+            checker.HttpClient = lambda: FakeClient(json_values={"/releases/latest": payload})
+            try:
+                result = checker.resolve_command(
+                    Namespace(
+                        repository="juicedata/juicefs",
+                        trigger_tag="v1.3.3",
+                        github_output=str(output_path),
+                        summary=str(summary_path),
+                    )
+                )
+            finally:
+                checker.HttpClient = original_client
+
+            self.assertEqual(0, result)
+            outputs = output_path.read_text(encoding="utf-8")
+            self.assertIn("target_version=1.4.1", outputs)
+            self.assertIn("release_id=362269109", outputs)
+            summary = summary_path.read_text(encoding="utf-8")
+            self.assertIn("Trigger release: `v1.3.3`", summary)
+            self.assertIn("Target latest release: `v1.4.1`", summary)
+
+    def test_latest_release_is_not_replaced_by_later_trigger(self):
+        latest = checker.parse_latest_release(
+            {
+                "id": 362269109,
+                "tag_name": "v1.4.1",
+                "published_at": "2026-07-30T08:03:19Z",
+                "draft": False,
+                "prerelease": False,
+            }
+        )
+
+        self.assertEqual("v1.4.1", latest.tag)
+        self.assertEqual("1.4.1", latest.version)
+        self.assertLess(
+            latest.published_at,
+            checker.parse_datetime("2026-08-07T09:12:29Z"),
+            "the later v1.3.3 trigger must not become the target release",
+        )
+
+    def test_invalid_latest_release_is_rejected(self):
+        cases = [
+            {"id": 1, "tag_name": "v1.4.1", "published_at": "2026-01-01T00:00:00Z", "draft": True},
+            {"id": 1, "tag_name": "v1.4.1", "published_at": "2026-01-01T00:00:00Z", "prerelease": True},
+        ]
+        for payload in cases:
+            with self.subTest(payload=payload), self.assertRaises(checker.CheckError):
+                checker.parse_latest_release(payload)
+
+
+class VersionTest(unittest.TestCase):
+    def test_package_and_binary_revisions_use_the_base_version(self):
+        current = [
+            "1.4.1",
+            "1.4.1-1",
+            "1:1.4.1-1~ubuntu24.04.1",
+            "1.4.1-1.fc42",
+            "juicefs version 1.4.1+2026-07-30.0b90c7d",
+        ]
+        for actual in current:
+            with self.subTest(actual=actual):
+                self.assertEqual("current", checker.version_status("1.4.1", actual))
+
+    def test_older_or_newer_base_version_is_stale(self):
+        for actual in ["1.3.3", "1.4.0-9", "1.4.2", "unknown"]:
+            with self.subTest(actual=actual):
+                self.assertEqual("stale", checker.version_status("1.4.1", actual))
+
+
+class GracePeriodTest(unittest.TestCase):
+    def setUp(self):
+        self.published = checker.parse_datetime("2026-07-30T08:03:19Z")
+
+    def test_grace_uses_latest_release_publication_time(self):
+        self.assertFalse(
+            checker.grace_expired(
+                self.published,
+                24,
+                checker.parse_datetime("2026-07-31T08:03:18Z"),
+            )
+        )
+        self.assertTrue(
+            checker.grace_expired(
+                self.published,
+                24,
+                checker.parse_datetime("2026-07-31T08:03:19Z"),
+            )
+        )
+
+    def test_later_maintenance_release_does_not_reset_grace(self):
+        later_v133 = checker.parse_datetime("2026-08-07T09:12:29Z")
+        self.assertTrue(checker.grace_expired(self.published, 24, later_v133))
+
+    def test_stale_and_unavailable_fail_only_after_grace(self):
+        results = [checker.CheckResult("test", "stale", "1.4.1", "1.3.3")]
+        self.assertFalse(checker.should_fail(results, expired=False))
+        self.assertTrue(checker.should_fail(results, expired=True))
+        invalid = [checker.CheckResult("test", "invalid", "1.4.1", "unknown")]
+        self.assertTrue(checker.should_fail(invalid, expired=False))
+
+
+class VerifyVersionCommandTest(unittest.TestCase):
+    def test_build_metadata_is_accepted(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            actual_path = Path(temp_dir, "actual.txt")
+            summary_path = Path(temp_dir, "summary.md")
+            actual_path.write_text("juicefs version 1.4.1+revision\n", encoding="utf-8")
+            result = checker.verify_version_command(
+                Namespace(
+                    channel="installer",
+                    expected="1.4.1",
+                    actual_file=str(actual_path),
+                    command_status=0,
+                    published_at=(dt.datetime.now(checker.UTC) - dt.timedelta(hours=1)).isoformat(),
+                    grace_hours=24,
+                    summary=str(summary_path),
+                )
+            )
+            self.assertEqual(0, result)
+            self.assertIn("current", summary_path.read_text(encoding="utf-8"))
+
+
+class ChannelFixtureTest(unittest.TestCase):
+    expected = "1.4.1"
+    release_payload = {
+        "assets": [
+            {"name": "checksums.txt"},
+            {"name": "juicefs-1.4.1-linux-amd64.tar.gz"},
+            {"name": "juicefs-hadoop-1.4.1.jar"},
+        ]
+    }
+
+    def assert_current_and_stale(self, build):
+        current, stale = build()
+        self.assertEqual("current", current.status)
+        self.assertEqual("stale", stale.status)
+
+    def test_cdn_current_and_stale(self):
+        def build():
+            common = {"checksums.txt": "hash  juicefs-1.4.1-linux-amd64.tar.gz\n"}
+            current = checker.check_cdn(
+                FakeClient(text_values={"latest-version.txt": "1.4.1\n", **common}),
+                self.expected,
+                self.release_payload,
+            )
+            stale = checker.check_cdn(
+                FakeClient(text_values={"latest-version.txt": "1.3.3\n", **common}),
+                self.expected,
+                self.release_payload,
+            )
+            return current, stale
+
+        self.assert_current_and_stale(build)
+
+    def test_homebrew_current_and_stale(self):
+        self.assert_current_and_stale(
+            lambda: (
+                checker.check_homebrew(FakeClient(json_values={"formula": {"versions": {"stable": "1.4.1"}}}), self.expected),
+                checker.check_homebrew(FakeClient(json_values={"formula": {"versions": {"stable": "1.3.3"}}}), self.expected),
+            )
+        )
+
+    def test_ppa_filters_unsupported_series(self):
+        def client(version):
+            entries = {
+                "entries": [
+                    {"distro_series_link": "https://api.launchpad.net/1.0/ubuntu/noble", "source_package_version": version},
+                    {"distro_series_link": "https://api.launchpad.net/1.0/ubuntu/oracular", "source_package_version": "1.2.0-1"},
+                ]
+            }
+            return FakeClient(
+                json_values={
+                    "+archive/ubuntu/ppa?": entries,
+                    "+archive/ubuntu/arm64?": entries,
+                    "/ubuntu/noble": {"supported": True},
+                    "/ubuntu/oracular": {"supported": False},
+                }
+            )
+
+        current = checker.check_ppa(client("1.4.1-1"), self.expected)
+        stale = checker.check_ppa(client("1.3.3-1"), self.expected)
+        self.assertEqual("current", current.status)
+        self.assertEqual("stale", stale.status)
+        self.assertNotIn("oracular", current.actual)
+
+    def test_copr_current_and_partial_failure(self):
+        def payload(state, version):
+            return {
+                "packages": [
+                    {
+                        "name": "juicefs",
+                        "chroots": {
+                            "fedora-x86_64": {"state": state, "pkg_version": version},
+                            "fedora-aarch64": {"state": "succeeded", "pkg_version": "1.4.1-1"},
+                        },
+                    }
+                ]
+            }
+
+        current = checker.check_copr(FakeClient(json_values={"monitor": payload("succeeded", "1.4.1-1")}), self.expected)
+        stale = checker.check_copr(FakeClient(json_values={"monitor": payload("failed", "1.3.3-1")}), self.expected)
+        self.assertEqual("current", current.status)
+        self.assertEqual("stale", stale.status)
+        self.assertIn("failed chroots", stale.detail)
+
+    def test_snap_uses_stable_channel_only(self):
+        def payload(stable):
+            return {
+                "channel-map": [
+                    {"channel": {"track": "latest", "risk": "stable", "architecture": "amd64"}, "version": stable},
+                    {"channel": {"track": "latest", "risk": "edge", "architecture": "amd64"}, "version": "9.9.9"},
+                ]
+            }
+
+        self.assert_current_and_stale(
+            lambda: (
+                checker.check_snap(FakeClient(json_values={"snaps/info": payload("1.4.1")}), self.expected),
+                checker.check_snap(FakeClient(json_values={"snaps/info": payload("1.3.3")}), self.expected),
+            )
+        )
+
+    def test_aur_checks_only_stable_packages(self):
+        def payload(version):
+            return {
+                "results": [
+                    {"Name": "juicefs", "Version": version},
+                    {"Name": "juicefs-bin", "Version": version},
+                    {"Name": "juicefs-git", "Version": "dev-1"},
+                ]
+            }
+
+        self.assert_current_and_stale(
+            lambda: (
+                checker.check_aur(FakeClient(json_values={"aur.archlinux": payload("1.4.1-1")}), self.expected),
+                checker.check_aur(FakeClient(json_values={"aur.archlinux": payload("1.3.3-1")}), self.expected),
+            )
+        )
+
+    def test_scoop_current_and_stale(self):
+        def payload(version):
+            return {
+                "version": version,
+                "architecture": {
+                    "64bit": {
+                        "url": f"https://github.com/juicedata/juicefs/releases/download/v{version}/juicefs.tar.gz",
+                        "hash": "abc",
+                    }
+                },
+            }
+
+        self.assert_current_and_stale(
+            lambda: (
+                checker.check_scoop(FakeClient(json_values={"juicefs.json": payload("1.4.1")}), self.expected),
+                checker.check_scoop(FakeClient(json_values={"juicefs.json": payload("1.3.3")}), self.expected),
+            )
+        )
+
+    def test_docker_requires_versioned_and_latest_tags(self):
+        current = checker.check_docker(
+            FakeClient(json_values={"ce-v1.4.1": {"tag_status": "active"}, "/latest": {"tag_status": "active"}}),
+            self.expected,
+        )
+        stale = checker.check_docker(
+            FakeClient(json_values={"ce-v1.4.1": {"tag_status": "active"}, "/latest": {"tag_status": "inactive"}}),
+            self.expected,
+        )
+        self.assertEqual("current", current.status)
+        self.assertEqual("stale", stale.status)
+
+    def test_maven_current_and_stale(self):
+        def metadata(version):
+            return (
+                "<metadata><versioning>"
+                f"<latest>{version}</latest><release>{version}</release>"
+                f"<versions><version>{version}</version></versions>"
+                "</versioning></metadata>"
+            )
+
+        self.assert_current_and_stale(
+            lambda: (
+                checker.check_maven(FakeClient(text_values={"maven-metadata": metadata("1.4.1")}), self.expected),
+                checker.check_maven(FakeClient(text_values={"maven-metadata": metadata("1.3.3")}), self.expected),
+            )
+        )
+
+    def test_every_channel_reports_unavailable_without_hiding_others(self):
+        client = FakeClient(fail=True)
+        checks = [
+            ("CDN", lambda: checker.check_cdn(client, self.expected, self.release_payload)),
+            ("Homebrew", lambda: checker.check_homebrew(client, self.expected)),
+            ("Ubuntu PPA", lambda: checker.check_ppa(client, self.expected)),
+            ("Fedora Copr", lambda: checker.check_copr(client, self.expected)),
+            ("Snap stable", lambda: checker.check_snap(client, self.expected)),
+            ("AUR stable", lambda: checker.check_aur(client, self.expected)),
+            ("Scoop", lambda: checker.check_scoop(client, self.expected)),
+            ("Docker Hub", lambda: checker.check_docker(client, self.expected)),
+            ("Maven Central", lambda: checker.check_maven(client, self.expected)),
+        ]
+        for name, check in checks:
+            with self.subTest(channel=name):
+                result = checker.run_channel(name, self.expected, check)
+                self.assertEqual("unavailable", result.status)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/release-distribution-check.yml
+++ b/.github/workflows/release-distribution-check.yml
@@ -1,0 +1,327 @@
+name: release distribution check
+
+on:
+  release:
+    types: [published]
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  latest-release:
+    if: ${{ github.event_name != 'release' || (github.event.release.draft == false && github.event.release.prerelease == false) }}
+    runs-on: ubuntu-latest
+    outputs:
+      target_version: ${{ steps.latest.outputs.target_version }}
+      target_tag: ${{ steps.latest.outputs.target_tag }}
+      release_id: ${{ steps.latest.outputs.release_id }}
+      published_at: ${{ steps.latest.outputs.published_at }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Test release distribution checker
+        run: python3 .github/scripts/check_release_distributions_test.py
+
+      - name: Resolve explicitly marked latest release
+        id: latest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TRIGGER_TAG: ${{ github.event.release.tag_name || '' }}
+        run: |
+          python3 .github/scripts/check_release_distributions.py resolve \
+            --repository "$GITHUB_REPOSITORY" \
+            --trigger-tag "$TRIGGER_TAG"
+
+  metadata:
+    needs: latest-release
+    runs-on: ubuntu-latest
+    outputs:
+      target_version: ${{ steps.check.outputs.target_version }}
+      target_tag: ${{ steps.check.outputs.target_tag }}
+      release_id: ${{ steps.check.outputs.release_id }}
+      published_at: ${{ steps.check.outputs.published_at }}
+      grace_expired: ${{ steps.check.outputs.grace_expired }}
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.latest-release.outputs.release_id }}-${{ needs.latest-release.outputs.target_version }}-metadata
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check distribution metadata
+        id: check
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TRIGGER_TAG: ${{ github.event.release.tag_name || '' }}
+        run: |
+          python3 .github/scripts/check_release_distributions.py check \
+            --repository "$GITHUB_REPOSITORY" \
+            --trigger-tag "$TRIGGER_TAG" \
+            --grace-hours 24
+
+      - name: Fail on overdue metadata mismatch
+        if: ${{ steps.check.outcome == 'failure' }}
+        run: exit 1
+
+  cdn-installer:
+    needs: [latest-release, metadata]
+    if: ${{ always() && needs.metadata.outputs.target_version != '' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.metadata.outputs.release_id }}-${{ needs.metadata.outputs.target_version }}-cdn
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install from the official CDN
+        id: install
+        env:
+          TARGET_VERSION: ${{ needs.metadata.outputs.target_version }}
+        run: |
+          set +e
+          smoke_dir=$(mktemp -d)
+          mkdir -p "$smoke_dir/bin"
+          curl -fsSL --retry 3 --max-time 30 https://d.juicefs.com/install -o "$smoke_dir/install.sh"
+          command_status=$?
+          if [ "$command_status" -eq 0 ]; then
+            sh "$smoke_dir/install.sh" "$smoke_dir/bin"
+            command_status=$?
+          fi
+          if [ "$command_status" -eq 0 ]; then
+            "$smoke_dir/bin/juicefs" version > actual-version.txt 2>&1
+            command_status=$?
+          else
+            echo "CDN installer failed; see the step log" > actual-version.txt
+          fi
+          rm -rf "$smoke_dir"
+          echo "command_status=$command_status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Verify installed CDN version
+        run: |
+          python3 .github/scripts/check_release_distributions.py verify-version \
+            --channel "CDN installer" \
+            --expected "${{ needs.metadata.outputs.target_version }}" \
+            --actual-file actual-version.txt \
+            --command-status "${{ steps.install.outputs.command_status }}" \
+            --published-at "${{ needs.metadata.outputs.published_at }}" \
+            --grace-hours 24
+
+  homebrew:
+    needs: [latest-release, metadata]
+    if: ${{ always() && needs.metadata.outputs.target_version != '' }}
+    runs-on: macos-latest
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.metadata.outputs.release_id }}-${{ needs.metadata.outputs.target_version }}-homebrew
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install with Homebrew
+        id: install
+        run: |
+          set +e
+          brew update && brew install juicefs
+          command_status=$?
+          if [ "$command_status" -eq 0 ]; then
+            juicefs version > actual-version.txt 2>&1
+            command_status=$?
+          else
+            echo "Homebrew installation failed; see the step log" > actual-version.txt
+          fi
+          echo "command_status=$command_status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Verify Homebrew version
+        run: |
+          python3 .github/scripts/check_release_distributions.py verify-version \
+            --channel "Homebrew install" \
+            --expected "${{ needs.metadata.outputs.target_version }}" \
+            --actual-file actual-version.txt \
+            --command-status "${{ steps.install.outputs.command_status }}" \
+            --published-at "${{ needs.metadata.outputs.published_at }}" \
+            --grace-hours 24
+
+  ubuntu-ppa:
+    needs: [latest-release, metadata]
+    if: ${{ always() && needs.metadata.outputs.target_version != '' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.metadata.outputs.release_id }}-${{ needs.metadata.outputs.target_version }}-ppa
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install from the x86 PPA
+        id: install
+        run: |
+          set +e
+          sudo add-apt-repository -y ppa:juicefs/ppa && \
+            sudo apt-get update && \
+            sudo apt-get install -y juicefs
+          command_status=$?
+          if [ "$command_status" -eq 0 ]; then
+            juicefs version > actual-version.txt 2>&1
+            command_status=$?
+          else
+            echo "PPA installation failed; see the step log" > actual-version.txt
+          fi
+          echo "command_status=$command_status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Verify PPA version
+        run: |
+          python3 .github/scripts/check_release_distributions.py verify-version \
+            --channel "Ubuntu PPA install" \
+            --expected "${{ needs.metadata.outputs.target_version }}" \
+            --actual-file actual-version.txt \
+            --command-status "${{ steps.install.outputs.command_status }}" \
+            --published-at "${{ needs.metadata.outputs.published_at }}" \
+            --grace-hours 24
+
+  scoop:
+    needs: [latest-release, metadata]
+    if: ${{ always() && needs.metadata.outputs.target_version != '' }}
+    runs-on: windows-latest
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.metadata.outputs.release_id }}-${{ needs.metadata.outputs.target_version }}-scoop
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install with Scoop
+        id: install
+        shell: pwsh
+        run: |
+          $commandStatus = 0
+          try {
+            Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+            Invoke-WebRequest -UseBasicParsing `
+              'https://raw.githubusercontent.com/ScoopInstaller/Install/master/install.ps1' `
+              -OutFile 'install-scoop.ps1'
+            .\install-scoop.ps1 -RunAsAdmin
+            if ($LASTEXITCODE -ne 0) { throw "Scoop installer exited with $LASTEXITCODE" }
+            scoop install juicefs
+            if ($LASTEXITCODE -ne 0) { throw "scoop install exited with $LASTEXITCODE" }
+            juicefs version 2>&1 | Out-File actual-version.txt -Encoding utf8
+            if ($LASTEXITCODE -ne 0) { throw "juicefs version exited with $LASTEXITCODE" }
+          } catch {
+            $commandStatus = 1
+            $_ | Out-String | Tee-Object -FilePath actual-version.txt
+          }
+          "command_status=$commandStatus" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - name: Verify Scoop version
+        shell: pwsh
+        run: |
+          python .github/scripts/check_release_distributions.py verify-version `
+            --channel "Scoop install" `
+            --expected "${{ needs.metadata.outputs.target_version }}" `
+            --actual-file actual-version.txt `
+            --command-status "${{ steps.install.outputs.command_status }}" `
+            --published-at "${{ needs.metadata.outputs.published_at }}" `
+            --grace-hours 24
+
+  docker:
+    needs: [latest-release, metadata]
+    if: ${{ always() && needs.metadata.outputs.target_version != '' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.metadata.outputs.release_id }}-${{ needs.metadata.outputs.target_version }}-docker
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Run the versioned and latest community images
+        id: run
+        env:
+          TARGET_VERSION: ${{ needs.metadata.outputs.target_version }}
+        run: |
+          set +e
+          docker pull "juicedata/mount:ce-v${TARGET_VERSION}" && \
+            docker run --rm "juicedata/mount:ce-v${TARGET_VERSION}" juicefs version \
+              > versioned-actual.txt 2>&1
+          versioned_status=$?
+          if [ "$versioned_status" -ne 0 ]; then
+            echo "versioned Docker image failed; see the step log" > versioned-actual.txt
+          fi
+          docker pull juicedata/mount:latest && \
+            docker run --rm juicedata/mount:latest juicefs version \
+              > latest-actual.txt 2>&1
+          latest_status=$?
+          if [ "$latest_status" -ne 0 ]; then
+            echo "latest Docker image failed; see the step log" > latest-actual.txt
+          fi
+          echo "versioned_status=$versioned_status" >> "$GITHUB_OUTPUT"
+          echo "latest_status=$latest_status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Verify Docker image versions
+        run: |
+          set +e
+          python3 .github/scripts/check_release_distributions.py verify-version \
+            --channel "Docker ce-v${{ needs.metadata.outputs.target_version }}" \
+            --expected "${{ needs.metadata.outputs.target_version }}" \
+            --actual-file versioned-actual.txt \
+            --command-status "${{ steps.run.outputs.versioned_status }}" \
+            --published-at "${{ needs.metadata.outputs.published_at }}" \
+            --grace-hours 24
+          versioned_check=$?
+          python3 .github/scripts/check_release_distributions.py verify-version \
+            --channel "Docker latest" \
+            --expected "${{ needs.metadata.outputs.target_version }}" \
+            --actual-file latest-actual.txt \
+            --command-status "${{ steps.run.outputs.latest_status }}" \
+            --published-at "${{ needs.metadata.outputs.published_at }}" \
+            --grace-hours 24
+          latest_check=$?
+          [ "$versioned_check" -eq 0 ] && [ "$latest_check" -eq 0 ]
+
+  maven-central:
+    needs: [latest-release, metadata]
+    if: ${{ always() && needs.metadata.outputs.target_version != '' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-distribution-check-${{ github.repository }}-${{ needs.metadata.outputs.release_id }}-${{ needs.metadata.outputs.target_version }}-maven
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "8"
+      - name: Resolve the Java SDK from Maven Central
+        id: resolve
+        env:
+          TARGET_VERSION: ${{ needs.metadata.outputs.target_version }}
+        run: |
+          set +e
+          mvn --batch-mode --quiet dependency:get \
+            -Dartifact="io.juicefs:juicefs-hadoop:${TARGET_VERSION}" \
+            -Dtransitive=false
+          command_status=$?
+          if [ "$command_status" -eq 0 ]; then
+            echo "$TARGET_VERSION" > actual-version.txt
+          else
+            echo "Maven dependency resolution failed; see the step log" > actual-version.txt
+          fi
+          echo "command_status=$command_status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Verify Maven Central version
+        run: |
+          python3 .github/scripts/check_release_distributions.py verify-version \
+            --channel "Maven Central resolve" \
+            --expected "${{ needs.metadata.outputs.target_version }}" \
+            --actual-file actual-version.txt \
+            --command-status "${{ steps.resolve.outputs.command_status }}" \
+            --published-at "${{ needs.metadata.outputs.published_at }}" \
+            --grace-hours 24

--- a/.github/workflows/release-distribution-check.yml
+++ b/.github/workflows/release-distribution-check.yml
@@ -22,12 +22,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Test release distribution checker
         run: python3 .github/scripts/check_release_distributions_test.py
 
-      - name: Resolve explicitly marked latest release
+      - name: Resolve target release
         id: latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -52,6 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Check distribution metadata
@@ -80,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Install from the official CDN
         id: install
@@ -124,6 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Install with Homebrew
         id: install
@@ -159,6 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Install from the x86 PPA
         id: install
@@ -196,6 +201,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Install with Scoop
         id: install
@@ -239,6 +245,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Run the versioned and latest community images
         id: run
@@ -294,6 +301,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary

Adds a CI workflow that verifies every JuiceFS stable release is actually distributed across all official channels. After each release publish (and on a 6-hour schedule, plus manual dispatch), it resolves GitHub's explicitly marked latest stable release and checks that each distribution channel serves that exact version.

## What's checked

Each distribution channel is verified against the latest stable release's version:

- **CDN** (`d.juicefs.com`) — latest-version marker, checksums.txt coverage, and reachability of every client archive
- **Homebrew** — stable formula version via the formulae API
- **Ubuntu PPA** — published source versions across both `ppa` and `arm64`, filtered to supported Ubuntu series
- **Fedora Copr** — per-chroot build states and package versions
- **Snap** — `latest/stable` channel per architecture
- **AUR** — `juicefs` and `juicefs-bin` only (git excluded)
- **Scoop** — manifest version, URL, and hash
- **Docker Hub** — `ce-v<version>` and `latest` tag states, plus a smoke run of both images
- **Maven Central** — metadata latest/release plus a real `dependency:get` resolution of the Java SDK

A 24-hour grace period starts at the latest release's publication time. Within the grace window, stale/unavailable channels are reported as warnings; after it expires they fail the check. Parser or network failures that produce invalid results always fail, so a broken channel check can never silently pass.

## Why

Package managers and mirrors are maintained out-of-band from the GitHub release. This workflow makes distribution lag or breakage visible automatically instead of relying on user reports, and gives maintainers a single summary of every channel's state per release.

## Files

- `.github/scripts/check_release_distributions.py` — the checker (commands: `check`, `resolve`, `verify-version`)
- `.github/scripts/check_release_distributions_test.py` — unit tests for resolution, version/grace logic, and every channel parser
- `.github/workflows/release-distribution-check.yml` — workflow with real-install smoke tests (CDN, Homebrew, PPA, Scoop, Docker, Maven) plus the metadata check

Concurrency groups keyed on `release_id` + `target_version` cancel stale runs when a newer release lands, and the workflow only writes read-permissions.
