### PR TITLE
ci: fix tikv env

### DIFF
--- a/.github/scripts/start_meta_engine.sh
+++ b/.github/scripts/start_meta_engine.sh
@@ -37,16 +37,21 @@ install_tikv(){
         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sudo sh
         export PATH=/root/.tiup/bin:$PATH
         tiup=/root/.tiup/bin/tiup
+        tiup_home=/root/.tiup
     elif [[ "$user" == "runner" ]]; then
         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
         export PATH=/home/runner/.tiup/bin:$PATH
         tiup=/home/runner/.tiup/bin/tiup
+        tiup_home=/home/runner/.tiup
     else
         echo "Unknown user $user"
         exit 1
     fi
     echo tiup is $tiup
     echo $(whoami) $(pwd)
+    # Drop stale manifest pointers so tiup re-resolves the current component
+    # manifest version instead of a pruned one, see https://github.com/pingcap/tiup/issues/2057
+    rm -f "$tiup_home/manifests/snapshot.json" "$tiup_home/manifests/timestamp.json"
     # TODO update to latest TiDB 
     $tiup playground 8.5.5 --mode tikv-slim > tikv.log 2>&1  &
     pid=$!
@@ -84,15 +89,20 @@ install_tidb(){
     if [[ "$user" == "root" ]]; then
         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sudo sh
         tiup=/root/.tiup/bin/tiup
+        tiup_home=/root/.tiup
     elif [[ "$user" == "runner" ]]; then
         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
         tiup=/home/runner/.tiup/bin/tiup
+        tiup_home=/home/runner/.tiup
     else
         echo "Unknown user $user"
         exit 1
     fi
     echo tiup is $tiup
     
+    # Drop stale manifest pointers so tiup re-resolves the current component
+    # manifest version instead of a pruned one, see https://github.com/pingcap/tiup/issues/2057
+    rm -f "$tiup_home/manifests/snapshot.json" "$tiup_home/manifests/timestamp.json"
     $tiup playground 8.5.5 > tidb.log 2>&1  &
     pid=$!
     timeout=60

--- a/.github/scripts/start_meta_engine.sh
+++ b/.github/scripts/start_meta_engine.sh
@@ -39,12 +39,24 @@ kill_tiup_playground() {
     return 0
 }
 
+# Dump why a playground failed: its own log plus any kernel OOM-killer records,
+# the usual reason a freshly bootstrapped pd-server/tikv-server dies within
+# seconds on a CI runner.
+dump_playground_diagnostics() {
+    local log=$1
+    echo "=== $log ==="
+    cat "$log" 2>/dev/null || true
+    echo "=== kernel OOM messages ==="
+    { dmesg 2>/dev/null || sudo dmesg 2>/dev/null; } | grep -iE "out of memory|oom-kill|killed process" | tail -20 || true
+    return 0
+}
+
 install_tikv(){
     [[ ! -d tcli ]] && git clone https://github.com/c4pt0r/tcli
     make -C tcli && sudo cp tcli/bin/tcli /usr/local/bin
     # retry because of: https://github.com/pingcap/tiup/issues/2057
     echo 'head -1' > /tmp/head.txt
-    if lsof -i:2379 && pgrep pd-server && tcli -pd 127.0.0.1:2379 < /tmp/head.txt; then
+    if lsof -i:2379 && pgrep pd-server && timeout 10 tcli -pd 127.0.0.1:2379 < /tmp/head.txt; then
         echo "TiKV is already running and healthy"
         return 0
     fi
@@ -81,13 +93,15 @@ install_tikv(){
         # Check if tiup playground process is still alive
         if ! kill -0 $pid 2>/dev/null; then
             echo "tiup playground process (pid=$pid) exited unexpectedly."
-            echo "=== tikv.log ==="
-            cat tikv.log || true
+            dump_playground_diagnostics tikv.log
             kill_tiup_playground "$tiup" 2379 2380 20160 20180
             exit 1
         fi
         echo 'head -1' > /tmp/head.txt
-        lsof -i:2379 && pgrep pd-server && tcli -pd 127.0.0.1:2379 < /tmp/head.txt && exit_code=0 || exit_code=$?
+        # Bound the probe with timeout: tcli keeps an internal PD client that
+        # retries forever, so if pd-server dies mid-probe the readiness check
+        # would hang and mask the timeout below (never dumping tikv.log).
+        lsof -i:2379 && pgrep pd-server && timeout 10 tcli -pd 127.0.0.1:2379 < /tmp/head.txt && exit_code=0 || exit_code=$?
         if [ $exit_code -eq 0 ]; then
             echo "TiKV is running."
             exit 0
@@ -96,8 +110,7 @@ install_tikv(){
         count=$((count+1))
         if [ $count -eq $timeout ]; then
             echo "TiKV failed to start within $timeout seconds."
-            echo "=== tikv.log ==="
-            cat tikv.log || true
+            dump_playground_diagnostics tikv.log
             kill -9 $pid 2>/dev/null || true
             kill_tiup_playground "$tiup" 2379 2380 20160 20180
             exit 1
@@ -133,7 +146,7 @@ install_tidb(){
     timeout=60
     count=0
     while true; do
-        lsof -i:4000 && pgrep pd-server && mysql -h127.0.0.1 -P4000 -uroot -e "select version();" && exit_code=0 || exit_code=$?
+        lsof -i:4000 && pgrep pd-server && timeout 10 mysql -h127.0.0.1 -P4000 -uroot -e "select version();" && exit_code=0 || exit_code=$?
         if [ $exit_code -eq 0 ]; then
             echo "TiDB is running."
             exit 0
@@ -142,8 +155,7 @@ install_tidb(){
         count=$((count+1))
         if [ $count -eq $timeout ]; then
             echo "TiDB failed to start within $timeout seconds."
-            echo "=== tidb.log ==="
-            cat tidb.log || true
+            dump_playground_diagnostics tidb.log
             kill -9 $pid 2>/dev/null || true
             kill_tiup_playground "$tiup" 4000 10080 2379 2380 20160 20180
             exit 1

--- a/.github/scripts/start_meta_engine.sh
+++ b/.github/scripts/start_meta_engine.sh
@@ -84,8 +84,10 @@ install_tikv(){
     # Drop stale manifest pointers so tiup re-resolves the current component
     # manifest version instead of a pruned one, see https://github.com/pingcap/tiup/issues/2057
     rm -f "$tiup_home/manifests/snapshot.json" "$tiup_home/manifests/timestamp.json"
-    # TODO update to latest TiDB 
-    $tiup playground 8.5.5 --mode tikv-slim > tikv.log 2>&1  &
+    # Pin 8.5.7: the tiup mirror currently serves tikv/pd tarballs for 8.5.3-8.5.6
+    # that no longer match their (republished) manifest checksums, so playground
+    # aborts with "sha256 checksum mismatch". 8.5.7 is consistent.
+    $tiup playground 8.5.7 --mode tikv-slim > tikv.log 2>&1  &
     pid=$!
     timeout=60
     count=0
@@ -141,7 +143,8 @@ install_tidb(){
     # Drop stale manifest pointers so tiup re-resolves the current component
     # manifest version instead of a pruned one, see https://github.com/pingcap/tiup/issues/2057
     rm -f "$tiup_home/manifests/snapshot.json" "$tiup_home/manifests/timestamp.json"
-    $tiup playground 8.5.5 > tidb.log 2>&1  &
+    # Pin 8.5.7, see the note in install_tikv (mirror checksum mismatch on 8.5.3-8.5.6).
+    $tiup playground 8.5.7 > tidb.log 2>&1  &
     pid=$!
     timeout=60
     count=0

--- a/.github/scripts/start_meta_engine.sh
+++ b/.github/scripts/start_meta_engine.sh
@@ -22,6 +22,23 @@ retry() {
     done
 }
 
+# Reap a tiup playground and every process it spawned. Killing only the tiup
+# parent orphans its pd-server/tikv-server/tidb-server children, which keep
+# holding the cluster ports and poison the next retry attempt with
+# "mismatch cluster id" / "connection refused" errors. Clean up the data dir
+# and kill whoever still holds the given ports (by their actual PIDs).
+kill_tiup_playground() {
+    local tiup_bin=$1
+    shift
+    local port pids
+    for port in "$@"; do
+        pids=$(lsof -ti tcp:"$port" 2>/dev/null || true)
+        [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
+    done
+    "$tiup_bin" clean --all >/dev/null 2>&1 || true
+    return 0
+}
+
 install_tikv(){
     [[ ! -d tcli ]] && git clone https://github.com/c4pt0r/tcli
     make -C tcli && sudo cp tcli/bin/tcli /usr/local/bin
@@ -49,6 +66,9 @@ install_tikv(){
     fi
     echo tiup is $tiup
     echo $(whoami) $(pwd)
+    # Reap orphaned pd-server/tikv-server left behind by a previous retry
+    # attempt so a fresh cluster can bootstrap cleanly, see tiup#2057.
+    kill_tiup_playground "$tiup" 2379 2380 20160 20180
     # Drop stale manifest pointers so tiup re-resolves the current component
     # manifest version instead of a pruned one, see https://github.com/pingcap/tiup/issues/2057
     rm -f "$tiup_home/manifests/snapshot.json" "$tiup_home/manifests/timestamp.json"
@@ -63,6 +83,7 @@ install_tikv(){
             echo "tiup playground process (pid=$pid) exited unexpectedly."
             echo "=== tikv.log ==="
             cat tikv.log || true
+            kill_tiup_playground "$tiup" 2379 2380 20160 20180
             exit 1
         fi
         echo 'head -1' > /tmp/head.txt
@@ -76,8 +97,9 @@ install_tikv(){
         if [ $count -eq $timeout ]; then
             echo "TiKV failed to start within $timeout seconds."
             echo "=== tikv.log ==="
-            tail -50 tikv.log || true
-            kill -9 $pid || true
+            cat tikv.log || true
+            kill -9 $pid 2>/dev/null || true
+            kill_tiup_playground "$tiup" 2379 2380 20160 20180
             exit 1
         fi
     done
@@ -100,6 +122,9 @@ install_tidb(){
     fi
     echo tiup is $tiup
     
+    # Reap orphaned pd-server/tikv-server/tidb-server left behind by a previous
+    # retry attempt so a fresh cluster can bootstrap cleanly, see tiup#2057.
+    kill_tiup_playground "$tiup" 4000 10080 2379 2380 20160 20180
     # Drop stale manifest pointers so tiup re-resolves the current component
     # manifest version instead of a pruned one, see https://github.com/pingcap/tiup/issues/2057
     rm -f "$tiup_home/manifests/snapshot.json" "$tiup_home/manifests/timestamp.json"
@@ -117,7 +142,10 @@ install_tidb(){
         count=$((count+1))
         if [ $count -eq $timeout ]; then
             echo "TiDB failed to start within $timeout seconds."
-            kill -9 $pid || true
+            echo "=== tidb.log ==="
+            cat tidb.log || true
+            kill -9 $pid 2>/dev/null || true
+            kill_tiup_playground "$tiup" 4000 10080 2379 2380 20160 20180
             exit 1
         fi
     done


### PR DESCRIPTION
tiup caches a snapshot.json pointing at a versioned component manifest (e.g. 7186.tikv.json). The mirror only keeps the current manifest version and prunes old ones, so a stale cache makes 'tiup playground' request a 404'd manifest and fail with 'Playground bootstrapping failed'. The retry wrapper cannot recover because every attempt reuses the same stale cache.

Remove snapshot.json/timestamp.json (keeping root.json) before launching so tiup re-resolves the current component manifest version. Applied to both install_tikv and install_tidb.