### PR TITLE
cache: exclude staged blocks from the cached block count

### DIFF
--- a/docs/en/reference/p8s_metrics.md
+++ b/docs/en/reference/p8s_metrics.md
@@ -68,8 +68,8 @@ If you haven't yet set up monitoring for JuiceFS, read [monitoring and data visu
 
 | Name                                    | Description                                 | Unit   |
 |:----------------------------------------|---------------------------------------------|--------|
-| `juicefs_blockcache_blocks`             | Number of cached blocks                     |        |
-| `juicefs_blockcache_bytes`              | Size of cached blocks                       | byte   |
+| `juicefs_blockcache_blocks`             | Number of cached blocks (staging excluded)  |        |
+| `juicefs_blockcache_bytes`              | Size of cached blocks (staging excluded)    | byte   |
 | `juicefs_blockcache_hits`               | Count of cached block hits                  |        |
 | `juicefs_blockcache_miss`               | Count of cached block miss                  |        |
 | `juicefs_blockcache_writes`             | Count of cached block writes                |        |

--- a/docs/zh_cn/reference/p8s_metrics.md
+++ b/docs/zh_cn/reference/p8s_metrics.md
@@ -68,8 +68,8 @@ sidebar_position: 4
 
 | 名称                                      | 描述          | 单位 |
 |-----------------------------------------|-------------|----|
-| `juicefs_blockcache_blocks`             | 缓存块的总个数     |    |
-| `juicefs_blockcache_bytes`              | 缓存块的总大小     | 字节 |
+| `juicefs_blockcache_blocks`             | 缓存块总数，不含暂存块 |    |
+| `juicefs_blockcache_bytes`              | 缓存块大小，不含暂存块 | 字节 |
 | `juicefs_blockcache_hits`               | 命中缓存块的总次数   |    |
 | `juicefs_blockcache_miss`               | 没有命中缓存块的总次数 |    |
 | `juicefs_blockcache_writes`             | 写入缓存块的总次数   |    |

--- a/docs/zh_cn/reference/p8s_metrics.md
+++ b/docs/zh_cn/reference/p8s_metrics.md
@@ -81,7 +81,7 @@ sidebar_position: 4
 | `juicefs_blockcache_read_hist_seconds`  | 读缓存块的延时分布   | 秒  |
 | `juicefs_blockcache_write_hist_seconds` | 写缓存块的延时分布   | 秒  |
 | `juicefs_staging_blocks`                | 暂存路径中的块数    |    |
-| `juicefs_staging_block_bytes`           | 暂存路径中块的总字节数 | 秒  |
+| `juicefs_staging_block_bytes`           | 暂存路径中块的总字节数 | 字节 |
 | `juicefs_staging_block_delay_seconds`   | 暂存块延迟的总秒数 | 秒  |
 
 ## 对象存储 {#object-storage}

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -990,7 +990,7 @@ func (store *cachedStore) regMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Name: "blockcache_blocks",
-			Help: "number of cached blocks",
+			Help: "number of cached blocks, staging blocks excluded",
 		},
 		func() float64 {
 			cnt, _ := store.bcache.stats()
@@ -999,7 +999,7 @@ func (store *cachedStore) regMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Name: "blockcache_bytes",
-			Help: "number of cached bytes",
+			Help: "number of cached bytes, staging blocks excluded",
 		},
 		func() float64 {
 			_, used := store.bcache.stats()

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -79,13 +79,15 @@ type diskCache struct {
 	pages         map[string]*Page
 	m             *cacheManagerMetrics
 
-	used      int64
-	keys      KeyIndex
-	scanned   bool
-	stageFull bool
-	rawFull   bool
-	checksum  string // checksum level
-	uploader  func(key, path string, force bool) bool
+	used int64
+	// cachedBlocks counts the same blocks as used, excluding staging ones.
+	cachedBlocks int64
+	keys         KeyIndex
+	scanned      bool
+	stageFull    bool
+	rawFull      bool
+	checksum     string // checksum level
+	uploader     func(key, path string, force bool) bool
 
 	opTs map[time.Duration]func() error
 	opMu sync.Mutex
@@ -331,7 +333,7 @@ func (cache *diskCache) usedMemory() int64 {
 func (cache *diskCache) stats() (int64, int64) {
 	cache.Lock()
 	defer cache.Unlock()
-	return int64(len(cache.pages) + cache.keys.len()), cache.used + cache.usedMemory()
+	return int64(len(cache.pages)) + cache.cachedBlocks, cache.used + cache.usedMemory()
 }
 
 func (cache *diskCache) isFull(usage DiskFreeRatio, stage bool) bool {
@@ -386,6 +388,7 @@ func (cache *diskCache) cleanupExpire() {
 					deleted++
 					freed += int64(v.size + 4096)
 					cache.used -= int64(v.size + 4096)
+					cache.cachedBlocks--
 					todel = append(todel, k)
 					cache.m.cacheEvicts.Add(1)
 				}
@@ -638,6 +641,7 @@ func (cache *diskCache) remove(key string, staging bool) {
 	if it := cache.keys.remove(k, staging); it != nil {
 		if it.size > 0 {
 			cache.used -= int64(it.size + 4096)
+			cache.cachedBlocks--
 		}
 	} else if cache.scanned || !staging {
 		path = "" // not existed or staging block
@@ -682,6 +686,7 @@ func (cache *diskCache) load(key string) (ReadCloser, error) {
 	if err != nil {
 		if it := cache.keys.remove(k, false); it != nil {
 			cache.used -= int64(it.size + 4096)
+			cache.cachedBlocks--
 		}
 	}
 	return f, err
@@ -712,6 +717,7 @@ func (cache *diskCache) exist(key string) (bool, error) {
 		return true, nil
 	} else if it := cache.keys.remove(k, false); it != nil {
 		cache.used -= int64(it.size + 4096)
+		cache.cachedBlocks--
 	}
 	return false, err
 }
@@ -758,12 +764,14 @@ func (cache *diskCache) add(key string, size int32, atime uint32) {
 	} else {
 		if iter.size > 0 {
 			cache.used -= int64(iter.size + 4096)
+			cache.cachedBlocks--
 		}
 		iter.size = size
 	}
 	cache.keys.add(k, *iter) // add or update
 	if size > 0 {
 		cache.used += int64(size + 4096)
+		cache.cachedBlocks++
 	}
 	if cache.full() && cache.keys.name() != EvictionNone {
 		logger.Debugf("Cleanup cache when add new data (%s): %d blocks (%s)", cache.dir, cache.keys.len(), humanize.IBytes(uint64(cache.used)))
@@ -857,6 +865,7 @@ func (cache *diskCache) cleanupFull() {
 	for k, item := range cache.keys.evictionIter() {
 		freed += int64(item.size + 4096)
 		cache.used -= int64(item.size + 4096)
+		cache.cachedBlocks--
 		todel = append(todel, k)
 
 		logger.Debugf("remove %s from cache, age: %ds", k, now-item.atime)
@@ -940,6 +949,7 @@ func (cache *diskCache) uploadStaging() {
 func (cache *diskCache) scanCached(fast bool) {
 	cache.Lock()
 	cache.used = 0
+	cache.cachedBlocks = 0
 	// atime in memory is more accurate than on disk, inherit it for the next round
 	lastSnap := cache.keys.reset()
 	cache.scanned = false
@@ -998,7 +1008,7 @@ func (cache *diskCache) scanCached(fast bool) {
 	})
 	cache.Lock()
 	cache.scanned = true
-	logger.Debugf("Found %s cached blocks (%s) in %s with %s", humanize.Comma(int64(cache.keys.len())), humanize.IBytes(uint64(cache.used)), cache.dir, time.Since(start))
+	logger.Debugf("Found %s cached blocks (%s) in %s with %s", humanize.Comma(cache.cachedBlocks), humanize.IBytes(uint64(cache.used)), cache.dir, time.Since(start))
 	cache.Unlock()
 }
 

--- a/pkg/chunk/disk_cache.go
+++ b/pkg/chunk/disk_cache.go
@@ -240,7 +240,7 @@ func (c *diskCache) enabled() bool {
 }
 
 func (c *diskCache) full() bool {
-	return c.used > c.capacity || (c.maxItems != 0 && int64(c.keys.len()) > c.maxItems)
+	return c.used > c.capacity || (c.maxItems != 0 && c.cachedBlocks > c.maxItems)
 }
 
 func (cache *diskCache) checkErr(f func() error) error {
@@ -395,7 +395,7 @@ func (cache *diskCache) cleanupExpire() {
 			}
 		}
 		if len(todel) > 0 {
-			logger.Debugf("cleanup expired cache (%s): %d blocks (%s), expired %d blocks (%s)", cache.dir, cache.keys.len(), humanize.IBytes(uint64(cache.used)), len(todel), humanize.IBytes(uint64(freed)))
+			logger.Debugf("cleanup expired cache (%s): %d blocks (%s), expired %d blocks (%s)", cache.dir, cache.cachedBlocks, humanize.IBytes(uint64(cache.used)), len(todel), humanize.IBytes(uint64(freed)))
 		}
 		cache.Unlock()
 		for _, k := range todel {
@@ -774,7 +774,7 @@ func (cache *diskCache) add(key string, size int32, atime uint32) {
 		cache.cachedBlocks++
 	}
 	if cache.full() && cache.keys.name() != EvictionNone {
-		logger.Debugf("Cleanup cache when add new data (%s): %d blocks (%s)", cache.dir, cache.keys.len(), humanize.IBytes(uint64(cache.used)))
+		logger.Debugf("Cleanup cache when add new data (%s): %d blocks (%s)", cache.dir, cache.cachedBlocks, humanize.IBytes(uint64(cache.used)))
 		cache.cleanupFull()
 	}
 }
@@ -832,7 +832,7 @@ func (cache *diskCache) cleanupFull() {
 	}
 
 	goal := cache.capacity * 95 / 100
-	num := int64(cache.keys.len()) * 99 / 100
+	num := cache.cachedBlocks * 99 / 100
 	if cache.maxItems != 0 && num > cache.maxItems*99/100 {
 		num = cache.maxItems * 99 / 100
 	}
@@ -848,13 +848,13 @@ func (cache *diskCache) cleanupFull() {
 		}
 	}
 	if toFree := cache.inodesToFree(usage); toFree > 0 {
-		if toFree > int64(cache.keys.len()) {
+		if toFree > cache.cachedBlocks {
 			num = 0
 		} else {
-			num = (int64(cache.keys.len()) - toFree) * 99 / 100
+			num = (cache.cachedBlocks - toFree) * 99 / 100
 		}
 	}
-	if int64(cache.keys.len()) <= num && cache.used <= goal {
+	if cache.cachedBlocks <= num && cache.used <= goal {
 		return // some other thread has done the cleanup
 	}
 
@@ -871,12 +871,12 @@ func (cache *diskCache) cleanupFull() {
 		logger.Debugf("remove %s from cache, age: %ds", k, now-item.atime)
 		cache.m.cacheEvicts.Add(1)
 
-		if int64(cache.keys.len()) <= num && cache.used <= goal {
+		if cache.cachedBlocks <= num && cache.used <= goal {
 			break
 		}
 	}
 	if len(todel) > 0 {
-		logger.Debugf("cleanup cache (%s) using %s eviction: %d blocks (%s), freed %d blocks (%s)", cache.dir, cache.keys.name(), cache.keys.len(), humanize.IBytes(uint64(cache.used)), len(todel), humanize.IBytes(uint64(freed)))
+		logger.Debugf("cleanup cache (%s) using %s eviction: %d blocks (%s), freed %d blocks (%s)", cache.dir, cache.keys.name(), cache.cachedBlocks, humanize.IBytes(uint64(cache.used)), len(todel), humanize.IBytes(uint64(freed)))
 	}
 	cache.Unlock()
 	for _, k := range todel {

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -538,3 +538,27 @@ func TestStagingBlocksExcludedFromStats(t *testing.T) {
 	require.EqualValues(t, 1, cnt)
 	require.EqualValues(t, 1024+4096, used)
 }
+
+// Staged blocks cannot be evicted, so counting them against --cache-items makes
+// cleanupFull chase a target it can never reach and drop read cache blocks
+// instead. The byte limit already excludes them through used.
+func TestStagingBlocksExcludedFromItemLimit(t *testing.T) {
+	conf := testConf()
+	conf.Writeback = true
+	conf.FreeSpace = 0.00001
+	conf.CacheScanInterval = -1
+	conf.CacheItems = 10
+	defer os.RemoveAll(conf.CacheDir)
+	s := newDiskCache(newCacheManagerMetrics(nil), conf.CacheDir, 1<<30, conf.CacheItems, 1, &conf, nil)
+
+	for i := 0; i < 20; i++ { // twice the item limit, none of them evictable
+		_, err := s.stage(fmt.Sprintf("chunks/0/0/%d_0_1024", i), make([]byte, 1024), 0)
+		require.NoError(t, err)
+	}
+	for i := 100; i < 105; i++ { // read cache blocks arriving afterwards
+		s.add(fmt.Sprintf("chunks/0/0/%d_0_1024", i), 1024, uint32(time.Now().Unix()))
+	}
+
+	cnt, _ := s.stats()
+	require.EqualValues(t, 5, cnt, "read cache must survive when staged blocks exceed cache-items")
+}

--- a/pkg/chunk/disk_cache_test.go
+++ b/pkg/chunk/disk_cache_test.go
@@ -512,3 +512,29 @@ func TestSpaceToFreeNoAction(t *testing.T) {
 		require.Equal(t, 0, uploadCount, "should not upload when disk has enough free space and inodes")
 	})
 }
+
+// A staging block is linked into the cache dir but excluded from used, so the
+// block count has to exclude it too: otherwise blockcache_blocks and
+// blockcache_bytes report different sets of blocks.
+func TestStagingBlocksExcludedFromStats(t *testing.T) {
+	conf := testConf()
+	conf.Writeback = true
+	conf.FreeSpace = 0.00001
+	defer os.RemoveAll(conf.CacheDir)
+	s := newDiskCache(newCacheManagerMetrics(nil), conf.CacheDir, 1<<30, conf.CacheItems, 1, &conf, nil)
+
+	key := "chunks/0/0/1_0_1024"
+	_, err := s.stage(key, make([]byte, 1024), 0)
+	require.NoError(t, err)
+
+	cnt, used := s.stats()
+	require.EqualValues(t, 0, cnt, "staging block must not count as a cached block")
+	require.EqualValues(t, 0, used)
+
+	s.uploaded(key, 1024)
+	require.NoError(t, s.removeStage(key))
+
+	cnt, used = s.stats()
+	require.EqualValues(t, 1, cnt)
+	require.EqualValues(t, 1024+4096, used)
+}


### PR DESCRIPTION
Resolves #7418

The cache now keeps its own block count, updated wherever `used` is updated. Neither counts staged blocks.

`blockcache_blocks` reports this count, so it now matches `blockcache_bytes`.

`--cache-items` uses it too, so the limit now applies to read cache blocks only. Staged blocks still take disk space, and `--free-space-ratio` still limits that.

Tested on a kind cluster with `--writeback`, 200 staged blocks and `--cache-items 50`: reading 100 files now keeps 50 read cache blocks instead of 1, and `staging_blocks` stays 200.