### PR TITLE
ci: pin workflow Go version to go.mod

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: 'oldstable'
+        go-version: '1.25.0'
         cache: true
 
     - name: Use distro fusermount3

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 'oldstable'
+          go-version: '1.25.0'
           cache: true
 
       - name: Build

--- a/.github/workflows/mutate-test.yml
+++ b/.github/workflows/mutate-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 'oldstable'
+          go-version: '1.25.0'
 
       - name: install go-mutesting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "oldstable"
+          go-version: "1.25.0"
 
       - name: Set up Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
## What changed
- Replace the moving `oldstable` Go version alias in CI workflows/actions with `1.25.0`, matching `go.mod`.

## Why
- `oldstable` resolved to Go 1.26.7 in the failing run, which caused `pkg/chunk` tests to fail while building `github.com/bytedance/mockey` due to missing runtime relocation targets.
- Pinning the workflow toolchain to the module Go version avoids unexpected CI breakage when the alias advances.

## Validation
- `git diff --check`
- Verified no `oldstable` references remain under `.github`.