### PR TITLE
cmd/gc: wait slice deletions before scanning objects

### DIFF
--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -203,9 +203,8 @@ func gc(ctx *cli.Context) error {
 	}
 
 	stats := newGcStats(progress, extSortDir != "", delSpin, cleanedFileSpin)
-	trashErr := scanTrashSlices(c, m, stats, delFlag, edge)
-	if trashErr != nil {
-		return errors.Errorf("scan trash slices: %s", trashErr)
+	if err := scanTrashSlices(c, m, stats, delFlag, edge); err != nil {
+		return errors.Errorf("scan trash slices: %s", err)
 	}
 	m.WaitDeleteSlices()
 	m.OnMsg(meta.DeleteSlice, func(args ...interface{}) error {

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -198,8 +198,10 @@ func gc(ctx *cli.Context) error {
 			return nil // ignore compaction
 		})
 	}
-	if st := m.CleanupSlices(c, delFlag); st != 0 {
-		logger.Fatalf("cleanup slices: %s", st)
+	if delFlag {
+		if st := m.CleanupSlices(c); st != 0 {
+			logger.Fatalf("cleanup slices: %s", st)
+		}
 	}
 
 	stats := newGcStats(progress, extSortDir != "", delSpin, cleanedFileSpin)

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -198,17 +198,29 @@ func gc(ctx *cli.Context) error {
 			return nil // ignore compaction
 		})
 	}
+	if st := m.CleanupSlices(c, delFlag); st != 0 {
+		logger.Fatalf("cleanup slices: %s", st)
+	}
 
 	stats := newGcStats(progress, extSortDir != "", delSpin, cleanedFileSpin)
-	var gcErr error
-	if extSortDir != "" {
-		gcErr = gcExternalSort(c, m, &chunkConf, blob, stats, extSortDir, threads, delFlag, compact, edge, maxMtime)
-	} else {
-		gcErr = gcInMemory(c, m, &chunkConf, blob, stats, threads, delFlag, compact, edge, maxMtime)
+	trashErr := scanTrashSlices(c, m, stats, delFlag, edge)
+	if trashErr != nil {
+		return errors.Errorf("scan trash slices: %s", trashErr)
 	}
+	m.WaitDeleteSlices()
 	m.OnMsg(meta.DeleteSlice, func(args ...interface{}) error {
 		return errors.New("stop deleting slice")
 	})
+
+	var gcErr error
+	if extSortDir != "" {
+		gcErr = gcExternalSort(c, m, &chunkConf, blob, stats, extSortDir, threads, delFlag, maxMtime)
+	} else {
+		gcErr = gcInMemory(c, m, &chunkConf, blob, stats, threads, delFlag, maxMtime)
+	}
+	if gcErr == nil {
+		stats.finish(delFlag, compact)
+	}
 	return gcErr
 }
 
@@ -220,23 +232,16 @@ func gcInMemory(
 	stats *gcStats,
 	threads int,
 	delFlag bool,
-	compact bool,
-	edge time.Time,
 	maxMtime time.Time,
 ) error {
 	// List all slices in metadata engine
 	slices := make(map[meta.Ino][]meta.Slice)
-	r := m.ScanSlices(c, &meta.ScanSlicesOption{ScanPending: true, Delete: delFlag, Progress: stats.slices.Increment}, func(ino meta.Ino, s meta.Slice) error {
+	r := m.ScanSlices(c, &meta.ScanSlicesOption{ScanPending: true, Progress: stats.slices.Increment}, func(ino meta.Ino, s meta.Slice) error {
 		slices[ino] = append(slices[ino], s)
 		return nil
 	})
 	if r != 0 {
 		logger.Fatalf("scan all slices: %s", r)
-	}
-
-	err := scanTrashSlices(c, m, stats, delFlag, edge)
-	if err != nil {
-		logger.Fatalf("statistic: %s", err)
 	}
 
 	vkeys := make(map[uint64]uint32)
@@ -351,7 +356,6 @@ func gcInMemory(
 		return errors.Errorf("list all blocks: %s", err)
 	}
 	stats.slices.Done()
-	stats.finish(delFlag, compact)
 	return nil
 }
 

--- a/cmd/gc_external.go
+++ b/cmd/gc_external.go
@@ -42,8 +42,6 @@ func gcExternalSort(
 	extSortDir string,
 	threads int,
 	delFlag bool,
-	compact bool,
-	edge time.Time,
 	maxMtime time.Time,
 ) error {
 	logger.Infof("Using external sort mode, dir: %s", extSortDir)
@@ -60,7 +58,7 @@ func gcExternalSort(
 
 	eg.Go(func() error {
 		defer stats.slices.Done()
-		if err := scanGcMetaRecords(sortMetaCtx, m, metaSorter.Input(), stats.slices, delFlag); err != nil {
+		if err := scanGcMetaRecords(sortMetaCtx, m, metaSorter.Input(), stats.slices); err != nil {
 			return errors.Errorf("produce meta records: %s", err)
 		}
 		metaSorter.CloseInput()
@@ -90,10 +88,6 @@ func gcExternalSort(
 	if sortErr != nil {
 		return sortErr
 	}
-	if err := scanTrashSlices(c, m, stats, delFlag, edge); err != nil {
-		return errors.Errorf("trash slice scan: %s", err)
-	}
-	stats.finish(delFlag, compact)
 	return nil
 }
 
@@ -130,8 +124,8 @@ func newGcExternalSorters(ctx context.Context, extSortDir string, threads int) (
 	return metaSorter, objSorter, nil
 }
 
-func scanGcMetaRecords(c meta.Context, m meta.Meta, output chan<- gcMetaRecord, metaSliceSpin *utils.Bar, delFlag bool) error {
-	st := m.ScanSlices(c, &meta.ScanSlicesOption{ScanPending: true, Delete: delFlag}, func(ino meta.Ino, s meta.Slice) error {
+func scanGcMetaRecords(c meta.Context, m meta.Meta, output chan<- gcMetaRecord, metaSliceSpin *utils.Bar) error {
+	st := m.ScanSlices(c, &meta.ScanSlicesOption{ScanPending: true}, func(ino meta.Ino, s meta.Slice) error {
 		select {
 		case <-c.Done():
 			return c.Err()

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1074,12 +1074,8 @@ func (m *baseMeta) cleanupSlices(ctx Context) {
 	}
 }
 
-func (m *baseMeta) CleanupSlices(ctx Context, delete bool) syscall.Errno {
-	var err error
-	if delete {
-		err = m.en.doCleanupSlices(ctx, nil)
-	}
-	return errno(err)
+func (m *baseMeta) CleanupSlices(ctx Context) syscall.Errno {
+	return errno(m.en.doCleanupSlices(ctx, nil))
 }
 
 func (m *baseMeta) WaitDeleteSlices() {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1079,18 +1079,11 @@ func (m *baseMeta) CleanupSlices(ctx Context, delete bool) syscall.Errno {
 	if delete {
 		err = m.en.doCleanupSlices(ctx, nil)
 	}
-	m.WaitDeleteSlices()
 	return errno(err)
 }
 
 func (m *baseMeta) WaitDeleteSlices() {
-	m.dSliceMu.Lock()
-	async := m.dslices != nil
-	m.dSliceMu.Unlock()
-	if async {
-		m.stopDeleteSliceTasks()
-		m.startDeleteSliceTasks()
-	}
+	m.stopDeleteSliceTasks()
 }
 
 func parseChangelogTime(entry string) (time.Time, error) {

--- a/pkg/meta/base.go
+++ b/pkg/meta/base.go
@@ -1074,6 +1074,25 @@ func (m *baseMeta) cleanupSlices(ctx Context) {
 	}
 }
 
+func (m *baseMeta) CleanupSlices(ctx Context, delete bool) syscall.Errno {
+	var err error
+	if delete {
+		err = m.en.doCleanupSlices(ctx, nil)
+	}
+	m.WaitDeleteSlices()
+	return errno(err)
+}
+
+func (m *baseMeta) WaitDeleteSlices() {
+	m.dSliceMu.Lock()
+	async := m.dslices != nil
+	m.dSliceMu.Unlock()
+	if async {
+		m.stopDeleteSliceTasks()
+		m.startDeleteSliceTasks()
+	}
+}
+
 func parseChangelogTime(entry string) (time.Time, error) {
 	idx := strings.IndexByte(entry, '|')
 	if idx < 0 {

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -504,7 +504,7 @@ type Meta interface {
 	Compact(ctx Context, inode Ino, concurrency int, preFunc, postFunc func()) syscall.Errno
 
 	// CleanupSlices performs metadata cleanup and schedules slice deletion tasks.
-	CleanupSlices(ctx Context, delete bool) syscall.Errno
+	CleanupSlices(ctx Context) syscall.Errno
 	// WaitDeleteSlices waits for pending slice deletion tasks and stops the workers.
 	WaitDeleteSlices()
 	// ScanSlices scans all slices used by all files, calling fn for each slice.

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -503,6 +503,10 @@ type Meta interface {
 	// Compact chunks for specified path
 	Compact(ctx Context, inode Ino, concurrency int, preFunc, postFunc func()) syscall.Errno
 
+	// CleanupSlices performs metadata cleanup and waits for pending slice deletion tasks.
+	CleanupSlices(ctx Context, delete bool) syscall.Errno
+	// WaitDeleteSlices waits for pending slice deletion tasks.
+	WaitDeleteSlices()
 	// ScanSlices scans all slices used by all files, calling fn for each slice.
 	// Ino is 0 for pending slices, 1 for trash slices, or the actual inode.
 	ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno
@@ -562,7 +566,6 @@ type Meta interface {
 
 type ScanSlicesOption struct {
 	ScanPending bool
-	Delete      bool
 	Progress    func()
 }
 

--- a/pkg/meta/interface.go
+++ b/pkg/meta/interface.go
@@ -503,9 +503,9 @@ type Meta interface {
 	// Compact chunks for specified path
 	Compact(ctx Context, inode Ino, concurrency int, preFunc, postFunc func()) syscall.Errno
 
-	// CleanupSlices performs metadata cleanup and waits for pending slice deletion tasks.
+	// CleanupSlices performs metadata cleanup and schedules slice deletion tasks.
 	CleanupSlices(ctx Context, delete bool) syscall.Errno
-	// WaitDeleteSlices waits for pending slice deletion tasks.
+	// WaitDeleteSlices waits for pending slice deletion tasks and stops the workers.
 	WaitDeleteSlices()
 	// ScanSlices scans all slices used by all files, calling fn for each slice.
 	// Ino is 0 for pending slices, 1 for trash slices, or the actual inode.

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3987,14 +3987,15 @@ func (m *redisMeta) hscanToMap(ctx context.Context, key string) (map[string]stri
 	return result, nil
 }
 
-func (m *redisMeta) ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno {
+func (m *redisMeta) CleanupSlices(ctx Context, delete bool) syscall.Errno {
 	logger.Debugf("start cleanup...")
-	m.cleanupLeakedInodes(opt.Delete)
-	m.cleanupLeakedChunks(opt.Delete)
-	m.cleanupOldSliceRefs(opt.Delete)
-	if opt.Delete {
-		_ = m.doCleanupSlices(ctx, nil)
-	}
+	m.cleanupLeakedInodes(delete)
+	m.cleanupLeakedChunks(delete)
+	m.cleanupOldSliceRefs(delete)
+	return m.baseMeta.CleanupSlices(ctx, delete)
+}
+
+func (m *redisMeta) ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno {
 	logger.Debugf("start scanning slices...")
 
 	p := m.rdb.Pipeline()

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -3987,12 +3987,12 @@ func (m *redisMeta) hscanToMap(ctx context.Context, key string) (map[string]stri
 	return result, nil
 }
 
-func (m *redisMeta) CleanupSlices(ctx Context, delete bool) syscall.Errno {
+func (m *redisMeta) CleanupSlices(ctx Context) syscall.Errno {
 	logger.Debugf("start cleanup...")
-	m.cleanupLeakedInodes(delete)
-	m.cleanupLeakedChunks(delete)
-	m.cleanupOldSliceRefs(delete)
-	return m.baseMeta.CleanupSlices(ctx, delete)
+	m.cleanupLeakedInodes(true)
+	m.cleanupLeakedChunks(true)
+	m.cleanupOldSliceRefs(true)
+	return m.baseMeta.CleanupSlices(ctx)
 }
 
 func (m *redisMeta) ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -3961,9 +3961,6 @@ func (m *dbMeta) scanAllChunks(ctx Context, ch chan<- cchunk, bar *utils.Bar) er
 }
 
 func (m *dbMeta) ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno {
-	if opt.Delete {
-		_ = m.doCleanupSlices(ctx, nil)
-	}
 	err := m.simpleTxn(ctx, func(s *xorm.Session) error {
 		var cs []chunk
 		err := s.Find(&cs)

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -3192,9 +3192,6 @@ func (m *kvMeta) scanAllChunks(ctx Context, ch chan<- cchunk, bar *utils.Bar) er
 }
 
 func (m *kvMeta) ScanSlices(ctx Context, opt *ScanSlicesOption, fn func(Ino, Slice) error) syscall.Errno {
-	if opt.Delete {
-		_ = m.doCleanupSlices(ctx, nil)
-	}
 	// AiiiiiiiiCnnnn     file chunks
 	klen := 1 + 8 + 1 + 4
 	var cbErr error


### PR DESCRIPTION
fix: https://github.com/juicedata/juicefs/issues/7420
