### PR TITLE
object: move shared S3 helpers out of nos3-gated s3.go

### DIFF
--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -451,3 +451,15 @@ func getOrDefaultScValue(v, defaultValue string) string {
 	}
 	return v
 }
+
+const s3RequestIDKey = "X-Amz-Request-Id"
+
+func isExists(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "BucketAlreadyExists") || strings.Contains(msg, "BucketAlreadyOwnedByYou")
+}
+
+func defaultPathStyle() bool {
+	v := os.Getenv("JFS_S3_VHOST_STYLE")
+	return v == "" || v == "0" || v == "false"
+}

--- a/pkg/object/s3.go
+++ b/pkg/object/s3.go
@@ -45,7 +45,6 @@ import (
 )
 
 const awsDefaultRegion = "us-east-1"
-const s3RequestIDKey = "X-Amz-Request-Id"
 
 func addS3UserAgent(stack *smithymiddleware.Stack) error {
 	return middleware.AddUserAgentKey(UserAgent)(stack)
@@ -78,11 +77,6 @@ func (s *s3client) Limits() Limits {
 		MaxPartSize:              5 << 30,
 		MaxPartCount:             10000,
 	}
-}
-
-func isExists(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "BucketAlreadyExists") || strings.Contains(msg, "BucketAlreadyOwnedByYou")
 }
 
 func (s *s3client) Create(ctx context.Context) error {
@@ -481,11 +475,6 @@ func parseRegion(endpoint string) string {
 		region = awsDefaultRegion
 	}
 	return region
-}
-
-func defaultPathStyle() bool {
-	v := os.Getenv("JFS_S3_VHOST_STYLE")
-	return v == "" || v == "0" || v == "false"
 }
 
 var oracleCompileRegexp = `^(?:.*\.)?(?:compat|vhcompat)\.objectstorage\.([^.]+)\.(?:oraclecloud\.com|oci\.customer-oci\.com)$`

--- a/pkg/object/s3_test.go
+++ b/pkg/object/s3_test.go
@@ -1,3 +1,6 @@
+//go:build !nos3
+// +build !nos3
+
 /*
  * JuiceFS, Copyright 2018 Juicedata, Inc.
  *


### PR DESCRIPTION
isExists, defaultPathStyle and s3RequestIDKey are used by backends (BOS/COS/OBS/OSS/Dragonfly/IBM COS/KS3) that are not gated behind the nos3 build tag, but were defined in s3.go which is excluded by -tags nos3, breaking builds without the S3 backend. Move them to the always-compiled object_storage.go and add the missing !nos3 build tag to the S3-only test file.