### PR TITLE
ci: allow checking a release distribution tag manually

### DIFF
--- a/.github/workflows/release-distribution-check.yml
+++ b/.github/workflows/release-distribution-check.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: "17 */6 * * *"
   workflow_dispatch:
+    inputs:
+      target_tag:
+        description: "Stable release tag to check, for example v1.3.3. Leave empty for GitHub latest release."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -32,7 +37,7 @@ jobs:
         id: latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TRIGGER_TAG: ${{ github.event.release.tag_name || '' }}
+          TRIGGER_TAG: ${{ github.event.release.tag_name || inputs.target_tag || '' }}
         run: |
           python3 .github/scripts/check_release_distributions.py resolve \
             --repository "$GITHUB_REPOSITORY" \
@@ -61,7 +66,7 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TRIGGER_TAG: ${{ github.event.release.tag_name || '' }}
+          TRIGGER_TAG: ${{ github.event.release.tag_name || inputs.target_tag || '' }}
         run: |
           python3 .github/scripts/check_release_distributions.py check \
             --repository "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
Add a workflow_dispatch target_tag input and pass it through to the existing release distribution checker so manual runs can validate a specific stable release tag.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>