### PR TITLE
build: enable java sdk auto publish

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -113,7 +113,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
-					<autoPublish>false</autoPublish>
+					<autoPublish>true</autoPublish>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
## What
- Enable automatic publishing for the Java SDK Central Publishing Maven plugin.

## Why
- Allow Java SDK release artifacts to be published automatically after deployment to Maven Central.

## Validation
- xmllint --noout sdk/java/pom.xml
- mvn -q -DskipTests validate (not run: mvn is not installed in this environment)