### PR TITLE
KEXT-less FUSE support for MacOS: FUSE-T (NFS, SMB, FSKit) + MacFUSE-FSKit backends via cgofuse

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -649,7 +649,7 @@ func mount(c *cli.Context) error {
 			foreground = os.Getppid() == 1 && !insideContainer()
 		}
 		if foreground {
-			go checkMountpoint(format.Name, mp, c.String("log"), false)
+			go checkMountpoint(format.Name, mp, c.String("log"), false, vfsConf.Fusemac)
 		} else {
 			daemonRun(c, addr, vfsConf) // only stage 0 needs the vfsConf
 		}

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -209,7 +209,7 @@ func readThreadStats(pid int, tid string, b *strings.Builder) {
 	}
 }
 
-func watchdog(ctx context.Context, mp string) {
+func watchdog(ctx context.Context, mp string, fusemac bool) {
 	var lastActive int64 = time.Now().Unix()
 	var pid int
 	var agentAddr string
@@ -224,7 +224,8 @@ func watchdog(ctx context.Context, mp string) {
 			var confStat syscall.Stat_t
 			err := syscall.Stat(filepath.Join(mp, confName), &confStat)
 			ino, _ := vfs.GetInternalNodeByName(confName)
-			if err == nil && confStat.Ino == uint64(ino) {
+			// fusemac remaps internal-node inodes; fall back to a regular-file check.
+			if err == nil && (confStat.Ino == uint64(ino) || (fusemac && runtime.GOOS == "darwin" && confStat.Mode&syscall.S_IFMT == syscall.S_IFREG)) {
 				if dev == 0 && runtime.GOOS == "linux" {
 					var st syscall.Stat_t
 					if err := syscall.Stat(mp, &st); err == nil && st.Ino == 1 {
@@ -297,7 +298,7 @@ func parseFuseFd(mountPoint string) (fd int) {
 	return fd
 }
 
-func checkMountpoint(name, mp, logPath string, background bool) {
+func checkMountpoint(name, mp, logPath string, background bool, fusemac bool) {
 	if parseFuseFd(mp) > 0 {
 		logger.Infof("\033[92mOK\033[0m, %s with special mount point %q", name, mp)
 		return
@@ -316,7 +317,8 @@ func checkMountpoint(name, mp, logPath string, background bool) {
 		time.Sleep(time.Duration(interval) * time.Millisecond)
 		st, err := os.Stat(mp)
 		if err == nil {
-			if sys, ok := st.Sys().(*syscall.Stat_t); ok && sys.Ino == uint64(meta.RootInode) {
+			// fusemac may report the root as fileid 2 instead of 1.
+			if sys, ok := st.Sys().(*syscall.Stat_t); ok && (sys.Ino == uint64(meta.RootInode) || (fusemac && sys.Ino == 2)) {
 				// in pod, pid probably the same
 				if csiCommPath == "" && oldConf != nil {
 					_, newConf, _ := loadConfig(mp)
@@ -560,10 +562,15 @@ func setFuseOption(c *cli.Context, format *meta.Format, vfsConf *vfs.Config) {
 	rawOpts, mt, noxattr, noacl, maxWrite := genFuseOptExt(c, format)
 	options := vfs.FuseOptions(fuse.GenFuseOpt(vfsConf, rawOpts, mt, noxattr, noacl, maxWrite))
 	vfsConf.FuseOpts = &options
+	if runtime.GOOS == "darwin" {
+		if backend, err := parseBackend(c.String("o")); err == nil && backend != "" {
+			vfsConf.Fusemac = true
+		}
+	}
 }
 
 func genFuseOpt(c *cli.Context, name string) string {
-	fuseOpt := c.String("o")
+	fuseOpt := stripBackendOpt(c.String("o"))
 	// todo: remove ?
 	prefix := os.Getenv("FSTAB_NAME_PREFIX")
 	if prefix == "" {
@@ -584,6 +591,41 @@ func genFuseOpt(c *cli.Context, name string) string {
 	}
 	fuseOpt = strings.TrimLeft(fuseOpt, ",")
 	return fuseOpt
+}
+
+var darwinBackends = map[string]struct{}{
+	"nfs":   {},
+	"smb":   {},
+	"fskit": {},
+}
+
+func stripBackendOpt(opts string) string {
+	kept := make([]string, 0, strings.Count(opts, ",")+1)
+	for _, opt := range strings.Split(opts, ",") {
+		opt = strings.TrimSpace(opt)
+		if key, _, ok := strings.Cut(opt, "="); ok && strings.TrimSpace(key) == "backend" {
+			continue
+		}
+		kept = append(kept, opt)
+	}
+	return strings.Join(kept, ",")
+}
+
+// parseBackend extracts -o backend=<name>; errors on an unknown value.
+func parseBackend(opts string) (string, error) {
+	for _, opt := range strings.Split(opts, ",") {
+		opt = strings.TrimSpace(opt)
+		key, val, ok := strings.Cut(opt, "=")
+		if !ok || strings.TrimSpace(key) != "backend" {
+			continue
+		}
+		name := strings.TrimSpace(val)
+		if _, ok := darwinBackends[name]; !ok {
+			return "", fmt.Errorf("unsupported FUSE backend %q (supported: fskit, nfs, smb)", name)
+		}
+		return name, nil
+	}
+	return "", nil
 }
 
 func prepareMp(mp string) {
@@ -891,7 +933,7 @@ func makeDaemon(c *cli.Context, conf *vfs.Config) error {
 	mp := conf.Meta.MountPoint
 	attrs.OnExit = func(stage int) error {
 		if stage == 0 {
-			checkMountpoint(conf.Format.Name, mp, logfile, true)
+			checkMountpoint(conf.Format.Name, mp, logfile, true, conf.Fusemac)
 		}
 		return nil
 	}
@@ -940,13 +982,14 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 	signalChan := make(chan os.Signal, 10)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 	go func() {
+		var tornDown atomic.Bool
 		for {
 			sig := <-signalChan
 			logger.Infof("Received signal %s, exiting...", sig.String())
 			if sig == syscall.SIGHUP {
 				path := fmt.Sprintf("/tmp/state%d.json", os.Getppid())
 				if err := v.FlushAll(""); err == nil {
-					if !fuse.Shutdown() {
+					if !fuseShutdown(v.Conf.Fusemac) {
 						logger.Warnf("FUSE session is busy, don't restart")
 						continue
 					}
@@ -963,6 +1006,9 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 					continue
 				}
 			}
+			if !tornDown.CompareAndSwap(false, true) {
+				continue
+			}
 			go func() {
 				time.Sleep(time.Second * 30)
 				if err := v.FlushAll(""); err != nil {
@@ -971,11 +1017,35 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 				logger.Errorf("exit after receiving signal %s, but umount does not finish in 30 seconds, force exit", sig)
 				os.Exit(meta.UmountCode)
 			}()
-			go func() { _ = doUmount(mp, true) }()
+			go func() {
+				if v.Conf.Fusemac {
+					if err := v.FlushAll(""); err != nil {
+						logger.Errorf("flush all: %s", err)
+					}
+					_ = m.CloseSession()
+				}
+				unmountActive(v.Conf.Fusemac)
+				if err := doUmount(mp, true); err != nil {
+					logger.Debugf("forced umount: %s", err)
+				}
+				if v.Conf.Fusemac {
+					for i := 0; i < 50; i++ {
+						if _, err := os.Stat(filepath.Join(mp, ".config")); err != nil {
+							logger.Infof("The juicefs mount process exit successfully, mountpoint: %q", mp)
+							os.Exit(0)
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+				}
+			}()
 		}
 	}()
 }
+
 func launchMount(c *cli.Context, mp string, conf *vfs.Config) error {
+	if conf.Fusemac {
+		signal.Ignore(syscall.SIGPIPE)
+	}
 	increaseRlimit()
 	utils.AdjustOOMKiller(-1000)
 	utils.SetIOFlusher()
@@ -1045,7 +1115,7 @@ func launchMount(c *cli.Context, mp string, conf *vfs.Config) error {
 		}
 
 		ctx, cancel := context.WithCancel(context.TODO())
-		go watchdog(ctx, mp)
+		go watchdog(ctx, mp, conf.Fusemac)
 		err = cmd.Wait()
 		cancel()
 		if notInCSI {
@@ -1057,10 +1127,19 @@ func launchMount(c *cli.Context, mp string, conf *vfs.Config) error {
 		} else {
 			var exitError *exec.ExitError
 			if ok := errors.As(err, &exitError); ok {
-				if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok && waitStatus.ExitStatus() == meta.UmountCode {
-					logger.Errorf("received umount exit code")
-					_ = doUmount(mp, true)
-					return nil
+				if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok {
+					teardownKill := conf.Fusemac && runtime.GOOS == "darwin" &&
+						waitStatus.Signaled() && waitStatus.Signal() == syscall.SIGPIPE
+					switch {
+					case waitStatus.ExitStatus() == meta.UmountCode:
+						logger.Errorf("received umount exit code (%s)", err)
+						_ = doUmount(mp, true)
+						return nil
+					case teardownKill:
+						logger.Infof("mount process %d was terminated by the FUSE backend during unmount", mountPid)
+						_ = doUmount(mp, true)
+						return nil
+					}
 				}
 			}
 			if fuseFd < 0 {
@@ -1163,7 +1242,7 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 		}
 	}
 	logger.Infof("Mounting volume %s at %q ...", conf.Format.Name, conf.Meta.MountPoint)
-	err := fuse.Serve(v, c.String("o"), c.Bool("enable-xattr"), c.Bool("enable-ioctl"))
+	err := mountServe(v, c.String("o"), c.Bool("enable-xattr"), c.Bool("enable-ioctl"), c)
 	if err != nil {
 		logger.Fatalf("fuse: %s", err)
 	}

--- a/cmd/mount_unix_darwin.go
+++ b/cmd/mount_unix_darwin.go
@@ -1,0 +1,70 @@
+//go:build darwin
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"time"
+
+	"github.com/juicedata/juicefs/pkg/fuse"
+	"github.com/juicedata/juicefs/pkg/fusemac"
+	"github.com/juicedata/juicefs/pkg/vfs"
+	"github.com/urfave/cli/v2"
+)
+
+func mountServe(v *vfs.VFS, options string, enableXattr, enableIoctl bool, c *cli.Context) error {
+	backend, err := parseBackend(options)
+	if err != nil {
+		return err
+	}
+	if backend == "" {
+		// Default: macFUSE kext variant via go-fuse.
+		return fuse.Serve(v, options, enableXattr, enableIoctl)
+	}
+	if err := fusemac.CheckBackend(backend, options); err != nil {
+		return err
+	}
+	err = fusemac.Serve(v, options, enableXattr, enableIoctl, c)
+	if errors.Is(err, fusemac.ErrGracefulUnmount) {
+		return nil
+	}
+	return err
+}
+
+func fuseShutdown(useFusemac bool) bool {
+	if !useFusemac {
+		return fuse.Shutdown()
+	}
+	return fusemac.UnmountActive()
+}
+
+func unmountActive(useFusemac bool) {
+	if !useFusemac {
+		return
+	}
+	done := make(chan bool, 1)
+	go func() { done <- fusemac.UnmountActive() }()
+	select {
+	case ok := <-done:
+		logger.Infof("clean unmount finished: %v", ok)
+	case <-time.After(10 * time.Second):
+		logger.Warnf("clean unmount did not finish in 10s, falling back to forced umount")
+	}
+	fusemac.MarkSignalShutdown()
+}

--- a/cmd/mount_unix_other.go
+++ b/cmd/mount_unix_other.go
@@ -1,0 +1,35 @@
+//go:build !windows && !darwin
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/juicedata/juicefs/pkg/fuse"
+	"github.com/juicedata/juicefs/pkg/vfs"
+	"github.com/urfave/cli/v2"
+)
+
+func mountServe(v *vfs.VFS, options string, enableXattr, enableIoctl bool, c *cli.Context) error {
+	return fuse.Serve(v, options, enableXattr, enableIoctl)
+}
+
+func fuseShutdown(bool) bool {
+	return fuse.Shutdown()
+}
+
+func unmountActive(bool) {}

--- a/cmd/mount_windows.go
+++ b/cmd/mount_windows.go
@@ -178,7 +178,7 @@ func mountMain(v *vfs.VFS, c *cli.Context) {
 	}
 }
 
-func checkMountpoint(name, mp, logPath string, background bool) {}
+func checkMountpoint(name, mp, logPath string, background bool, fusemac bool) {}
 
 func prepareMp(mp string) {}
 

--- a/pkg/fusemac/fs.go
+++ b/pkg/fusemac/fs.go
@@ -1,0 +1,889 @@
+//go:build darwin
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fusemac
+
+import (
+	"path"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/utils"
+	"github.com/juicedata/juicefs/pkg/vfs"
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+const fhUnset = ^uint64(0)
+
+// ufImmutable and ufAppend are the native BSD flags (UF_IMMUTABLE, UF_APPEND)
+// the kernel sends to Chflags and expects back in stat. UF_READONLY is also
+// accepted as input for backwards compatibility.
+const (
+	ufImmutable = 0x2
+	ufAppend    = 0x4
+)
+
+var logger = utils.GetLogger("juicefs")
+
+var (
+	_ fuse.FileSystemInterface = (*FS)(nil)
+	_ fuse.FileSystemOpenEx    = (*FS)(nil)
+)
+
+// FS is the POSIX filesystem on top of vfs.VFS.
+type FS struct {
+	fuse.FileSystemBase
+	sync.RWMutex
+	vfs              *vfs.VFS
+	conf             *vfs.Config
+	host             *fuse.FileSystemHost
+	handles          map[uint64]meta.Ino
+	asRoot           bool
+	xattrs           bool
+	disableSymlink   bool
+	readdirBatchSize int
+	destroyed        atomic.Int32
+}
+
+func NewFS(conf *vfs.Config, v *vfs.VFS) *FS {
+	jfs := &FS{
+		vfs:              v,
+		conf:             conf,
+		handles:          make(map[uint64]meta.Ino),
+		readdirBatchSize: 1024,
+	}
+	return jfs
+}
+
+func (fsys *FS) newContext() vfs.LogContext {
+	if fsys.asRoot {
+		return vfs.NewLogContext(meta.Background())
+	}
+	uid, gid, pid := fuse.Getcontext()
+	if uid == 0xffffffff {
+		uid = 0
+	}
+	if gid == 0xffffffff {
+		gid = 0
+	}
+	if pid == -1 {
+		pid = 0
+	}
+	if uid == 0 && fsys.conf != nil && fsys.conf.RootSquash != nil {
+		uid = fsys.conf.RootSquash.Uid
+		gid = fsys.conf.RootSquash.Gid
+	}
+	if fsys.conf != nil && fsys.conf.AllSquash != nil {
+		uid = fsys.conf.AllSquash.Uid
+		gid = fsys.conf.AllSquash.Gid
+	}
+	ctx := meta.NewContext(uint32(pid), uid, []uint32{gid})
+	return vfs.NewLogContext(ctx)
+}
+
+func (fsys *FS) Init() {
+	fsys.Lock()
+	defer fsys.Unlock()
+	if fsys.handles == nil {
+		fsys.handles = make(map[uint64]meta.Ino)
+	}
+}
+
+func (fsys *FS) Destroy() {
+	// cgofuse calls Destroy only after the session ends, so once this flag is
+	// set the mount is already gone and unmounting again would just race teardown.
+	fsys.destroyed.Store(1)
+	fsys.Lock()
+	defer fsys.Unlock()
+	fsys.handles = nil
+}
+
+func errorconv(err syscall.Errno) int {
+	if err == 0 {
+		return 0
+	}
+	switch err {
+	case syscall.EPERM:
+		return -fuse.EPERM
+	case syscall.ENOENT:
+		return -fuse.ENOENT
+	case syscall.ESRCH:
+		return -fuse.ESRCH
+	case syscall.EINTR:
+		return -fuse.EINTR
+	case syscall.EIO:
+		return -fuse.EIO
+	case syscall.ENXIO:
+		return -fuse.ENXIO
+	case syscall.E2BIG:
+		return -fuse.E2BIG
+	case syscall.ENOEXEC:
+		return -fuse.ENOEXEC
+	case syscall.EBADF:
+		return -fuse.EBADF
+	case syscall.ECHILD:
+		return -fuse.ECHILD
+	case syscall.EAGAIN:
+		return -fuse.EAGAIN
+	case syscall.ENOMEM:
+		return -fuse.ENOMEM
+	case syscall.EACCES:
+		return -fuse.EACCES
+	case syscall.EFAULT:
+		return -fuse.EFAULT
+	case syscall.EBUSY:
+		return -fuse.EBUSY
+	case syscall.EEXIST:
+		return -fuse.EEXIST
+	case syscall.EXDEV:
+		return -fuse.EXDEV
+	case syscall.ENODEV:
+		return -fuse.ENODEV
+	case syscall.ENOTDIR:
+		return -fuse.ENOTDIR
+	case syscall.EISDIR:
+		return -fuse.EISDIR
+	case syscall.EINVAL:
+		return -fuse.EINVAL
+	case syscall.ENFILE:
+		return -fuse.ENFILE
+	case syscall.EMFILE:
+		return -fuse.EMFILE
+	case syscall.ENOTTY:
+		return -fuse.ENOTTY
+	case syscall.EFBIG:
+		return -fuse.EFBIG
+	case syscall.ENOSPC:
+		return -fuse.ENOSPC
+	case syscall.ESPIPE:
+		return -fuse.ESPIPE
+	case syscall.EROFS:
+		return -fuse.EROFS
+	case syscall.EMLINK:
+		return -fuse.EMLINK
+	case syscall.EPIPE:
+		return -fuse.EPIPE
+	case syscall.ENAMETOOLONG:
+		return -fuse.ENAMETOOLONG
+	case syscall.ENOSYS:
+		return -fuse.ENOSYS
+	case syscall.ENOTEMPTY:
+		return -fuse.ENOTEMPTY
+	case syscall.ELOOP:
+		return -fuse.ELOOP
+	case syscall.ENODATA:
+		return -fuse.ENODATA
+	case syscall.ENOATTR: // Darwin alias of ENODATA
+		return -fuse.ENODATA
+	default:
+		return -int(err)
+	}
+}
+
+func fuseFlagToSyscall(flag int) int {
+	var ret int
+	if flag&fuse.O_WRONLY != 0 {
+		ret |= syscall.O_WRONLY
+	} else if flag&fuse.O_RDWR != 0 {
+		ret |= syscall.O_RDWR
+	} else {
+		ret |= syscall.O_RDONLY
+	}
+	if flag&fuse.O_APPEND != 0 {
+		ret |= syscall.O_APPEND
+	}
+	if flag&fuse.O_CREAT != 0 {
+		ret |= syscall.O_CREAT
+	}
+	if flag&fuse.O_EXCL != 0 {
+		ret |= syscall.O_EXCL
+	}
+	if flag&fuse.O_TRUNC != 0 {
+		ret |= syscall.O_TRUNC
+	}
+	return ret
+}
+
+func (fsys *FS) attrToStat(inode meta.Ino, attr *meta.Attr, stat *fuse.Stat_t) {
+	*stat = fuse.Stat_t{}
+	stat.Ino = uint64(inode)
+	stat.Mode = attr.SMode()
+	stat.Uid = attr.Uid
+	stat.Gid = attr.Gid
+	stat.Nlink = attr.Nlink
+	stat.Atim = fuse.Timespec{Sec: attr.Atime, Nsec: int64(attr.Atimensec)}
+	stat.Mtim = fuse.Timespec{Sec: attr.Mtime, Nsec: int64(attr.Mtimensec)}
+	stat.Ctim = fuse.Timespec{Sec: attr.Ctime, Nsec: int64(attr.Ctimensec)}
+	stat.Birthtim = stat.Ctim
+
+	var rdev uint32
+	var size, blocks uint64
+	switch attr.Typ {
+	case meta.TypeDirectory, meta.TypeSymlink, meta.TypeFile:
+		size = attr.Length
+		blocks = (size + 511) / 512
+		stat.Blksize = 4096
+	case meta.TypeBlockDev, meta.TypeCharDev:
+		rdev = attr.Rdev
+	}
+	stat.Size = int64(size)
+	stat.Blocks = int64(blocks)
+	stat.Rdev = uint64(rdev)
+	if attr.Flags&meta.FlagImmutable != 0 {
+		stat.Flags |= ufImmutable
+	}
+	if attr.Flags&meta.FlagAppend != 0 {
+		stat.Flags |= ufAppend
+	}
+}
+
+// resolvePath walks p component by component from the root.
+func (fsys *FS) resolvePath(ctx vfs.LogContext, p string) (meta.Ino, *meta.Entry, syscall.Errno) {
+	p = path.Clean(p)
+	if p == "/" || p == "." || p == "" {
+		entry, err := fsys.vfs.GetAttr(ctx, meta.RootInode, 0)
+		return meta.RootInode, entry, err
+	}
+
+	base := path.Base(p)
+	if path.Dir(p) == "/" && vfs.IsSpecialName(base) {
+		ino, attr := vfs.GetInternalNodeByName(base)
+		if ino == 0 {
+			return 0, nil, syscall.ENOENT
+		}
+		return ino, &meta.Entry{Inode: ino, Attr: attr}, 0
+	}
+
+	currentIno := meta.RootInode
+	var currentEntry *meta.Entry
+	var err syscall.Errno
+
+	parts := strings.SplitSeq(strings.Trim(p, "/"), "/")
+	for seg := range parts {
+		if seg == "" || seg == "." {
+			continue
+		}
+		currentEntry, err = fsys.vfs.Lookup(ctx, currentIno, seg)
+		if err != 0 {
+			return 0, nil, err
+		}
+		currentIno = currentEntry.Inode
+	}
+
+	return currentIno, currentEntry, 0
+}
+
+// resolveParent returns the parent inode and the last path component.
+func (fsys *FS) resolveParent(ctx vfs.LogContext, p string) (meta.Ino, string, syscall.Errno) {
+	p = path.Clean(p)
+	if p == "/" || p == "." || p == "" {
+		return 0, "", syscall.EINVAL
+	}
+	dir, base := path.Split(p)
+	parentIno, _, err := fsys.resolvePath(ctx, dir)
+	if err != 0 {
+		return 0, "", err
+	}
+	return parentIno, base, 0
+}
+
+// resolveIno returns the inode for a path, preferring the open handle fh.
+// opened is 1 when the inode came from a handle; useFh is the handle to pass
+// on to the vfs layer (0 when the path was resolved).
+func (fsys *FS) resolveIno(ctx vfs.LogContext, p string, fh uint64) (ino meta.Ino, opened uint8, useFh uint64, err syscall.Errno) {
+	if fh != 0 && fh != fhUnset {
+		fsys.RLock()
+		ino = fsys.handles[fh]
+		fsys.RUnlock()
+		if ino != 0 {
+			return ino, 1, fh, 0
+		}
+	}
+	ino, _, err = fsys.resolvePath(ctx, p)
+	return ino, 0, 0, err
+}
+
+func (fsys *FS) Statfs(p string, stat *fuse.Statfs_t) int {
+	ctx := fsys.newContext()
+	var totalspace, availspace, iused, iavail uint64
+	if errno := fsys.vfs.Meta.StatFS(ctx, meta.RootInode, &totalspace, &availspace, &iused, &iavail); errno != 0 {
+		return errorconv(errno)
+	}
+	var bsize uint64 = 4096
+	blocks := totalspace / bsize
+	bavail := availspace / bsize
+	// FUSE-T/FSKit only keep 32 bits of the block counts, so cap them before
+	// large capacities wrap to zero or negative (df would complain otherwise).
+	const maxBlocks = 1<<32 - 1
+	if blocks > maxBlocks {
+		blocks = maxBlocks
+	}
+	if bavail > maxBlocks {
+		bavail = maxBlocks
+	}
+	stat.Namemax = 255
+	stat.Frsize = 4096
+	stat.Bsize = bsize
+	stat.Blocks = blocks
+	stat.Bfree = bavail
+	stat.Bavail = bavail
+	stat.Files = iused + iavail
+	stat.Ffree = iavail
+	stat.Favail = iavail
+	return 0
+}
+
+func (fsys *FS) Mknod(p string, mode uint32, dev uint64) int {
+	ctx := fsys.newContext()
+	parentIno, base, err := fsys.resolveParent(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	_, errno := fsys.vfs.Mknod(ctx, parentIno, base, uint16(mode), 0, uint32(dev))
+	return errorconv(errno)
+}
+
+func (fsys *FS) Mkdir(p string, mode uint32) int {
+	if p == "/.UMOUNTIT" {
+		if fsys.conf != nil {
+			logger.Infof("Umount %s ...", fsys.conf.Meta.MountPoint)
+		}
+		if fsys.host != nil {
+			go fsys.host.Unmount()
+		}
+		return -fuse.ENOENT
+	}
+	ctx := fsys.newContext()
+	parentIno, base, err := fsys.resolveParent(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	_, errno := fsys.vfs.Mkdir(ctx, parentIno, base, uint16(mode), 0)
+	return errorconv(errno)
+}
+
+func (fsys *FS) Unlink(p string) int {
+	ctx := fsys.newContext()
+	parentIno, base, err := fsys.resolveParent(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return errorconv(fsys.vfs.Unlink(ctx, parentIno, base))
+}
+
+func (fsys *FS) Rmdir(p string) int {
+	ctx := fsys.newContext()
+	parentIno, base, err := fsys.resolveParent(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return errorconv(fsys.vfs.Rmdir(ctx, parentIno, base))
+}
+
+func (fsys *FS) Link(oldpath string, newpath string) int {
+	ctx := fsys.newContext()
+	oldIno, _, err := fsys.resolvePath(ctx, oldpath)
+	if err != 0 {
+		return errorconv(err)
+	}
+	newParentIno, newBase, err := fsys.resolveParent(ctx, newpath)
+	if err != 0 {
+		return errorconv(err)
+	}
+	_, errno := fsys.vfs.Link(ctx, oldIno, newParentIno, newBase)
+	return errorconv(errno)
+}
+
+func (fsys *FS) Symlink(target string, newpath string) int {
+	if fsys.disableSymlink {
+		return -fuse.ENOSYS
+	}
+	ctx := fsys.newContext()
+	parentIno, base, err := fsys.resolveParent(ctx, newpath)
+	if err != 0 {
+		return errorconv(err)
+	}
+	_, errno := fsys.vfs.Symlink(ctx, target, parentIno, base)
+	return errorconv(errno)
+}
+
+func (fsys *FS) Readlink(p string) (int, string) {
+	if p == "/" && fsys.disableSymlink {
+		return -fuse.ENOSYS, ""
+	}
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err), ""
+	}
+	t, errno := fsys.vfs.Readlink(ctx, ino)
+	return errorconv(errno), string(t)
+}
+
+func (fsys *FS) Rename(oldpath string, newpath string) int {
+	ctx := fsys.newContext()
+	oldParentIno, oldBase, err := fsys.resolveParent(ctx, oldpath)
+	if err != 0 {
+		return errorconv(err)
+	}
+	newParentIno, newBase, err := fsys.resolveParent(ctx, newpath)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return errorconv(fsys.vfs.Rename(ctx, oldParentIno, oldBase, newParentIno, newBase, 0))
+}
+
+func (fsys *FS) Chmod(p string, mode uint32) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	_, errno := fsys.vfs.SetAttr(ctx, ino, meta.SetAttrMode, 0, mode, 0, 0, 0, 0, 0, 0, 0)
+	return errorconv(errno)
+}
+
+func (fsys *FS) Chown(p string, uid uint32, gid uint32) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	set := 0
+	if uid != 0xffffffff {
+		set |= meta.SetAttrUID
+	}
+	if gid != 0xffffffff {
+		set |= meta.SetAttrGID
+	}
+	_, errno := fsys.vfs.SetAttr(ctx, ino, set, 0, 0, uid, gid, 0, 0, 0, 0, 0)
+	return errorconv(errno)
+}
+
+func (fsys *FS) Utimens(p string, tmsp []fuse.Timespec) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	if len(tmsp) < 2 {
+		return 0
+	}
+	// cgofuse leaves UTIME_NOW/UTIME_OMIT in the nsec field; translate them
+	// into the matching SetAttr flags instead of passing the sentinel down.
+	var set int
+	var atime, mtime int64
+	var atimensec, mtimensec uint32
+	switch tmsp[0].Nsec {
+	case fuse.UTIME_NOW:
+		set |= meta.SetAttrAtimeNow
+	case fuse.UTIME_OMIT:
+	default:
+		set |= meta.SetAttrAtime
+		atime = tmsp[0].Sec
+		atimensec = uint32(tmsp[0].Nsec)
+	}
+	switch tmsp[1].Nsec {
+	case fuse.UTIME_NOW:
+		set |= meta.SetAttrMtimeNow
+	case fuse.UTIME_OMIT:
+	default:
+		set |= meta.SetAttrMtime
+		mtime = tmsp[1].Sec
+		mtimensec = uint32(tmsp[1].Nsec)
+	}
+	if set == 0 {
+		return 0
+	}
+	_, errno := fsys.vfs.SetAttr(ctx, ino, set, 0, 0, 0, 0, atime, mtime, atimensec, mtimensec, 0)
+	return errorconv(errno)
+}
+
+// Chflags mirrors chflags(2): only immutable and append are supported, and
+// only the owner (or root) may change them.
+func (fsys *FS) Chflags(p string, flags uint32) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	if vfs.IsSpecialNode(ino) {
+		return -fuse.EPERM
+	}
+
+	if flags&^(fuse.UF_READONLY|ufImmutable|ufAppend) != 0 {
+		return -fuse.ENOTSUP
+	}
+
+	var cur meta.Attr
+	if errno := fsys.vfs.Meta.GetAttr(ctx, ino, &cur); errno != 0 {
+		return errorconv(errno)
+	}
+	if ctx.CheckPermission() && ctx.Uid() != 0 && ctx.Uid() != cur.Uid {
+		return -fuse.EPERM
+	}
+
+	newFlags := cur.Flags &^ (uint8(meta.FlagImmutable) | uint8(meta.FlagAppend))
+	if flags&(fuse.UF_READONLY|ufImmutable) != 0 {
+		newFlags |= meta.FlagImmutable
+	}
+	if flags&ufAppend != 0 {
+		newFlags |= meta.FlagAppend
+	}
+	return errorconv(fsys.vfs.Meta.SetAttr(ctx, ino, meta.SetAttrFlag, 0, &meta.Attr{Flags: newFlags}))
+}
+
+func (fsys *FS) Access(p string, mask uint32) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return errorconv(fsys.vfs.Access(ctx, ino, int(mask)))
+}
+
+func (fsys *FS) Create(p string, flags int, mode uint32) (int, uint64) {
+	var fi fuse.FileInfo_t
+	fi.Flags = flags
+	errc := fsys.CreateEx(p, mode, &fi)
+	return errc, fi.Fh
+}
+
+func (fsys *FS) CreateEx(p string, mode uint32, fi *fuse.FileInfo_t) int {
+	ctx := fsys.newContext()
+	parentIno, base, err := fsys.resolveParent(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	entry, fh, errno := fsys.vfs.Create(ctx, parentIno, base, uint16(mode), 0, uint32(fuseFlagToSyscall(fi.Flags)))
+	if errno == 0 {
+		fi.Fh = fh
+		if vfs.IsSpecialNode(entry.Inode) {
+			fi.DirectIo = true
+		} else {
+			fi.KeepCache = entry.Attr.KeepCache
+		}
+		fsys.Lock()
+		fsys.handles[fh] = entry.Inode
+		fsys.Unlock()
+	}
+	return errorconv(errno)
+}
+
+func (fsys *FS) Open(p string, flags int) (int, uint64) {
+	var fi fuse.FileInfo_t
+	fi.Flags = flags
+	e := fsys.OpenEx(p, &fi)
+	return e, fi.Fh
+}
+
+func (fsys *FS) OpenEx(p string, fi *fuse.FileInfo_t) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	entry, fh, errno := fsys.vfs.Open(ctx, ino, uint32(fuseFlagToSyscall(fi.Flags)))
+	if errno == 0 {
+		fi.Fh = fh
+		if vfs.IsSpecialNode(ino) {
+			fi.DirectIo = true
+		} else {
+			fi.KeepCache = entry.Attr.KeepCache
+		}
+		fsys.Lock()
+		fsys.handles[fh] = ino
+		fsys.Unlock()
+	}
+	return errorconv(errno)
+}
+
+func (fsys *FS) Getattr(p string, stat *fuse.Stat_t, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, opened, _, err := fsys.resolveIno(ctx, p, fh)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	entry, errno := fsys.vfs.GetAttr(ctx, ino, opened)
+	if errno != 0 {
+		return errorconv(errno)
+	}
+
+	fsys.vfs.UpdateLength(entry.Inode, entry.Attr)
+	fsys.attrToStat(entry.Inode, entry.Attr, stat)
+	return 0
+}
+
+func (fsys *FS) Truncate(p string, size int64, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, _, useFh, err := fsys.resolveIno(ctx, p, fh)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	return errorconv(fsys.vfs.Truncate(ctx, ino, size, useFh, nil))
+}
+
+func (fsys *FS) Read(p string, buff []byte, ofst int64, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, _, useFh, err := fsys.resolveIno(ctx, p, fh)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	n, err := fsys.vfs.Read(ctx, ino, buff, uint64(ofst), useFh)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return n
+}
+
+func (fsys *FS) Write(p string, buff []byte, ofst int64, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, _, useFh, err := fsys.resolveIno(ctx, p, fh)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	errno := fsys.vfs.Write(ctx, ino, buff, uint64(ofst), useFh)
+	if errno != 0 {
+		return errorconv(errno)
+	}
+	return len(buff)
+}
+
+func (fsys *FS) Flush(p string, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, _, useFh, err := fsys.resolveIno(ctx, p, fh)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	return errorconv(fsys.vfs.Flush(ctx, ino, useFh, 0))
+}
+
+func (fsys *FS) Release(p string, fh uint64) int {
+	fsys.Lock()
+	ino, ok := fsys.handles[fh]
+	if ok {
+		delete(fsys.handles, fh)
+	}
+	fsys.Unlock()
+
+	if !ok {
+		ino, _, _ = fsys.resolvePath(fsys.newContext(), p)
+	}
+
+	if ino != 0 {
+		fsys.vfs.Release(fsys.newContext(), ino, fh)
+	}
+	return 0
+}
+
+func (fsys *FS) Fsync(p string, datasync bool, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, _, useFh, err := fsys.resolveIno(ctx, p, fh)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	syncFlag := 0
+	if datasync {
+		syncFlag = 1
+	}
+	return errorconv(fsys.vfs.Fsync(ctx, ino, syncFlag, useFh))
+}
+
+func (fsys *FS) Opendir(p string) (int, uint64) {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err), 0
+	}
+	fh, errno := fsys.vfs.Opendir(ctx, ino, 0)
+	if errno == 0 {
+		fsys.Lock()
+		fsys.handles[fh] = ino
+		fsys.Unlock()
+	}
+	return errorconv(errno), fh
+}
+
+func (fsys *FS) Readdir(p string, fill func(name string, stat *fuse.Stat_t, ofst int64) bool, ofst int64, fh uint64) int {
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+
+	// Directories can't be seeked; reject a non-zero offset.
+	if ofst > 0 {
+		return -fuse.ESPIPE
+	}
+
+	// FSKit calls Readdir without Opendir first, so the host fh isn't a valid
+	// vfs handle; open one for the whole listing instead.
+	dirfh, errno := fsys.vfs.Opendir(ctx, ino, 0)
+	if errno != 0 {
+		return errorconv(errno)
+	}
+	defer fsys.vfs.Releasedir(ctx, ino, dirfh)
+
+	// FUSE-T/NFS expects "." and ".." to be present.
+	if !fill(".", nil, 0) || !fill("..", nil, 0) {
+		return 0
+	}
+
+	// Read everything in one pass, always with offset 0, so the host can't
+	// resume in the middle.
+	batchSize := fsys.readdirBatchSize
+	if batchSize <= 0 {
+		batchSize = 1024
+	}
+
+	currentOffset := 0
+	for {
+		entries, readAt, err := fsys.vfs.Readdir(ctx, ino, uint32(batchSize), currentOffset, dirfh, true)
+		if err != 0 {
+			return errorconv(err)
+		}
+		if len(entries) == 0 {
+			break
+		}
+
+		ok := true
+		for _, entry := range entries {
+			name := string(entry.Name)
+			if name == "." || name == ".." {
+				continue
+			}
+			var st fuse.Stat_t
+			if fsys.vfs.ModifiedSince(entry.Inode, readAt) {
+				if e2, err := fsys.vfs.GetAttr(ctx, entry.Inode, 0); err == 0 {
+					entry.Attr = e2.Attr
+				}
+			}
+			fsys.vfs.UpdateLength(entry.Inode, entry.Attr)
+			fsys.attrToStat(entry.Inode, entry.Attr, &st)
+			ok = fill(name, &st, 0)
+			if !ok {
+				break
+			}
+		}
+		if !ok {
+			break
+		}
+		currentOffset += len(entries)
+	}
+	return 0
+}
+
+func (fsys *FS) Releasedir(p string, fh uint64) int {
+	fsys.Lock()
+	ino, ok := fsys.handles[fh]
+	if ok {
+		delete(fsys.handles, fh)
+	}
+	fsys.Unlock()
+
+	if !ok {
+		ino, _, _ = fsys.resolvePath(fsys.newContext(), p)
+	}
+
+	if ino != 0 {
+		return fsys.vfs.Releasedir(fsys.newContext(), ino, fh)
+	}
+	return 0
+}
+
+func (fsys *FS) Fsyncdir(p string, datasync bool, fh uint64) int {
+	return 0
+}
+
+func (fsys *FS) Setxattr(p string, name string, value []byte, flags int) int {
+	if !fsys.xattrs {
+		return -fuse.ENOSYS
+	}
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return errorconv(fsys.vfs.SetXattr(ctx, ino, name, value, uint32(flags)))
+}
+
+func (fsys *FS) Getxattr(p string, name string) (int, []byte) {
+	if !fsys.xattrs {
+		return -fuse.ENOSYS, nil
+	}
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err), nil
+	}
+	val, errno := fsys.vfs.GetXattr(ctx, ino, name, 0)
+	if errno != 0 {
+		return errorconv(errno), nil
+	}
+	return 0, val
+}
+
+func (fsys *FS) Removexattr(p string, name string) int {
+	if !fsys.xattrs {
+		return -fuse.ENOSYS
+	}
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	return errorconv(fsys.vfs.RemoveXattr(ctx, ino, name))
+}
+
+func (fsys *FS) Listxattr(p string, fill func(name string) bool) int {
+	if !fsys.xattrs {
+		return -fuse.ENOSYS
+	}
+	ctx := fsys.newContext()
+	ino, _, err := fsys.resolvePath(ctx, p)
+	if err != 0 {
+		return errorconv(err)
+	}
+	data, errno := fsys.vfs.ListXattr(ctx, ino, 0)
+	if errno != 0 {
+		return errorconv(errno)
+	}
+	start := 0
+	for i := range data {
+		if data[i] == 0 {
+			if i > start {
+				if !fill(string(data[start:i])) {
+					break
+				}
+			}
+			start = i + 1
+		}
+	}
+	return 0
+}

--- a/pkg/fusemac/serve_darwin.go
+++ b/pkg/fusemac/serve_darwin.go
@@ -133,9 +133,13 @@ func buildDarwinMountOptions(conf *vfs.Config, userOpts string) []string {
 		}
 	}
 	for opt := range strings.SplitSeq(userOpts, ",") {
-		if opt = strings.TrimSpace(opt); opt != "" {
-			opts = append(opts, "-o", opt)
+		opt = strings.TrimSpace(opt)
+		// JuiceFS-internal flags are consumed by CheckBackend and must not
+		// reach libfuse, which rejects unknown options.
+		if opt == "" || opt == allowUnsafeFskit {
+			continue
 		}
+		opts = append(opts, "-o", opt)
 	}
 	return opts
 }

--- a/pkg/fusemac/serve_darwin.go
+++ b/pkg/fusemac/serve_darwin.go
@@ -1,0 +1,183 @@
+//go:build darwin
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fusemac
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/juicedata/juicefs/pkg/vfs"
+	"github.com/urfave/cli/v2"
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+const (
+	fuseTURL   = "https://www.fuse-t.org/"
+	macfuseURL = "https://osxfuse.github.io/"
+)
+
+var (
+	activeHostMu sync.Mutex
+	activeHost   *fuse.FileSystemHost
+	activeFS     *FS
+	signalled    atomic.Bool
+)
+
+var ErrGracefulUnmount = errors.New("fuse session ended by unmount")
+
+func MarkSignalShutdown() {
+	signalled.Store(true)
+}
+
+func UnmountActive() bool {
+	activeHostMu.Lock()
+	defer activeHostMu.Unlock()
+	if activeHost == nil {
+		return false
+	}
+	if activeFS != nil && activeFS.destroyed.Load() != 0 {
+		return true
+	}
+	return activeHost.Unmount()
+}
+
+// allowUnsafeFskit is the -o escape hatch that opts into macFUSE's FSKit
+// backend despite its broken write path.
+const allowUnsafeFskit = "allow_unsafe_fskit_macfuse"
+
+func hasOpt(opts, name string) bool {
+	for opt := range strings.SplitSeq(opts, ",") {
+		if strings.TrimSpace(opt) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// installedLibs is a variable so tests can fake which FUSE libraries exist.
+var installedLibs = func() (fuseT, macfuse bool) {
+	if _, err := os.Stat("/usr/local/lib/libfuse-t.dylib"); err == nil {
+		fuseT = true
+	}
+	if _, err := os.Stat("/usr/local/lib/libfuse.2.dylib"); err == nil {
+		macfuse = true
+	}
+	if _, err := os.Stat("/usr/local/lib/libosxfuse.2.dylib"); err == nil {
+		macfuse = true
+	}
+	return
+}
+
+func CheckBackend(backend, opts string) error {
+	fuseT, macfuse := installedLibs()
+
+	switch backend {
+	case "nfs", "smb":
+		if macfuse {
+			return fmt.Errorf("backend=%s is designed for FUSE-T (%s); to prevent cgofuse from defaulting to macFUSE, please temporarily remove the macFUSE dylibs from /usr/local/lib", backend, fuseTURL)
+		}
+		if !fuseT {
+			return fmt.Errorf("backend=%s requires FUSE-T; please install it from %s to continue", backend, fuseTURL)
+		}
+
+	case "fskit":
+		if macfuse {
+			if !hasOpt(opts, allowUnsafeFskit) {
+				return fmt.Errorf("backend=fskit has known compatibility issues with macFUSE; please install FUSE-T (%s) for stable operation, or add '%s' to your -o options to proceed anyway", fuseTURL, allowUnsafeFskit)
+			}
+			logger.Warnf("Running backend=fskit with macFUSE via the '%s' flag; note that write operations may be unstable", allowUnsafeFskit)
+			return nil
+		}
+		if !fuseT {
+			return fmt.Errorf("backend=fskit requires a compatible FUSE runtime; please install either FUSE-T (%s) or macFUSE (%s)", fuseTURL, macfuseURL)
+		}
+	}
+
+	return nil
+}
+func buildDarwinMountOptions(conf *vfs.Config, userOpts string) []string {
+	var opts []string
+	if volName := conf.Format.Name; volName != "" {
+		opts = append(opts, "-o", "volname="+volName)
+	}
+	// daemon_timeout keeps slow operations (e.g. flushes over NFS/SMB) from
+	// getting killed; making defaults it to 10 minutes on macOS.
+	opts = append(opts, "-o", "daemon_timeout=600")
+	opts = append(opts, "-o", "atomic_o_trunc")
+	opts = append(opts, "-o", fmt.Sprintf("attr_timeout=%g", conf.AttrTimeout.Seconds()))
+	opts = append(opts, "-o", fmt.Sprintf("entry_timeout=%g", conf.EntryTimeout.Seconds()))
+	opts = append(opts, "-o", fmt.Sprintf("max_readahead=%d", 1024*1024))
+	if conf.FuseOpts != nil {
+		if conf.FuseOpts.AllowOther {
+			opts = append(opts, "-o", "allow_other")
+		}
+	}
+	for opt := range strings.SplitSeq(userOpts, ",") {
+		if opt = strings.TrimSpace(opt); opt != "" {
+			opts = append(opts, "-o", opt)
+		}
+	}
+	return opts
+}
+
+func mountFailure(jfs *FS, mp string) error {
+	if jfs.destroyed.Load() != 0 || signalled.Load() {
+		return ErrGracefulUnmount
+	}
+	return fmt.Errorf("cgofuse host.Mount failed on %s", mp)
+}
+
+func Serve(v *vfs.VFS, userOpts string, xattrs, ioctl bool, c *cli.Context) error {
+	jfs := NewFS(v.Conf, v)
+	jfs.xattrs = xattrs
+	if c != nil {
+		jfs.asRoot = c.Bool("as-root")
+		if c.IsSet("readdir-batch-size") {
+			jfs.readdirBatchSize = c.Int("readdir-batch-size")
+		}
+	}
+
+	host := fuse.NewFileSystemHost(jfs)
+	jfs.host = host
+
+	activeHostMu.Lock()
+	activeHost = host
+	activeFS = jfs
+	activeHostMu.Unlock()
+	defer func() {
+		activeHostMu.Lock()
+		if activeHost == host {
+			activeHost = nil
+			activeFS = nil
+		}
+		activeHostMu.Unlock()
+	}()
+
+	options := buildDarwinMountOptions(v.Conf, userOpts)
+	logger.Infof("Mounting with Kext-less mode on macOS")
+
+	if !host.Mount(v.Conf.Meta.MountPoint, options) {
+		return mountFailure(jfs, v.Conf.Meta.MountPoint)
+	}
+	return nil
+}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -17,6 +17,7 @@
 package vfs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -151,6 +152,7 @@ type Config struct {
 	StatePath string       `json:",omitempty"`
 	FuseOpts  *FuseOptions `json:",omitempty"`
 
+	Fusemac bool `json:",omitempty"`
 	// the mount point for current volume (to follow symlink)
 	Mountpoint string
 }
@@ -180,6 +182,13 @@ func (v *VFS) Lookup(ctx Context, parent Ino, name string) (entry *meta.Entry, e
 		n := getInternalNodeByName(name)
 		if n != nil {
 			entry = &meta.Entry{Inode: n.inode, Attr: n.attr}
+			// .stats size must be re-announced for the FSKit/NFS bridge.
+			if v.Conf.Fusemac && n.inode == StatsInode {
+				v.refreshStats()
+				attr := *n.attr
+				attr.Length = v.statsLen
+				entry.Attr = &attr
+			}
 			return
 		}
 	}
@@ -203,10 +212,33 @@ func (v *VFS) Lookup(ctx Context, parent Ino, name string) (entry *meta.Entry, e
 	return
 }
 
+func (v *VFS) configContent() []byte {
+	v.Conf.Format = v.Meta.GetFormat()
+	if v.UpdateFormat != nil {
+		v.UpdateFormat(&v.Conf.Format)
+	}
+	v.Conf.Format.RemoveSecret()
+	data, _ := json.MarshalIndent(v.Conf, "", " ")
+	return data
+}
+
 func (v *VFS) GetAttr(ctx Context, ino Ino, opened uint8) (entry *meta.Entry, err syscall.Errno) {
 	if IsSpecialNode(ino) && getInternalNode(ino) != nil {
 		n := getInternalNode(ino)
 		entry = &meta.Entry{Inode: n.inode, Attr: n.attr}
+		// Re-announce live special-file sizes for the FSKit/NFS bridge.
+		if v.Conf.Fusemac {
+			if ino == StatsInode {
+				v.refreshStats()
+				attr := *n.attr
+				attr.Length = v.statsLen
+				entry.Attr = &attr
+			} else if ino == ConfigInode {
+				attr := *n.attr
+				attr.Length = uint64(len(v.configContent()))
+				entry.Attr = &attr
+			}
+		}
 		return
 	}
 	defer func() { logit(ctx, "getattr", err, "(%d):%s", ino, (*Entry)(entry)) }()
@@ -571,14 +603,12 @@ func (v *VFS) Open(ctx Context, ino Ino, flags uint32) (entry *meta.Entry, fh ui
 		case logInode:
 			openAccessLog(fh)
 		case StatsInode:
-			h.data = CollectMetrics(v.registry)
-		case ConfigInode:
-			v.Conf.Format = v.Meta.GetFormat()
-			if v.UpdateFormat != nil {
-				v.UpdateFormat(&v.Conf.Format)
+			h.data = v.statsContent()
+			if v.Conf.Fusemac {
+				entry.Attr.Length = v.statsLen
 			}
-			v.Conf.Format.RemoveSecret()
-			h.data, _ = json.MarshalIndent(v.Conf, "", " ")
+		case ConfigInode:
+			h.data = v.configContent()
 			entry.Attr.Length = uint64(len(h.data))
 		}
 		return
@@ -704,14 +734,9 @@ func (v *VFS) Read(ctx Context, ino Ino, buf []byte, off uint64, fh uint64) (n i
 		if len(h.data) == 0 {
 			switch ino {
 			case StatsInode:
-				h.data = CollectMetrics(v.registry)
+				h.data = v.statsContent()
 			case ConfigInode:
-				v.Conf.Format = v.Meta.GetFormat()
-				if v.UpdateFormat != nil {
-					v.UpdateFormat(&v.Conf.Format)
-				}
-				v.Conf.Format.RemoveSecret()
-				h.data, _ = json.MarshalIndent(v.Conf, "", " ")
+				h.data = v.configContent()
 			}
 		}
 
@@ -1240,6 +1265,36 @@ type VFS struct {
 	modifiedAt map[Ino]time.Time
 
 	registry *prometheus.Registry
+
+	statsMu  sync.Mutex
+	statsLen uint64
+}
+
+// statsSlack keeps the announced .stats size ahead of the growing metrics.
+const statsSlack = 64 << 10
+
+// refreshStats records the announced .stats size (fusemac only).
+func (v *VFS) refreshStats() {
+	if !v.Conf.Fusemac {
+		return
+	}
+	v.statsMu.Lock()
+	defer v.statsMu.Unlock()
+	v.statsLen = uint64(len(CollectMetrics(v.registry))) + statsSlack
+}
+
+// statsContent returns .stats content, padded to the announced size on fusemac.
+func (v *VFS) statsContent() []byte {
+	data := CollectMetrics(v.registry)
+	if !v.Conf.Fusemac {
+		return data
+	}
+	v.statsMu.Lock()
+	defer v.statsMu.Unlock()
+	if v.statsLen < uint64(len(data)) {
+		v.statsLen = uint64(len(data)) + statsSlack
+	}
+	return append(data, bytes.Repeat([]byte{'\n'}, int(v.statsLen)-len(data))...)
 }
 
 func NewVFS(conf *Config, m meta.Meta, store chunk.ChunkStore, registerer prometheus.Registerer, registry *prometheus.Registry) *VFS {


### PR DESCRIPTION
JuiceFS can now be mounted on macOS **without any kernel extension** through **FUSE-T**
with three selectable transports (`-o backend=nfs|smb|fskit`), plus the macFUSE-FSKit
path through the same cgofuse adapter (`pkg/fusemac`).


**Procedure, and Technique:**

1. **Path-based frontend over `vfs.VFS`** — a Darwin-only adapter (`pkg/fusemac`) implements
   the cgofuse `FileSystemInterface` on top of the shared VFS layer. cgofuse's callback set
   (no single `SetAttr`; separate `Chmod`/`Chown`/`Utimens`) is translated onto VFS's
   bitmask-style `SetAttr`.
2. **Backend selection & routing** — default mounts stay on macFUSE-KEXT via go-fuse;
   `-o backend=` routes through cgofuse. Runtime library detection refuses impossible
   combinations instead of failing mysteriously mid-mount.
3. **Upstream-contract verification** — each fix was checked against the pinned dependency
   sources (cgofuse v1.6.0 `hostUtimens`, dlopen order, commented-out Lock op) rather than
   assumed from release notes.



## Key Findings


### 1. cgofuse dylib selection escape hatch is missing from our pinned version


Upstream cgofuse added `CGOFUSE_LIBFUSE_PATH`, which lets the application choose the FUSE-T
dylib explicitly when both FUSE-T and macFUSE are installed. Because we pin cgofuse v1.6.0
(which predates this), that variable is unavailable — and cgofuse v1.6.0 dlopens macFUSE's
`libfuse.2.dylib` *before* `libfuse-t.dylib`, silently hijacking every `backend=` mount on
dual installs. Until we upgrade cgofuse, `CheckBackend` fails closed on those combinations
and asks users to remove the macFUSE dylibs from `/usr/local/lib`.


### 2. pjdfstest tests - FUSE-T FSKit wins on compliance, but workloads reveal the true performance.


| Backend       | Total Tests | Failed | Passed |
| ------------- | ----------: | -----: | -----: |
| FUSE-T fskit  |        8686 |   4835 |   3851 |
| MacFUSE KEXT  |        8686 |   6919 |   1767 |


MacFUSE KEXT scores lower than FUSE-T in pjdfstest, but remains the battle-tested option
under high concurrency due to its mature kernel-mode implementation, advantages the
still-maturing FSKit backends cannot match yet. FUSE-T NFS handled all high-workload
scenarios correctly, with throughput bounded by the local network interface rather than by
correctness or stability.


#### Recommendation: switching backends for heavy workloads


If high-load work fails with the FUSE-T `fskit` backend, it is recommended to temporarily
switch to the NFS backend (`-o backend=nfs`) or (`-o backend=smb`), perform the high-chunk work there, and then
switch back to `fskit`. While NFS,SMB  is slower than FSKit, it handled all high-workload
scenarios correctly — making it the safer choice for heavy chunk operations until the FSKit
backend matures.


### 3. What the kext-less bridges do not expose

**a) Protocol-level operations** that FSKit/NFS/SMB bridges do not forward:

- flock/fcntl locks (per-host)
- fallocate
- ioctl
- copy_file_range
- SEEK_HOLE / SEEK_DATA
- chflags forwarding

**b) Maintenance subcommands** that depend on the `.control` request/response channel,
whose write-then-read pattern the kext-less bridges cannot service reliably:

> Affected JuiceFS subcommands: `info`, `rmr`, `clone`, `compact`, `summary`, `warmup`.

## Additional Hardening Included

- **Fail-closed backend guard**: cgofuse loads macFUSE's library first; `nfs`/`smb`
  error out on dual installs, and `backend=fskit` requires explicit
  `-o allow_unsafe_fskit_macfuse` because macFUSE-FSKit's write path delivers zeroed
  buffers upstream.
- **xattr parity with go-fuse**: `--enable-xattr` gates the xattr callbacks
  (ENOSYS when off).
- **chflags**: native `UF_IMMUTABLE`/`UF_APPEND` mapping, owner-or-root enforcement,
  preservation of unrelated meta flag bits, round-trip via `st_flags`.
- **utimens**: single-sided `UTIME_NOW`/`UTIME_OMIT` sentinels translated instead of
  written as timestamps (prevents corruption on macFUSE).
- **Unmount safety**: data + meta session flush **before** teardown; a SIGPIPE-killed
  child during FUSE-T cleanup is classified by the supervisor as expected teardown
  (data already durable).

---

## Verification


Tested on macOS platform:


| Item   | Value                                                                                     |
| ------ | ----------------------------------------------------------------------------------------- |
| Arch   | darwin arm64                                                                              |
| Kernel | Darwin 25.5.0; root:xnu-12377.121.10~1/RELEASE_ARM64_T8103 arm64                          |
| OS     | macOS 26.5.2 (BuildVersion 25F84)                                                         |


- ^C durability: unsynced 8 MB write survives immediate unmount + remount
- Supervised signal flow matches the go-fuse/macFUSE behavior end-to-end


## Known Limitations

- Per-host file locks
- No fallocate / ioctl / copy_file_range / SEEK_HOLE on kext-less backends
- Birthtime reported as ctime
- chflags forwarding dormant on FUSE-T (client-side refusal)
- macFUSE-FSKit unusable until upstream fixes its write path [#1187](https://github.com/macfuse/macfuse/issues/1187)