### PR TITLE
security: authenticate distributed sync and SFTP peers

### DIFF
--- a/docs/en/guide/sync.md
+++ b/docs/en/guide/sync.md
@@ -193,6 +193,8 @@ juicefs sync /media/ "username:password"@192.168.1.100:/backup/
 
 When using the SFTP/SSH protocol, if no password is specified, the sync task will prompt for the password. If you want to explicitly specify the username and password, you need to enclose them in double quotation marks, with a colon separating the username and password.
 
+JuiceFS verifies the server host key against `~/.ssh/known_hosts`. Set `SSH_KNOWN_HOSTS` to a platform-specific list of alternate known-hosts files when needed. Unknown or changed host keys are rejected; verify the server fingerprint through a trusted channel before adding it.
+
 SFTP remote paths use the following formats:
 
 - Default SSH port: `username@host:/path`
@@ -308,7 +310,7 @@ When copying large scale data, node bandwidth can easily bottleneck the synchron
 
 The manager node executes the `sync` command as the master and defines multiple worker nodes by setting the `--worker` option (the manager node also serves as a worker node). JuiceFS splits the workload and distributes it to workers for distributed synchronization. This increases the amount of data that can be processed per unit time, and the total bandwidth is also multiplied.
 
-When using distributed syncing, you should configure SSH logins so that the manager can access all worker nodes without a password. If the SSH port is not the default 22, you need to include that in the manager's `~/.ssh/config`. The manager will distribute the JuiceFS Client to all worker nodes, so they should all use the same architecture to avoid compatibility problems.
+When using distributed syncing, you should configure SSH logins so that the manager can access all worker nodes without a password. The workers' SSH host keys must already be present in the manager's `~/.ssh/known_hosts`; JuiceFS rejects unknown or changed host keys. Verify each fingerprint through a trusted channel before adding it. If the SSH port is not the default 22, you need to include that in the manager's `~/.ssh/config`. The manager will distribute the JuiceFS Client to all worker nodes, so they should all use the same architecture to avoid compatibility problems. Manager-to-worker task traffic is authenticated and encrypted automatically with per-run credentials.
 
 For example, to synchronize data between two object storage services:
 

--- a/docs/en/reference/how_to_set_up_object_storage.md
+++ b/docs/en/reference/how_to_set_up_object_storage.md
@@ -1285,6 +1285,7 @@ juicefs format  \
 - `--bucket` is used to set the server address and storage path in the format `[sftp://]<IP/Domain>:[port]:<Path>`. Note that the directory name should end with `/`, and the port number is optionally defaulted to `22`, e.g. `192.168.1.11:22:myjfs/`.
 - `--access-key` set the username of the remote server
 - `--secret-key` set the password of the remote server
+- JuiceFS verifies the SFTP server host key against `~/.ssh/known_hosts`. Set `SSH_KNOWN_HOSTS` to a platform-specific list of alternate known-hosts files when needed. Connections to unknown hosts or hosts whose keys have changed are rejected; verify the server fingerprint through a trusted channel before adding it.
 
 ### CIFS/SMB {#cifs}
 

--- a/docs/zh_cn/guide/sync.md
+++ b/docs/zh_cn/guide/sync.md
@@ -204,6 +204,8 @@ juicefs sync /media/ "username:password"@192.168.1.100:/backup/
 
 当使用 SFTP/SSH 协议时，如果没有指定密码，执行 sync 任务时会提示输入密码。如果希望显式指定用户名和密码，则需要用半角引号把用户名和密码括起来，用户名和密码之间用半角冒号分隔。
 
+JuiceFS 会使用 `~/.ssh/known_hosts` 验证服务器主机密钥。如需使用其他 known-hosts 文件，可通过 `SSH_KNOWN_HOSTS` 设置符合当前平台格式的文件列表。未知主机或主机密钥已变化时连接会被拒绝；添加密钥前，请先通过可信渠道核对服务器指纹。
+
 SFTP 远端路径支持以下格式：
 
 - 使用默认 SSH 端口：`username@host:/path`
@@ -318,7 +320,7 @@ juicefs sync ./empty-dir/ s3://mybucket.s3.us-east-2.amazonaws.com/ --match-full
 
 Manager 作为主控执行 `sync` 命令，通过 `--worker` 参数定义多个 Worker 节点（Manager 自身也参与同步），JuiceFS 会根据 Worker 的总数量，动态拆分同步任务并分发给各个节点并发执行，单位时间内能处理的数据量更大，总带宽也成倍增加。
 
-在配置多机并发同步任务时，需要提前配置好 Manager 节点到 Worker 节点的 SSH 免密登录，如果 Worker 节点的 SSH 端口不是默认的 22，请在 Manager 节点的 `~/.ssh/config` 设置其端口号。Manager 会将 JuiceFS 客户端程序分发到 Worker 节点，为避免兼容性问题，Manager 和 Worker 应使用相同类型和架构的操作系统。
+在配置多机并发同步任务时，需要提前配置好 Manager 节点到 Worker 节点的 SSH 免密登录，并将所有 Worker 的 SSH 主机密钥预先加入 Manager 的 `~/.ssh/known_hosts`；JuiceFS 会拒绝未知或发生变化的主机密钥。添加密钥前，请先通过可信渠道核对服务器指纹。如果 Worker 节点的 SSH 端口不是默认的 22，请在 Manager 节点的 `~/.ssh/config` 设置其端口号。Manager 会将 JuiceFS 客户端程序分发到 Worker 节点，为避免兼容性问题，Manager 和 Worker 应使用相同类型和架构的操作系统。Manager 与 Worker 之间的任务通信会自动使用每次运行生成的凭据进行身份验证和加密。
 
 举例说明，用分布式同步的方式进行对象存储间的数据同步：
 

--- a/docs/zh_cn/reference/how_to_set_up_object_storage.md
+++ b/docs/zh_cn/reference/how_to_set_up_object_storage.md
@@ -1241,6 +1241,7 @@ juicefs format  \
 - `--bucket` 用来设置服务器的地址及存储路径，格式为 `[sftp://]<IP/Domain>:[port]:<Path>`。注意，目录名应该以 `/` 结尾，端口号为可选项默认为 `22`，例如 `192.168.1.11:22:myjfs/`。
 - `--access-key` 用来设置远程服务器的用户名
 - `--secret-key` 用来设置远程服务器的密码
+- JuiceFS 会使用 `~/.ssh/known_hosts` 验证 SFTP 服务器的主机密钥。如需使用其他 known-hosts 文件，可通过 `SSH_KNOWN_HOSTS` 设置符合当前平台格式的文件列表。未知主机或主机密钥已变化时连接会被拒绝；添加密钥前，请先通过可信渠道核对服务器指纹。
 
 ### CIFS/SMB {#cifs}
 

--- a/pkg/object/object_storage_test.go
+++ b/pkg/object/object_storage_test.go
@@ -19,6 +19,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
@@ -26,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -42,6 +44,8 @@ import (
 
 	"github.com/colinmarc/hdfs/v2/hadoopconf"
 	"github.com/juicedata/juicefs/pkg/utils"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 
 	blob2 "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 
@@ -979,6 +983,72 @@ func TestParseSftpEndpoint(t *testing.T) {
 					test.endpoint, host, port, root, test.wantHost, test.wantPort, test.wantRoot)
 			}
 		})
+	}
+}
+
+func TestSftpPathRejectsTraversal(t *testing.T) {
+	store := &sftpStore{root: "/safe/root/"}
+	for key, want := range map[string]string{
+		"":               "/safe/root/",
+		"file":           "/safe/root/file",
+		"nested/file":    "/safe/root/nested/file",
+		"nested/dir/":    "/safe/root/nested/dir/",
+		"repeated//file": "/safe/root/repeated/file",
+	} {
+		got, err := store.path(key)
+		if err != nil {
+			t.Fatalf("path(%q): %v", key, err)
+		}
+		if got != want {
+			t.Fatalf("path(%q) = %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range []string{"../outside", "dir/../outside", "./file", "dir/./file", "/absolute", "nul\x00byte"} {
+		if got, err := store.path(key); err == nil {
+			t.Fatalf("path(%q) accepted traversal as %q", key, got)
+		}
+	}
+}
+
+func TestSftpHostKeyVerificationFailsClosed(t *testing.T) {
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if _, err := sftpHostKeyCallback(); err == nil {
+		t.Fatal("missing known_hosts should fail closed")
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	knownHosts := filepath.Join(sshDir, "known_hosts")
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := knownhosts.Line([]string{"test.example"}, signer.PublicKey()) + "\n"
+	if err := os.WriteFile(knownHosts, []byte(line), 0600); err != nil {
+		t.Fatal(err)
+	}
+	callback, err := sftpHostKeyCallback()
+	if err != nil {
+		t.Fatalf("standard known_hosts should be accepted: %v", err)
+	}
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}
+	if err := callback("test.example:22", remote, signer.PublicKey()); err != nil {
+		t.Fatalf("known host key should be accepted: %v", err)
+	}
+	if err := callback("unknown.example:22", remote, signer.PublicKey()); err == nil {
+		t.Fatal("unknown host key should be rejected")
+	}
+	t.Setenv("SSH_KNOWN_HOSTS", knownHosts)
+	t.Setenv("HOME", "")
+	if _, err := sftpHostKeyCallback(); err != nil {
+		t.Fatalf("configured known_hosts should be accepted: %v", err)
 	}
 }
 

--- a/pkg/object/sftp.go
+++ b/pkg/object/sftp.go
@@ -156,25 +156,46 @@ func (f *sftpStore) String() string {
 }
 
 // always preserve suffix `/` for directory key
-func (f *sftpStore) path(key string) string {
-	return f.root + key
+func (f *sftpStore) path(key string) (string, error) {
+	if strings.ContainsRune(key, 0) || strings.HasPrefix(key, "/") {
+		return "", fmt.Errorf("object key %q escapes SFTP root %q", key, f.root)
+	}
+	for _, component := range strings.Split(key, "/") {
+		if component == "." || component == ".." {
+			return "", fmt.Errorf("object key %q escapes SFTP root %q", key, f.root)
+		}
+	}
+	root := path.Clean(f.root)
+	p := path.Join(root, key)
+	wantDirectory := strings.HasSuffix(key, dirSuffix) || key == "" && strings.HasSuffix(f.root, dirSuffix)
+	if wantDirectory && !strings.HasSuffix(p, dirSuffix) {
+		p += dirSuffix
+	}
+	if root != "/" && root != "." && p != root && !strings.HasPrefix(p, strings.TrimSuffix(root, dirSuffix)+dirSuffix) {
+		return "", fmt.Errorf("object key %q escapes SFTP root %q", key, f.root)
+	}
+	return p, nil
 }
 
 func (f *sftpStore) Head(ctx context.Context, key string) (Object, error) {
+	p, err := f.path(key)
+	if err != nil {
+		return nil, err
+	}
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return nil, err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
 
-	info, err := c.sftpClient.Lstat(f.path(key))
+	info, err := c.sftpClient.Lstat(p)
 	if err != nil {
 		return nil, err
 	}
 	var isSymlink bool
 	if info.Mode()&os.ModeSymlink != 0 {
 		isSymlink = true
-		info, err = c.sftpClient.Stat(f.path(key))
+		info, err = c.sftpClient.Stat(p)
 		if err != nil {
 			return nil, err
 		}
@@ -183,13 +204,16 @@ func (f *sftpStore) Head(ctx context.Context, key string) (Object, error) {
 }
 
 func (f *sftpStore) Get(ctx context.Context, key string, off, limit int64, getters ...AttrGetter) (io.ReadCloser, error) {
+	p, err := f.path(key)
+	if err != nil {
+		return nil, err
+	}
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return nil, err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
 
-	p := f.path(key)
 	ff, err := c.sftpClient.Open(p)
 	if err != nil {
 		return nil, err
@@ -213,13 +237,16 @@ func (f *sftpStore) Get(ctx context.Context, key string, off, limit int64, gette
 }
 
 func (f *sftpStore) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) (err error) {
+	p, err := f.path(key)
+	if err != nil {
+		return err
+	}
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
 
-	p := f.path(key)
 	if strings.HasSuffix(p, dirSuffix) {
 		return c.sftpClient.MkdirAll(p)
 	}
@@ -265,6 +292,10 @@ func (f *sftpStore) Put(ctx context.Context, key string, in io.Reader, getters .
 }
 
 func (f *sftpStore) Chtimes(key string, mtime time.Time) (err error) {
+	p, err := f.path(key)
+	if err != nil {
+		return err
+	}
 	var c *conn
 	c, err = f.getSftpConnection()
 	if err != nil {
@@ -273,20 +304,28 @@ func (f *sftpStore) Chtimes(key string, mtime time.Time) (err error) {
 	defer func() { f.putSftpConnection(c, err) }()
 	// fixme: 1. The Chtimes of sftp always follows link 2. Only pass the mtime field to avoid updating atime
 	// ref: https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-8.6
-	return c.sftpClient.Chtimes(f.path(key), mtime, mtime)
+	return c.sftpClient.Chtimes(p, mtime, mtime)
 }
 
 func (f *sftpStore) Chmod(key string, mode os.FileMode) (err error) {
+	p, err := f.path(key)
+	if err != nil {
+		return err
+	}
 	var c *conn
 	c, err = f.getSftpConnection()
 	if err != nil {
 		return err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
-	return c.sftpClient.Chmod(f.path(key), mode)
+	return c.sftpClient.Chmod(p, mode)
 }
 
 func (f *sftpStore) Chown(key string, owner, group string) (err error) {
+	p, err := f.path(key)
+	if err != nil {
+		return err
+	}
 	var c *conn
 	c, err = f.getSftpConnection()
 	if err != nil {
@@ -298,40 +337,51 @@ func (f *sftpStore) Chown(key string, owner, group string) (err error) {
 	if uid == -1 || gid == -1 {
 		return fmt.Errorf("user(%s):group(%s) not found", owner, group)
 	}
-	return c.sftpClient.Chown(f.path(key), uid, gid)
+	return c.sftpClient.Chown(p, uid, gid)
 }
 
 func (f *sftpStore) Symlink(oldName, newName string) error {
+	p, err := f.path(newName)
+	if err != nil {
+		return err
+	}
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
-	p := f.path(newName)
 	err = c.sftpClient.Symlink(oldName, p)
 	if err != nil && os.IsNotExist(err) {
-		_ = c.sftpClient.MkdirAll(filepath.Dir(p))
+		_ = c.sftpClient.MkdirAll(path.Dir(p))
 		err = c.sftpClient.Symlink(oldName, p)
 	}
 	return err
 }
 
 func (f *sftpStore) Readlink(name string) (link string, err error) {
+	p, err := f.path(name)
+	if err != nil {
+		return "", err
+	}
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return "", err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
-	return c.sftpClient.ReadLink(f.path(name))
+	return c.sftpClient.ReadLink(p)
 }
 
 func (f *sftpStore) Delete(ctx context.Context, key string, getters ...AttrGetter) error {
+	p, err := f.path(key)
+	if err != nil {
+		return err
+	}
 	c, err := f.getSftpConnection()
 	if err != nil {
 		return err
 	}
 	defer func() { f.putSftpConnection(c, err) }()
-	err = c.sftpClient.Remove(strings.TrimRight(f.path(key), dirSuffix))
+	err = c.sftpClient.Remove(strings.TrimRight(p, dirSuffix))
 	if err != nil && os.IsNotExist(err) {
 		err = nil
 	}
@@ -402,9 +452,12 @@ func (f *sftpStore) List(ctx context.Context, prefix, marker, token, delimiter s
 	defer func() { f.putSftpConnection(c, err) }()
 
 	var objs []Object
-	dir := f.path(prefix)
+	dir, err := f.path(prefix)
+	if err != nil {
+		return nil, false, "", err
+	}
 	if !strings.HasSuffix(dir, "/") {
-		dir = filepath.Dir(dir)
+		dir = path.Dir(dir)
 		if !strings.HasSuffix(dir, dirSuffix) {
 			dir += dirSuffix
 		}
@@ -451,6 +504,22 @@ func (f *sftpStore) List(ctx context.Context, prefix, marker, token, delimiter s
 		}
 	}
 	return generateListResult(objs, limit)
+}
+
+func sftpHostKeyCallback() (ssh.HostKeyCallback, error) {
+	if configured := os.Getenv("SSH_KNOWN_HOSTS"); configured != "" {
+		return knownhosts.New(filepath.SplitList(configured)...)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("SSH_KNOWN_HOSTS is not set and the user home directory is unavailable: %w", err)
+	}
+	knownHosts := filepath.Join(home, ".ssh", "known_hosts")
+	callback, err := knownhosts.New(knownHosts)
+	if err != nil {
+		return nil, fmt.Errorf("load SSH known hosts %q: %w", knownHosts, err)
+	}
+	return callback, nil
 }
 
 func sshInteractive(user, instruction string, questions []string, echos []bool) (answers []string, err error) {
@@ -608,15 +677,9 @@ func newSftp(endpoint, username, pass, token string) (ObjectStorage, error) {
 	if pass == "" {
 		auth = append(auth, ssh.KeyboardInteractive(sshInteractive))
 	}
-	var hostKeyCallback ssh.HostKeyCallback
-	if kn := os.Getenv("SSH_KNOWN_HOSTS"); kn != "" {
-		var err error
-		hostKeyCallback, err = knownhosts.New(kn)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		hostKeyCallback = ssh.InsecureIgnoreHostKey()
+	hostKeyCallback, err := sftpHostKeyCallback()
+	if err != nil {
+		return nil, err
 	}
 
 	config := &ssh.ClientConfig{

--- a/pkg/sync/cluster.go
+++ b/pkg/sync/cluster.go
@@ -19,10 +19,21 @@ package sync
 import (
 	"bufio"
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -60,6 +71,13 @@ type Stat struct {
 
 const maxClusterWorkerConfigSize = 16 << 20
 
+const (
+	managerTokenEnv        = "JFS_MANAGER_TOKEN"
+	managerCAEnv           = "JFS_MANAGER_CA"
+	maxClusterStatsSize    = 16 << 20
+	maxClusterResponseSize = 64 << 20
+)
+
 type clusterWorkerConfig struct {
 	Source      string            `json:"source"`
 	Destination string            `json:"destination"`
@@ -88,22 +106,64 @@ func updateStats(r *Stat) {
 	handled.IncrInt64(r.Copied + r.Deleted + r.Skipped + r.Failed)
 }
 
-func httpRequest(url string, body []byte) (ans []byte, err error) {
+var clusterHTTPClients sync.Map
+
+func getClusterHTTPClient(config *Config) (*http.Client, error) {
+	ca := config.Env[managerCAEnv]
+	if ca == "" {
+		return nil, errors.New("missing cluster manager CA")
+	}
+	if cached, ok := clusterHTTPClients.Load(ca); ok {
+		return cached.(*http.Client), nil
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(ca)) {
+		return nil, errors.New("invalid cluster manager CA")
+	}
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig:       &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS13},
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Minute,
+		IdleConnTimeout:       time.Minute,
+	}}
+	actual, _ := clusterHTTPClients.LoadOrStore(ca, client)
+	return actual.(*http.Client), nil
+}
+
+func httpRequest(config *Config, endpoint string, body []byte) (ans []byte, err error) {
 	method := "GET"
 	if body != nil {
 		method = "POST"
 	}
-	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	req, err := http.NewRequest(method, fmt.Sprintf("https://%s%s", config.Manager, endpoint), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
-	var resp *http.Response
-	resp, err = http.DefaultClient.Do(req)
+	token := config.Env[managerTokenEnv]
+	if token == "" {
+		return nil, errors.New("missing cluster manager token")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client, err := getClusterHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
+	ans, err = io.ReadAll(io.LimitReader(resp.Body, maxClusterResponseSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(ans) > maxClusterResponseSize {
+		return nil, errors.New("cluster manager response is too large")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cluster manager returned %s: %s", resp.Status, strings.TrimSpace(string(ans)))
+	}
+	return ans, nil
 }
 
 var sendStatMu sync.Mutex
@@ -175,7 +235,7 @@ func clearSentMultipartParts(workerUploads *workerMultipartUploads, uploads map[
 	}
 }
 
-func sendStats(addr string, multipartUploads *workerMultipartUploads) {
+func sendStats(config *Config, multipartUploads *workerMultipartUploads) {
 	sendStatMu.Lock()
 	defer sendStatMu.Unlock()
 	var r Stat
@@ -205,7 +265,7 @@ func sendStats(addr string, multipartUploads *workerMultipartUploads) {
 	}
 	r.MultipartUploads = getMultipartUploads(multipartUploads)
 	d, _ := json.Marshal(r)
-	ans, err := httpRequest(fmt.Sprintf("http://%s/stats", addr), d)
+	ans, err := httpRequest(config, "/stats", d)
 	if err != nil || string(ans) != "OK" {
 		srcDelayDelMu.Lock()
 		srcDelayDel = append(srcDelayDel, r.DelayDelDir...)
@@ -238,9 +298,117 @@ func sendStats(addr string, multipartUploads *workerMultipartUploads) {
 	}
 }
 
+func generateClusterCredentials(addr string) (string, string, tls.Certificate, error) {
+	tokenBytes := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, tokenBytes); err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	token := base64.RawURLEncoding.EncodeToString(tokenBytes)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "juicefs-sync-manager"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	host = strings.Trim(host, "[]")
+	if ip := net.ParseIP(host); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{host}
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return "", "", tls.Certificate{}, err
+	}
+	return token, string(certPEM), cert, nil
+}
+
+func authenticateClusterRequest(token string, next http.Handler) http.Handler {
+	want := []byte("Bearer " + token)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		got := []byte(req.Header.Get("Authorization"))
+		if len(got) != len(want) || subtle.ConstantTimeCompare(got, want) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, req)
+	})
+}
+
+func validateClusterStat(config *Config, r *Stat, issued map[string]struct{}) error {
+	counters := []int64{r.Copied, r.CopiedBytes, r.Checked, r.CheckedBytes, r.Deleted, r.Skipped, r.SkippedBytes, r.Failed}
+	for _, value := range counters {
+		if value < 0 {
+			return errors.New("negative cluster statistic")
+		}
+	}
+	handledCounters := []int64{r.Copied, r.Deleted, r.Skipped, r.Failed}
+	var handledTotal int64
+	for _, value := range handledCounters {
+		if value > math.MaxInt64-handledTotal {
+			return errors.New("cluster statistic overflow")
+		}
+		handledTotal += value
+	}
+	if len(r.DelayDelDir) > 0 && !config.DeleteSrc && !config.DeleteSrcAfter {
+		return errors.New("source deletion was not enabled")
+	}
+	check := func(key string) error {
+		if _, ok := issued[key]; !ok {
+			return fmt.Errorf("key %q was not issued to a worker", key)
+		}
+		return nil
+	}
+	for _, keys := range [][]string{r.DelayDelDir, r.CompletedKeys, r.FailedKeys} {
+		for _, key := range keys {
+			if err := check(key); err != nil {
+				return err
+			}
+		}
+	}
+	for key := range r.MultipartUploads {
+		if err := check(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *CheckpointManager) (string, error) {
 	mux := http.NewServeMux()
+	var issuedMu sync.Mutex
+	issued := make(map[string]struct{})
 	mux.HandleFunc("/fetch", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			http.Error(w, "GET required", http.StatusMethodNotAllowed)
+			return
+		}
 		var objs []object.Object
 		var total int64
 		obj, ok := <-tasks
@@ -274,6 +442,11 @@ func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *Che
 				}
 			}
 		}
+		issuedMu.Lock()
+		for _, o := range objs {
+			issued[o.Key()] = struct{}{}
+		}
+		issuedMu.Unlock()
 		d, err := marshalObjects(objs)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -287,13 +460,25 @@ func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *Che
 			http.Error(w, "POST required", http.StatusBadRequest)
 			return
 		}
+		if req.ContentLength > maxClusterStatsSize {
+			http.Error(w, "request body is too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		req.Body = http.MaxBytesReader(w, req.Body, maxClusterStatsSize)
 		d, err := io.ReadAll(req.Body)
 		if err != nil {
-			logger.Errorf("read: %s", err)
+			http.Error(w, "request body is too large", http.StatusRequestEntityTooLarge)
 			return
 		}
 		var r Stat
 		err = json.Unmarshal(d, &r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		issuedMu.Lock()
+		err = validateClusterStat(config, &r, issued)
+		issuedMu.Unlock()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -347,8 +532,26 @@ func startManager(config *Config, tasks <-chan object.Object, checkpointMgr *Che
 	if err != nil {
 		return "", fmt.Errorf("listen: %s", err)
 	}
+	token, ca, cert, err := generateClusterCredentials(l.Addr().String())
+	if err != nil {
+		_ = l.Close()
+		return "", fmt.Errorf("generate cluster credentials: %s", err)
+	}
+	if config.Env == nil {
+		config.Env = make(map[string]string)
+	}
+	config.Env[managerTokenEnv] = token
+	config.Env[managerCAEnv] = ca
 	logger.Infof("Listen at %s", l.Addr())
-	go func() { _ = http.Serve(l, mux) }()
+	server := &http.Server{
+		Handler:           authenticateClusterRequest(token, mux),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       time.Minute,
+		MaxHeaderBytes:    16 << 10,
+	}
+	tlsListener := tls.NewListener(l, &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS13})
+	go func() { _ = server.Serve(tlsListener) }()
 	return l.Addr().String(), nil
 }
 
@@ -439,12 +642,12 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 				return
 			}
 			rpath := filepath.Join("/tmp", filepath.Base(path))
-			cmd := exec.Command("rsync", "-a", "-e", "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no", path, host+":"+rpath)
+			cmd := exec.Command("rsync", "-a", "-e", "ssh -o StrictHostKeyChecking=yes -o PasswordAuthentication=no", path, host+":"+rpath)
 			output, err := cmd.CombinedOutput()
 			logger.Debugf("exec: %q,err: %s", cmd.String(), string(output))
 			if err != nil {
 				// fallback to scp
-				cmd = exec.Command("scp", "-o", "StrictHostKeyChecking=no", "-o", "PasswordAuthentication=no", path, host+":"+rpath)
+				cmd = exec.Command("scp", "-o", "StrictHostKeyChecking=yes", "-o", "PasswordAuthentication=no", path, host+":"+rpath)
 				output, err = cmd.CombinedOutput()
 				logger.Debugf("exec: %q,err: %s", cmd.String(), string(output))
 			}
@@ -460,7 +663,7 @@ func launchWorker(address string, config *Config, wg *sync.WaitGroup) {
 			}
 			defer clear(payload)
 			logger.Debugf("launch worker command args: [ssh, %q]", strings.Join(args, ", "))
-			cmd = exec.Command("ssh", args...)
+			cmd = exec.Command("ssh", append([]string{"-o", "StrictHostKeyChecking=yes"}, args...)...)
 			cmd.Stdin = bytes.NewReader(payload)
 			stderr, err := cmd.StderrPipe()
 			if err != nil {
@@ -561,8 +764,7 @@ func unmarshalObjects(d []byte) ([]object.Object, error) {
 
 func fetchJobs(tasks chan<- object.Object, config *Config, uploads multipartUploads) {
 	for {
-		url := fmt.Sprintf("http://%s/fetch", config.Manager)
-		ans, err := httpRequest(url, nil)
+		ans, err := httpRequest(config, "/fetch", nil)
 		if err != nil {
 			logger.Errorf("fetch jobs: %s", err)
 			time.Sleep(time.Second)

--- a/pkg/sync/cluster_test.go
+++ b/pkg/sync/cluster_test.go
@@ -17,7 +17,9 @@ package sync
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -52,6 +54,10 @@ type file struct {
 	obj
 }
 
+type endlessReader struct{}
+
+func (endlessReader) Read(p []byte) (int, error) { return len(p), nil }
+
 func (o *file) Owner() string     { return "" }
 func (o *file) Group() string     { return "" }
 func (o *file) Mode() os.FileMode { return 0 }
@@ -71,21 +77,37 @@ func TestCluster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp, err := http.Get("http://" + addr + "/debug/pprof/cmdline"); err != nil {
+	conf.Manager = addr
+	client, err := getClusterHTTPClient(&conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp, err := client.Get("https://" + addr + "/debug/pprof/cmdline"); err != nil {
 		t.Fatalf("get pprof: %s", err)
 	} else {
 		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("manager exposed /debug/pprof: status %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("manager accepted unauthenticated request: status %d", resp.StatusCode)
 		}
 		if strings.Contains(string(body), os.Args[0]) {
 			t.Fatalf("manager leaked process command line via /debug/pprof/cmdline")
 		}
 	}
-	// sendStats(addr)
+	req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/debug/pprof/cmdline", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+conf.Env[managerTokenEnv])
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("manager exposed authenticated pprof route: status %d", resp.StatusCode)
+	}
 	// worker
-	conf.Manager = addr
 	mytodo := make(chan object.Object, 100)
 	go fetchJobs(mytodo, &conf, nil)
 
@@ -98,6 +120,87 @@ func TestCluster(t *testing.T) {
 	}
 	if _, ok := <-mytodo; ok {
 		t.Fatalf("should end")
+	}
+}
+
+func TestClusterStatsRejectUnauthorizedState(t *testing.T) {
+	srcDelayDelMu.Lock()
+	savedDelayDel := srcDelayDel
+	srcDelayDel = nil
+	srcDelayDelMu.Unlock()
+	t.Cleanup(func() {
+		srcDelayDelMu.Lock()
+		srcDelayDel = savedDelayDel
+		srcDelayDelMu.Unlock()
+	})
+
+	tasks := make(chan object.Object, 1)
+	config := &Config{Workers: []string{"127.0.0.1"}}
+	addr, err := startManager(config, tasks, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Manager = addr
+	tasks <- &obj{key: "issued", isDir: true}
+	close(tasks)
+	if _, err := httpRequest(config, "/fetch", nil); err != nil {
+		t.Fatal(err)
+	}
+	client, err := getClusterHTTPClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthenticated, err := http.NewRequest(http.MethodPost, "https://"+addr+"/stats", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(unauthenticated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated stats returned %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	oversizedBody := io.LimitReader(endlessReader{}, maxClusterStatsSize+1)
+	oversized, err := http.NewRequest(http.MethodPost, "https://"+addr+"/stats", oversizedBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversized.ContentLength = maxClusterStatsSize + 1
+	oversized.Header.Set("Authorization", "Bearer "+config.Env[managerTokenEnv])
+	oversized.Header.Set("Expect", "100-continue")
+	resp, err = client.Do(oversized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized stats returned %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+	if err := validateClusterStat(&Config{DeleteSrc: true}, &Stat{DelayDelDir: []string{"issued"}}, map[string]struct{}{"issued": {}}); err != nil {
+		t.Fatalf("valid stats were rejected: %v", err)
+	}
+
+	for _, stat := range []Stat{
+		{DelayDelDir: []string{"issued"}},
+		{CompletedKeys: []string{"not-issued"}},
+		{Copied: -1},
+		{Copied: math.MaxInt64, Deleted: 1},
+	} {
+		body, err := json.Marshal(stat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = httpRequest(config, "/stats", body); err == nil {
+			t.Fatalf("manager accepted invalid stats: %+v", stat)
+		}
+	}
+
+	srcDelayDelMu.Lock()
+	defer srcDelayDelMu.Unlock()
+	if len(srcDelayDel) != 0 {
+		t.Fatalf("invalid stats scheduled source deletion: %v", srcDelayDel)
 	}
 }
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -2317,9 +2317,9 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 				}
 			}
 		} else {
-			sendStats(config.Manager, workerUploads)
+			sendStats(config, workerUploads)
 			for len(srcDelayDel) > 0 {
-				sendStats(config.Manager, workerUploads)
+				sendStats(config, workerUploads)
 			}
 			logger.Infof("This worker process has already completed its tasks")
 		}
@@ -2399,7 +2399,7 @@ func Sync(src, dst object.ObjectStorage, config *Config) error {
 		go fetchJobs(tasks, config, uploads)
 		go func() {
 			for {
-				sendStats(config.Manager, workerUploads)
+				sendStats(config, workerUploads)
 				time.Sleep(time.Second)
 			}
 		}()


### PR DESCRIPTION
## Summary
- protect the distributed sync manager with per-run TLS 1.3 certificate pinning and bearer authentication
- bound and validate worker HTTP state, keep pprof unreachable, and enforce SSH host verification
- make SFTP host verification fail closed and reject traversal keys

## Verification
- go test ./pkg/sync ./pkg/object
- go vet ./pkg/sync ./pkg/object
- command and documentation compatibility reviewed