### PR TITLE
security: harden local object and ciphertext boundaries

### DIFF
--- a/pkg/object/encrypt.go
+++ b/pkg/object/encrypt.go
@@ -277,6 +277,9 @@ func (e *dataEncryptor) Decrypt(ciphertext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(nonce) != aead.NonceSize() {
+		return nil, fmt.Errorf("malformed ciphertext: nonce length %d, expected %d", len(nonce), aead.NonceSize())
+	}
 	return aead.Open(ciphertext[:0], nonce, ciphertext, nil)
 }
 

--- a/pkg/object/encrypt_test.go
+++ b/pkg/object/encrypt_test.go
@@ -268,6 +268,29 @@ func TestDataEncryptor(t *testing.T) {
 	}
 }
 
+func TestDataEncryptorRejectsInvalidNonceLength(t *testing.T) {
+	cases := []struct {
+		name string
+		kek  string
+		algo string
+	}{
+		{"rsa_aesgcm", "rsa", AES256GCM_RSA},
+		{"rsa_chacha20", "rsa", CHACHA20_RSA},
+		{"sm2_sm4gcm", "sm2", SM4GCM},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			de, err := NewDataEncryptor(NewKeyEncryptor(genPrivateKey(c.kek)), c.algo)
+			require.NoError(t, err)
+			ciphertext, err := de.Encrypt([]byte("hello"))
+			require.NoError(t, err)
+			ciphertext[2] = 0
+			_, err = de.Decrypt(ciphertext)
+			require.ErrorContains(t, err, "nonce length")
+		})
+	}
+}
+
 func TestEncryptorMaxOverhead(t *testing.T) {
 	rsa1024Key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)

--- a/pkg/object/file.go
+++ b/pkg/object/file.go
@@ -28,6 +28,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/juicedata/juicefs/pkg/utils"
 )
@@ -45,26 +46,24 @@ type filestore struct {
 }
 
 func (d *filestore) Symlink(oldName, newName string) error {
-	p, err := d.path(newName)
+	root, name, err := d.rootedPath(newName, true)
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(filepath.Dir(p)); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(p), os.FileMode(0777)); err != nil {
-			return err
-		}
-	} else if err != nil && !os.IsNotExist(err) {
+	defer root.Close()
+	if err := root.MkdirAll(filepath.Dir(name), os.FileMode(0777)); err != nil {
 		return err
 	}
-	return os.Symlink(oldName, p)
+	return root.Symlink(oldName, name)
 }
 
 func (d *filestore) Readlink(name string) (string, error) {
-	p, err := d.path(name)
+	root, name, err := d.rootedPath(name, false)
 	if err != nil {
 		return "", err
 	}
-	return os.Readlink(p)
+	defer root.Close()
+	return root.Readlink(name)
 }
 
 func (d *filestore) String() string {
@@ -95,18 +94,76 @@ func (d *filestore) path(key string) (string, error) {
 	return p, nil
 }
 
-func (d *filestore) Head(ctx context.Context, key string) (Object, error) {
+func (d *filestore) rootedPath(key string, create bool) (*os.Root, string, error) {
 	p, err := d.path(key)
+	if err != nil {
+		return nil, "", err
+	}
+	boundary := d.root
+	if !strings.HasSuffix(boundary, dirSuffix) {
+		boundary = filepath.Dir(boundary)
+	}
+	if create {
+		if err := os.MkdirAll(boundary, os.FileMode(0777)); err != nil {
+			return nil, "", err
+		}
+	}
+	root, err := os.OpenRoot(boundary)
+	if err != nil {
+		return nil, "", err
+	}
+	name, err := filepath.Rel(boundary, p)
+	if err != nil {
+		_ = root.Close()
+		return nil, "", err
+	}
+	return root, name, nil
+}
+
+func openRootFileFollowingFinal(root *os.Root, name string) (*os.File, error) {
+	parent, base, err := openRootParent(root, name)
 	if err != nil {
 		return nil, err
 	}
-	fi, err := os.Lstat(p)
+	defer parent.Close()
+	return openFileAt(parent, base)
+}
+
+func openRootParent(root *os.Root, name string) (*os.File, string, error) {
+	parent, err := root.Open(filepath.Dir(name))
+	if err != nil {
+		return nil, "", err
+	}
+	fi, err := parent.Stat()
+	if err != nil {
+		_ = parent.Close()
+		return nil, "", err
+	}
+	if !fi.IsDir() {
+		_ = parent.Close()
+		return nil, "", &os.PathError{Op: "open", Path: filepath.Dir(name), Err: syscall.ENOTDIR}
+	}
+	return parent, filepath.Base(name), nil
+}
+
+func (d *filestore) Head(ctx context.Context, key string) (Object, error) {
+	root, name, err := d.rootedPath(key, false)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	fi, err := root.Lstat(name)
 	if err != nil {
 		return nil, err
 	}
 	isSymlink := fi.Mode()&os.ModeSymlink != 0
 	if isSymlink {
-		fi, err = os.Stat(p)
+		f, err := openRootFileFollowingFinal(root, name)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		fi, err = f.Stat()
 		if err != nil {
 			return nil, err
 		}
@@ -142,12 +199,12 @@ type SectionReaderCloser struct {
 }
 
 func (d *filestore) Get(ctx context.Context, key string, off, limit int64, getters ...AttrGetter) (io.ReadCloser, error) {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, false)
 	if err != nil {
 		return nil, err
 	}
-
-	f, err := os.Open(p)
+	f, err := openRootFileFollowingFinal(root, name)
+	_ = root.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -172,38 +229,39 @@ func (d *filestore) Get(ctx context.Context, key string, off, limit int64, gette
 }
 
 func (d *filestore) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) (err error) {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, true)
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 
 	if strings.HasSuffix(key, dirSuffix) || key == "" && strings.HasSuffix(d.root, dirSuffix) {
-		return os.MkdirAll(p, os.FileMode(0777))
+		return root.MkdirAll(name, os.FileMode(0777))
 	}
 
 	var tmp string
 	if PutInplace {
-		tmp = p
+		tmp = name
 	} else {
-		name := filepath.Base(p)
-		if len(name) > 200 {
-			name = name[:200]
+		base := filepath.Base(name)
+		if len(base) > 200 {
+			base = base[:200]
 		}
-		tmp = TmpFilePath(p, name)
+		tmp = TmpFilePath(name, base)
 		defer func() {
 			if err != nil {
-				if e := os.Remove(tmp); e != nil && !os.IsNotExist(e) {
+				if e := root.Remove(tmp); e != nil && !os.IsNotExist(e) {
 					logger.Warnf("delete %s: %s", tmp, e)
 				}
 			}
 		}()
 	}
-	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	f, err := root.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
 	if err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(p), os.FileMode(0777)); err != nil {
+		if err := root.MkdirAll(filepath.Dir(name), os.FileMode(0777)); err != nil {
 			return err
 		}
-		f, err = os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+		f, err = root.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
 	}
 	if err != nil {
 		return err
@@ -225,7 +283,7 @@ func (d *filestore) Put(ctx context.Context, key string, in io.Reader, getters .
 		return err
 	}
 	if !PutInplace {
-		err = os.Rename(tmp, p)
+		err = root.Rename(tmp, name)
 	}
 	return err
 }
@@ -240,11 +298,12 @@ func (d *filestore) Copy(ctx context.Context, dst, src string) error {
 }
 
 func (d *filestore) Delete(ctx context.Context, key string, getters ...AttrGetter) error {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, false)
 	if err != nil {
 		return err
 	}
-	err = os.Remove(p)
+	defer root.Close()
+	err = root.Remove(name)
 	if err != nil && os.IsNotExist(err) {
 		err = nil
 	}
@@ -278,8 +337,8 @@ func (m *mEntry) IsDir() bool {
 
 // readDirSorted reads the directory named by dir and returns
 // a sorted list of directory entries.
-func readDirSorted(dir string, followLink bool) ([]*mEntry, error) {
-	f, err := os.Open(dir)
+func readDirSorted(root *os.Root, dir string, followLink bool) ([]*mEntry, error) {
+	f, err := openRootFileFollowingFinal(root, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +354,13 @@ func readDirSorted(dir string, followLink bool) ([]*mEntry, error) {
 		if e.IsDir() {
 			mEntries = append(mEntries, &mEntry{e, e.Name() + dirSuffix, nil, false})
 		} else if isSymlink && followLink {
-			fi, err := os.Stat(filepath.Join(dir, e.Name()))
+			target, err := openFileAt(f, e.Name())
+			if err != nil {
+				mEntries = append(mEntries, &mEntry{e, e.Name(), nil, true})
+				continue
+			}
+			fi, err := target.Stat()
+			_ = target.Close()
 			if err != nil {
 				mEntries = append(mEntries, &mEntry{e, e.Name(), nil, true})
 				continue
@@ -324,12 +389,21 @@ func (d *filestore) List(ctx context.Context, prefix, marker, token, delimiter s
 	if delimiter != "/" {
 		return nil, false, "", notSupported
 	}
-	if _, err := d.path(prefix); err != nil {
+	prefixPath, err := d.path(prefix)
+	if err != nil {
 		return nil, false, "", err
 	}
-	var dir string = d.root + prefix
+	root, _, err := d.rootedPath(prefix, false)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, "", nil
+		}
+		return nil, false, "", err
+	}
+	defer root.Close()
+	var dir string = prefixPath
 	var objs []Object
-	if !strings.HasSuffix(dir, dirSuffix) {
+	if !strings.HasSuffix(d.root+prefix, dirSuffix) {
 		dir = path.Dir(dir)
 		if !strings.HasSuffix(dir, dirSuffix) {
 			dir += dirSuffix
@@ -344,7 +418,15 @@ func (d *filestore) List(ctx context.Context, prefix, marker, token, delimiter s
 		}
 		objs = append(objs, obj)
 	}
-	entries, err := readDirSorted(dir, followLink)
+	boundary := d.root
+	if !strings.HasSuffix(boundary, dirSuffix) {
+		boundary = filepath.Dir(boundary)
+	}
+	rootedDir, err := filepath.Rel(boundary, dir)
+	if err != nil {
+		return nil, false, "", err
+	}
+	entries, err := readDirSorted(root, rootedDir, followLink)
 	if err != nil {
 		if os.IsPermission(err) {
 			logger.Warnf("skip %s: %s", dir, err)
@@ -379,24 +461,31 @@ func (d *filestore) List(ctx context.Context, prefix, marker, token, delimiter s
 }
 
 func (d *filestore) Chmod(key string, mode os.FileMode) error {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, false)
 	if err != nil {
 		return err
 	}
-	return os.Chmod(p, mode)
+	defer root.Close()
+	parent, base, err := openRootParent(root, name)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	return chmodAt(parent, base, mode)
 }
 
 func (d *filestore) Chown(key string, owner, group string) error {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, false)
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 	uid := utils.LookupUser(owner)
 	gid := utils.LookupGroup(group)
 	if uid == -1 || gid == -1 {
 		return fmt.Errorf("user(%s):group(%s) not found", owner, group)
 	}
-	return os.Lchown(p, uid, gid)
+	return root.Lchown(name, uid, gid)
 }
 
 func newDisk(root, accesskey, secretkey, token string) (ObjectStorage, error) {

--- a/pkg/object/file_darwin.go
+++ b/pkg/object/file_darwin.go
@@ -34,6 +34,10 @@ func getAtime(fi os.FileInfo) time.Time {
 }
 
 func lchtimes(name string, atime time.Time, mtime time.Time) error {
+	return lchtimesat(unix.AT_FDCWD, name, atime, mtime)
+}
+
+func lchtimesat(dirfd int, name string, atime time.Time, mtime time.Time) error {
 	var ts = make([]unix.Timespec, 2)
 	///Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include//sys/stat.h
 	// define UTIME_NOW       -1
@@ -41,7 +45,7 @@ func lchtimes(name string, atime time.Time, mtime time.Time) error {
 	// only change mtime
 	ts[0] = unix.Timespec{Sec: -2, Nsec: -2}
 	ts[1] = unix.NsecToTimespec(mtime.UnixNano())
-	if e := unix.UtimesNanoAt(unix.AT_FDCWD, name, ts, unix.AT_SYMLINK_NOFOLLOW); e != nil {
+	if e := unix.UtimesNanoAt(dirfd, name, ts, unix.AT_SYMLINK_NOFOLLOW); e != nil {
 		return &os.PathError{Op: "lchtimes", Path: name, Err: e}
 	}
 	return nil

--- a/pkg/object/file_linux.go
+++ b/pkg/object/file_linux.go
@@ -33,12 +33,16 @@ func getAtime(fi os.FileInfo) time.Time {
 }
 
 func lchtimes(name string, atime time.Time, mtime time.Time) error {
+	return lchtimesat(unix.AT_FDCWD, name, atime, mtime)
+}
+
+func lchtimesat(dirfd int, name string, atime time.Time, mtime time.Time) error {
 	var ts = make([]unix.Timespec, 2)
 	// only change mtime
 	ts[0] = unix.Timespec{Sec: unix.UTIME_OMIT, Nsec: unix.UTIME_OMIT}
 	ts[1] = unix.NsecToTimespec(mtime.UnixNano())
 
-	if e := unix.UtimesNanoAt(unix.AT_FDCWD, name, ts, unix.AT_SYMLINK_NOFOLLOW); e != nil {
+	if e := unix.UtimesNanoAt(dirfd, name, ts, unix.AT_SYMLINK_NOFOLLOW); e != nil {
 		return &os.PathError{Op: "lchtimes", Path: name, Err: e}
 	}
 	return nil

--- a/pkg/object/file_test.go
+++ b/pkg/object/file_test.go
@@ -71,3 +71,41 @@ func TestFilestoreRejectsKeyPathTraversal(t *testing.T) {
 		t.Fatal("expected Chtimes to reject a key escaping the storage root")
 	}
 }
+
+func TestFilestoreRejectsSymlinkAncestorEscape(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "dest") + "/"
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	store, err := newDisk(root, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(context.Background(), "link/pwned.txt", strings.NewReader("PWNED")); err == nil {
+		t.Fatal("expected Put to reject a symlink ancestor escaping the storage root")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "pwned.txt")); !os.IsNotExist(err) {
+		t.Fatalf("escaped file should not exist, got %v", err)
+	}
+	if err := store.Put(context.Background(), "nested/ok.txt", strings.NewReader("OK")); err != nil {
+		t.Fatalf("legitimate nested Put failed: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(root, "nested", "ok.txt")); err != nil || string(data) != "OK" {
+		t.Fatalf("legitimate nested Put produced %q, %v", data, err)
+	}
+	links := store.(SupportSymlink)
+	if err := links.Symlink(outside, "external-link"); err != nil {
+		t.Fatalf("creating a symlink object should remain supported: %v", err)
+	}
+	if target, err := links.Readlink("external-link"); err != nil || target != outside {
+		t.Fatalf("readlink returned %q, %v", target, err)
+	}
+}

--- a/pkg/object/file_unix.go
+++ b/pkg/object/file_unix.go
@@ -26,7 +26,23 @@ import (
 
 	"github.com/juicedata/juicefs/pkg/utils"
 	"github.com/pkg/sftp"
+	"golang.org/x/sys/unix"
 )
+
+func openFileAt(parent *os.File, name string) (*os.File, error) {
+	fd, err := unix.Openat(int(parent.Fd()), name, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "openat", Path: name, Err: err}
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+func chmodAt(parent *os.File, name string, mode os.FileMode) error {
+	if err := unix.Fchmodat(int(parent.Fd()), name, uint32(mode.Perm()), 0); err != nil {
+		return &os.PathError{Op: "chmodat", Path: name, Err: err}
+	}
+	return nil
+}
 
 func getOwnerGroup(info os.FileInfo) (string, string) {
 	var owner, group string
@@ -42,9 +58,15 @@ func getOwnerGroup(info os.FileInfo) (string, string) {
 }
 
 func (d *filestore) Chtimes(key string, mtime time.Time) error {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, false)
 	if err != nil {
 		return err
 	}
-	return lchtimes(p, time.Time{}, mtime)
+	defer root.Close()
+	parent, base, err := openRootParent(root, name)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	return lchtimesat(int(parent.Fd()), base, time.Time{}, mtime)
 }

--- a/pkg/object/file_windows.go
+++ b/pkg/object/file_windows.go
@@ -18,8 +18,17 @@ package object
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 )
+
+func openFileAt(parent *os.File, name string) (*os.File, error) {
+	return os.Open(filepath.Join(parent.Name(), name))
+}
+
+func chmodAt(parent *os.File, name string, mode os.FileMode) error {
+	return os.Chmod(filepath.Join(parent.Name(), name), mode)
+}
 
 func getOwnerGroup(info os.FileInfo) (string, string) {
 	return "", ""
@@ -34,9 +43,10 @@ func lookupGroup(name string) int {
 }
 
 func (d *filestore) Chtimes(key string, mtime time.Time) error {
-	p, err := d.path(key)
+	root, name, err := d.rootedPath(key, false)
 	if err != nil {
 		return err
 	}
-	return os.Chtimes(p, time.Time{}, mtime)
+	defer root.Close()
+	return root.Chtimes(name, time.Time{}, mtime)
 }


### PR DESCRIPTION
## Summary
- anchor local object operations to an os.Root boundary so symlink ancestors cannot redirect writes outside storage
- preserve legitimate final-symlink and permission semantics with descriptor-relative operations
- reject malformed AEAD nonce lengths without panicking

## Verification
- go test ./pkg/object
- go test ./pkg/sync
- go vet ./pkg/object ./pkg/sync