### PR TITLE
security: fail closed on service authentication

### DIFF
--- a/cmd/webdav.go
+++ b/cmd/webdav.go
@@ -96,8 +96,7 @@ func webdav(c *cli.Context) error {
 	setup(c, 2)
 	metaUrl := c.Args().Get(0)
 	listenAddr := c.Args().Get(1)
-	_, jfs := initForSvc(c, c.String("mountpoint"), "webdav", metaUrl, listenAddr)
-	fs.StartHTTPServer(jfs, fs.WebdavConfig{
+	config := fs.WebdavConfig{
 		Addr:            listenAddr,
 		DisallowList:    c.Bool("disallowList"),
 		EnableGzip:      c.Bool("gzip"),
@@ -107,6 +106,11 @@ func webdav(c *cli.Context) error {
 		KeyFile:         c.String("key-file"),
 		EnableProppatch: c.Bool("enable-proppatch"),
 		MaxDeletes:      c.Int("threads"),
-	})
+	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
+	_, jfs := initForSvc(c, c.String("mountpoint"), "webdav", metaUrl, listenAddr)
+	fs.StartHTTPServer(jfs, config)
 	return jfs.Meta().CloseSession()
 }

--- a/docs/en/deployment/webdav.md
+++ b/docs/en/deployment/webdav.md
@@ -47,9 +47,13 @@ export WEBDAV_PASSWORD=mypassword
 sudo juicefs webdav sqlite3://myjfs.db 192.168.1.8:80
 ```
 
+Set both variables together. Setting only one is rejected at startup; leave both empty only when intentionally running an anonymous server.
+
 ## Enable HTTPS support
 
 JuiceFS supports configuring WebDAV server protected by the HTTPS protocol, specifying certificates and private keys through `--cert-file` and `--key-file` options, either using a certificate issued by a trusted digital certificate authority CA or using OpenSSL to create self-signed certificate.
+
+`--cert-file` and `--key-file` must be specified together. An incomplete TLS configuration is rejected at startup.
 
 ### Self-signed certificate
 

--- a/docs/en/reference/command_reference.mdx
+++ b/docs/en/reference/command_reference.mdx
@@ -71,6 +71,8 @@ COPYRIGHT:
    Apache License 2.0
 ```
 
+Commands that use a mounted file system's internal `.control` interface—such as `info`, `summary`, `warmup`, `rmr`, `clone`, and `compact`—must be run as the mount process owner or root.
+
 ## Auto completion {#auto-completion}
 
 To enable commands completion, simply source the script provided within [`hack/autocomplete`](https://github.com/juicedata/juicefs/tree/main/hack/autocomplete) directory. For example:

--- a/docs/zh_cn/deployment/webdav.md
+++ b/docs/zh_cn/deployment/webdav.md
@@ -25,6 +25,8 @@ juicefs webdav META-URL LISTENING-ADDRESS:PORT
 sudo juicefs webdav sqlite3://myjfs.db 192.168.1.8:80
 ```
 
+这两个环境变量必须同时设置。只设置其中一个时服务会拒绝启动；仅在明确需要匿名服务时才应同时留空。
+
 WebDAV 服务需要通过设定的监听地址和端口进行访问，如上例中使用了内网的 IP 地址 `192.168.1.8`，以及标准的 Web 端口号 `80`，访问时无需指定端口，直接访问 `http://192.168.1.8` 即可。
 
 如果使用了其他端口号，则需要在地址中明确指定，例如，监听 `9007` 端口，访问地址则应该用 `http://192.168.1.8:9007`。
@@ -50,6 +52,8 @@ sudo juicefs webdav sqlite3://myjfs.db 192.168.1.8:80
 ## 启用 HTTPS 支持
 
 JuiceFS 支持配置通过 HTTPS 协议保护的 WebDAV 服务，通过 `--cert-file` 和 `--key-file` 选项指定证书和私钥，既可以使用受信任的数字证书颁发机构 CA 签发的证书，也可以使用 OpenSSL 创建自签名证书。
+
+`--cert-file` 和 `--key-file` 必须同时指定，TLS 配置不完整时服务会拒绝启动。
 
 ### 自签名证书
 

--- a/docs/zh_cn/reference/command_reference.mdx
+++ b/docs/zh_cn/reference/command_reference.mdx
@@ -71,6 +71,8 @@ COPYRIGHT:
    Apache License 2.0
 ```
 
+通过已挂载文件系统的内部 `.control` 接口工作的命令（例如 `info`、`summary`、`warmup`、`rmr`、`clone` 和 `compact`）必须由挂载进程的所有者或 root 执行。
+
 ## 自动补全 {#auto-completion}
 
 通过加载 [`hack/autocomplete`](https://github.com/juicedata/juicefs/tree/main/hack/autocomplete) 目录下的对应脚本可以启用命令的自动补全，例如：

--- a/pkg/fs/http.go
+++ b/pkg/fs/http.go
@@ -258,6 +258,16 @@ type WebdavConfig struct {
 	MaxDeletes      int
 }
 
+func (c WebdavConfig) Validate() error {
+	if (c.Username == "") != (c.Password == "") {
+		return errors.New("WebDAV username and password must be configured together")
+	}
+	if (c.CertFile == "") != (c.KeyFile == "") {
+		return errors.New("WebDAV certificate and key must be configured together")
+	}
+	return nil
+}
+
 type indexHandler struct {
 	*webdav.Handler
 	WebdavConfig
@@ -362,6 +372,9 @@ func newWebdavHandler(fs *FileSystem, config WebdavConfig) http.Handler {
 }
 
 func StartHTTPServer(fs *FileSystem, config WebdavConfig) {
+	if err := config.Validate(); err != nil {
+		logger.Fatalf("Invalid WebDAV configuration: %v", err)
+	}
 	handler := newWebdavHandler(fs, config)
 	logger.Infof("WebDAV listening on %s", config.Addr)
 	var err error

--- a/pkg/fs/http_test.go
+++ b/pkg/fs/http_test.go
@@ -119,3 +119,27 @@ func TestWebdavNoPprofExposure(t *testing.T) {
 		}
 	}
 }
+
+func TestWebdavConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  WebdavConfig
+		wantErr bool
+	}{
+		{name: "anonymous plaintext", config: WebdavConfig{}},
+		{name: "authenticated", config: WebdavConfig{Username: "user", Password: "pass"}},
+		{name: "authenticated TLS", config: WebdavConfig{Username: "user", Password: "pass", CertFile: "cert.pem", KeyFile: "key.pem"}},
+		{name: "username only", config: WebdavConfig{Username: "user"}, wantErr: true},
+		{name: "password only", config: WebdavConfig{Password: "pass"}, wantErr: true},
+		{name: "certificate only", config: WebdavConfig{CertFile: "cert.pem"}, wantErr: true},
+		{name: "key only", config: WebdavConfig{KeyFile: "key.pem"}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.config.Validate()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/vfs/internal.go
+++ b/pkg/vfs/internal.go
@@ -77,7 +77,7 @@ type internalNode struct {
 }
 
 var internalNodes = []*internalNode{
-	{controlInode, ".control", &Attr{Mode: 0666}},
+	{controlInode, ".control", &Attr{Mode: 0600}},
 	{logInode, ".accesslog", &Attr{Mode: 0400}},
 	{StatsInode, ".stats", &Attr{Mode: 0444}},
 	{ConfigInode, ".config", &Attr{Mode: 0400}},

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -560,12 +560,16 @@ func (v *VFS) Open(ctx Context, ino Ino, flags uint32) (entry *meta.Entry, fh ui
 			err = syscall.EACCES
 			return
 		}
-		h := v.newHandle(ino, true, 0)
-		fh = h.fh
 		n := getInternalNode(ino)
 		if n == nil {
 			return
 		}
+		if ino == controlInode && ctx.Uid() != 0 && ctx.Uid() != n.attr.Uid {
+			err = syscall.EACCES
+			return
+		}
+		h := v.newHandle(ino, true, 0)
+		fh = h.fh
 		entry = &meta.Entry{Inode: ino, Attr: n.attr}
 		switch ino {
 		case logInode:

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -715,6 +715,12 @@ func TestInternalFile(t *testing.T) {
 	if e != 0 {
 		t.Fatalf("lookup .control: %s", e)
 	}
+	if fe.Attr.Mode != 0600 {
+		t.Fatalf(".control mode is %04o, want 0600", fe.Attr.Mode)
+	}
+	if _, _, e = v.Open(ctx2, fe.Inode, syscall.O_RDWR); e != syscall.EACCES {
+		t.Fatalf("other user opened .control: %s", e)
+	}
 	fe, fh, e = v.Open(ctx, fe.Inode, syscall.O_RDWR)
 	if e != 0 {
 		t.Fatalf("open .stats: %s", e)


### PR DESCRIPTION
## Summary
- reject incomplete WebDAV credential and TLS configurations before service initialization
- restrict the mounted internal control interface to the mount owner or root
- document the updated operator requirements in English and Chinese

## Verification
- go test ./pkg/fs
- go test ./pkg/vfs -run ^TestInternalFile$ -count=1
- go test ./cmd -run ^$
- go vet ./pkg/fs ./pkg/vfs ./cmd