### PR TITLE
meta/backup: fix goroutine leak in metadata backup

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -68,7 +68,7 @@ var (
 	extra, extraBytes       *utils.Bar
 	deleted, failed         *utils.Bar
 	listedPrefix            *utils.Bar
-	concurrent              = make(chan int, 10) // default for standalone CopyData; Sync overrides it
+	concurrent              = make(chan int, 10)
 	limiter                 *mixedLimiter
 	totalHandled            atomic.Int64
 )
@@ -762,7 +762,7 @@ func (w *withProgress) Read(b []byte) (int, error) {
 		limiter.Wait(int64(len(b)))
 	}
 	n, err := w.r.Read(b)
-	if copiedBytes != nil { // not set by standalone CopyData callers, e.g. metadata backup
+	if copiedBytes != nil {
 		copiedBytes.IncrInt64(int64(n))
 	}
 	return n, err

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -68,7 +68,7 @@ var (
 	extra, extraBytes       *utils.Bar
 	deleted, failed         *utils.Bar
 	listedPrefix            *utils.Bar
-	concurrent              chan int
+	concurrent              = make(chan int, 10) // default for standalone CopyData; Sync overrides it
 	limiter                 *mixedLimiter
 	totalHandled            atomic.Int64
 )
@@ -762,7 +762,9 @@ func (w *withProgress) Read(b []byte) (int, error) {
 		limiter.Wait(int64(len(b)))
 	}
 	n, err := w.r.Read(b)
-	copiedBytes.IncrInt64(int64(n))
+	if copiedBytes != nil { // not set by standalone CopyData callers, e.g. metadata backup
+		copiedBytes.IncrInt64(int64(n))
+	}
 	return n, err
 }
 
@@ -997,13 +999,6 @@ func doCopyMultiple(src, dst object.ObjectStorage, key string, size int64, mtime
 	}
 
 	return chksum, nil
-}
-
-func InitForCopyData() {
-	concurrent = make(chan int, 10)
-	progress := utils.NewProgress(true)
-	copied = progress.AddCountSpinner("Copied objects")
-	copiedBytes = progress.AddByteSpinner("Copied bytes")
 }
 
 func CopyData(src, dst object.ObjectStorage, key string, size int64, calChksum bool) (uint32, error) {

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -21,12 +21,14 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1400,5 +1402,51 @@ func TestGlobalLimitDrainWaitersOnFailure(t *testing.T) {
 	}
 	if g.healthy.Load() {
 		t.Fatalf("expected global limit to be marked unhealthy")
+	}
+}
+
+// CopyData must be usable standalone (e.g. by metadata backup) without the
+// progress bars set up by Sync, and must not leak goroutines per call.
+func TestCopyDataWithoutProgress(t *testing.T) {
+	savedCopied, savedCopiedBytes := copied, copiedBytes
+	copied, copiedBytes = nil, nil
+	defer func() { copied, copiedBytes = savedCopied, savedCopiedBytes }()
+
+	src, err := object.CreateStorage("mem", "", "", "", "")
+	if err != nil {
+		t.Fatalf("create src: %s", err)
+	}
+	dst, err := object.CreateStorage("mem", "", "", "", "")
+	if err != nil {
+		t.Fatalf("create dst: %s", err)
+	}
+	data := bytes.Repeat([]byte("juicefs"), 50)
+	if err = src.Put(ctx, "backup", bytes.NewReader(data)); err != nil {
+		t.Fatalf("put: %s", err)
+	}
+	wantChksum := crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+
+	settleGoroutines := func() {
+		runtime.GC()
+		time.Sleep(300 * time.Millisecond)
+		runtime.GC()
+	}
+	settleGoroutines()
+	base := runtime.NumGoroutine()
+
+	const cycles = 50
+	for i := 0; i < cycles; i++ {
+		chksum, err := CopyData(src, dst, "backup", int64(len(data)), true)
+		if err != nil {
+			t.Fatalf("CopyData: %s", err)
+		}
+		if chksum != wantChksum {
+			t.Fatalf("checksum mismatch: got %d, want %d", chksum, wantChksum)
+		}
+	}
+
+	settleGoroutines()
+	if leaked := runtime.NumGoroutine() - base; leaked > cycles/10 {
+		t.Fatalf("leaked %d goroutines after %d CopyData calls", leaked, cycles)
 	}
 }

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1405,8 +1405,6 @@ func TestGlobalLimitDrainWaitersOnFailure(t *testing.T) {
 	}
 }
 
-// CopyData must be usable standalone (e.g. by metadata backup) without the
-// progress bars set up by Sync, and must not leak goroutines per call.
 func TestCopyDataWithoutProgress(t *testing.T) {
 	savedCopied, savedCopiedBytes := copied, copiedBytes
 	copied, copiedBytes = nil, nil

--- a/pkg/vfs/backup.go
+++ b/pkg/vfs/backup.go
@@ -136,7 +136,6 @@ func backup(m meta.Meta, blob object.ObjectStorage, now time.Time, fast, skipTra
 	if err != nil {
 		return "", err
 	}
-	osync.InitForCopyData()
 	_, err = osync.CopyData(disk, blob, fpath, size, true)
 	return blob.String() + fpath, err
 }


### PR DESCRIPTION
Follow-up to #7224, completes the fix for the goroutine growth reported in #7222.

## Root cause

PR #7224 added `defer progress.Done()` to the three `DumpMeta` implementations, but the backup path has a second leak it didn't cover. Every metadata backup run calls `osync.InitForCopyData()`, which creates a fresh `utils.NewProgress(true)`:

- `mpb.New()` unconditionally spawns a `serve` goroutine plus a ticker-forwarding goroutine; both only exit when all bars complete or `Wait()` is called
- the two spinners added there (total 0) are never completed, and `Done()` is never called
- the old `*Progress` is dropped on the floor and the globals reassigned

With the default `--backup-meta 1h`, a long-running mount leaks **2 goroutines + 2 bars per backup (~48 goroutines/day)**.

The progress bars were never the goal: backup adopted `CopyData` (#5564) only for multipart upload + checksum verification, and `InitForCopyData` existed solely to satisfy `copyData`'s package globals (`concurrent`, `copiedBytes`), which are otherwise initialized only by the CLI sync path.

## Fix

Make `CopyData` usable standalone without any progress machinery:

- `pkg/sync/sync.go`: initialize the `concurrent` semaphore at package level (default cap 10, same as before; `Sync` still overrides it with `config.Threads` before workers start); delete `InitForCopyData`; nil-guard `copiedBytes` in `withProgress.Read` - the only touchpoint of the backup path, same pattern as the adjacent `limiter != nil` check and the existing guard in `download.go`
- `pkg/vfs/backup.go`: drop the `InitForCopyData()` call

Result: zero mpb objects and zero resident goroutines on the backup path. This also removes a latent permanent hang: standalone `CopyData` without prior init would block forever on the nil-channel send in `doCopySingle0`.

CLI `juicefs sync` behavior is unchanged (channel cap, progress bars, checkpoints).

## Test plan

- [x] Added `TestCopyDataWithoutProgress` (`pkg/sync/sync_test.go`): runs `CopyData` 50 times with the progress globals unset (the daemon scenario), asserts correct CRC32C checksums and a stable goroutine count
- [x] Verified pre-fix code hangs without init (nil `concurrent` semaphore) and the new test passes after the fix (`-count=3`, also under `-race`)
- [x] `go test ./pkg/sync/...` passes; `go test ./pkg/vfs/...` shows only the pre-existing `TestAccessLog` timezone failure, which fails identically on main
- [ ] CI

Known limitation: the mem test storage doesn't support multipart upload, so the test exercises the `doCopySingle` path; the multipart path shares the same guarded `withProgress.Read` (verified by review).
