### PR TITLE
docs: restore star history chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,4 +226,4 @@ For more FAQs, please see the [full list](https://juicefs.com/docs/community/faq
 
 ## Stargazers over time
 
-[![Star History Chart](https://api.star-history.com/svg?repos=juicedata/juicefs&type=Date)](https://star-history.com/#juicedata/juicefs&Date)
+[![Star History Chart](https://api.star-history.com/chart?repos=juicedata/juicefs&type=date&legend=top-left&sealed_token=AUPzWbz1Elv7AekY9St7cKr1TSra2dWqnSh9w0zWai1edsijV6IgdKkXG7xJxCclB9_thUvNCFeVeIPiS5kVVD_X-7wQ_TzbioycAPV5TToRqH6tIT2s6w)](https://www.star-history.com/?repos=juicedata%2Fjuicefs&type=date&legend=top-left)

--- a/README.md
+++ b/README.md
@@ -226,4 +226,4 @@ For more FAQs, please see the [full list](https://juicefs.com/docs/community/faq
 
 ## Stargazers over time
 
-[![Star History Chart](https://api.star-history.com/chart?repos=juicedata/juicefs&type=date&legend=top-left&sealed_token=AUPzWbz1Elv7AekY9St7cKr1TSra2dWqnSh9w0zWai1edsijV6IgdKkXG7xJxCclB9_thUvNCFeVeIPiS5kVVD_X-7wQ_TzbioycAPV5TToRqH6tIT2s6w)](https://www.star-history.com/?repos=juicedata%2Fjuicefs&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/chart?repos=juicedata/juicefs&type=date&legend=top-left&sealed_token=YlzRuLnesjVEGDsZfhxQn_x-AFvNcHrCh-GCEfzzeyrGEJ3OIcLwrd23Yo576hxaTuFXCms0QDsFoBmiDB8XYm6Gbtetv8qW1UFDXbbjrm7-pFJyioXO6A)](https://www.star-history.com/?type=date&repos=juicedata%2Fjuicefs)

--- a/README_CN.md
+++ b/README_CN.md
@@ -224,4 +224,4 @@ JuiceFS 的设计参考了 [Google File System](https://research.google/pubs/pub
 
 ## 历史加星
 
-[![Stargazers over time](https://starchart.cc/juicedata/juicefs.svg)](https://starchart.cc/juicedata/juicefs)
+[![Stargazers over time](https://api.star-history.com/chart?repos=juicedata/juicefs&type=date&legend=top-left&sealed_token=AUPzWbz1Elv7AekY9St7cKr1TSra2dWqnSh9w0zWai1edsijV6IgdKkXG7xJxCclB9_thUvNCFeVeIPiS5kVVD_X-7wQ_TzbioycAPV5TToRqH6tIT2s6w)](https://www.star-history.com/?repos=juicedata%2Fjuicefs&type=date&legend=top-left)

--- a/README_CN.md
+++ b/README_CN.md
@@ -224,4 +224,4 @@ JuiceFS 的设计参考了 [Google File System](https://research.google/pubs/pub
 
 ## 历史加星
 
-[![Stargazers over time](https://api.star-history.com/chart?repos=juicedata/juicefs&type=date&legend=top-left&sealed_token=AUPzWbz1Elv7AekY9St7cKr1TSra2dWqnSh9w0zWai1edsijV6IgdKkXG7xJxCclB9_thUvNCFeVeIPiS5kVVD_X-7wQ_TzbioycAPV5TToRqH6tIT2s6w)](https://www.star-history.com/?repos=juicedata%2Fjuicefs&type=date&legend=top-left)
+[![Stargazers over time](https://api.star-history.com/chart?repos=juicedata/juicefs&type=date&legend=top-left&sealed_token=YlzRuLnesjVEGDsZfhxQn_x-AFvNcHrCh-GCEfzzeyrGEJ3OIcLwrd23Yo576hxaTuFXCms0QDsFoBmiDB8XYm6Gbtetv8qW1UFDXbbjrm7-pFJyioXO6A)](https://www.star-history.com/?type=date&repos=juicedata%2Fjuicefs)


### PR DESCRIPTION
## Problem

The star history charts in both READMEs no longer render a curve. GitHub
[restricted the stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/)
to a repository's own admins and collaborators, so third-party chart
services can no longer read the data on our behalf.

Current state on `main`:

| README | Service | Result |
| --- | --- | --- |
| `README.md` | star-history.com | `200` with `x-chart-status: restricted`, renders an access notice instead of the curve |
| `README_CN.md` | starchart.cc | `{"error":"rate limited, please try again later"}` |

## Change

Both files now use the star-history embed URL that carries an encrypted
token authorized to read this repository. The token is sealed with
star-history's public key, so only their server can decrypt it.

`README_CN.md` previously pointed at starchart.cc, which has been failing
independently of this restriction; it now shows the same chart as
`README.md`.

## Verification

The URL was extracted directly from the committed files and fetched, to
confirm what actually landed in the READMEs works:

```
README.md    -> 200 chart-status=None size=65113 OK
README_CN.md -> 200 chart-status=None size=65113 OK
```

- No `x-chart-status: restricted` header, and no access-notice text in the response
- Chart renders the full curve; Y axis reaches 14K, consistent with the current count of 14,353
- For contrast, the old `/svg?...` endpoint and a tokenless `/chart?...` request both still return `restricted`