### PR TITLE
S3/gateway: fix DeleteObjects API wrongly delete sibling object named as bucket

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -526,6 +526,7 @@ func (n *jfsObjects) DeleteObjects(ctx context.Context, bucket string, objects [
 		p := path.Dir(path.Clean(n.path(bucket, o.ObjectName)))
 		delMap[p] = append(delMap[p], idx)
 	}
+	root := n.path(bucket)
 	var g errgroup.Group
 	g.SetLimit(runtime.NumCPU())
 	for ppath := range delMap {
@@ -544,7 +545,7 @@ func (n *jfsObjects) DeleteObjects(ctx context.Context, bucket string, objects [
 				}
 				return err
 			}
-			if e := n.delObj(bucket, ppath); e != nil {
+			if e := n.delObj(bucket, strings.TrimPrefix(strings.TrimPrefix(ppath, root), sep)); e != nil {
 				for _, idx := range idxs {
 					errs[idx] = e
 				}

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -220,3 +220,48 @@ func TestGetObjectInfo(t *testing.T) {
 		assertHeadObject(t, jfsObj, bucket, "dir1/key1/", false)
 	})
 }
+
+func TestDeleteObjects(t *testing.T) {
+	t.Run("keep sibling object named as bucket", func(t *testing.T) {
+		jfsObj, jfs, _ := newTestGateway(t, Config{MultiBucket: true})
+		bucket := "jmrq"
+		if eno := jfs.Mkdir(mctx, "/"+bucket, 0777, 022); eno != 0 {
+			t.Fatalf("mkdir bucket: %s", eno)
+		}
+		createTestFile(t, jfs, "/"+bucket+"/"+bucket) // key == bucket name -> /jmrq/jmrq
+		createTestFile(t, jfs, "/"+bucket+"/rror")
+
+		_, errs := jfsObj.DeleteObjects(context.Background(), bucket,
+			[]minio.ObjectToDelete{{ObjectName: "rror"}}, minio.ObjectOptions{})
+		for _, e := range errs {
+			if e != nil {
+				t.Fatalf("delete rror: %s", e)
+			}
+		}
+		assertHeadObject(t, jfsObj, bucket, bucket, true)
+		assertHeadObject(t, jfsObj, bucket, "rror", false)
+	})
+
+	t.Run("prune empty implicit directories", func(t *testing.T) {
+		jfsObj, jfs, _ := newTestGateway(t, Config{MultiBucket: true})
+		bucket := "bkt2"
+		if eno := jfs.Mkdir(mctx, "/"+bucket, 0777, 022); eno != 0 {
+			t.Fatalf("mkdir bucket: %s", eno)
+		}
+		if eno := jfs.MkdirAll(mctx, "/"+bucket+"/x/y", 0777, 022); eno != 0 {
+			t.Fatalf("mkdir x/y: %s", eno)
+		}
+		createTestFile(t, jfs, "/"+bucket+"/x/y/z")
+
+		_, errs := jfsObj.DeleteObjects(context.Background(), bucket,
+			[]minio.ObjectToDelete{{ObjectName: "x/y/z"}}, minio.ObjectOptions{})
+		for _, e := range errs {
+			if e != nil {
+				t.Fatalf("delete x/y/z: %s", e)
+			}
+		}
+		if fi, eno := jfs.Stat(mctx, "/"+bucket+"/x"); eno == 0 {
+			t.Fatalf("implicit dir /x should be pruned, still exists: isDir=%v", fi.IsDir())
+		}
+	})
+}


### PR DESCRIPTION
Fix #7426