### PR TITLE
hadoop: skip kerberos authentication when server principal is not configured

### DIFF
--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -2340,8 +2340,8 @@ public class JuiceFileSystemImpl extends FileSystem {
   }
 
   public AuthCredential buildAuthCredential(String spn) throws IOException {
-    // auth use kerberos
-    if (UserGroupInformation.getLoginUser().hasKerberosCredentials()) {
+    // auth use kerberos, only when the server principal is configured
+    if (spn != null && !spn.isEmpty() && UserGroupInformation.getLoginUser().hasKerberosCredentials()) {
       dtEnabled = true;
       byte[] cred;
       try {


### PR DESCRIPTION


### Problem

On a kerberized cluster,`hdfs dfs -ls jfs://{VOL}/` fails right after kinit:

`-ls: Empty nameString not allowed`

Without kinit, the same command works and this does not happen with the 1.3 Hadoop SDK
The code path was introduced in 1.4 by #6445

### Cause

`buildAuthCredential()` decides to build a Kerberos AP-REQ based only on whether the login user holds Kerberos credentials. When `juicefs.server-principal` is not configured, spn is the empty string, so `GSSManager.createName("", GSSName.NT_USER_NAME, ...)` in `KerberosUtil.genApReq()` throws `IllegalArgumentException: Empty nameString not allowed`

### Fix

Require a non-empty SPN as well.
Verified on a kerberized cluster with the patched hadoop sdk