### PR TITLE
sql: preserve batch unlink state across retried SQL transactions

### DIFF
--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2793,7 +2793,6 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 		n         *node  // n edges : 1 inode
 		trashName string // cached trash entry name when hard links go to trash
 	}
-	var entryInfos []*entryInfo
 	type dNode struct {
 		opened bool
 		length uint64
@@ -2817,11 +2816,15 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 		var batchDirLength, batchDirSpace, batchDirInodes int64
 		var batchTrashLength, batchTrashSpace, batchTrashInodes int64
 		var deltas ugQuotaDeltas
+		var batchDelNodes map[Ino]*dNode
+		var invalidatedInodes map[Ino]struct{}
 		err := m.txn(func(s *xorm.Session) error {
 			batchDirLength, batchDirSpace, batchDirInodes = 0, 0, 0
 			batchFsSpace, batchFsInodes = 0, 0
 			batchTrashLength, batchTrashSpace, batchTrashInodes = 0, 0, 0
 			deltas = make(ugQuotaDeltas)
+			batchDelNodes = make(map[Ino]*dNode)
+			invalidatedInodes = make(map[Ino]struct{})
 			pn := node{Inode: parent}
 			ok, err := s.Get(&pn)
 			if err != nil {
@@ -2842,7 +2845,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 				return syscall.EPERM
 			}
 			now := time.Now().UnixNano()
-			entryInfos = make([]*entryInfo, 0, len(batch))
+			entryInfos := make([]*entryInfo, 0, len(batch))
 			names := make([][]byte, 0, len(batch))
 			for _, entry := range batch {
 				names = append(names, entry.Name)
@@ -2935,7 +2938,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 					if m.sid > 0 {
 						opened = m.of.IsOpen(info.n.Inode)
 					}
-					delNodes[info.n.Inode] = &dNode{opened, info.n.Length}
+					batchDelNodes[info.n.Inode] = &dNode{opened, info.n.Length}
 				}
 			}
 
@@ -2982,7 +2985,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 						switch info.n.Type {
 						case TypeFile:
 							entrySpace = align4K(info.n.Length)
-							if dnode, ok := delNodes[info.n.Inode]; ok && dnode.opened {
+							if dnode, ok := batchDelNodes[info.n.Inode]; ok && dnode.opened {
 								sustainedIns = append(sustainedIns, &sustained{Sid: m.sid, Inode: info.e.Inode})
 								if _, err := s.Cols("nlink", "ctime", "ctimensec").Update(info.n, &node{Inode: info.n.Inode}); err != nil {
 									return err
@@ -3021,7 +3024,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 						}
 						xattrsDel = append(xattrsDel, info.e.Inode)
 					}
-					m.of.InvalidateChunk(info.e.Inode, invalidateAttrOnly)
+					invalidatedInodes[info.e.Inode] = struct{}{}
 				}
 				if info.n.Nlink > 0 && info.trash > 0 {
 					// still has links and should be moved to trash; create new trash edge
@@ -3122,6 +3125,12 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 
 		if err != nil {
 			return errno(err)
+		}
+		for inode, info := range batchDelNodes {
+			delNodes[inode] = info
+		}
+		for inode := range invalidatedInodes {
+			m.of.InvalidateChunk(inode, invalidateAttrOnly)
 		}
 
 		delta.length += batchDirLength

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	xormlog "xorm.io/xorm/log"
 )
 
 func TestSQLiteClient(t *testing.T) {
@@ -32,6 +34,94 @@ func TestSQLiteClient(t *testing.T) {
 		t.Fatalf("create meta: %s", err)
 	}
 	testMeta(t, m)
+}
+
+type commitOnSQLiteBusyLogger struct {
+	xormlog.ContextLogger
+	commit    func() error
+	committed bool
+	commitErr error
+}
+
+func (l *commitOnSQLiteBusyLogger) AfterSQL(ctx xormlog.LogContext) {
+	l.ContextLogger.AfterSQL(ctx)
+	if !l.committed && ctx.Err != nil && strings.Contains(strings.ToLower(ctx.Err.Error()), "locked") {
+		l.committed = true
+		l.commitErr = l.commit()
+	}
+}
+
+func TestSQLiteBatchUnlinkRetryDiscardsFailedAttemptDeletes(t *testing.T) {
+	metaClient, err := newSQLMeta("sqlite3", path.Join(t.TempDir(), "jfs-batch-unlink-retry.db")+"?_timeout=1", testConfig())
+	if err != nil {
+		t.Fatalf("create meta: %s", err)
+	}
+	m := metaClient.(*dbMeta)
+	t.Cleanup(func() { _ = m.Shutdown() })
+	if err := m.Reset(); err != nil {
+		t.Fatalf("reset meta: %s", err)
+	}
+	if err := m.Init(testFormat(), true); err != nil {
+		t.Fatalf("init meta: %s", err)
+	}
+
+	ctx := Background()
+	var inode Ino
+	var attr Attr
+	if st := m.Mknod(ctx, RootInode, "victim", TypeFile, 0644, 022, 0, "", &inode, &attr); st != 0 {
+		t.Fatalf("mknod victim: %s", st)
+	}
+	m.sid = 1
+	m.of.Open(inode, &attr)
+	t.Cleanup(func() { m.of.Close(inode) })
+
+	writer := m.db.NewSession()
+	t.Cleanup(func() { _ = writer.Close() })
+	if err := writer.Begin(); err != nil {
+		t.Fatalf("begin concurrent writer: %s", err)
+	}
+	t.Cleanup(func() { _ = writer.Rollback() })
+	if _, err := writer.Insert(&edge{Parent: RootInode, Name: []byte("survivor"), Inode: inode, Type: TypeFile}); err != nil {
+		t.Fatalf("insert concurrent hardlink: %s", err)
+	}
+	if n, err := writer.Cols("nlink").Update(&node{Nlink: 2}, &node{Inode: inode}); err != nil || n != 1 {
+		t.Fatalf("update concurrent hardlink nlink: rows=%d err=%v", n, err)
+	}
+
+	retryLogger := &commitOnSQLiteBusyLogger{
+		ContextLogger: m.db.Logger(),
+		commit:        writer.Commit,
+	}
+	m.db.SetLogger(retryLogger)
+	m.db.ShowSQL(true)
+
+	delta := dirStat{}
+	entry := &Entry{Inode: inode, Name: []byte("victim"), Attr: &attr}
+	if st := m.doBatchUnlink(ctx, RootInode, []*Entry{entry}, &delta, true); st != 0 {
+		t.Fatalf("batch unlink after retry: %s", st)
+	}
+	if !retryLogger.committed {
+		t.Fatal("expected SQLite BUSY retry was not triggered")
+	}
+	if retryLogger.commitErr != nil {
+		t.Fatalf("commit concurrent hardlink: %s", retryLogger.commitErr)
+	}
+
+	var survivor Ino
+	var survivorAttr Attr
+	if st := m.Lookup(ctx, RootInode, "survivor", &survivor, &survivorAttr, false); st != 0 {
+		t.Fatalf("lookup surviving hardlink: %s", st)
+	}
+	if survivor != inode || survivorAttr.Nlink != 1 {
+		t.Fatalf("surviving hardlink: inode=%d nlink=%d, want inode=%d nlink=1", survivor, survivorAttr.Nlink, inode)
+	}
+
+	m.Lock()
+	removed := m.removedFiles[inode]
+	m.Unlock()
+	if removed {
+		t.Fatalf("live inode %d retained delete state from failed transaction attempt", inode)
+	}
 }
 
 func TestSQLiteBatchUpdateChunkRefs(t *testing.T) {


### PR DESCRIPTION
## 为什么发生
数据库 rollback 只能回滚数据库状态，无法回滚事务 callback 对外部 Go map 的修改。

失败 attempt 可以把 inode 写入 delNodes。后续成功 attempt 可能重新计算出该 inode 仍然存活，但旧的 map 项仍然存在，最终触发异步 chunk 删除。

## 复现场景
BatchUnlink 第一次 attempt 把 inode 100 的 nlink 计算为 0，并写入 delNodes。
后续 SQL 操作返回 retryable error，整个数据库事务回滚。
并发 namespace 操作让 inode 100 保持存活。
第二次 attempt 成功提交，并没有删除 inode 100。
失败 attempt 留下的 delNodes[100] 仍被消费。
fileDeleted(100) 删除仍存活 inode 的数据块。

## 影响
仍然具有有效 node 和 namespace entry 的文件可能丢失数据块，属于不可恢复的数据丢失风险。

## 建议修复
每个事务 attempt 创建独立的 attemptDelNodes。
只有该 attempt 成功 commit 后才能发布和消费结果。
其他 cache invalidation、callback 和统计输出也应采用 attempt-local/after-commit 机制。
删除 chunk 前增加防御性校验：inode 必须不存在，并且存在匹配的 deletion marker 或 claim。
增加强制第一次 attempt retry 的回归测试。