### PR TITLE
cmd/mount: skip the oom_score_adj adjustment inside a container

### DIFF
--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -495,10 +495,6 @@ func mountFlags() []cli.Flag {
 			Name:  "disable-transparent-hugepage",
 			Usage: "disable transparent huge page to avoid latency spikes caused by kernel's memory compaction",
 		})
-		selfFlags = append(selfFlags, &cli.BoolFlag{
-			Name:  "disable-oom-protection",
-			Usage: "do not set oom_score_adj to -1000, keeping the mount process killable by the OOM killer",
-		})
 	}
 	return append(selfFlags, fuseFlags()...)
 }
@@ -981,7 +977,7 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 }
 func launchMount(c *cli.Context, mp string, conf *vfs.Config) error {
 	increaseRlimit()
-	if !c.Bool("disable-oom-protection") {
+	if os.Getenv("JFS_INSIDE_CONTAINER") != "1" {
 		utils.AdjustOOMKiller(-1000)
 	}
 	utils.SetIOFlusher()

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -495,6 +495,10 @@ func mountFlags() []cli.Flag {
 			Name:  "disable-transparent-hugepage",
 			Usage: "disable transparent huge page to avoid latency spikes caused by kernel's memory compaction",
 		})
+		selfFlags = append(selfFlags, &cli.BoolFlag{
+			Name:  "disable-oom-protection",
+			Usage: "do not set oom_score_adj to -1000, keeping the mount process killable by the OOM killer",
+		})
 	}
 	return append(selfFlags, fuseFlags()...)
 }
@@ -977,7 +981,9 @@ func installHandler(m meta.Meta, mp string, v *vfs.VFS, blob object.ObjectStorag
 }
 func launchMount(c *cli.Context, mp string, conf *vfs.Config) error {
 	increaseRlimit()
-	utils.AdjustOOMKiller(-1000)
+	if !c.Bool("disable-oom-protection") {
+		utils.AdjustOOMKiller(-1000)
+	}
 	utils.SetIOFlusher()
 
 	if c.Bool("disable-transparent-hugepage") {


### PR DESCRIPTION
Resolves #7466 