### PR TITLE
docs: add Community AI deployment assistant guide

### DIFF
--- a/.agents/skills/juicefs-community-support/SKILL.md
+++ b/.agents/skills/juicefs-community-support/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: juicefs-community-support
+description: Support, deploy, operate, and troubleshoot JuiceFS Community Edition and its CSI integration. Use when a request involves open-source JuiceFS clients, metadata engines, object storage, FUSE mounts, gateways, cache, upgrades, recovery, Kubernetes PV or PVC behavior, Mount Pods, or implementation questions that may require reading the matching public source code.
+---
+
+# JuiceFS Community Support
+
+## Outcome
+
+Help users deploy, operate, and troubleshoot JuiceFS Community Edition and its Kubernetes integration using verified environment facts, version-matched public documentation and source code, sanitized runtime evidence, and explicit safety boundaries.
+
+Do not assume JuiceFS Cloud Service or Enterprise Edition components, fields, workflows, or capabilities.
+
+## Route the request
+
+Before giving commands or conclusions, identify:
+
+1. The stage: design, installation, deployment, validation, operation, upgrade, troubleshooting, or recovery.
+2. Exact versions: JuiceFS client, CSI Driver, client image, Helm chart or manifests, and Kubernetes when relevant.
+3. Topology: standalone or distributed, metadata engine, object storage, clients, and Kubernetes components.
+4. Access path: FUSE, S3 Gateway, Hadoop SDK, CSI, sidecar, or another supported interface.
+5. Existing state: new deployment, existing filesystem, degraded service, suspected data loss, or migration.
+
+Load only the references needed for the request:
+
+- Community deployment and operations: [deployment and operations reference](references/community-deployment.md)
+- Community CSI integration: [Community CSI reference](references/community-csi.md)
+- Version-matched source investigation: [source investigation reference](references/source-code.md)
+- Troubleshooting and recovery: [troubleshooting and recovery reference](references/troubleshooting.md)
+
+## Use evidence in this order
+
+1. Public documentation that matches the deployed release.
+2. Public source code at the matching release tag or exact commit.
+3. Sanitized runtime evidence from the affected environment.
+4. The current development branch, explicitly labeled as possible later behavior.
+5. Inference, explicitly labeled and paired with a verification step.
+
+If public documentation is unavailable, ask for the local JuiceFS source or documentation root and its release tag, commit, or download date. For the current Community repository layout, use `<JUICEFS_ROOT>/docs/en/` for English or `<JUICEFS_ROOT>/docs/zh_cn/` for Chinese. Read only the locale and topic relevant to the request, and do not assume that the local copy matches the deployed client version.
+
+If documentation, source code, and runtime behavior disagree, report the mismatch. Do not silently choose one.
+
+## Keep product and system layers separate
+
+- Community Edition uses a customer-selected metadata engine and data storage backend. Object storage is common but not the only supported backend.
+- Do not introduce Cloud Service console workflows, managed metadata services, Enterprise Edition distributed cache, license fields, or enterprise authentication fields.
+- Separate the application, kernel cache, FUSE, VFS and buffers, local cache, metadata engine, object storage, gateway, CSI Controller, CSI Node, Mount Pod, sidecar, and workload Pod.
+- Treat requests for other JuiceFS service models as outside this skill and use the documentation and operating model for the requested product.
+
+## Read open-source code safely
+
+Reading the public JuiceFS and CSI Driver source is allowed and encouraged when behavior is version-sensitive, undocumented, or unclear.
+
+- Pin the deployed release tag, image version, or exact commit before drawing conclusions.
+- Follow the real call path and cite repository, revision, file path, and relevant lines or symbols.
+- Do not use an unpinned development branch as proof of behavior in an older deployed release.
+- Do not recommend building unreleased source for production as the default remediation.
+- Distinguish implementation facts from tests, commit intent, documentation, runtime observations, and inference.
+
+See [references/source-code.md](references/source-code.md) for routing details.
+
+## Protect credentials and data
+
+Treat metadata URLs, database passwords, object storage keys, encryption material, kubeconfig content, and Kubernetes Secret values as sensitive. Ask for redacted evidence and never echo secrets in commands or reports.
+
+A plan or diagnosis does not authorize changes. Before any state-changing action, state:
+
+- exact target and scope;
+- expected effect and risk;
+- prerequisite backup or recovery point;
+- verification and rollback procedure;
+- approval required from the environment owner.
+
+High-risk actions include filesystem initialization or replacement, metadata import or repair, leaked-object deletion, destructive garbage collection, cache removal, bucket or prefix changes, PV or PVC deletion, credential rotation, and changes to reclaim policy.
+
+## Require end-to-end acceptance
+
+For a controlled test path, create a unique file, close it, reopen it, read it back, and verify its checksum. When relevant, repeat from another client or Pod and correlate the result with events, logs, and metrics.
+
+Do not equate any single intermediate state with success. Keep these separate:
+
+- application write completion;
+- `close` or `fsync` return;
+- internal buffer flush;
+- object upload;
+- metadata commit;
+- backend durability;
+- a Bound PVC or Running Mount Pod;
+- successful workload I/O.
+
+## Communicate confidence
+
+Label important findings as one of:
+
+- **Verified:** observed directly in the target environment.
+- **Documentation-based:** supported by version-matched public documentation.
+- **Source-verified:** supported by version-matched public source code.
+- **Unconfirmed:** evidence is insufficient or conflicting.
+- **Inference:** a reasoned hypothesis with a concrete verification step.
+
+Finish with the current state, unresolved risks, next safe action, and success criteria.
+
+## Stop conditions
+
+Stop and request clarification or explicit approval when:
+
+- the target filesystem, cluster, bucket, prefix, metadata endpoint, PV, or PVC is ambiguous;
+- credentials or recovery materials are missing;
+- the available source revision does not match the deployed artifact;
+- the next step could delete, overwrite, reinitialize, or irreversibly migrate data;
+- suspected data loss or corruption requires preserving evidence before further action.

--- a/.agents/skills/juicefs-community-support/references/community-csi.md
+++ b/.agents/skills/juicefs-community-support/references/community-csi.md
@@ -1,0 +1,87 @@
+# Community CSI
+
+## Start from the current public documentation
+
+- [Introduction](https://juicefs.com/docs/csi/introduction)
+- [Getting started](https://juicefs.com/docs/csi/getting_started)
+- [Use JuiceFS volumes](https://juicefs.com/docs/csi/guide/pv)
+- [Configurations](https://juicefs.com/docs/csi/guide/configurations)
+- [Production recommendations](https://juicefs.com/docs/csi/administration/going-production)
+- [Troubleshooting](https://juicefs.com/docs/csi/troubleshooting)
+- [Upgrade the CSI Driver](https://juicefs.com/docs/csi/upgrade-csi-driver)
+
+Match documentation and source investigation to the installed CSI Driver, JuiceFS client image, Helm chart or manifests, and Kubernetes version.
+
+If the public site is unavailable, ask for a local CSI Driver documentation checkout and its release tag, commit, or download date. For the current source layout, use `<CSI_ROOT>/docs/en/` for English or `<CSI_ROOT>/docs/zh_cn/` for Chinese. Verify the layout and revision instead of assuming that a website path matches a source-tree path.
+
+## Record the deployment shape
+
+Identify:
+
+- Kubernetes version and distribution;
+- CSI Driver version and installation method;
+- CSI Controller and CSI Node namespaces and images;
+- JuiceFS client image and mount mode;
+- dynamic or static provisioning;
+- Secret, StorageClass, PV, PVC, workload, node, and Mount Pod involved;
+- use of sidecar mode or JuiceFS Operator, if any.
+
+For Community Edition, use only version-matched Community CSI fields. Do not add Cloud Service tokens, Enterprise Edition console fields, licenses, or managed-service assumptions.
+
+Never expose Kubernetes Secret values. Request resource names and redacted field presence instead.
+
+## Diagnose by stage
+
+Keep the control and data paths separate:
+
+1. **Provisioning:** the CSI Controller processes PVC or PV allocation and creates or updates Kubernetes resources.
+2. **Scheduling:** kubelet and the CSI Node component prepare the selected node.
+3. **Mount creation:** the driver creates or reuses the mount process or Mount Pod and invokes the JuiceFS client.
+4. **Mount propagation:** the volume is made available to the workload Pod.
+5. **Workload I/O:** the application opens, writes, closes, reopens, and reads files through the mounted volume.
+
+A Bound PVC, Running Mount Pod, or successful mount command is not end-to-end acceptance. Verify workload I/O and, where relevant, cross-Pod visibility.
+
+## Read CSI source when behavior is unclear
+
+At the exact deployed revision, start with:
+
+- `pkg/driver/controller.go` and `pkg/driver/provisioner.go` for controller-side provisioning;
+- `pkg/driver/node.go` for node publish, unpublish, staging, and cleanup;
+- `pkg/juicefs/` and `pkg/juicefs/mount/` for mount orchestration and lifecycle;
+- `pkg/juicefs/mount/builder/` for command construction and option precedence;
+- `pkg/config/` for configuration parsing and defaults;
+- `pkg/controller/` for controller reconciliation;
+- `pkg/webhook/` for admission and mutation behavior.
+
+Trace from the Kubernetes or gRPC entry point to the actual JuiceFS client invocation and cleanup path. Cite the revision and files used. See [source-code.md](source-code.md) for the evidence format.
+
+## Collect evidence by stage
+
+- PVC, PV, Pod, and node events for scheduling and lifecycle failures.
+- CSI Controller logs for provisioning and deletion failures.
+- CSI Node logs for node-side publish, mount, and cleanup failures.
+- Mount Pod or sidecar logs for JuiceFS client startup and runtime errors.
+- Workload logs and a controlled I/O test for application-visible failures.
+- Version-matched JuiceFS CSI diagnostic tools, such as the documented `kubectl jfs` workflow or CSI doctor, when available in that release.
+
+Redact metadata URLs, passwords, object storage keys, Secret data, kubeconfig content, internal hostnames where required, and customer data paths.
+
+## Protect production state
+
+- Verify reclaim policy and business ownership before deleting a PVC, PV, StorageClass, Secret, or backing filesystem.
+- Do not restart or delete all Mount Pods as an initial diagnostic step.
+- Do not remove cache directories, mount paths, finalizers, or Kubernetes resources without understanding the matching driver cleanup path.
+- Confirm CPU, memory, ephemeral storage, cache capacity, scheduling constraints, and node pressure for CSI and Mount Pods.
+- Change one variable at a time and preserve before-and-after evidence.
+
+## Acceptance checklist
+
+Confirm at least:
+
+1. Provisioning and scheduling complete without unexplained warning events.
+2. The expected mount process or Mount Pod remains healthy after restart scenarios.
+3. The workload creates a unique file, closes it, reopens it, reads it, and verifies its checksum.
+4. Another Pod or node observes the expected data and permissions when the topology requires it.
+5. Metrics and logs can be correlated across workload, Mount Pod, CSI Node, and CSI Controller.
+6. Upgrade, rollback, reclaim, and recovery responsibilities are documented.

--- a/.agents/skills/juicefs-community-support/references/community-deployment.md
+++ b/.agents/skills/juicefs-community-support/references/community-deployment.md
@@ -1,0 +1,91 @@
+# Community Deployment and Operations
+
+## Start from the current public documentation
+
+- [Community Edition introduction](https://juicefs.com/docs/community/introduction)
+- [Installation](https://juicefs.com/docs/community/getting-started/installation)
+- [Standalone mode](https://juicefs.com/docs/community/getting-started/standalone)
+- [Distributed mode](https://juicefs.com/docs/community/getting-started/for_distributed)
+- [Production deployment recommendations](https://juicefs.com/docs/community/production_deployment_recommendations)
+- [Metadata engines](https://juicefs.com/docs/community/databases_for_metadata)
+- [Object storage](https://juicefs.com/docs/community/reference/how_to_set_up_object_storage)
+- [Command reference](https://juicefs.com/docs/community/command_reference)
+- [Status check and maintenance](https://juicefs.com/docs/community/administration/status_check_and_maintenance)
+- [Metadata backup and restore](https://juicefs.com/docs/community/metadata_dump_load)
+- [Monitoring](https://juicefs.com/docs/community/administration/monitoring)
+- [Upgrade](https://juicefs.com/docs/community/administration/upgrade)
+
+Confirm that the documentation applies to the deployed release. If a page describes a newer version, say so and verify the behavior against the matching tag.
+
+If the public site is unavailable, ask for the local Community repository or documentation root plus its release tag, commit, or download date. Use `<JUICEFS_ROOT>/docs/en/` for English or `<JUICEFS_ROOT>/docs/zh_cn/` for Chinese, and verify that the supplied revision matches the deployed client before treating it as version evidence.
+
+## Establish the topology
+
+### Standalone mode
+
+Standalone mode can use a local metadata database such as SQLite. Treat it as a local, single-file metadata topology rather than a shared distributed metadata service. Confirm where the metadata file resides, who backs it up, and whether more than one client is expected.
+
+### Distributed mode
+
+For multiple clients or production workloads, identify the network metadata engine and verify:
+
+- high availability and backup ownership;
+- latency and connection limits;
+- authentication and transport security;
+- supported server and JuiceFS client versions;
+- restore testing and recovery objectives.
+
+Keep these components separate:
+
+- the metadata engine stores filesystem metadata;
+- object storage holds file data chunks;
+- clients provide filesystem and gateway access;
+- local cache is disposable acceleration, not the authoritative filesystem copy.
+
+For object storage, confirm bucket and prefix ownership, endpoint, region, credentials, lifecycle rules, capacity, and availability. Do not assume an empty prefix or exclusive ownership without evidence.
+
+## Create and mount deliberately
+
+Use an exact released JuiceFS client and record:
+
+- client version and installation source;
+- redacted metadata URL and metadata engine type;
+- object storage type, endpoint, bucket, and prefix;
+- filesystem name and UUID after creation;
+- mount, cache, metrics, and process-management options;
+- service ownership and operating-system user.
+
+Before running `juicefs format`, verify that the metadata target is intentionally new and that the bucket or prefix is correct. Formatting is not a connectivity probe, and it must not be repeated against an existing filesystem merely to test access.
+
+Before mounting, verify filesystem identity and configuration. Explain the operational implications of options that affect writeback, cache placement, trash, metadata backup, permissions, or resource usage.
+
+## Prepare for production
+
+Require a documented owner and acceptance criteria for:
+
+- metadata high availability, backups, restore tests, and capacity;
+- object storage availability, lifecycle policy, credentials, and billing or quotas;
+- client metrics, alerting, log retention, time synchronization, and upgrades;
+- cache paths, capacity limits, eviction behavior, and failure handling;
+- UID, GID, mode, ACL, quota, and actual workload compatibility.
+
+Validate the real workload path. A successful mount alone does not prove data-path durability, cross-client visibility, permissions, or recovery readiness.
+
+## Operate with read-only evidence first
+
+Collect current versions, topology, filesystem identity, health, metrics, and logs before changing state.
+
+Metadata import or restore, configuration repair, leaked-object deletion, destructive garbage collection, compaction, filesystem destruction, and object lifecycle changes require version-matched documentation, a verified backup, explicit scope, approval, and rollback or recovery steps.
+
+For upgrades, read release notes for every skipped version and verify metadata, mixed-client, gateway, and CSI compatibility. Do not assume an in-place binary replacement is sufficient for every topology.
+
+## Acceptance checklist
+
+Confirm at least:
+
+1. Expected clients can mount or connect after restart.
+2. A unique test file survives close, reopen, readback, and checksum verification.
+3. Cross-client visibility and permissions behave as designed.
+4. Metrics and logs identify the filesystem and client version.
+5. Metadata backup and restore procedures are documented and tested on a controlled target.
+6. Owners know the rollback and escalation path.

--- a/.agents/skills/juicefs-community-support/references/source-code.md
+++ b/.agents/skills/juicefs-community-support/references/source-code.md
@@ -1,0 +1,72 @@
+# Open-Source Investigation
+
+## Repositories and revisions
+
+- JuiceFS Community Edition: [JuiceFS repository](https://github.com/juicedata/juicefs).
+- JuiceFS CSI Driver: [JuiceFS CSI Driver repository](https://github.com/juicedata/juicefs-csi-driver).
+
+Treat each repository's unpinned default branch as development code. Verify the current default branch rather than assuming its name.
+
+Bind the investigation to the deployed binary or image:
+
+1. Record the reported version, image digest, release tag, or build commit.
+2. Resolve that identifier to an exact public revision.
+3. Inspect files without changing the user's active worktree when possible, for example with `git show <REVISION>:<PATH>` and `git grep -n <PATTERN> <REVISION> -- <PATHS>`.
+4. If only the development branch contains the relevant behavior, state the commit and date and label the finding as possible later behavior, not deployed behavior.
+
+If a vendor-built artifact cannot be mapped to a public revision, report the evidence gap. Do not claim source verification.
+
+## Community Edition source routing
+
+Start from the command entry point and follow the call path:
+
+- `main.go` and `cmd/main.go` for process and command registration;
+- `cmd/<command>.go` for command flags, validation, and invocation;
+- `pkg/meta/` for metadata clients, transactions, sessions, locks, quotas, and metadata maintenance;
+- `pkg/object/` for object storage backends, requests, retries, and backend-specific behavior;
+- `pkg/chunk/` for chunk I/O, upload, read, cache, and buffering paths;
+- `pkg/vfs/` for filesystem semantics between FUSE or SDK entry points and lower layers;
+- `pkg/fuse/` for FUSE request handling and kernel-facing behavior;
+- `pkg/fs/` for higher-level filesystem operations;
+- `pkg/gateway/` for S3 Gateway behavior;
+- `pkg/sync/` for synchronization workflows.
+
+Do not collapse application completion, FUSE response, VFS buffering, local cache admission, object upload, metadata commit, and backend durability into one event. Follow the actual path for the deployed revision.
+
+## CSI Driver source routing
+
+Trace the Kubernetes request through the driver and mount lifecycle:
+
+- `cmd/` for component entry points and flags;
+- `pkg/driver/controller.go` and `pkg/driver/provisioner.go` for controller services and provisioning;
+- `pkg/driver/node.go` for node services, publish, unpublish, and cleanup;
+- `pkg/juicefs/` for JuiceFS-specific orchestration;
+- `pkg/juicefs/mount/` for mount creation, reuse, monitoring, and cleanup;
+- `pkg/juicefs/mount/builder/` for client command and option construction;
+- `pkg/config/` for configuration parsing, defaults, and precedence;
+- `pkg/controller/` for Kubernetes reconciliation;
+- `pkg/webhook/` for admission-time mutation;
+- `pkg/util/resource/` for Kubernetes resource construction and lookup.
+
+For a failure, identify the external entry point, validation and configuration path, client invocation, error wrapping, retry or timeout behavior, resource mutation, and cleanup path.
+
+## Report source evidence precisely
+
+For each source-backed conclusion, include:
+
+- repository and exact revision;
+- file path and relevant symbol or line range;
+- the call chain that makes the code relevant;
+- whether a condition is a default, optional branch, error path, or release-specific behavior;
+- the runtime observation needed to prove that the path executed.
+
+Classify claims as:
+
+- **Source-verified:** proven by matching implementation code.
+- **Observed:** proven by sanitized runtime evidence.
+- **Documentation-based:** stated in version-matched public documentation.
+- **Inference:** a hypothesis that still needs verification.
+
+Tests and commit messages can clarify intent but do not replace the implementation path. Keep quotations small and prefer precise file and symbol citations.
+
+Source inspection alone does not authorize compiling, deploying, or replacing production binaries. Treat any build or rollout as a separate reviewed change with compatibility, rollback, and acceptance criteria.

--- a/.agents/skills/juicefs-community-support/references/troubleshooting.md
+++ b/.agents/skills/juicefs-community-support/references/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting and Recovery
+
+## Frame the incident
+
+Record before proposing a fix:
+
+- exact symptom and first observed time;
+- JuiceFS client, CSI Driver, image, metadata engine, object storage, and Kubernetes versions as applicable;
+- topology, access path, and affected clients, nodes, Pods, filesystems, or workloads;
+- blast radius and business impact;
+- recent changes;
+- last known good state and available metadata or infrastructure backups.
+
+Use the smallest evidence set that can distinguish the likely layers. Do not ask for broad unredacted archives by default.
+
+## Collect read-only evidence first
+
+Depending on the path, collect:
+
+- client version, process state, mount state, filesystem identity, status, and information commands documented for that release;
+- metrics, access logs, client logs, and kernel or FUSE errors;
+- metadata engine health, latency, connections, capacity, and backup status;
+- object storage authentication, throttling, timeout, capacity, and request errors;
+- cache capacity, permissions, eviction, disk health, and resource pressure;
+- Kubernetes events and CSI Controller, CSI Node, Mount Pod, sidecar, and workload logs.
+
+Redact metadata credentials, database passwords, object storage keys, Secret values, encryption material, kubeconfig content, and customer data.
+
+## Route by layer
+
+- **Installation or startup:** binary, architecture, dependencies, permissions, service manager, flags, and configuration.
+- **Metadata:** reachability, authentication, latency, capacity, sessions, locks, transactions, backup, and filesystem identity.
+- **Object storage:** endpoint, region, credentials, bucket or prefix, throttling, lifecycle policy, consistency, and request failures.
+- **Mount or I/O:** application, kernel, FUSE, VFS, chunk I/O, local cache, network, metadata, and object storage.
+- **CSI:** provisioning, scheduling, node publish, mount lifecycle, propagation, workload I/O, and cleanup.
+- **Performance:** workload shape, concurrency, file sizes, cache state, client resources, metadata latency, object latency, network, and throttling.
+
+Read the matching public source when an error path, retry, timeout, option precedence, cleanup path, or suspected regression remains unclear. Do not use development-branch code as proof for the deployed release.
+
+## Preserve evidence and data
+
+Do not use cleanup, mass restart, credential rotation, reformatting, metadata import, object deletion, cache deletion, or PV or PVC deletion as an initial test.
+
+If there is suspected data loss, corruption, wrong bucket or prefix, filesystem UUID mismatch, unexpected metadata replacement, or widespread I/O failure:
+
+1. Stop avoidable writes and automation that may change state.
+2. Preserve logs, versions, configurations, filesystem identity, and time ranges.
+3. Verify backups and recovery targets without overwriting the affected system.
+4. Escalate before repair, import, deletion, or destructive garbage collection.
+
+## Propose bounded remediation
+
+Each change should state:
+
+- evidence and hypothesis;
+- exact target and command or configuration field;
+- expected result and failure mode;
+- prerequisites and backup;
+- rollback or recovery procedure;
+- verification signal and observation window;
+- required approval.
+
+Change one variable at a time whenever possible. Preserve before-and-after evidence and distinguish temporary mitigation from root-cause correction.
+
+## Recover on a controlled target
+
+Use recovery procedures that match the deployed version and metadata engine. Confirm source backup, destination, filesystem identity, object storage mapping, credentials, and expected downtime before proceeding.
+
+Avoid running competing metadata services or clients against an ambiguous restore target. After recovery, perform end-to-end read and write validation, cross-client checks, metrics review, and an explicit decision on how the old environment will be isolated or retired.
+
+## Close with evidence
+
+Report:
+
+1. Verified symptom and impact.
+2. Evidence collected and sensitive fields removed.
+3. Confirmed or most likely failing layer.
+4. Documentation and exact source revision used.
+5. Actions performed and approvals received.
+6. End-to-end acceptance result.
+7. Remaining risk, monitoring window, and follow-up owner.

--- a/docs/en/administration/ai-assisted-deployment-guide.md
+++ b/docs/en/administration/ai-assisted-deployment-guide.md
@@ -1,0 +1,226 @@
+---
+title: JuiceFS AI Deployment Assistant User Guide
+sidebar_position: 10
+description: Install and use the JuiceFS Community Support Skill for Community Edition deployment, operations, troubleshooting, recovery, and Kubernetes integration.
+---
+
+The JuiceFS AI-Assisted Deployment Assistant is an Agent Skill for JuiceFS Community Edition. It combines version-matched Community documentation and public source code with sanitized evidence from the target environment. It can help plan, validate, operate, and troubleshoot clients, metadata engines, object storage, FUSE mounts, gateways, cache, upgrades, recovery, and Community CSI integration.
+
+Install the complete skill directory once. During a task, the assistant loads only the reference files relevant to the selected scenario.
+
+## Prerequisites {#prerequisites}
+
+Before installation:
+
+- use an AI coding agent that can load a directory containing `SKILL.md` and supporting reference files;
+- identify the deployed JuiceFS client, CSI Driver, client image, and Kubernetes versions relevant to the task;
+- identify the metadata engine, data storage backend, access path, and existing file system state that must be preserved;
+- ensure that the agent can access the public documentation and repositories, or provide local documentation and source roots with their release tags, commits, or download dates;
+- arrange separate authorization for every state-changing operation.
+
+Do not provide complete metadata URLs with passwords, object-storage keys, encryption material, kubeconfigs, or Kubernetes Secret values. Share only focused and sanitized evidence.
+
+## Install the complete skill {#install}
+
+Download the skill to a temporary review directory:
+
+```shell
+SKILL_BASE=https://raw.githubusercontent.com/juicedata/juicefs/main/.agents/skills/juicefs-community-support
+REVIEW_DIR=$(mktemp -d)
+mkdir -p "$REVIEW_DIR/references"
+
+curl -fsSL "$SKILL_BASE/SKILL.md" -o "$REVIEW_DIR/SKILL.md"
+for file in community-deployment.md community-csi.md source-code.md troubleshooting.md; do
+  curl -fsSL "$SKILL_BASE/references/$file" -o "$REVIEW_DIR/references/$file"
+done
+
+find "$REVIEW_DIR" -type f -print
+less "$REVIEW_DIR/SKILL.md"
+```
+
+Choose an installation target:
+
+| Agent runtime | Project scope | User scope |
+| --- | --- | --- |
+| Claude Code | `.claude/skills/juicefs-community-support` | `~/.claude/skills/juicefs-community-support` |
+| Codex | `.agents/skills/juicefs-community-support` | `~/.agents/skills/juicefs-community-support` |
+| Cursor | `.cursor/skills/juicefs-community-support` or `.agents/skills/juicefs-community-support` | `~/.cursor/skills/juicefs-community-support` or `~/.agents/skills/juicefs-community-support` |
+| ZCode | Use user scope or import an external Agent Skill from **Settings > Skills** | `~/.zcode/skills/juicefs-community-support` |
+| DeepSeek Harness | `.dsh/skills/juicefs-community-support` or `.agents/skills/juicefs-community-support` | `~/.dsh/skills/juicefs-community-support` or `~/.agents/skills/juicefs-community-support` |
+| Qwen Code (Alibaba Cloud) | `.qwen/skills/juicefs-community-support` | `~/.qwen/skills/juicefs-community-support` |
+| CodeBuddy (Tencent Cloud) | `.codebuddy/skills/juicefs-community-support` | `~/.codebuddy/skills/juicefs-community-support` |
+| TRAE (ByteDance) | `.trae/skills/juicefs-community-support` | `~/.trae/skills/juicefs-community-support` |
+
+Copy the complete reviewed directory. This example uses Codex project scope:
+
+```shell
+SKILL_DIR=.agents/skills/juicefs-community-support
+mkdir -p "$SKILL_DIR/references"
+install -m 0644 "$REVIEW_DIR/SKILL.md" "$SKILL_DIR/SKILL.md"
+install -m 0644 "$REVIEW_DIR"/references/*.md "$SKILL_DIR/references/"
+```
+
+Do not translate or rename `SKILL.md` or its reference files. Refresh the runtime Skills page or start a new task after installation. A runtime that imports only `SKILL.md` receives the core safeguards but not complete scenario coverage.
+
+## Choose a Community Edition scenario {#use}
+
+Example requests:
+
+- “Help me prepare a production JuiceFS Community Edition deployment with PostgreSQL metadata and S3-compatible object storage.”
+- “Review this existing file system before I upgrade all clients.”
+- “The mount reports an I/O error. Diagnose the first failing layer without changing anything.”
+- “Investigate this behavior against the source code for the deployed release.”
+- “Help me troubleshoot a Community Edition volume through JuiceFS CSI Driver.”
+
+| Scenario | Reference files loaded |
+| --- | --- |
+| Deployment, production readiness, maintenance, or upgrade | `community-deployment.md` |
+| Kubernetes, PVC, Mount Pod, sidecar, or Operator | `community-csi.md` plus the relevant Community reference |
+| Version-sensitive or undocumented behavior | `source-code.md` plus the relevant scenario reference |
+| Focused failure, suspected data loss, or recovery | `troubleshooting.md` plus the relevant component reference |
+
+## Coverage and limits {#coverage}
+
+The assistant covers Community Edition clients, metadata engines, data storage backends, FUSE and gateway access, local cache, monitoring, upgrades, backup and recovery, public source investigation, and Community CSI integration.
+
+It does not act as an unattended installer. It does not treat an unpinned development branch as proof of deployed behavior, recommend unreleased production builds by default, invent flags or configuration fields, or perform changes without target-specific approval.
+
+## Safety and acceptance {#safety}
+
+Before formatting, importing or repairing metadata, deleting leaked objects, running destructive garbage collection, deleting Kubernetes resources, changing a bucket or prefix, rotating credentials, or destroying a filesystem, the assistant must identify the exact target, verify backup or recovery material, state the expected effect and rollback, and obtain explicit approval.
+
+A successful mount, Bound PVC, or Running Mount Pod is not sufficient proof. Acceptance requires a scoped workload to create a unique file, close it, reopen it, read it back, verify its checksum, and confirm cross-client or cross-Pod visibility when the topology requires it.
+
+## Review the skill contents {#skill-content}
+
+The entrypoint contains the always-on routing and safety boundaries. Detailed procedures are loaded only when the selected scenario requires them.
+
+| File | Purpose |
+| --- | --- |
+| [`SKILL.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/SKILL.md) | Scope, evidence order, source rules, safety boundaries, and acceptance |
+| [`community-deployment.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/community-deployment.md) | Deployment, topology, production readiness, operations, and upgrades |
+| [`community-csi.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/community-csi.md) | Community CSI provisioning, mount lifecycle, evidence, and acceptance |
+| [`source-code.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/source-code.md) | Version-matched JuiceFS and CSI Driver source investigation |
+| [`troubleshooting.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/troubleshooting.md) | Focused diagnosis, evidence preservation, remediation, and recovery |
+
+## Complete SKILL.md {#complete-skill}
+
+````markdown
+---
+name: juicefs-community-support
+description: Support, deploy, operate, and troubleshoot JuiceFS Community Edition and its CSI integration. Use when a request involves open-source JuiceFS clients, metadata engines, object storage, FUSE mounts, gateways, cache, upgrades, recovery, Kubernetes PV or PVC behavior, Mount Pods, or implementation questions that may require reading the matching public source code.
+---
+
+# JuiceFS Community Support
+
+## Outcome
+
+Help users deploy, operate, and troubleshoot JuiceFS Community Edition and its Kubernetes integration using verified environment facts, version-matched public documentation and source code, sanitized runtime evidence, and explicit safety boundaries.
+
+Do not assume JuiceFS Cloud Service or Enterprise Edition components, fields, workflows, or capabilities.
+
+## Route the request
+
+Before giving commands or conclusions, identify:
+
+1. The stage: design, installation, deployment, validation, operation, upgrade, troubleshooting, or recovery.
+2. Exact versions: JuiceFS client, CSI Driver, client image, Helm chart or manifests, and Kubernetes when relevant.
+3. Topology: standalone or distributed, metadata engine, object storage, clients, and Kubernetes components.
+4. Access path: FUSE, S3 Gateway, Hadoop SDK, CSI, sidecar, or another supported interface.
+5. Existing state: new deployment, existing filesystem, degraded service, suspected data loss, or migration.
+
+Load only the references needed for the request:
+
+- Community deployment and operations: [deployment and operations reference](references/community-deployment.md)
+- Community CSI integration: [Community CSI reference](references/community-csi.md)
+- Version-matched source investigation: [source investigation reference](references/source-code.md)
+- Troubleshooting and recovery: [troubleshooting and recovery reference](references/troubleshooting.md)
+
+## Use evidence in this order
+
+1. Public documentation that matches the deployed release.
+2. Public source code at the matching release tag or exact commit.
+3. Sanitized runtime evidence from the affected environment.
+4. The current development branch, explicitly labeled as possible later behavior.
+5. Inference, explicitly labeled and paired with a verification step.
+
+If public documentation is unavailable, ask for the local JuiceFS source or documentation root and its release tag, commit, or download date. For the current Community repository layout, use `<JUICEFS_ROOT>/docs/en/` for English or `<JUICEFS_ROOT>/docs/zh_cn/` for Chinese. Read only the locale and topic relevant to the request, and do not assume that the local copy matches the deployed client version.
+
+If documentation, source code, and runtime behavior disagree, report the mismatch. Do not silently choose one.
+
+## Keep product and system layers separate
+
+- Community Edition uses a customer-selected metadata engine and data storage backend. Object storage is common but not the only supported backend.
+- Do not introduce Cloud Service console workflows, managed metadata services, Enterprise Edition distributed cache, license fields, or enterprise authentication fields.
+- Separate the application, kernel cache, FUSE, VFS and buffers, local cache, metadata engine, object storage, gateway, CSI Controller, CSI Node, Mount Pod, sidecar, and workload Pod.
+- Treat requests for other JuiceFS service models as outside this skill and use the documentation and operating model for the requested product.
+
+## Read open-source code safely
+
+Reading the public JuiceFS and CSI Driver source is allowed and encouraged when behavior is version-sensitive, undocumented, or unclear.
+
+- Pin the deployed release tag, image version, or exact commit before drawing conclusions.
+- Follow the real call path and cite repository, revision, file path, and relevant lines or symbols.
+- Do not use an unpinned development branch as proof of behavior in an older deployed release.
+- Do not recommend building unreleased source for production as the default remediation.
+- Distinguish implementation facts from tests, commit intent, documentation, runtime observations, and inference.
+
+See [references/source-code.md](references/source-code.md) for routing details.
+
+## Protect credentials and data
+
+Treat metadata URLs, database passwords, object storage keys, encryption material, kubeconfig content, and Kubernetes Secret values as sensitive. Ask for redacted evidence and never echo secrets in commands or reports.
+
+A plan or diagnosis does not authorize changes. Before any state-changing action, state:
+
+- exact target and scope;
+- expected effect and risk;
+- prerequisite backup or recovery point;
+- verification and rollback procedure;
+- approval required from the environment owner.
+
+High-risk actions include filesystem initialization or replacement, metadata import or repair, leaked-object deletion, destructive garbage collection, cache removal, bucket or prefix changes, PV or PVC deletion, credential rotation, and changes to reclaim policy.
+
+## Require end-to-end acceptance
+
+For a controlled test path, create a unique file, close it, reopen it, read it back, and verify its checksum. When relevant, repeat from another client or Pod and correlate the result with events, logs, and metrics.
+
+Do not equate any single intermediate state with success. Keep these separate:
+
+- application write completion;
+- `close` or `fsync` return;
+- internal buffer flush;
+- object upload;
+- metadata commit;
+- backend durability;
+- a Bound PVC or Running Mount Pod;
+- successful workload I/O.
+
+## Communicate confidence
+
+Label important findings as one of:
+
+- **Verified:** observed directly in the target environment.
+- **Documentation-based:** supported by version-matched public documentation.
+- **Source-verified:** supported by version-matched public source code.
+- **Unconfirmed:** evidence is insufficient or conflicting.
+- **Inference:** a reasoned hypothesis with a concrete verification step.
+
+Finish with the current state, unresolved risks, next safe action, and success criteria.
+
+## Stop conditions
+
+Stop and request clarification or explicit approval when:
+
+- the target filesystem, cluster, bucket, prefix, metadata endpoint, PV, or PVC is ambiguous;
+- credentials or recovery materials are missing;
+- the available source revision does not match the deployed artifact;
+- the next step could delete, overwrite, reinitialize, or irreversibly migrate data;
+- suspected data loss or corruption requires preserving evidence before further action.
+````
+
+## Update or remove the skill {#update}
+
+To update, download all files to a new temporary directory, review the changes, and replace the complete installed directory. Do not update only `SKILL.md` because its routing may depend on updated references.
+
+To remove the skill, delete only the installed `juicefs-community-support` directory from the project or user scope that you selected. This does not change any JuiceFS filesystem, client, metadata engine, or Kubernetes resource.

--- a/docs/zh_cn/administration/ai-assisted-deployment-guide.md
+++ b/docs/zh_cn/administration/ai-assisted-deployment-guide.md
@@ -1,0 +1,226 @@
+---
+title: JuiceFS AI 辅助部署助手使用指南
+sidebar_position: 10
+description: 安装并使用 JuiceFS 社区版 Support Skill，辅助社区版部署、运维、排障、恢复和 Kubernetes 接入。
+---
+
+JuiceFS AI 辅助部署助手是一项面向 JuiceFS 社区版的 Agent Skill。它结合与实际版本匹配的社区版文档、公开源代码和目标环境中的脱敏证据，辅助规划、验证、运维和排查客户端、元数据引擎、数据存储后端、FUSE 挂载、网关、缓存、升级、恢复及社区版 CSI 接入问题。
+
+只需安装一次完整 Skill 目录。执行任务时，助手仅加载当前场景需要的 reference 文件。
+
+## 前置条件 {#prerequisites}
+
+安装前请确认：
+
+- AI 编程 Agent 能加载包含 `SKILL.md` 和 reference 文件的完整目录；
+- 已确认任务相关的 JuiceFS 客户端、CSI Driver、客户端镜像及 Kubernetes 版本；
+- 已确认元数据引擎、数据存储后端、访问方式，以及必须保留的现有文件系统状态；
+- Agent 可以访问公开文档和仓库；如果处于离线环境，则提供本地文档及源码根目录，并说明其 release tag、commit 或下载日期；
+- 每个状态变更都由环境责任人单独授权。
+
+不要提供包含密码的完整元数据 URL、对象存储密钥、加密材料、kubeconfig 或 Kubernetes Secret 值。只提供聚焦且脱敏的证据。
+
+## 安装完整 Skill {#install}
+
+先将 Skill 下载到临时审阅目录：
+
+```shell
+SKILL_BASE=https://raw.githubusercontent.com/juicedata/juicefs/main/.agents/skills/juicefs-community-support
+REVIEW_DIR=$(mktemp -d)
+mkdir -p "$REVIEW_DIR/references"
+
+curl -fsSL "$SKILL_BASE/SKILL.md" -o "$REVIEW_DIR/SKILL.md"
+for file in community-deployment.md community-csi.md source-code.md troubleshooting.md; do
+  curl -fsSL "$SKILL_BASE/references/$file" -o "$REVIEW_DIR/references/$file"
+done
+
+find "$REVIEW_DIR" -type f -print
+less "$REVIEW_DIR/SKILL.md"
+```
+
+选择安装位置：
+
+| Agent 运行时 | 项目范围 | 用户范围 |
+| --- | --- | --- |
+| Claude Code | `.claude/skills/juicefs-community-support` | `~/.claude/skills/juicefs-community-support` |
+| Codex | `.agents/skills/juicefs-community-support` | `~/.agents/skills/juicefs-community-support` |
+| Cursor | `.cursor/skills/juicefs-community-support` 或 `.agents/skills/juicefs-community-support` | `~/.cursor/skills/juicefs-community-support` 或 `~/.agents/skills/juicefs-community-support` |
+| ZCode | 使用用户范围，或在 **Settings > Skills** 中导入外部 Agent Skill | `~/.zcode/skills/juicefs-community-support` |
+| DeepSeek Harness | `.dsh/skills/juicefs-community-support` 或 `.agents/skills/juicefs-community-support` | `~/.dsh/skills/juicefs-community-support` 或 `~/.agents/skills/juicefs-community-support` |
+| Qwen Code（阿里云） | `.qwen/skills/juicefs-community-support` | `~/.qwen/skills/juicefs-community-support` |
+| CodeBuddy（腾讯云） | `.codebuddy/skills/juicefs-community-support` | `~/.codebuddy/skills/juicefs-community-support` |
+| TRAE（字节跳动） | `.trae/skills/juicefs-community-support` | `~/.trae/skills/juicefs-community-support` |
+
+复制审阅后的完整目录。以下示例使用 Codex 项目范围：
+
+```shell
+SKILL_DIR=.agents/skills/juicefs-community-support
+mkdir -p "$SKILL_DIR/references"
+install -m 0644 "$REVIEW_DIR/SKILL.md" "$SKILL_DIR/SKILL.md"
+install -m 0644 "$REVIEW_DIR"/references/*.md "$SKILL_DIR/references/"
+```
+
+请勿翻译或重命名 `SKILL.md` 及其 reference 文件。安装后刷新运行时的 Skills 页面，或者新建任务。只导入 `SKILL.md` 可以获得核心安全规则，但无法获得完整场景覆盖。
+
+## 选择社区版场景 {#use}
+
+示例请求：
+
+- 「帮助我准备使用 PostgreSQL 元数据和 S3 兼容对象存储的 JuiceFS 社区版生产部署。」
+- 「升级全部客户端之前，帮我审阅现有文件系统。」
+- 「挂载点报告 I/O error，请从第一个失败层开始排查，不要修改环境。」
+- 「根据已部署版本的源代码核对这个行为。」
+- 「帮助我排查通过 JuiceFS CSI Driver 使用社区版卷的问题。」
+
+| 场景 | 加载的 reference 文件 |
+| --- | --- |
+| 部署、生产就绪、维护或升级 | `community-deployment.md` |
+| Kubernetes、PVC、Mount Pod、Sidecar 或 Operator | `community-csi.md` 及相关社区版 reference |
+| 版本敏感或文档未明确的行为 | `source-code.md` 及相关场景 reference |
+| 聚焦故障、疑似数据丢失或恢复 | `troubleshooting.md` 及相关组件 reference |
+
+## 覆盖范围与限制 {#coverage}
+
+助手覆盖社区版客户端、元数据引擎、数据存储后端、FUSE 和网关访问、本地缓存、监控、升级、备份恢复、公开源码核对及社区版 CSI 接入。
+
+它不是无人值守安装器；不会把未固定版本的开发分支当作已部署行为的证据，不会默认建议使用未发布源码构建生产版本，不会编造参数或配置字段，也不会在缺少明确目标授权时执行变更。
+
+## 安全与验收 {#safety}
+
+执行格式化、元数据导入或修复、泄漏对象删除、破坏性垃圾回收、Kubernetes 资源删除、Bucket 或 Prefix 变更、凭据轮换或文件系统销毁前，助手必须确认确切目标，核对备份或恢复材料，说明预期影响和回滚方式，并获得明确授权。
+
+成功挂载、Bound PVC 或 Running Mount Pod 都不足以证明部署完成。验收必须由限定范围的工作负载创建唯一文件，关闭并重新打开，读回并校验 checksum；拓扑需要时，还要确认跨客户端或跨 Pod 可见性。
+
+## 审阅 Skill 内容 {#skill-content}
+
+入口文件保存始终生效的路由和安全边界。只有当前场景需要时，助手才加载详细 reference。
+
+| 文件 | 用途 |
+| --- | --- |
+| [`SKILL.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/SKILL.md) | 适用范围、证据顺序、源码规则、安全边界和验收 |
+| [`community-deployment.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/community-deployment.md) | 部署、拓扑、生产就绪、运维和升级 |
+| [`community-csi.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/community-csi.md) | 社区版 CSI provisioning、挂载生命周期、证据和验收 |
+| [`source-code.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/source-code.md) | 按版本核对 JuiceFS 与 CSI Driver 公开源码 |
+| [`troubleshooting.md`](https://github.com/juicedata/juicefs/blob/main/.agents/skills/juicefs-community-support/references/troubleshooting.md) | 聚焦诊断、证据保全、修复和恢复 |
+
+## 完整 SKILL.md {#complete-skill}
+
+````markdown
+---
+name: juicefs-community-support
+description: Support, deploy, operate, and troubleshoot JuiceFS Community Edition and its CSI integration. Use when a request involves open-source JuiceFS clients, metadata engines, object storage, FUSE mounts, gateways, cache, upgrades, recovery, Kubernetes PV or PVC behavior, Mount Pods, or implementation questions that may require reading the matching public source code.
+---
+
+# JuiceFS Community Support
+
+## Outcome
+
+Help users deploy, operate, and troubleshoot JuiceFS Community Edition and its Kubernetes integration using verified environment facts, version-matched public documentation and source code, sanitized runtime evidence, and explicit safety boundaries.
+
+Do not assume JuiceFS Cloud Service or Enterprise Edition components, fields, workflows, or capabilities.
+
+## Route the request
+
+Before giving commands or conclusions, identify:
+
+1. The stage: design, installation, deployment, validation, operation, upgrade, troubleshooting, or recovery.
+2. Exact versions: JuiceFS client, CSI Driver, client image, Helm chart or manifests, and Kubernetes when relevant.
+3. Topology: standalone or distributed, metadata engine, object storage, clients, and Kubernetes components.
+4. Access path: FUSE, S3 Gateway, Hadoop SDK, CSI, sidecar, or another supported interface.
+5. Existing state: new deployment, existing filesystem, degraded service, suspected data loss, or migration.
+
+Load only the references needed for the request:
+
+- Community deployment and operations: [deployment and operations reference](references/community-deployment.md)
+- Community CSI integration: [Community CSI reference](references/community-csi.md)
+- Version-matched source investigation: [source investigation reference](references/source-code.md)
+- Troubleshooting and recovery: [troubleshooting and recovery reference](references/troubleshooting.md)
+
+## Use evidence in this order
+
+1. Public documentation that matches the deployed release.
+2. Public source code at the matching release tag or exact commit.
+3. Sanitized runtime evidence from the affected environment.
+4. The current development branch, explicitly labeled as possible later behavior.
+5. Inference, explicitly labeled and paired with a verification step.
+
+If public documentation is unavailable, ask for the local JuiceFS source or documentation root and its release tag, commit, or download date. For the current Community repository layout, use `<JUICEFS_ROOT>/docs/en/` for English or `<JUICEFS_ROOT>/docs/zh_cn/` for Chinese. Read only the locale and topic relevant to the request, and do not assume that the local copy matches the deployed client version.
+
+If documentation, source code, and runtime behavior disagree, report the mismatch. Do not silently choose one.
+
+## Keep product and system layers separate
+
+- Community Edition uses a customer-selected metadata engine and data storage backend. Object storage is common but not the only supported backend.
+- Do not introduce Cloud Service console workflows, managed metadata services, Enterprise Edition distributed cache, license fields, or enterprise authentication fields.
+- Separate the application, kernel cache, FUSE, VFS and buffers, local cache, metadata engine, object storage, gateway, CSI Controller, CSI Node, Mount Pod, sidecar, and workload Pod.
+- Treat requests for other JuiceFS service models as outside this skill and use the documentation and operating model for the requested product.
+
+## Read open-source code safely
+
+Reading the public JuiceFS and CSI Driver source is allowed and encouraged when behavior is version-sensitive, undocumented, or unclear.
+
+- Pin the deployed release tag, image version, or exact commit before drawing conclusions.
+- Follow the real call path and cite repository, revision, file path, and relevant lines or symbols.
+- Do not use an unpinned development branch as proof of behavior in an older deployed release.
+- Do not recommend building unreleased source for production as the default remediation.
+- Distinguish implementation facts from tests, commit intent, documentation, runtime observations, and inference.
+
+See [references/source-code.md](references/source-code.md) for routing details.
+
+## Protect credentials and data
+
+Treat metadata URLs, database passwords, object storage keys, encryption material, kubeconfig content, and Kubernetes Secret values as sensitive. Ask for redacted evidence and never echo secrets in commands or reports.
+
+A plan or diagnosis does not authorize changes. Before any state-changing action, state:
+
+- exact target and scope;
+- expected effect and risk;
+- prerequisite backup or recovery point;
+- verification and rollback procedure;
+- approval required from the environment owner.
+
+High-risk actions include filesystem initialization or replacement, metadata import or repair, leaked-object deletion, destructive garbage collection, cache removal, bucket or prefix changes, PV or PVC deletion, credential rotation, and changes to reclaim policy.
+
+## Require end-to-end acceptance
+
+For a controlled test path, create a unique file, close it, reopen it, read it back, and verify its checksum. When relevant, repeat from another client or Pod and correlate the result with events, logs, and metrics.
+
+Do not equate any single intermediate state with success. Keep these separate:
+
+- application write completion;
+- `close` or `fsync` return;
+- internal buffer flush;
+- object upload;
+- metadata commit;
+- backend durability;
+- a Bound PVC or Running Mount Pod;
+- successful workload I/O.
+
+## Communicate confidence
+
+Label important findings as one of:
+
+- **Verified:** observed directly in the target environment.
+- **Documentation-based:** supported by version-matched public documentation.
+- **Source-verified:** supported by version-matched public source code.
+- **Unconfirmed:** evidence is insufficient or conflicting.
+- **Inference:** a reasoned hypothesis with a concrete verification step.
+
+Finish with the current state, unresolved risks, next safe action, and success criteria.
+
+## Stop conditions
+
+Stop and request clarification or explicit approval when:
+
+- the target filesystem, cluster, bucket, prefix, metadata endpoint, PV, or PVC is ambiguous;
+- credentials or recovery materials are missing;
+- the available source revision does not match the deployed artifact;
+- the next step could delete, overwrite, reinitialize, or irreversibly migrate data;
+- suspected data loss or corruption requires preserving evidence before further action.
+````
+
+## 更新或移除 Skill {#update}
+
+更新时，请把全部文件下载到新的临时目录，审阅变更后替换完整安装目录。不要只更新 `SKILL.md`，因为它的路由可能依赖已经更新的 reference。
+
+移除时，只删除所选项目范围或用户范围内的 `juicefs-community-support` 安装目录。该操作不会修改任何 JuiceFS 文件系统、客户端、元数据引擎或 Kubernetes 资源。


### PR DESCRIPTION
## Summary

- Add English and Chinese Community Edition AI Deployment Assistant guides under **Administration**, after the upgrade guide.
- Add the installable `juicefs-community-support` Agent Skill under `.agents/skills/`.
- Keep the core `SKILL.md` concise and route deployment, CSI, source-code investigation, and troubleshooting details to four on-demand references.
- Support version-matched public source investigation for both JuiceFS and JuiceFS CSI Driver.
- Document offline documentation roots and installation locations for Claude Code, Codex, Cursor, ZCode, DeepSeek Harness, Qwen Code, CodeBuddy, and TRAE.
- Display the complete English `SKILL.md` directly in both guide pages.
- Keep the scope specific to Community Edition, with change approval, credential protection, data-safety, and end-to-end acceptance requirements.

## Placement

- `docs/en/administration/ai-assisted-deployment-guide.md`
- `docs/zh_cn/administration/ai-assisted-deployment-guide.md`
- `sidebar_position: 10`, immediately after the upgrade guide
- Community documentation on juicefs.com is synchronized from these source directories.

## Validation

- `python3 .../quick_validate.py .agents/skills/juicefs-community-support`
- `npm run markdown-lint`
- `npm run check-broken-link`
- AutoCorrect lint for `docs/` and `README*.md`
- `git diff --check`
- Verified that the embedded `SKILL.md` is identical in both language pages
- Verified explicit heading anchors match across the English and Chinese pages
- Verified the English page contains no Chinese text
