### PR TITLE
sql: verify exact edge identity on mutation to prevent lost updates

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -2070,6 +2070,109 @@ func testRace(t *testing.T, m Meta) {
 	t.Run("TrashSliceClaim", func(t *testing.T) {
 		testTrashSliceClaimRace(t, m)
 	})
+	t.Run("SQLExactEdgeCAS", func(t *testing.T) {
+		db, ok := m.(*dbMeta)
+		if !ok {
+			t.Skip("SQL transaction invariant")
+		}
+		testSQLExactEdgeCAS(t, db)
+	})
+}
+
+func testSQLExactEdgeCAS(t *testing.T, m *dbMeta) {
+	insert := func(e *edge) {
+		t.Helper()
+		if _, err := m.db.Insert(e); err != nil {
+			t.Fatalf("insert edge %q: %s", e.Name, err)
+		}
+		if e.Id == 0 {
+			t.Fatalf("insert edge %q returned zero id", e.Name)
+		}
+	}
+	remove := func(id int64) {
+		t.Helper()
+		if _, err := m.db.ID(id).Delete(&edge{}); err != nil {
+			t.Errorf("remove edge %d: %s", id, err)
+		}
+	}
+	get := func(id int64) edge {
+		t.Helper()
+		var e edge
+		ok, err := m.db.ID(id).Get(&e)
+		if err != nil {
+			t.Fatalf("get edge %d: %s", id, err)
+		}
+		if !ok {
+			t.Fatalf("edge %d not found", id)
+		}
+		return e
+	}
+
+	t.Run("DeleteRejectsChangedIdentity", func(t *testing.T) {
+		original := edge{Parent: RootInode, Name: []byte("sql-c05-changed"), Inode: 101, Type: TypeFile}
+		insert(&original)
+		defer remove(original.Id)
+		stale := get(original.Id)
+		if n, err := m.db.ID(original.Id).Cols("inode", "type").Update(&edge{Inode: 102, Type: TypeSymlink}); err != nil || n != 1 {
+			t.Fatalf("replace edge identity: rows=%d err=%v", n, err)
+		}
+
+		_, err := m.db.Transaction(func(s *xorm.Session) (interface{}, error) { return nil, deleteEdge(s, &stale) })
+		if !errors.Is(err, errEdgeChanged) {
+			t.Fatalf("delete stale edge: got %v, want %v", err, errEdgeChanged)
+		}
+		current := get(original.Id)
+		if current.Inode != 102 || current.Type != TypeSymlink {
+			t.Fatalf("replacement edge changed: inode=%d type=%d", current.Inode, current.Type)
+		}
+	})
+
+	t.Run("UpdateRejectsABAIdentity", func(t *testing.T) {
+		original := edge{Parent: RootInode, Name: []byte("sql-c05-aba"), Inode: 201, Type: TypeFile}
+		insert(&original)
+		stale := get(original.Id)
+		if n, err := m.db.ID(original.Id).Delete(&edge{}); err != nil || n != 1 {
+			t.Fatalf("delete original edge: rows=%d err=%v", n, err)
+		}
+		replacement := edge{Parent: original.Parent, Name: original.Name, Inode: original.Inode, Type: original.Type}
+		insert(&replacement)
+		defer remove(replacement.Id)
+
+		_, err := m.db.Transaction(func(s *xorm.Session) (interface{}, error) {
+			return nil, updateEdge(s, &stale, &edge{Inode: 202, Type: TypeSymlink})
+		})
+		if !errors.Is(err, errEdgeChanged) {
+			t.Fatalf("update ABA edge: got %v, want %v", err, errEdgeChanged)
+		}
+		current := get(replacement.Id)
+		if current.Inode != original.Inode || current.Type != original.Type {
+			t.Fatalf("ABA replacement changed: inode=%d type=%d", current.Inode, current.Type)
+		}
+	})
+
+	t.Run("BatchAffectedRowsRollback", func(t *testing.T) {
+		first := edge{Parent: RootInode, Name: []byte("sql-c05-batch-first"), Inode: 301, Type: TypeFile}
+		second := edge{Parent: RootInode, Name: []byte("sql-c05-batch-second"), Inode: 302, Type: TypeFile}
+		insert(&first)
+		defer remove(first.Id)
+		insert(&second)
+		defer remove(second.Id)
+		stale := []edge{get(first.Id), get(second.Id)}
+		if n, err := m.db.ID(second.Id).Cols("inode").Update(&edge{Inode: 303}); err != nil || n != 1 {
+			t.Fatalf("replace batch edge identity: rows=%d err=%v", n, err)
+		}
+
+		_, err := m.db.Transaction(func(s *xorm.Session) (interface{}, error) { return nil, deleteEdges(s, stale) })
+		if !errors.Is(err, errEdgeChanged) {
+			t.Fatalf("delete stale edge batch: got %v, want %v", err, errEdgeChanged)
+		}
+		if current := get(first.Id); current.Inode != first.Inode {
+			t.Fatalf("first edge deletion was not rolled back: inode=%d", current.Inode)
+		}
+		if current := get(second.Id); current.Inode != 303 {
+			t.Fatalf("second replacement changed: inode=%d", current.Inode)
+		}
+	})
 }
 
 func testTrashSliceClaimRace(t *testing.T, m Meta) {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -1195,7 +1195,12 @@ func (m *dbMeta) doCleanupChangelog(ctx Context, maxAge time.Duration, maxLines 
 
 var errBusy error
 
+var errEdgeChanged = errors.New("edge was changed by a concurrent transaction")
+
 func (m *dbMeta) shouldRetry(err error) bool {
+	if errors.Is(err, errEdgeChanged) {
+		return true
+	}
 	if m.Name() == "mysql" && err == syscall.EBUSY {
 		// Retry transaction when parent node update return 0 rows in MySQL
 		return true
@@ -1947,6 +1952,91 @@ func (m *dbMeta) doMknod(ctx Context, parent Ino, name string, _type uint8, mode
 	}))
 }
 
+func (m *dbMeta) getEdge(ctx Context, s *xorm.Session, parent Ino, name string) (edge, bool, error) {
+	e := edge{Parent: parent, Name: []byte(name)}
+	ok, err := s.Get(&e)
+	if err != nil || ok || !m.conf.CaseInsensi {
+		return e, ok, err
+	}
+	entry := m.resolveCase(ctx, parent, name)
+	if entry == nil {
+		return e, false, nil
+	}
+	e = edge{Parent: parent, Name: entry.Name}
+	ok, err = s.Get(&e)
+	return e, ok, err
+}
+
+func edgeIdentity(s *xorm.Session, e *edge) *xorm.Session {
+	q := s.Where("parent = ? AND name = ? AND inode = ? AND type = ?", e.Parent, e.Name, e.Inode, e.Type)
+	if e.Id > 0 {
+		q = q.And("id = ?", e.Id)
+	}
+	return q
+}
+
+func deleteEdge(s *xorm.Session, e *edge) error {
+	n, err := edgeIdentity(s, e).Delete(&edge{})
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errEdgeChanged
+	}
+	return nil
+}
+
+func deleteEdges(s *xorm.Session, edges []edge) error {
+	if len(edges) == 0 {
+		return nil
+	}
+	q := s.Table(&edge{})
+	for i := range edges {
+		e := &edges[i]
+		cond := "parent = ? AND name = ? AND inode = ? AND type = ?"
+		args := []interface{}{e.Parent, e.Name, e.Inode, e.Type}
+		if e.Id > 0 {
+			cond += " AND id = ?"
+			args = append(args, e.Id)
+		}
+		if i == 0 {
+			q = q.Where(cond, args...)
+		} else {
+			q = q.Or(cond, args...)
+		}
+	}
+	n, err := q.Delete(&edge{})
+	if err != nil {
+		return err
+	}
+	if n != int64(len(edges)) {
+		return errEdgeChanged
+	}
+	return nil
+}
+
+func updateEdge(s *xorm.Session, old, new *edge) error {
+	if old.Inode == new.Inode && old.Type == new.Type {
+		var current edge
+		ok, err := edgeIdentity(s.ForUpdate(), old).Get(&current)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errEdgeChanged
+		}
+		return nil
+	}
+	n, err := edgeIdentity(s, old).Cols("inode", "type").Update(&edge{Inode: new.Inode, Type: new.Type})
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errEdgeChanged
+	}
+	return nil
+}
+
 func (m *dbMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, skipCheckTrash ...bool) syscall.Errno {
 	var trash Ino
 	if !(len(skipCheckTrash) == 1 && skipCheckTrash[0]) {
@@ -1979,18 +2069,9 @@ func (m *dbMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, skip
 		if (pn.Flags&FlagAppend) != 0 || (pn.Flags&FlagImmutable) != 0 {
 			return syscall.EPERM
 		}
-		var e = edge{Parent: parent, Name: []byte(name)}
-		ok, err = s.Get(&e)
+		e, ok, err := m.getEdge(ctx, s, parent, name)
 		if err != nil {
 			return err
-		}
-		if !ok && m.conf.CaseInsensi {
-			if ee := m.resolveCase(ctx, parent, name); ee != nil {
-				ok = true
-				e.Name = ee.Name
-				e.Inode = ee.Inode
-				e.Type = ee.Attr.Typ
-			}
 		}
 		if !ok {
 			return syscall.ENOENT
@@ -2042,7 +2123,7 @@ func (m *dbMeta) doUnlink(ctx Context, parent Ino, name string, attr *Attr, skip
 			updateParent = true
 		}
 
-		if _, err := s.Delete(&edge{Parent: parent, Name: e.Name}); err != nil {
+		if err := deleteEdge(s, &e); err != nil {
 			return err
 		}
 
@@ -2161,18 +2242,9 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, attr
 		if pn.Flags&FlagImmutable != 0 || pn.Flags&FlagAppend != 0 {
 			return syscall.EPERM
 		}
-		var e = edge{Parent: parent, Name: []byte(name)}
-		ok, err = s.Get(&e)
+		e, ok, err := m.getEdge(ctx, s, parent, name)
 		if err != nil {
 			return err
-		}
-		if !ok && m.conf.CaseInsensi {
-			if ee := m.resolveCase(ctx, parent, name); ee != nil {
-				ok = true
-				e.Inode = ee.Inode
-				e.Name = ee.Name
-				e.Type = ee.Attr.Typ
-			}
 		}
 		if !ok {
 			return syscall.ENOENT
@@ -2218,7 +2290,7 @@ func (m *dbMeta) doRmdir(ctx Context, parent Ino, name string, pinode *Ino, attr
 		pn.setMtime(now)
 		pn.setCtime(now)
 
-		if _, err := s.Delete(&edge{Parent: parent, Name: e.Name}); err != nil {
+		if err := deleteEdge(s, &e); err != nil {
 			return err
 		}
 		if _, err := s.Delete(&dirStats{Inode: e.Inode}); err != nil {
@@ -2331,20 +2403,9 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		if st := m.Access(ctx, parentDst, MODE_MASK_W|MODE_MASK_X, &dpattr); st != 0 {
 			return st
 		}
-		var se = edge{Parent: parentSrc, Name: []byte(nameSrc)}
-		ok, err := s.Get(&se)
+		se, ok, err := m.getEdge(ctx, s, parentSrc, nameSrc)
 		if err != nil {
 			return err
-		}
-		if !ok && m.conf.CaseInsensi {
-			if e := m.resolveCase(ctx, parentSrc, nameSrc); e != nil {
-				if string(e.Name) != nameSrc || parentSrc != parentDst {
-					ok = true
-					se.Inode = e.Inode
-					se.Type = e.Attr.Typ
-					se.Name = e.Name
-				}
-			}
 		}
 		if !ok {
 			return syscall.ENOENT
@@ -2380,20 +2441,15 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		if st := m.Access(ctx, parentDst, MODE_MASK_W|MODE_MASK_X, &dpattr); st != 0 {
 			return st
 		}
-		var de = edge{Parent: parentDst, Name: []byte(nameDst)}
-		ok, err = s.Get(&de)
+		de, ok, err := m.getEdge(ctx, s, parentDst, nameDst)
 		if err != nil {
 			return err
 		}
-		if !ok && m.conf.CaseInsensi {
-			if e := m.resolveCase(ctx, parentDst, nameDst); e != nil {
-				if string(e.Name) != nameSrc || parentSrc != parentDst {
-					ok = true
-					de.Inode = e.Inode
-					de.Type = e.Attr.Typ
-					de.Name = e.Name
-				}
-			}
+		if ok && parentSrc == parentDst && de.Id == se.Id && nameDst != nameSrc {
+			// case-insensitive lookup resolved the destination to the source
+			// itself; treat the destination as missing
+			ok = false
+			de = edge{Parent: parentDst, Name: []byte(nameDst)}
 		}
 		var supdate, dupdate bool
 		var srcnlink, dstnlink int32
@@ -2511,20 +2567,18 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 		}
 
 		if exchange {
-			if _, err := s.Cols("inode", "type").Update(&de, &edge{Parent: parentSrc, Name: se.Name}); err != nil {
+			if err := updateEdge(s, &se, &edge{Inode: de.Inode, Type: de.Type}); err != nil {
 				return err
 			}
-			if _, err := s.Cols("inode", "type").Update(&se, &edge{Parent: parentDst, Name: de.Name}); err != nil {
+			if err := updateEdge(s, &de, &edge{Inode: se.Inode, Type: se.Type}); err != nil {
 				return err
 			}
 			if _, err := s.Cols("ctime", "ctimensec", "parent").Update(dn, &node{Inode: dino}); err != nil {
 				return err
 			}
 		} else {
-			if n, err := s.Delete(&edge{Parent: parentSrc, Name: se.Name}); err != nil {
+			if err := deleteEdge(s, &se); err != nil {
 				return err
-			} else if n != 1 {
-				return fmt.Errorf("delete src failed")
 			}
 			if dino > 0 {
 				if trash > 0 {
@@ -2576,7 +2630,7 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 						return err
 					}
 				}
-				if _, err := s.Delete(&edge{Parent: parentDst, Name: de.Name}); err != nil {
+				if err := deleteEdge(s, &de); err != nil {
 					return err
 				}
 				if de.Type == TypeDirectory {
@@ -2965,7 +3019,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 			edgesIns := make([]interface{}, 0)
 			// walk each edge to decide whether to move to trash, decrement nlink or delete inode & xattrs
 			for _, info := range entryInfos {
-				edgesDel = append(edgesDel, edge{Parent: parent, Name: info.e.Name})
+				edgesDel = append(edgesDel, *info.e)
 				if info.n.Inode != 0 {
 					if info.n.Type == TypeFile {
 						batchDirLength -= int64(info.n.Length)
@@ -3049,18 +3103,8 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 				visited[info.n.Inode] = true
 			}
 
-			if len(edgesDel) > 0 {
-				query := s.Table(&edge{})
-				for j, e := range edgesDel {
-					if j == 0 {
-						query = query.Where("parent = ? AND name = ?", e.Parent, e.Name)
-					} else {
-						query = query.Or("parent = ? AND name = ?", e.Parent, e.Name)
-					}
-				}
-				if _, err := query.Delete(&edge{}); err != nil {
-					return err
-				}
+			if err := deleteEdges(s, edgesDel); err != nil {
+				return err
 			}
 
 			// execute SQL statements in batches


### PR DESCRIPTION
## Problem

In the SQL metadata engine, directory-entry (edge) mutations delete or update rows by `(parent, name)` only, without verifying that the row still matches the edge read earlier in the transaction, and mostly ignore the affected-row count. With MySQL MVCC, a transaction can read an edge from its snapshot while a later DELETE/UPDATE acts on the latest committed row. A concurrent rename/unlink/create can therefore replace the edge between the read and mutation, causing the mutation to hit a different inode (lost update / ABA), or to delete a re-created entry.

## Solution

- Add an `errEdgeChanged` retryable sentinel, recognized by `shouldRetry` so the transaction restarts against a fresh snapshot.
- Add `edgeIdentity`-based helpers `deleteEdge` / `deleteEdges` / `updateEdge` that match the full identity `(parent, name, inode, type [, id])` and verify the affected-row count; any mismatch returns `errEdgeChanged`.
- Add `getEdge` helper (with case-insensitive resolution) so successful lookups return the complete edge row, including its `id`, for exact matching.
- Use these helpers in `doUnlink`, `doRmdir`, `doRename` (both exchange and replace paths), and `doBatchUnlink`.
- When a case-insensitive destination lookup resolves to the exact source edge, compare edge IDs and treat the destination as missing so a requested case-only rename is performed.

## Tests

- `testSQLExactEdgeCAS` directly verifies the helper invariants:
  - stale-identity delete returns `errEdgeChanged` and preserves the replacement;
  - ABA update returns `errEdgeChanged` and preserves the re-created edge;
  - partial batch delete returns `errEdgeChanged` and rolls back earlier deletions in the transaction.
- With the helpers mutated back to the old `(parent, name)` behavior, all three subtests fail.
- These are helper-level tests; they do not simulate concurrent public `Rename` / `Unlink` calls or verify the transaction retry loop end to end.
- `TestSQLiteClient` passes on the current commit.

## Notes

- Duplicate-name handling in `BatchUnlink` is intentionally not part of this PR; it is handled separately by #7526 for SQL, Redis, and KV metadata engines.
- Part of a 3-PR split, each independently based on `main`:
  - this PR — SQL exact edge identity CAS (delete/update verify identity, retry on conflict);
  - #7472 — SQL ordered namespace-node locking;
  - #7477 — trash decision consistency across transaction retries and clients (all engines).
- They touch the same functions in `pkg/meta/sql.go`; whichever merges later resolves textual conflicts by keeping the union of both changes.