### PR TITLE
Export volume name to tikv metrics

### DIFF
--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/txnutil"
+	"github.com/tikv/client-go/v2/util"
 	"github.com/tikv/pd/client/opt"
 	"go.uber.org/zap"
 )
@@ -86,8 +87,8 @@ func newTikvClient(addr string) (tkvClient, error) {
 			dur = time.Hour
 		}
 		interval = dur
+		logger.Infof("TiKV gc interval is set to %s", interval)
 	}
-	logger.Infof("TiKV gc interval is set to %s", interval)
 
 	client, err := txnkv.NewClient(strings.Split(tUrl.Host, ","))
 	if err != nil {
@@ -115,7 +116,7 @@ func newTikvClient(addr string) (tkvClient, error) {
 	}
 
 	prefix := strings.TrimLeft(tUrl.Path, "/")
-	return withPrefix(&tikvClient{client: client.KVStore, gcInterval: interval, changeLogShards: tiKVChangeLogShards()}, append([]byte(prefix), 0xFD)), nil
+	return withPrefix(&tikvClient{client: client.KVStore, gcInterval: interval, changeLogShards: tiKVChangeLogShards(), volume: prefix}, append([]byte(prefix), 0xFD)), nil
 }
 
 type tikvTxn struct {
@@ -310,6 +311,7 @@ type tikvClient struct {
 	client          *tikv.KVStore
 	gcInterval      time.Duration
 	changeLogShards int
+	volume          string
 }
 
 func (c *tikvClient) name() string {
@@ -337,6 +339,7 @@ func (c *tikvClient) simpleTxn(ctx context.Context, f func(*kvTxn) error, retry 
 	if err != nil {
 		return errors.Wrap(err, "failed to begin transaction")
 	}
+	tx.SetRequestSourceType(c.volume)
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(error); ok {
@@ -365,6 +368,7 @@ func (c *tikvClient) txn(ctx context.Context, f func(*kvTxn) error, retry int) (
 	if err != nil {
 		return err
 	}
+	tx.SetRequestSourceType(c.volume)
 	defer func() {
 		if r := recover(); r != nil {
 			fe, ok := r.(error)
@@ -396,6 +400,7 @@ OUT:
 			return err
 		}
 		snap := c.client.GetSnapshot(ts)
+		snap.SetRequestSourceType(c.volume)
 		snap.SetScanBatchSize(10240)
 		snap.SetNotFillCache(true)
 		snap.SetPriority(txnutil.PriorityLow)
@@ -442,7 +447,9 @@ func (c *tikvClient) gc() {
 		return
 	}
 
-	safePoint, err := c.client.GC(context.Background(), oracle.GoTimeToTS(oracle.GetTimeFromTS(currentTs).Add(-c.gcInterval)))
+	// Set request source to `internal_gc` instead of the default `unknown`.
+	ctx := util.WithInternalSourceType(context.Background(), util.InternalTxnGC)
+	safePoint, err := c.client.GC(ctx, oracle.GoTimeToTS(oracle.GetTimeFromTS(currentTs).Add(-c.gcInterval)))
 	if err == nil {
 		logger.Debugf("TiKV GC returns new safe point: %d (%s)", safePoint, oracle.GetTimeFromTS(safePoint))
 	} else {

--- a/pkg/meta/tkv_tikv.go
+++ b/pkg/meta/tkv_tikv.go
@@ -48,7 +48,6 @@ import (
 func init() {
 	Register("tikv", newKVMeta)
 	drivers["tikv"] = newTikvClient
-
 }
 
 func newTikvClient(addr string) (tkvClient, error) {


### PR DESCRIPTION
A TiKV cluster can serve metadata for multiple JuiceFS volumes. This PR exposes each JuiceFS volume name as a tenant identity in TiKV request-source metrics, which allows operators to monitor:

- Request rate per volume with `tikv_grpc_request_source_counter_vec`
- Average TiKV request latency per volume with `tikv_grpc_request_source_duration_vec/tikv_grpc_request_source_counter_vec`

When a TiKV cluster is under pressure, this makes it easier to quickly identify which volumes contribute most of the request traffic.

Following dashboard screenshot shows real per-volume source labels after this change:
<img width="2588" height="454" alt="image" src="https://github.com/user-attachments/assets/9e3c3e62-849f-4412-86e4-ae97e0c2f141" />
