### PR TITLE
sdk: fix python sdk ctypes ABI widths

### DIFF
--- a/.github/scripts/pysdk/pysdk_test.py
+++ b/.github/scripts/pysdk/pysdk_test.py
@@ -3,6 +3,7 @@ import fractions
 import unittest
 import os
 import pwd
+import stat
 from os.path import dirname
 import sys
 import time
@@ -231,6 +232,44 @@ class NonLocalSymlinkTests(FileTests):
         src = os.path.join(TESTFN, 'some_link')
         self.v.symlink('/some_dir', src)
         assert self.v.readlink(src) == '../some_dir'
+
+
+class ListdirTests(FileTests):
+    def test_listdir_empty(self):
+        d = os.path.join(TESTFN, 'empty_dir')
+        self.v.mkdir(d)
+        self.assertEqual(self.v.listdir(d), [])
+        self.assertEqual(self.v.listdir(d, detail=True), [])
+
+    def test_listdir_names(self):
+        d = os.path.join(TESTFN, 'names_dir')
+        self.v.mkdir(d)
+        names = ['a', 'b' * 200, 'with space', '中文名字']
+        for n in names:
+            self.create_file(os.path.join(d, n))
+        self.v.mkdir(os.path.join(d, 'subdir'))
+        self.assertEqual(sorted(self.v.listdir(d)), sorted(names + ['subdir']))
+
+    def test_listdir_detail(self):
+        d = os.path.join(TESTFN, 'detail_dir')
+        self.v.mkdir(d)
+        self.create_file(os.path.join(d, 'f'), b'0123456789')
+        self.v.mkdir(os.path.join(d, 'sub'))
+        infos = dict(self.v.listdir(d, detail=True))
+        self.assertEqual(sorted(infos), ['f', 'sub'])
+        self.assertTrue(stat.S_ISREG(infos['f'].st_mode))
+        self.assertEqual(infos['f'].st_size, 10)
+        self.assertTrue(stat.S_ISDIR(infos['sub'].st_mode))
+
+    def test_listdir_many(self):
+        d = os.path.join(TESTFN, 'many_dir')
+        self.v.mkdir(d)
+        names = ['file_%03d' % i for i in range(200)]
+        for n in names:
+            self.create_file(os.path.join(d, n))
+        self.assertEqual(sorted(self.v.listdir(d)), sorted(names))
+        infos = self.v.listdir(d, detail=True)
+        self.assertEqual(sorted(n for n, _ in infos), sorted(names))
 
 
 class ExtendedAttributeTests(FileTests):

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -1219,7 +1219,7 @@ func jfs_listXattr(pid int64, h int64, path *C.char, buf uintptr, bufsize int32)
 }
 
 //export jfs_listXattr2
-func jfs_listXattr2(pid int64, h int64, path *C.char, value **C.char, size *C.int) int32 {
+func jfs_listXattr2(pid int64, h int64, path *C.char, value **C.char, size *int64) int32 {
 	*value = nil
 	*size = 0
 	w := F(h)
@@ -1229,7 +1229,7 @@ func jfs_listXattr2(pid int64, h int64, path *C.char, value **C.char, size *C.in
 	t, err := w.ListXattr(w.withPid(pid), C.GoString(path))
 	if err == 0 {
 		*value = C.CString(string(t))
-		*size = C.int(len(t))
+		*size = int64(len(t))
 	}
 	return errno(err)
 }

--- a/sdk/java/libjfs/main.go
+++ b/sdk/java/libjfs/main.go
@@ -1219,7 +1219,9 @@ func jfs_listXattr(pid int64, h int64, path *C.char, buf uintptr, bufsize int32)
 }
 
 //export jfs_listXattr2
-func jfs_listXattr2(pid int64, h int64, path *C.char, value **C.char, size *int) int32 {
+func jfs_listXattr2(pid int64, h int64, path *C.char, value **C.char, size *C.int) int32 {
+	*value = nil
+	*size = 0
 	w := F(h)
 	if w == nil {
 		return EINVAL
@@ -1227,7 +1229,7 @@ func jfs_listXattr2(pid int64, h int64, path *C.char, value **C.char, size *int)
 	t, err := w.ListXattr(w.withPid(pid), C.GoString(path))
 	if err == 0 {
 		*value = C.CString(string(t))
-		*size = len(t)
+		*size = C.int(len(t))
 	}
 	return errno(err)
 }
@@ -1690,6 +1692,8 @@ func jfs_listdir(pid int64, h int64, cpath *C.char, offset int64, buf uintptr, b
 func jfs_listdir2(pid int64, h int64, cpath *C.char, plus bool, buf **byte, size *int64) int32 {
 	var ctx meta.Context
 	var f *fs.File
+	*buf = nil
+	*size = 0
 	w := F(h)
 	if w == nil {
 		return EINVAL
@@ -1705,7 +1709,6 @@ func jfs_listdir2(pid int64, h int64, cpath *C.char, plus bool, buf **byte, size
 		return ENOTDIR
 	}
 
-	*size = 0
 	if plus {
 		es, err := f.ReaddirPlus(ctx, 0)
 		if err != 0 {

--- a/sdk/python/juicefs/juicefs/juicefs.py
+++ b/sdk/python/juicefs/juicefs/juicefs.py
@@ -278,8 +278,7 @@ class Client(object):
     def listdir(self, path, detail=False):
         """Return a list containing the names of the entries in the directory given by path."""
         buf = c_void_p()
-        size = c_int()
-        # func jfs_listdir(pid int, h int64, cpath *C.char, offset int, buf uintptr, bufsize int) int {
+        size = c_int64()
 
         self.lib.jfs_listdir2(c_int64(_tid()), c_int64(self.h), _bin(path), bool(detail), byref(buf), byref(size))
         data = string_at(buf, size)
@@ -420,7 +419,7 @@ class Client(object):
         """Get the summary of a directory."""
         buf = c_void_p()
 
-        n = self.lib.jfs_gettreesummary(_tid(), self.h, _bin(path), c_uint8(depth), c_uint32(entries), byref(buf))
+        n = self.lib.jfs_gettreesummary(c_int64(_tid()), c_int64(self.h), _bin(path), c_uint8(depth), c_uint8(entries), byref(buf))
         data = string_at(buf, n)
         res = json.loads(str(data, encoding='utf-8'))
 

--- a/sdk/python/juicefs/juicefs/juicefs.py
+++ b/sdk/python/juicefs/juicefs/juicefs.py
@@ -281,7 +281,7 @@ class Client(object):
         size = c_int64()
 
         self.lib.jfs_listdir2(c_int64(_tid()), c_int64(self.h), _bin(path), bool(detail), byref(buf), byref(size))
-        data = string_at(buf, size)
+        data = string_at(buf, size.value)
         infos = []
         pos = 0
         while pos < len(data):
@@ -355,9 +355,9 @@ class Client(object):
     def listxattr(self, path):
         """List extended attributes on a file."""
         buf = c_void_p()
-        size = c_int()
+        size = c_int64()
         self.lib.jfs_listXattr2(c_int64(_tid()), c_int64(self.h), _bin(path), byref(buf), byref(size))
-        data = string_at(buf, size).decode()
+        data = string_at(buf, size.value).decode()
         self.lib.free(buf)
         if not data:
             return []


### PR DESCRIPTION
## Summary

Fix ctypes width mismatches between the Python SDK and the `libjfs` exported functions.

`jfs_listXattr2` declared its `size` out-parameter as Go `*int`, which cgo emits as `GoInt*` (8 bytes), while the Python SDK passed `byref(c_int())` (4 bytes). `jfs_listdir2` had the same mismatch: its `size` is `*int64`, but Python also passed `c_int()`.

The out-parameter is passed by address, so the call itself is fine; the problem is that the callee writes 8 bytes into a 4-byte target. In practice CPython absorbs this — a `c_int` stores its value in a 16-byte inline union — and on little-endian platforms the low half still reads back correctly, so no user-visible failure is known. The declared widths should still match.

Reported by @OvOhao in #7481.

## Changes

**Go — `sdk/java/libjfs/main.go`**

- `jfs_listXattr2`: `size *int` → `*int64`. `GoInt` and `GoInt64` are both `long long` in the generated header, so the exported ABI is unchanged while the width becomes explicit and consistent with `jfs_listdir2`.
- Initialize the output parameters before the error paths in `jfs_listXattr2` and `jfs_listdir2`, so a caller never reads uninitialised memory when the call fails.

**Python — `sdk/python/juicefs/juicefs/juicefs.py`**

- `listdir()` / `listxattr()`: use `c_int64()` for the size out-parameter and pass `size.value` to `string_at()`. `string_at` declares its second argument as `c_int` and rejects a `c_int64` instance, so the value has to be unwrapped.
- `summary()`: wrap `_tid()` and `self.h` with `c_int64()`. A bare Python int is passed as a 32-bit C int, and thread ids routinely exceed 2^32, so the pid and handle were being truncated. Also pass `entries` as `c_uint8()` to match the Go `entries uint8` parameter.

**Tests — `.github/scripts/pysdk/pysdk_test.py`**

- Add `ListdirTests` covering an empty directory, long and non-ASCII names, `detail=True` stat fields, and 200 entries. This file previously had no `listdir` coverage.

## Verification

Built `libjfs` and ran against a local sqlite volume:

- `sdk/python/juicefs/juicefs/juicefs.py` self-test passes.
- `ListdirTests` passes, and fails without the `string_at` change.
- `listxattr` round-trips 61 attributes, including a 180-character name.
- The generated header still declares `GoInt64* size` (8 bytes), identical in width to the previously exported `GoInt*`.
