### PR TITLE
ci: wait for the block to be cached before evicting it in TestWarmup

### DIFF
--- a/cmd/warmup_test.go
+++ b/cmd/warmup_test.go
@@ -41,7 +41,6 @@ func TestWarmup(t *testing.T) {
 	}
 	uuid := format.UUID
 	var cacheDir = "/var/jfsCache"
-	var filePath string
 	switch runtime.GOOS {
 	case "linux":
 		if os.Getuid() == 0 {
@@ -58,27 +57,44 @@ func TestWarmup(t *testing.T) {
 
 	defer os.RemoveAll(fmt.Sprintf("%s/%s", cacheDir, uuid))
 
+	filePath := fmt.Sprintf("%s/%s/raw/chunks/0/0/1_0_4", cacheDir, uuid)
+	// The cached block may carry a checksum footer, so only compare the block data.
+	cached := func() bool {
+		content, err := os.ReadFile(filePath)
+		return err == nil && len(content) >= 4 && string(content[:4]) == "test"
+	}
+	// The block is cached asynchronously while being uploaded. Wait until it has
+	// been flushed into the disk cache, otherwise evicting it only cancels the
+	// pending flush and the following warmup races with it. See #7464.
+	if !waitFor(cached) {
+		t.Fatalf("block was not cached after write")
+	}
+
 	if err = Main([]string{"", "warmup", "--evict", testMountPoint}); err != nil {
 		t.Fatalf("evict: %s", err)
+	}
+	if !waitFor(func() bool { _, err := os.Stat(filePath); return os.IsNotExist(err) }) {
+		t.Fatalf("evict: cache block still exists")
 	}
 
 	if err = Main([]string{"", "warmup", testMountPoint}); err != nil {
 		t.Fatalf("warmup: %s", err)
 	}
 
-	filePath = fmt.Sprintf("%s/%s/raw/chunks/0/0/1_0_4", cacheDir, uuid)
-	deadline := time.Now().Add(10 * time.Second)
-	var content []byte
-	for {
-		content, err = os.ReadFile(filePath)
-		if err == nil && len(content) >= 4 && string(content[:4]) == "test" {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("warmup: %s; got content %s", err, content)
+	if !waitFor(cached) {
+		content, err := os.ReadFile(filePath)
+		t.Fatalf("warmup: %s; got content %s", err, content)
+	}
+}
+
+func waitFor(cond func() bool) bool {
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); {
+		if cond() {
+			return true
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+	return false
 }
 
 func TestWarmupWithRangeFile(t *testing.T) {


### PR DESCRIPTION
Fixes the `TestWarmup` CI flake tracked in #7464.

The test writes a file and evicts its cache immediately. The block is cached asynchronously while being uploaded (`upload()` queues the page before the object PUT), so the evict may land while the page is still in the flush queue. In that case the evict only cancels the pending flush: the flusher's completion handling then drops the block that the following warmup has just cached, so warmup reports success but the cache file never appears. Full root-cause analysis: https://github.com/juicedata/juicefs/issues/7464#issuecomment-5504081388

This PR only removes the racy precondition from the test:

1. after the write, wait for `raw/chunks/0/0/1_0_4` to actually reach the disk cache before evicting;
2. after `warmup --evict`, wait for the block to disappear (bounded wait, since the unlink may be deferred to the flusher's cleanup when the evict lands between the rename and `add()`);
3. after `warmup`, wait for the block to come back, as before.

Step 2 also makes the test assert that the evict really happened; previously a silently skipped evict would let the final check pass vacuously on the block cached by the write.

The underlying race in `pkg/chunk` is intentionally left unfixed, as its practical impact (a self-healing cache miss, only reachable via `warmup --evict` on a just-written block) does not justify extra bookkeeping on the cache write path.
