### PR TITLE
sync: avoid excess bandwidth reservations for small objects

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -758,10 +758,10 @@ type withProgress struct {
 }
 
 func (w *withProgress) Read(b []byte) (int, error) {
-	if limiter != nil {
-		limiter.Wait(int64(len(b)))
-	}
 	n, err := w.r.Read(b)
+	if limiter != nil && n > 0 {
+		limiter.Wait(int64(n))
+	}
 	if copiedBytes != nil {
 		copiedBytes.IncrInt64(int64(n))
 	}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -749,35 +749,19 @@ func doCopySingle0(src, dst object.ObjectStorage, key string, size int64, calChk
 	}
 	r := &chksumReader{in, 0, calChksum}
 	defer in.Close()
-	err = dst.Put(ctx, key, &withProgress{r: r, remaining: size})
+	err = dst.Put(ctx, key, io.LimitReader(&withProgress{r}, size))
 	return r.chksum, err
 }
 
 type withProgress struct {
-	r         io.Reader
-	remaining int64
-	reserved  int64 // tokens reserved for bytes not read yet
+	r io.Reader
 }
 
 func (w *withProgress) Read(b []byte) (int, error) {
-	if w.remaining == 0 {
-		return 0, io.EOF
+	if limiter != nil {
+		limiter.Wait(int64(len(b)))
 	}
-	if int64(len(b)) > w.remaining {
-		b = b[:w.remaining]
-	}
-	l := limiter
-	if l != nil {
-		if need := int64(len(b)) - w.reserved; need > 0 {
-			l.Wait(need)
-			w.reserved += need
-		}
-	}
-	n, err := w.r.Read(b)
-	if l != nil {
-		w.reserved -= int64(n)
-	}
-	w.remaining -= int64(n)
+	n, err := io.ReadFull(w.r, b)
 	if copiedBytes != nil {
 		copiedBytes.IncrInt64(int64(n))
 	}
@@ -825,7 +809,7 @@ func doUploadPart(src, dst object.ObjectStorage, srckey string, off, size int64,
 		}
 		defer in.Close()
 		r := &chksumReader{in, 0, calChksum}
-		pr := &withProgress{r: r, remaining: size}
+		pr := io.LimitReader(&withProgress{r}, size)
 		err = utils.ErrNotSUP
 		if obj, ok := dst.(object.SupportUploadPartStream); ok {
 			part, err = obj.UploadPartStream(key, uploadID, num+1, pr)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -749,19 +749,35 @@ func doCopySingle0(src, dst object.ObjectStorage, key string, size int64, calChk
 	}
 	r := &chksumReader{in, 0, calChksum}
 	defer in.Close()
-	err = dst.Put(ctx, key, &withProgress{r})
+	err = dst.Put(ctx, key, &withProgress{r: r, remaining: size})
 	return r.chksum, err
 }
 
 type withProgress struct {
-	r io.Reader
+	r         io.Reader
+	remaining int64
+	reserved  int64 // tokens reserved for bytes not read yet
 }
 
 func (w *withProgress) Read(b []byte) (int, error) {
-	n, err := w.r.Read(b)
-	if limiter != nil && n > 0 {
-		limiter.Wait(int64(n))
+	if w.remaining == 0 {
+		return 0, io.EOF
 	}
+	if int64(len(b)) > w.remaining {
+		b = b[:w.remaining]
+	}
+	l := limiter
+	if l != nil {
+		if need := int64(len(b)) - w.reserved; need > 0 {
+			l.Wait(need)
+			w.reserved += need
+		}
+	}
+	n, err := w.r.Read(b)
+	if l != nil {
+		w.reserved -= int64(n)
+	}
+	w.remaining -= int64(n)
 	if copiedBytes != nil {
 		copiedBytes.IncrInt64(int64(n))
 	}
@@ -809,7 +825,7 @@ func doUploadPart(src, dst object.ObjectStorage, srckey string, off, size int64,
 		}
 		defer in.Close()
 		r := &chksumReader{in, 0, calChksum}
-		pr := &withProgress{r}
+		pr := &withProgress{r: r, remaining: size}
 		err = utils.ErrNotSUP
 		if obj, ok := dst.(object.SupportUploadPartStream); ok {
 			part, err = obj.UploadPartStream(key, uploadID, num+1, pr)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -749,19 +749,24 @@ func doCopySingle0(src, dst object.ObjectStorage, key string, size int64, calChk
 	}
 	r := &chksumReader{in, 0, calChksum}
 	defer in.Close()
-	err = dst.Put(ctx, key, io.LimitReader(&withProgress{r}, size))
+	err = dst.Put(ctx, key, io.LimitReader(&withProgress{r: r}, size))
 	return r.chksum, err
 }
 
 type withProgress struct {
-	r io.Reader
+	r        io.Reader
+	reserved int64 // bytes allowed but not yet consumed by a source read
 }
 
 func (w *withProgress) Read(b []byte) (int, error) {
-	if limiter != nil {
-		limiter.Wait(int64(len(b)))
+	if need := int64(len(b)) - w.reserved; need > 0 {
+		if limiter != nil {
+			limiter.Wait(need)
+		}
+		w.reserved += need
 	}
-	n, err := io.ReadFull(w.r, b)
+	n, err := w.r.Read(b)
+	w.reserved -= int64(n)
 	if copiedBytes != nil {
 		copiedBytes.IncrInt64(int64(n))
 	}
@@ -809,7 +814,7 @@ func doUploadPart(src, dst object.ObjectStorage, srckey string, off, size int64,
 		}
 		defer in.Close()
 		r := &chksumReader{in, 0, calChksum}
-		pr := io.LimitReader(&withProgress{r}, size)
+		pr := io.LimitReader(&withProgress{r: r}, size)
 		err = utils.ErrNotSUP
 		if obj, ok := dst.(object.SupportUploadPartStream); ok {
 			part, err = obj.UploadPartStream(key, uploadID, num+1, pr)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -749,13 +749,21 @@ func doCopySingle0(src, dst object.ObjectStorage, key string, size int64, calChk
 	}
 	r := &chksumReader{in, 0, calChksum}
 	defer in.Close()
-	err = dst.Put(ctx, key, io.LimitReader(&withProgress{r: r}, size))
+	err = dst.Put(ctx, key, newProgressReader(r, size))
 	return r.chksum, err
 }
 
 type withProgress struct {
 	r        io.Reader
 	reserved int64 // bytes allowed but not yet consumed by a source read
+}
+
+func newProgressReader(r io.Reader, size int64) io.Reader {
+	p := &withProgress{r: r}
+	if size < 0 {
+		return p
+	}
+	return io.LimitReader(p, size)
 }
 
 func (w *withProgress) Read(b []byte) (int, error) {
@@ -814,7 +822,7 @@ func doUploadPart(src, dst object.ObjectStorage, srckey string, off, size int64,
 		}
 		defer in.Close()
 		r := &chksumReader{in, 0, calChksum}
-		pr := io.LimitReader(&withProgress{r: r}, size)
+		pr := newProgressReader(r, size)
 		err = utils.ErrNotSUP
 		if obj, ok := dst.(object.SupportUploadPartStream); ok {
 			part, err = obj.UploadPartStream(key, uploadID, num+1, pr)

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1276,6 +1276,12 @@ func TestSyncEncryptLargeFile(t *testing.T) {
 	}
 }
 
+type readerFunc func([]byte) (int, error)
+
+func (f readerFunc) Read(b []byte) (int, error) {
+	return f(b)
+}
+
 func TestWithProgressLimitsActualBytes(t *testing.T) {
 	const readSize = 1 << 20
 	local := ratelimit.NewBucket(time.Hour, 2*readSize)
@@ -1285,15 +1291,32 @@ func TestWithProgressLimitsActualBytes(t *testing.T) {
 		limiter, copiedBytes = oldLimiter, oldCopiedBytes
 	})
 
-	r := &withProgress{bytes.NewReader([]byte{'x'})}
+	data := []byte("abc")
+	reads := 0
+	r := &withProgress{
+		remaining: int64(len(data)),
+		r: readerFunc(func(b []byte) (int, error) {
+			if got, want := local.Available(), int64(2*readSize-len(data)); got != want {
+				t.Fatalf("available tokens before source read: got %d, want %d", got, want)
+			}
+			if reads == len(data) {
+				t.Fatal("source read after all expected bytes")
+			}
+			b[0] = data[reads]
+			reads++
+			return 1, nil
+		}),
+	}
 	b := make([]byte, readSize)
-	if n, err := r.Read(b); n != 1 || err != nil {
-		t.Fatalf("first read: got (%d, %v), want (1, nil)", n, err)
+	for i := range data {
+		if n, err := r.Read(b); n != 1 || err != nil {
+			t.Fatalf("read %d: got (%d, %v), want (1, nil)", i, n, err)
+		}
 	}
 	if n, err := r.Read(b); n != 0 || err != io.EOF {
-		t.Fatalf("second read: got (%d, %v), want (0, EOF)", n, err)
+		t.Fatalf("final read: got (%d, %v), want (0, EOF)", n, err)
 	}
-	if got, want := local.Available(), int64(2*readSize-1); got != want {
+	if got, want := local.Available(), int64(2*readSize-len(data)); got != want {
 		t.Fatalf("available tokens: got %d, want %d", got, want)
 	}
 }

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1276,6 +1276,28 @@ func TestSyncEncryptLargeFile(t *testing.T) {
 	}
 }
 
+func TestWithProgressLimitsActualBytes(t *testing.T) {
+	const readSize = 1 << 20
+	local := ratelimit.NewBucket(time.Hour, 2*readSize)
+	oldLimiter, oldCopiedBytes := limiter, copiedBytes
+	limiter, copiedBytes = &mixedLimiter{local: local}, nil
+	t.Cleanup(func() {
+		limiter, copiedBytes = oldLimiter, oldCopiedBytes
+	})
+
+	r := &withProgress{bytes.NewReader([]byte{'x'})}
+	b := make([]byte, readSize)
+	if n, err := r.Read(b); n != 1 || err != nil {
+		t.Fatalf("first read: got (%d, %v), want (1, nil)", n, err)
+	}
+	if n, err := r.Read(b); n != 0 || err != io.EOF {
+		t.Fatalf("second read: got (%d, %v), want (0, EOF)", n, err)
+	}
+	if got, want := local.Available(), int64(2*readSize-1); got != want {
+		t.Fatalf("available tokens: got %d, want %d", got, want)
+	}
+}
+
 // TestMixedLimiterFailover verifies that the global traffic control takes
 // precedence, falls back to the local bwlimit when the global service is
 // unavailable, and switches back to the global limit once it recovers.

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/juicedata/juicefs/pkg/object"
@@ -1276,12 +1277,6 @@ func TestSyncEncryptLargeFile(t *testing.T) {
 	}
 }
 
-type readerFunc func([]byte) (int, error)
-
-func (f readerFunc) Read(b []byte) (int, error) {
-	return f(b)
-}
-
 func TestWithProgressLimitsActualBytes(t *testing.T) {
 	const readSize = 1 << 20
 	local := ratelimit.NewBucket(time.Hour, 2*readSize)
@@ -1292,26 +1287,10 @@ func TestWithProgressLimitsActualBytes(t *testing.T) {
 	})
 
 	data := []byte("abc")
-	reads := 0
-	r := &withProgress{
-		remaining: int64(len(data)),
-		r: readerFunc(func(b []byte) (int, error) {
-			if got, want := local.Available(), int64(2*readSize-len(data)); got != want {
-				t.Fatalf("available tokens before source read: got %d, want %d", got, want)
-			}
-			if reads == len(data) {
-				t.Fatal("source read after all expected bytes")
-			}
-			b[0] = data[reads]
-			reads++
-			return 1, nil
-		}),
-	}
+	r := io.LimitReader(&withProgress{iotest.OneByteReader(bytes.NewReader(data))}, int64(len(data)))
 	b := make([]byte, readSize)
-	for i := range data {
-		if n, err := r.Read(b); n != 1 || err != nil {
-			t.Fatalf("read %d: got (%d, %v), want (1, nil)", i, n, err)
-		}
+	if n, err := r.Read(b); n != len(data) || err != nil {
+		t.Fatalf("first read: got (%d, %v), want (%d, nil)", n, err, len(data))
 	}
 	if n, err := r.Read(b); n != 0 || err != io.EOF {
 		t.Fatalf("final read: got (%d, %v), want (0, EOF)", n, err)

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1292,7 +1292,7 @@ func TestWithProgressLimitsActualBytes(t *testing.T) {
 	source := bytes.NewReader(data)
 	readErr := errors.New("source read failed")
 	wantTokens := int64(2*readSize - len(data))
-	r := io.LimitReader(&withProgress{r: progressReaderFunc(func(b []byte) (int, error) {
+	r := newProgressReader(progressReaderFunc(func(b []byte) (int, error) {
 		if got := local.Available(); got != wantTokens {
 			t.Fatalf("tokens before source read: got %d, want %d", got, wantTokens)
 		}
@@ -1301,7 +1301,7 @@ func TestWithProgressLimitsActualBytes(t *testing.T) {
 			err = readErr
 		}
 		return n, err
-	})}, int64(len(data)))
+	}), int64(len(data)))
 	b := make([]byte, readSize)
 	for _, wantErr := range []error{nil, nil, readErr} {
 		if n, err := r.Read(b); n != 1 || err != wantErr {
@@ -1318,27 +1318,58 @@ func TestWithProgressLimitsActualBytes(t *testing.T) {
 
 func TestCopyLimitsSmallObject(t *testing.T) {
 	const readSize = 1 << 20
-	local := ratelimit.NewBucket(time.Hour, 2*readSize)
-	oldLimiter, oldCopiedBytes := limiter, copiedBytes
-	limiter, copiedBytes = &mixedLimiter{local: local}, nil
-	t.Cleanup(func() { limiter, copiedBytes = oldLimiter, oldCopiedBytes })
+	cases := []struct {
+		name string
+		body string
+		size int64
+		// wantTokens is the exact reservation expected, or -1 when the size is
+		// unknown and only the copied content matters.
+		wantTokens int64
+	}{
+		{"empty", "", 0, 0},
+		{"tiny", "x", 1, 1},
+		{"unknownSize", "hello", -1, -1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			local := ratelimit.NewBucket(time.Hour, 2*readSize)
+			oldLimiter, oldCopiedBytes := limiter, copiedBytes
+			limiter, copiedBytes = &mixedLimiter{local: local}, nil
+			t.Cleanup(func() { limiter, copiedBytes = oldLimiter, oldCopiedBytes })
 
-	src, err := object.CreateStorage("mem", "", "", "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dst, err := object.CreateStorage("file", t.TempDir()+"/", "", "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := src.Put(ctx, "key", bytes.NewReader([]byte("x"))); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := doCopySingle0(src, dst, "key", 1, false); err != nil {
-		t.Fatal(err)
-	}
-	if got, want := local.Available(), int64(2*readSize-1); got != want {
-		t.Fatalf("available tokens: got %d, want %d", got, want)
+			src, err := object.CreateStorage("mem", "", "", "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			dst, err := object.CreateStorage("file", t.TempDir()+"/", "", "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := src.Put(ctx, "key", strings.NewReader(c.body)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := doCopySingle0(src, dst, "key", c.size, false); err != nil {
+				t.Fatal(err)
+			}
+
+			in, err := dst.Get(ctx, "key", 0, -1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			got, err := io.ReadAll(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != c.body {
+				t.Fatalf("copied content: got %q, want %q", got, c.body)
+			}
+			if c.wantTokens >= 0 {
+				if used := int64(2*readSize) - local.Available(); used != c.wantTokens {
+					t.Fatalf("reserved tokens: got %d, want %d", used, c.wantTokens)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -32,7 +33,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"testing/iotest"
 	"time"
 
 	"github.com/juicedata/juicefs/pkg/object"
@@ -1277,25 +1277,67 @@ func TestSyncEncryptLargeFile(t *testing.T) {
 	}
 }
 
+type progressReaderFunc func([]byte) (int, error)
+
+func (f progressReaderFunc) Read(b []byte) (int, error) { return f(b) }
+
 func TestWithProgressLimitsActualBytes(t *testing.T) {
 	const readSize = 1 << 20
 	local := ratelimit.NewBucket(time.Hour, 2*readSize)
 	oldLimiter, oldCopiedBytes := limiter, copiedBytes
 	limiter, copiedBytes = &mixedLimiter{local: local}, nil
-	t.Cleanup(func() {
-		limiter, copiedBytes = oldLimiter, oldCopiedBytes
-	})
+	t.Cleanup(func() { limiter, copiedBytes = oldLimiter, oldCopiedBytes })
 
 	data := []byte("abc")
-	r := io.LimitReader(&withProgress{iotest.OneByteReader(bytes.NewReader(data))}, int64(len(data)))
+	source := bytes.NewReader(data)
+	readErr := errors.New("source read failed")
+	wantTokens := int64(2*readSize - len(data))
+	r := io.LimitReader(&withProgress{r: progressReaderFunc(func(b []byte) (int, error) {
+		if got := local.Available(); got != wantTokens {
+			t.Fatalf("tokens before source read: got %d, want %d", got, wantTokens)
+		}
+		n, err := source.Read(b[:1])
+		if source.Len() == 0 && n > 0 {
+			err = readErr
+		}
+		return n, err
+	})}, int64(len(data)))
 	b := make([]byte, readSize)
-	if n, err := r.Read(b); n != len(data) || err != nil {
-		t.Fatalf("first read: got (%d, %v), want (%d, nil)", n, err, len(data))
+	for _, wantErr := range []error{nil, nil, readErr} {
+		if n, err := r.Read(b); n != 1 || err != wantErr {
+			t.Fatalf("read: got (%d, %v), want (1, %v)", n, err, wantErr)
+		}
 	}
 	if n, err := r.Read(b); n != 0 || err != io.EOF {
 		t.Fatalf("final read: got (%d, %v), want (0, EOF)", n, err)
 	}
-	if got, want := local.Available(), int64(2*readSize-len(data)); got != want {
+	if got := local.Available(); got != wantTokens {
+		t.Fatalf("tokens after EOF: got %d, want %d", got, wantTokens)
+	}
+}
+
+func TestCopyLimitsSmallObject(t *testing.T) {
+	const readSize = 1 << 20
+	local := ratelimit.NewBucket(time.Hour, 2*readSize)
+	oldLimiter, oldCopiedBytes := limiter, copiedBytes
+	limiter, copiedBytes = &mixedLimiter{local: local}, nil
+	t.Cleanup(func() { limiter, copiedBytes = oldLimiter, oldCopiedBytes })
+
+	src, err := object.CreateStorage("mem", "", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst, err := object.CreateStorage("file", t.TempDir()+"/", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := src.Put(ctx, "key", bytes.NewReader([]byte("x"))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := doCopySingle0(src, dst, "key", 1, false); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := local.Available(), int64(2*readSize-1); got != want {
 		t.Fatalf("available tokens: got %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
## What problem does this PR solve?

Sync can reserve 2 MiB of bandwidth tokens when copying a 1-byte object through a destination's 1 MiB buffer: the data read and the final EOF read are both charged by the requested buffer size. Short source reads can also cause repeated reservations.

Fixes #6627.

## What is changed?

- Bound read requests by the known object/part size with `io.LimitReader`.
- Keep unused reservations across short reads and wait only for additional bytes, before reading from the source.
- Perform a single underlying `Read` and preserve its returned byte count and error.

A completed, known-size transfer reserves exactly its size. As with the existing pre-read limiter, unused reservations are not refunded if the source ends early or fails.

## Verification

Two regression tests cover real mem-to-file copying through the 1 MiB buffer, pre-read token reservation, short reads, data returned with an error, and the final EOF. Running these tests against the original implementation, the post-read variant, and the `ReadFull` variant reproduces their respective failures.

Passed:
- Targeted regression tests: `-count=100`.
- Regression and existing limiter failover tests with `-race -count=10`.
- `go test ./pkg/sync -count=1`.

`make test.pkg` was attempted but could not build the Gluster backend because this local environment lacks `pkg-config`.
