### PR TITLE
chunk: don't let an abandoned fetch turn a failed read into a success

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -697,13 +697,13 @@ type getResult struct {
 	sc    string
 }
 
-func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page, off int) (n int, err error) {
+func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page, off int) (int, error) {
 	p := page.Data
 	fullPage, err := store.group.TryPiggyback(key)
 	if fullPage != nil {
 		defer fullPage.Release()
 		if err == nil { // piggybacked a full read
-			n = copy(p, fullPage.Data[off:])
+			n := copy(p, fullPage.Data[off:])
 			return n, nil
 		}
 	}
@@ -714,45 +714,33 @@ func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page,
 		store.downLimit.Wait(int64(len(p)))
 	}
 
+	tmp := getResult{sc: object.DefaultStorageClass}
 	start := time.Now()
-	// see load(): the closure may outlive this call, so it shares nothing with us
-	var fetched getResult
 	page.Acquire()
 	err = utils.WithTimeout(ctx, func(cCtx context.Context) error {
 		defer page.Release()
-		var (
-			nn    int
-			reqID string
-			sc    = object.DefaultStorageClass
-		)
-		in, err := store.storage.Get(cCtx, key, int64(off), int64(len(p)), object.WithRequestID(&reqID), object.WithStorageClass(&sc))
-		if err == nil {
-			nn, err = io.ReadFull(in, p)
+		in, getErr := store.storage.Get(cCtx, key, int64(off), int64(len(p)), object.WithRequestID(&tmp.reqID), object.WithStorageClass(&tmp.sc))
+		if getErr == nil {
+			tmp.n, getErr = io.ReadFull(in, p)
 			_ = in.Close()
 		}
-		if err == nil {
-			fetched.n, fetched.reqID, fetched.sc = nn, reqID, sc
-		}
-		return err
+		return getErr
 	}, store.conf.GetTimeout)
 
 	used := time.Since(start)
-	var (
-		reqID string
-		sc    = object.DefaultStorageClass
-	)
+	res := getResult{sc: object.DefaultStorageClass}
 	if err == nil {
-		n, reqID, sc = fetched.n, fetched.reqID, fetched.sc
+		res = tmp
 	}
-	logRequest("GET", key, fmt.Sprintf("RANGE(%d,%d) ", off, len(p)), reqID, err, used)
+	logRequest("GET", key, fmt.Sprintf("RANGE(%d,%d) ", off, len(p)), res.reqID, err, used)
 	if errors.Is(err, context.Canceled) {
 		return 0, err
 	}
-	store.objectDataBytes.WithLabelValues("GET", sc).Add(float64(n))
-	store.objectReqsHistogram.WithLabelValues("GET", sc).Observe(used.Seconds())
+	store.objectDataBytes.WithLabelValues("GET", res.sc).Add(float64(res.n))
+	store.objectReqsHistogram.WithLabelValues("GET", res.sc).Observe(used.Seconds())
 	if err == nil {
 		store.fetcher.fetch(key)
-		return n, nil
+		return res.n, nil
 	}
 	store.objectReqErrors.Add(1)
 	// fall back to full read
@@ -785,59 +773,44 @@ func (store *cachedStore) load(ctx context.Context, key string, page *Page, cach
 	} else {
 		p = page
 	}
-	// WithTimeout leaves the closure running after a timeout, so it must not write any
-	// variable of ours (a late write could turn a failure into a success, and hand out a
-	// page it never filled); it publishes into fetched, only readable once it finished.
-	var fetched getResult
+	tmp := getResult{sc: object.DefaultStorageClass}
 	p.Acquire()
 	err = utils.WithTimeout(ctx, func(cCtx context.Context) error {
 		defer p.Release()
-		var (
-			n     int
-			reqID string
-			sc    = object.DefaultStorageClass
-		)
 		// it will be retried in the upper layer.
-		in, err := store.storage.Get(cCtx, key, 0, -1, object.WithRequestID(&reqID), object.WithStorageClass(&sc))
-		if err == nil {
-			n, err = io.ReadFull(in, p.Data)
+		in, getErr := store.storage.Get(cCtx, key, 0, -1, object.WithRequestID(&tmp.reqID), object.WithStorageClass(&tmp.sc))
+		if getErr == nil {
+			tmp.n, getErr = io.ReadFull(in, p.Data)
 			_ = in.Close()
 		}
-		if compressed && err == io.ErrUnexpectedEOF {
-			err = nil
+		if compressed && getErr == io.ErrUnexpectedEOF {
+			getErr = nil
 		}
-		if err == nil {
-			fetched.n, fetched.reqID, fetched.sc = n, reqID, sc
-		}
-		return err
+		return getErr
 	}, store.conf.GetTimeout)
 	if errors.Is(err, context.Canceled) {
 		return err
 	}
 	used := time.Since(start)
-	var (
-		n     int
-		reqID string
-		sc    = object.DefaultStorageClass
-	)
+	res := getResult{sc: object.DefaultStorageClass}
 	if err == nil {
-		n, reqID, sc = fetched.n, fetched.reqID, fetched.sc
+		res = tmp
 	}
-	logRequest("GET", key, "", reqID, err, used)
+	logRequest("GET", key, "", res.reqID, err, used)
 	if store.downLimit != nil && compressed {
-		store.downLimit.Wait(int64(n))
+		store.downLimit.Wait(int64(res.n))
 	}
-	store.objectDataBytes.WithLabelValues("GET", sc).Add(float64(n))
-	store.objectReqsHistogram.WithLabelValues("GET", sc).Observe(used.Seconds())
+	store.objectDataBytes.WithLabelValues("GET", res.sc).Add(float64(res.n))
+	store.objectReqsHistogram.WithLabelValues("GET", res.sc).Observe(used.Seconds())
 	if err != nil {
 		store.objectReqErrors.Add(1)
 		return fmt.Errorf("get %s: %s", key, err)
 	}
 	if compressed {
-		n, err = store.compressor.Decompress(page.Data, p.Data[:n])
+		res.n, err = store.compressor.Decompress(page.Data, p.Data[:res.n])
 	}
-	if err != nil || n < len(page.Data) {
-		return fmt.Errorf("read %s fully: %v (%d < %d) after %s", key, err, n, len(page.Data), used)
+	if err != nil || res.n < len(page.Data) {
+		return fmt.Errorf("read %s fully: %v (%d < %d) after %s", key, err, res.n, len(page.Data), used)
 	}
 	if cache {
 		store.bcache.cache(key, page, forceCache, !store.conf.OSCache)

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -709,22 +709,39 @@ func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page,
 	}
 
 	start := time.Now()
-	var (
+	// see load(): the closure may outlive this call, so it shares nothing with us
+	var fetched struct {
+		n     int
 		reqID string
-		sc    = object.DefaultStorageClass
-	)
+		sc    string
+	}
 	page.Acquire()
 	err = utils.WithTimeout(ctx, func(cCtx context.Context) error {
 		defer page.Release()
+		var (
+			nn    int
+			reqID string
+			sc    = object.DefaultStorageClass
+		)
 		in, err := store.storage.Get(cCtx, key, int64(off), int64(len(p)), object.WithRequestID(&reqID), object.WithStorageClass(&sc))
 		if err == nil {
-			n, err = io.ReadFull(in, p)
+			nn, err = io.ReadFull(in, p)
 			_ = in.Close()
+		}
+		if err == nil {
+			fetched.n, fetched.reqID, fetched.sc = nn, reqID, sc
 		}
 		return err
 	}, store.conf.GetTimeout)
 
 	used := time.Since(start)
+	var (
+		reqID string
+		sc    = object.DefaultStorageClass
+	)
+	if err == nil {
+		n, reqID, sc = fetched.n, fetched.reqID, fetched.sc
+	}
 	logRequest("GET", key, fmt.Sprintf("RANGE(%d,%d) ", off, len(p)), reqID, err, used)
 	if errors.Is(err, context.Canceled) {
 		return 0, err
@@ -756,11 +773,7 @@ func (store *cachedStore) load(ctx context.Context, key string, page *Page, cach
 		store.downLimit.Wait(int64(len(page.Data)))
 	}
 	var (
-		in    io.ReadCloser
-		n     int
 		p     *Page
-		reqID string
-		sc    = object.DefaultStorageClass
 		start = time.Now()
 	)
 	if compressed {
@@ -770,11 +783,24 @@ func (store *cachedStore) load(ctx context.Context, key string, page *Page, cach
 	} else {
 		p = page
 	}
+	// WithTimeout leaves the closure running after a timeout, so it must not write any
+	// variable of ours (a late write could turn a failure into a success, and hand out a
+	// page it never filled); it publishes into fetched, only readable once it finished.
+	var fetched struct {
+		n     int
+		reqID string
+		sc    string
+	}
 	p.Acquire()
 	err = utils.WithTimeout(ctx, func(cCtx context.Context) error {
 		defer p.Release()
+		var (
+			n     int
+			reqID string
+			sc    = object.DefaultStorageClass
+		)
 		// it will be retried in the upper layer.
-		in, err = store.storage.Get(cCtx, key, 0, -1, object.WithRequestID(&reqID), object.WithStorageClass(&sc))
+		in, err := store.storage.Get(cCtx, key, 0, -1, object.WithRequestID(&reqID), object.WithStorageClass(&sc))
 		if err == nil {
 			n, err = io.ReadFull(in, p.Data)
 			_ = in.Close()
@@ -782,12 +808,23 @@ func (store *cachedStore) load(ctx context.Context, key string, page *Page, cach
 		if compressed && err == io.ErrUnexpectedEOF {
 			err = nil
 		}
+		if err == nil {
+			fetched.n, fetched.reqID, fetched.sc = n, reqID, sc
+		}
 		return err
 	}, store.conf.GetTimeout)
 	if errors.Is(err, context.Canceled) {
 		return err
 	}
 	used := time.Since(start)
+	var (
+		n     int
+		reqID string
+		sc    = object.DefaultStorageClass
+	)
+	if err == nil {
+		n, reqID, sc = fetched.n, fetched.reqID, fetched.sc
+	}
 	logRequest("GET", key, "", reqID, err, used)
 	if store.downLimit != nil && compressed {
 		store.downLimit.Wait(int64(n))

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -691,6 +691,12 @@ func logRequest(typeStr, key, param, reqID string, err error, used time.Duration
 
 var errTryFullRead = errors.New("try full read")
 
+type getResult struct {
+	n     int
+	reqID string
+	sc    string
+}
+
 func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page, off int) (n int, err error) {
 	p := page.Data
 	fullPage, err := store.group.TryPiggyback(key)
@@ -710,11 +716,7 @@ func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page,
 
 	start := time.Now()
 	// see load(): the closure may outlive this call, so it shares nothing with us
-	var fetched struct {
-		n     int
-		reqID string
-		sc    string
-	}
+	var fetched getResult
 	page.Acquire()
 	err = utils.WithTimeout(ctx, func(cCtx context.Context) error {
 		defer page.Release()
@@ -786,11 +788,7 @@ func (store *cachedStore) load(ctx context.Context, key string, page *Page, cach
 	// WithTimeout leaves the closure running after a timeout, so it must not write any
 	// variable of ours (a late write could turn a failure into a success, and hand out a
 	// page it never filled); it publishes into fetched, only readable once it finished.
-	var fetched struct {
-		n     int
-		reqID string
-		sc    string
-	}
+	var fetched getResult
 	p.Acquire()
 	err = utils.WithTimeout(ctx, func(cCtx context.Context) error {
 		defer p.Release()

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -441,4 +442,91 @@ func TestBlockIndexes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// lateBody blocks on the first Read, so io.ReadFull stays pending past get-timeout.
+type lateBody struct {
+	data    []byte
+	off     int
+	blocked bool
+}
+
+func (b *lateBody) Read(p []byte) (int, error) {
+	if !b.blocked {
+		b.blocked = true
+		time.Sleep(50 * time.Millisecond)
+	}
+	if b.off >= len(b.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, b.data[b.off:])
+	b.off += n
+	return n, nil
+}
+
+func (b *lateBody) Close() error { return nil }
+
+// lateStore completes a GET just after the caller gave up: it ignores cancellation and
+// returns success a hair after get-timeout, with a body that has no bytes ready yet.
+type lateStore struct {
+	object.ObjectStorage
+	data  []byte
+	delay time.Duration
+	seq   atomic.Int64
+}
+
+func (s *lateStore) Get(ctx context.Context, key string, off, limit int64, getters ...object.AttrGetter) (io.ReadCloser, error) {
+	time.Sleep(s.delay + time.Duration(s.seq.Add(1)%400)*time.Microsecond)
+	return &lateBody{data: s.data}, nil
+}
+
+// Regression: a fetch abandoned by WithTimeout used to assign load's named return err,
+// so a late `err = nil` could turn the timeout into a success and hand out a pooled page
+// this read never filled - the block that previously occupied it. The page is pre-filled
+// to stand in for that residue: a successful ReadAt must hold the requested block.
+func TestReadAtNeverReportsSuccessWithUnfilledBuffer(t *testing.T) {
+	const (
+		bs          = 64 << 10
+		iterations  = 400
+		concurrency = 16
+	)
+	want := bytes.Repeat([]byte{'b'}, bs)
+	residue := bytes.Repeat([]byte{'a'}, bs) // another block's bytes, left in a pooled page
+
+	mem, _ := object.CreateStorage("mem", "", "", "", "")
+	conf := defaultConf
+	conf.BlockSize = bs
+	conf.CacheDir = t.TempDir()
+	conf.GetTimeout = 5 * time.Millisecond
+	conf.MaxRetries = 1
+	slow := &lateStore{ObjectStorage: mem, data: want, delay: conf.GetTimeout}
+	store := NewCachedStore(slow, conf, nil)
+
+	var bad, ok, failed atomic.Int64
+	var wg sync.WaitGroup
+	for g := 0; g < concurrency; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				sliceID := uint64(g*iterations + i + 1) // distinct key => one load per read
+				page := NewOffPage(bs)
+				copy(page.Data, residue)
+				n, err := store.NewReader(sliceID, bs).ReadAt(context.Background(), page, 0)
+				switch {
+				case err != nil:
+					failed.Add(1)
+				case !bytes.Equal(page.Data[:n], want[:n]):
+					bad.Add(1)
+				default:
+					ok.Add(1)
+				}
+				page.Release()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	t.Logf("reads: ok=%d failed=%d CORRUPT=%d", ok.Load(), failed.Load(), bad.Load())
+	require.Zero(t, bad.Load(), "ReadAt reported success but delivered another block's bytes")
 }


### PR DESCRIPTION
Depends on #7503, which makes a successful `WithTimeout` return synchronize with callback completion.

`utils.WithTimeout` does not wait for its worker, and `load()`'s closure assigned `load`'s named return `err`. A late `err = nil` landing during `load`'s defers could make it report success without having filled the page, so `ReadAt` could return data left in a pooled page.

Keep GET results separate from the function return state and use them only after `WithTimeout` succeeds; apply the same handling to `loadRange`.