### PR TITLE
utils: avoid racing callback results in WithTimeout

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -108,25 +108,22 @@ func FindLocalIPs(allowedInterfaces ...string) ([]net.IP, error) {
 }
 
 func WithTimeout(pCtx context.Context, f func(context.Context) error, timeout time.Duration) error {
-	var done = make(chan int, 1)
-	var t = time.NewTimer(timeout)
-	var err error
+	done := make(chan error, 1)
+	t := time.NewTimer(timeout)
 	ctx, cancel := context.WithCancel(pCtx)
+	defer cancel()
+	defer t.Stop()
 	go func() {
-		err = f(ctx)
-		done <- 1
+		done <- f(ctx)
 	}()
 	select {
 	case <-ctx.Done():
-		err = ctx.Err()
-		t.Stop()
-	case <-done:
-		t.Stop()
+		return ctx.Err()
+	case err := <-done:
+		return err
 	case <-t.C:
-		err = fmt.Errorf("timeout after %s: %w", timeout, ErrFuncTimeout)
+		return fmt.Errorf("timeout after %s: %w", timeout, ErrFuncTimeout)
 	}
-	cancel()
-	return err
 }
 
 func RemovePassword(uri string) string {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -153,6 +153,38 @@ func TestTimeout(t *testing.T) {
 	close(cancelRelease)
 }
 
+func TestWithTimeoutCancelResultRace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	release := make(chan struct{})
+	callbackReturning := make(chan struct{})
+
+	result := make(chan error, 1)
+	go func() {
+		result <- WithTimeout(ctx, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			<-release
+			// Let the cancellation branch return before publishing the callback result.
+			time.Sleep(10 * time.Millisecond)
+			close(callbackReturning)
+			return nil
+		}, time.Second)
+	}()
+
+	<-started
+	cancel()
+	close(release)
+	err := <-result
+	if err != context.Canceled {
+		t.Fatalf("canceled context should be returned: %s", err)
+	}
+
+	<-callbackReturning
+	// Give the callback goroutine time to publish its late result to the race detector.
+	time.Sleep(time.Millisecond)
+}
+
 func TestRemovePassword(t *testing.T) {
 	testCase := []struct {
 		uri      string

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	"context"
-	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -106,51 +106,13 @@ func TestTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fast function should return nil")
 	}
-
-	expected := errors.New("callback failed")
 	err = WithTimeout(context.TODO(), func(context.Context) error {
-		return expected
+		time.Sleep(time.Millisecond * 100)
+		return nil
 	}, time.Millisecond*10)
-	if !errors.Is(err, expected) {
-		t.Fatalf("callback error should be returned: %s", err)
+	if err == nil || !strings.HasPrefix(err.Error(), "timeout after") {
+		t.Fatalf("slow function should  be timeout: %s", err)
 	}
-
-	timeoutStarted := make(chan struct{})
-	timeoutRelease := make(chan struct{})
-	timeoutResult := make(chan error, 1)
-	go func() {
-		timeoutResult <- WithTimeout(context.TODO(), func(context.Context) error {
-			close(timeoutStarted)
-			<-timeoutRelease
-			return nil
-		}, time.Millisecond*10)
-	}()
-	<-timeoutStarted
-	err = <-timeoutResult
-	if !errors.Is(err, ErrFuncTimeout) {
-		t.Fatalf("slow function should be timeout: %s", err)
-	}
-	close(timeoutRelease)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancelStarted := make(chan struct{})
-	cancelRelease := make(chan struct{})
-	cancelResult := make(chan error, 1)
-	go func() {
-		cancelResult <- WithTimeout(ctx, func(ctx context.Context) error {
-			close(cancelStarted)
-			<-ctx.Done()
-			<-cancelRelease
-			return nil
-		}, time.Second)
-	}()
-	<-cancelStarted
-	cancel()
-	err = <-cancelResult
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("canceled context should be returned: %s", err)
-	}
-	close(cancelRelease)
 }
 
 func TestWithTimeoutCancelResultRace(t *testing.T) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 	"time"
 )
@@ -106,13 +106,51 @@ func TestTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fast function should return nil")
 	}
+
+	expected := errors.New("callback failed")
 	err = WithTimeout(context.TODO(), func(context.Context) error {
-		time.Sleep(time.Millisecond * 100)
-		return nil
+		return expected
 	}, time.Millisecond*10)
-	if err == nil || !strings.HasPrefix(err.Error(), "timeout after") {
-		t.Fatalf("slow function should  be timeout: %s", err)
+	if !errors.Is(err, expected) {
+		t.Fatalf("callback error should be returned: %s", err)
 	}
+
+	timeoutStarted := make(chan struct{})
+	timeoutRelease := make(chan struct{})
+	timeoutResult := make(chan error, 1)
+	go func() {
+		timeoutResult <- WithTimeout(context.TODO(), func(context.Context) error {
+			close(timeoutStarted)
+			<-timeoutRelease
+			return nil
+		}, time.Millisecond*10)
+	}()
+	<-timeoutStarted
+	err = <-timeoutResult
+	if !errors.Is(err, ErrFuncTimeout) {
+		t.Fatalf("slow function should be timeout: %s", err)
+	}
+	close(timeoutRelease)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelStarted := make(chan struct{})
+	cancelRelease := make(chan struct{})
+	cancelResult := make(chan error, 1)
+	go func() {
+		cancelResult <- WithTimeout(ctx, func(ctx context.Context) error {
+			close(cancelStarted)
+			<-ctx.Done()
+			<-cancelRelease
+			return nil
+		}, time.Second)
+	}()
+	<-cancelStarted
+	cancel()
+	err = <-cancelResult
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled context should be returned: %s", err)
+	}
+	close(cancelRelease)
 }
 
 func TestRemovePassword(t *testing.T) {


### PR DESCRIPTION
## Summary

Pass callback errors through the completion channel instead of sharing an `err` variable between goroutines. A callback completing after a timeout or cancellation could otherwise race with `WithTimeout` and overwrite the selected error, potentially reporting a canceled operation as successful.

The original `TestTimeout` changes have been reverted. The PR now adds a focused `TestWithTimeoutCancelResultRace` regression test that lets cancellation return first and then allows the callback to publish its late result.

With the pre-fix implementation, the race detector reports concurrent writes from the cancellation branch and callback. With the channel-based implementation, callback results no longer share the selected error and the test passes.

## Tests

- `go test ./pkg/utils`
- `go test -race ./pkg/utils -run "^TestWithTimeoutCancelResultRace$" -count=50`
- Pre-fix verification: the targeted race test fails with `WARNING: DATA RACE` as expected
