### PR TITLE
chunk: exit the fallback watchdog after switching to memory cache

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -883,6 +883,7 @@ func NewCachedStore(storage object.ObjectStorage, config Config, reg prometheus.
 				config.CacheSize = 100 << 20
 				config.CacheDir = "memory"
 				store.bcache = newMemStore(&config, store.bcache.getMetrics())
+				return
 			}
 			time.Sleep(time.Second)
 		}


### PR DESCRIPTION
Once the cache manager degrades to the memory cache, the watchdog loop can never fire again. Exit it instead of polling every second for the remaining process lifetime.