### PR TITLE
sdk/java: run positioned reads on one stream concurrently

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -196,9 +196,6 @@ func (s *rSlice) ReadCachedAt(p []byte, off int) (int, bool) {
 		s.store.cacheHits.Add(1)
 		s.store.cacheHitBytes.Add(float64(n))
 		s.store.cacheReadHist.Observe(time.Since(start).Seconds())
-		if n != l {
-			return got + n, false
-		}
 		got += n
 		off += n
 	}

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -167,6 +167,44 @@ func (s *rSlice) ReadAt(ctx context.Context, page *Page, off int) (n int, err er
 	return len(p), nil
 }
 
+// ReadCachedAt reads only from the local cache; see CachedReader.
+func (s *rSlice) ReadCachedAt(p []byte, off int) (int, bool) {
+	if !s.store.conf.CacheEnabled() || off < 0 || off+len(p) > s.length {
+		return 0, false
+	}
+	got := 0
+	for got < len(p) {
+		indx := s.index(off)
+		boff := off % s.store.conf.BlockSize
+		l := min(len(p)-got, s.blockSize(indx)-boff)
+		key := s.key(indx)
+		start := time.Now()
+		r, err := s.store.bcache.load(key)
+		if err != nil {
+			return got, false
+		}
+		n, err := r.ReadAt(p[got:got+l], int64(boff))
+		if !s.store.conf.OSCache {
+			dropOSCache(r)
+		}
+		_ = r.Close()
+		if err != nil {
+			logger.Warnf("remove partial cached block %s: %d %s", key, n, err)
+			s.store.bcache.remove(key, false)
+			return got, false
+		}
+		s.store.cacheHits.Add(1)
+		s.store.cacheHitBytes.Add(float64(n))
+		s.store.cacheReadHist.Observe(time.Since(start).Seconds())
+		if n != l {
+			return got + n, false
+		}
+		got += n
+		off += n
+	}
+	return got, true
+}
+
 func (s *rSlice) delete(indx int) error {
 	key := s.key(indx)
 	return s.store.delete(key)

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -205,6 +205,20 @@ func TestReadCachedAt(t *testing.T) {
 		t.Fatalf("cached read at %d: data mismatch", conf.BlockSize)
 	}
 
+	// a cached block shorter than the data it claims is dropped
+	key := sliceForRead(1, size, store.(*cachedStore)).key(1)
+	bcache := store.(*cachedStore).bcache
+	bcache.remove(key, false)
+	short := NewOffPage(10)
+	bcache.cache(key, short, true, false)
+	short.Release()
+	if _, ok := cr.ReadCachedAt(buf, conf.BlockSize); ok {
+		t.Fatalf("read of a partial cached block should fail")
+	}
+	if _, ok := bcache.exist(key); ok {
+		t.Fatalf("partial cached block should be removed")
+	}
+
 	// cache disabled
 	conf.CacheSize = 0
 	store = NewCachedStore(mem, conf, nil)

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -146,6 +146,73 @@ func TestStoreMemCache(t *testing.T) {
 		t.Fatalf("cache cnt %d used %d, expect both 0", cnt, used)
 	}
 }
+func TestReadCachedAt(t *testing.T) {
+	mem, _ := object.CreateStorage("mem", "", "", "", "")
+	conf := defaultConf
+	conf.CacheDir = "memory"
+	conf.CacheFullBlock = true
+	store := NewCachedStore(mem, conf, nil)
+	size := conf.BlockSize + 100 // two blocks
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i * 3)
+	}
+	w := store.NewWriter(1, 0)
+	if _, err := w.WriteAt(data, 0); err != nil {
+		t.Fatalf("write: %s", err)
+	}
+	if err := w.Finish(size); err != nil {
+		t.Fatalf("finish: %s", err)
+	}
+	r := store.NewReader(1, size)
+	cr := r.(CachedReader)
+
+	// nothing cached yet
+	buf := make([]byte, 100)
+	if _, ok := cr.ReadCachedAt(buf, 0); ok {
+		t.Fatalf("read of uncached block should fail")
+	}
+	// populate the cache through the regular path
+	p := NewOffPage(size)
+	if n, err := r.ReadAt(ctx, p, 0); err != nil || n != size {
+		t.Fatalf("read: (%d,%s)", n, err)
+	}
+	p.Release()
+
+	// across the block boundary
+	off := conf.BlockSize - 50
+	if n, ok := cr.ReadCachedAt(buf, off); !ok || n != len(buf) {
+		t.Fatalf("cached read at %d: (%d,%v)", off, n, ok)
+	}
+	if !bytes.Equal(buf, data[off:off+len(buf)]) {
+		t.Fatalf("cached read at %d: data mismatch", off)
+	}
+	// beyond the slice
+	if _, ok := cr.ReadCachedAt(buf, size-50); ok {
+		t.Fatalf("read beyond the slice should fail")
+	}
+	// evicting one block fails only the reads that need it
+	if err := store.EvictCache(1, uint32(size), []Range{{0, 1}}); err != nil {
+		t.Fatalf("evict: %s", err)
+	}
+	if _, ok := cr.ReadCachedAt(buf, off); ok {
+		t.Fatalf("read of evicted block should fail")
+	}
+	if n, ok := cr.ReadCachedAt(buf, conf.BlockSize); !ok || n != len(buf) {
+		t.Fatalf("cached read at %d: (%d,%v)", conf.BlockSize, n, ok)
+	}
+	if !bytes.Equal(buf, data[conf.BlockSize:conf.BlockSize+len(buf)]) {
+		t.Fatalf("cached read at %d: data mismatch", conf.BlockSize)
+	}
+
+	// cache disabled
+	conf.CacheSize = 0
+	store = NewCachedStore(mem, conf, nil)
+	if _, ok := store.NewReader(1, size).(CachedReader).ReadCachedAt(buf, conf.BlockSize); ok {
+		t.Fatalf("read with cache disabled should fail")
+	}
+}
+
 func TestStoreCompressed(t *testing.T) {
 	mem, _ := object.CreateStorage("mem", "", "", "", "")
 	conf := defaultConf

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -27,6 +27,14 @@ type Reader interface {
 	ReadAt(ctx context.Context, p *Page, off int) (int, error)
 }
 
+// CachedReader is implemented by readers that can serve a range from the
+// local cache alone, without contacting the object storage.
+type CachedReader interface {
+	// ReadCachedAt fills p from the local cache. It returns false as soon as
+	// any part of the range is not cached; the caller then falls back to ReadAt.
+	ReadCachedAt(p []byte, off int) (int, bool)
+}
+
 type Writer interface {
 	io.WriterAt
 	ID() uint64

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -174,6 +174,8 @@ type File struct {
 	dircache []os.FileInfo
 	entries  []*meta.Entry
 	data     []byte
+	preads   sync.WaitGroup // positioned reads running outside the lock
+	closed   bool
 }
 
 func NewFileSystem(conf *vfs.Config, m meta.Meta, d chunk.ChunkStore, registry *prometheus.Registry) (*FileSystem, error) {
@@ -1336,37 +1338,62 @@ func (f *File) Pread(ctx meta.Context, b []byte, offset int64) (n int, err error
 	defer task.End()
 	l := vfs.NewLogContext(ctx)
 	defer func() { f.fs.log(l, "Pread (%s,%d,%d): (%d,%s)", f.path, len(b), offset, n, errstr(err)) }()
+	// Hold the lock only while touching the File's own state; the read itself
+	// may wait on the object storage, and positioned reads on one file must be
+	// able to overlap there (vfs.FileReader is safe for concurrent Read/Close).
 	f.Lock()
-	defer f.Unlock()
-	n, err = f.pread(ctx, b, offset)
-	return
+	rdata, b, n, err := f.preparePread(ctx, b, offset)
+	if rdata != nil {
+		f.preads.Add(1)
+		defer f.preads.Done()
+	}
+	f.Unlock()
+	if rdata == nil {
+		return
+	}
+	return f.readData(ctx, rdata, b, offset)
 }
 
 func (f *File) pread(ctx meta.Context, b []byte, offset int64) (n int, err error) {
+	rdata, b, n, err := f.preparePread(ctx, b, offset)
+	if rdata == nil {
+		return
+	}
+	return f.readData(ctx, rdata, b, offset)
+}
+
+// preparePread must be called with f locked. It returns a nil reader when the
+// request is already complete (EOF, in-memory data, or a flush error).
+func (f *File) preparePread(ctx meta.Context, b []byte, offset int64) (rdata vfs.FileReader, buf []byte, n int, err error) {
+	if f.closed {
+		return nil, nil, 0, syscall.EBADF
+	}
 	if offset >= f.info.Size() {
-		return 0, io.EOF
+		return nil, nil, 0, io.EOF
 	}
 	if int64(len(b))+offset > f.info.Size() {
 		b = b[:f.info.Size()-offset]
 	}
 	if f.data != nil {
 		n := copy(b, f.data[offset:])
-		return n, nil
+		return nil, nil, n, nil
 	}
 	if f.wdata != nil {
 		eno := f.wdata.Flush(ctx)
 		if eno != 0 {
-			err = eno
-			return
+			return nil, nil, 0, eno
 		}
 	}
 	if f.rdata == nil {
 		f.rdata = f.fs.reader.Open(f.inode, uint64(f.info.Size()))
 	}
+	return f.rdata, b, 0, nil
+}
 
-	got, eno := f.rdata.Read(ctx, uint64(offset), b)
+func (f *File) readData(ctx meta.Context, rdata vfs.FileReader, b []byte, offset int64) (n int, err error) {
+	got, eno := rdata.Read(ctx, uint64(offset), b)
 	for eno == syscall.EAGAIN {
-		got, eno = f.rdata.Read(ctx, uint64(offset), b)
+		got, eno = rdata.Read(ctx, uint64(offset), b)
 	}
 	if eno != 0 {
 		err = eno
@@ -1474,6 +1501,10 @@ func (f *File) Close(ctx meta.Context) (err syscall.Errno) {
 	f.Lock()
 	defer f.Unlock()
 	if f.flags != 0 && !f.info.IsDir() {
+		// Later reads fail with EBADF instead of opening a new reader on a
+		// closed file; then drain the positioned reads already in flight.
+		f.closed = true
+		f.preads.Wait()
 		f.offset = 0
 		if f.rdata != nil {
 			rdata := f.rdata

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -17,10 +17,15 @@
 package fs
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -380,10 +385,17 @@ func TestResolveRelativeSymlinkAfterRedirection(t *testing.T) {
 }
 
 func createTestFS(t testing.TB) *FileSystem {
+	objStore, _ := object.CreateStorage("mem", "", "", "", "")
+	return createTestFSWithStorage(t, objStore, 4096)
+}
+
+// createTestFSWithStorage builds a FileSystem on the given object storage with
+// no block cache, so every read goes to the storage. blockSize is in KiB.
+func createTestFSWithStorage(t testing.TB, objStore object.ObjectStorage, blockSize int) *FileSystem {
 	m := meta.NewClient("memkv://", nil)
 	format := &meta.Format{
 		Name:      "test",
-		BlockSize: 4096,
+		BlockSize: blockSize,
 		Capacity:  1 << 30,
 		DirStats:  true,
 	}
@@ -401,7 +413,6 @@ func createTestFS(t testing.TB) *FileSystem {
 		AttrTimeout:     time.Millisecond * 100,
 		AccessLog:       filepath.Join(t.TempDir(), "juicefs.access.log"),
 	}
-	objStore, _ := object.CreateStorage("mem", "", "", "", "")
 	store := chunk.NewCachedStore(objStore, *conf.Chunk, nil)
 	jfs, err := NewFileSystem(&conf, m, store, nil)
 	if err != nil {
@@ -411,4 +422,182 @@ func createTestFS(t testing.TB) *FileSystem {
 	jfs.rotateAccessLog = 500
 	t.Cleanup(func() { _ = jfs.Close() })
 	return jfs
+}
+
+// gatedStorage counts how many Get calls are in flight at the same time. Each Get
+// waits until `want` calls have arrived or `timeout` passes, so callers that are
+// serialized upstream show up as maxInflight == 1 instead of a flaky timing gap.
+type gatedStorage struct {
+	object.ObjectStorage
+	want        int32
+	timeout     time.Duration
+	arrived     int32
+	inflight    int32
+	maxInflight int32
+	release     chan struct{}
+	once        sync.Once
+}
+
+func newGatedStorage(base object.ObjectStorage, want int, timeout time.Duration) *gatedStorage {
+	return &gatedStorage{ObjectStorage: base, want: int32(want), timeout: timeout, release: make(chan struct{})}
+}
+
+func (g *gatedStorage) Get(ctx context.Context, key string, off, limit int64, getters ...object.AttrGetter) (io.ReadCloser, error) {
+	cur := atomic.AddInt32(&g.inflight, 1)
+	defer atomic.AddInt32(&g.inflight, -1)
+	for {
+		old := atomic.LoadInt32(&g.maxInflight)
+		if cur <= old || atomic.CompareAndSwapInt32(&g.maxInflight, old, cur) {
+			break
+		}
+	}
+	if atomic.AddInt32(&g.arrived, 1) >= g.want {
+		g.once.Do(func() { close(g.release) })
+	}
+	select {
+	case <-g.release:
+	case <-time.After(g.timeout):
+	}
+	return g.ObjectStorage.Get(ctx, key, off, limit, getters...)
+}
+
+// Positioned reads on one File must not wait for each other: HBase issues many
+// preads on a single open HFile from different handler threads, and each read of
+// an uncached block costs one round trip to the object storage.
+func TestFileConcurrentPread(t *testing.T) {
+	const (
+		blockSize = 64 << 10
+		readers   = 4
+		readLen   = 4096
+	)
+	base, _ := object.CreateStorage("mem", "", "", "", "")
+	gated := newGatedStorage(base, readers, 2*time.Second)
+	fs := createTestFSWithStorage(t, gated, blockSize>>10)
+	ctx := meta.NewContext(1, 1, []uint32{2})
+
+	// 6 blocks; the reads below stay away from block 0 and from the last 32 KiB,
+	// which are the two places the reader starts readahead on its own.
+	data := make([]byte, 6*blockSize)
+	for i := range data {
+		data[i] = byte(i * 7)
+	}
+	f, err := fs.Create(ctx, "/pread", 0644, 022)
+	if err != 0 {
+		t.Fatalf("create: %s", err)
+	}
+	if _, err := f.Write(ctx, data); err != 0 {
+		t.Fatalf("write: %s", err)
+	}
+	if err := f.Close(ctx); err != 0 {
+		t.Fatalf("close: %s", err)
+	}
+
+	f, err = fs.Open(ctx, "/pread", vfs.MODE_MASK_R)
+	if err != 0 {
+		t.Fatalf("open: %s", err)
+	}
+	defer f.Close(ctx)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, readers)
+	for i := 0; i < readers; i++ {
+		off := int64((i + 1) * blockSize)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, readLen)
+			n, err := f.Pread(ctx, buf, off)
+			if err != nil || n != readLen {
+				errs <- fmt.Errorf("pread at %d: (%d,%v)", off, n, err)
+				return
+			}
+			if !bytes.Equal(buf, data[off:off+readLen]) {
+				errs <- fmt.Errorf("pread at %d: data mismatch", off)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if got := atomic.LoadInt32(&gated.arrived); got != readers {
+		t.Fatalf("expected %d storage reads (one per uncached block), got %d", readers, got)
+	}
+	if got := atomic.LoadInt32(&gated.maxInflight); got != readers {
+		t.Fatalf("expected %d concurrent storage reads from one file, got %d", readers, got)
+	}
+}
+
+// Close must wait for positioned reads that are already in flight, the way the
+// FUSE path drains readers with handle.Wlock: otherwise a slow read observes the
+// closed reader and returns EOF instead of data.
+func TestFileCloseWaitsForPread(t *testing.T) {
+	const (
+		blockSize = 64 << 10
+		readLen   = 4096
+	)
+	base, _ := object.CreateStorage("mem", "", "", "", "")
+	// want=2 never arrives, so the single read below sits in Get for 2s.
+	gated := newGatedStorage(base, 2, 2*time.Second)
+	fs := createTestFSWithStorage(t, gated, blockSize>>10)
+	ctx := meta.NewContext(1, 1, []uint32{2})
+
+	data := make([]byte, 4*blockSize)
+	for i := range data {
+		data[i] = byte(i * 13)
+	}
+	f, err := fs.Create(ctx, "/pread-close", 0644, 022)
+	if err != 0 {
+		t.Fatalf("create: %s", err)
+	}
+	if _, err := f.Write(ctx, data); err != 0 {
+		t.Fatalf("write: %s", err)
+	}
+	if err := f.Close(ctx); err != 0 {
+		t.Fatalf("close: %s", err)
+	}
+
+	f, err = fs.Open(ctx, "/pread-close", vfs.MODE_MASK_R)
+	if err != 0 {
+		t.Fatalf("open: %s", err)
+	}
+	type result struct {
+		n   int
+		err error
+	}
+	got := make(chan result, 1)
+	off := int64(blockSize)
+	buf := make([]byte, readLen)
+	go func() {
+		n, err := f.Pread(ctx, buf, off)
+		got <- result{n, err}
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt32(&gated.arrived) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("pread never reached the storage")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if err := f.Close(ctx); err != 0 {
+		t.Fatalf("close: %s", err)
+	}
+	// A drained read has already returned; one still stuck in Get needs ~2s.
+	var r result
+	select {
+	case r = <-got:
+	case <-time.After(time.Second):
+		t.Fatal("Close returned while a positioned read was still in flight")
+	}
+	if r.err != nil || r.n != readLen {
+		t.Fatalf("pread during close: (%d,%v), want (%d,<nil>)", r.n, r.err, readLen)
+	}
+	if !bytes.Equal(buf, data[off:off+readLen]) {
+		t.Fatal("pread during close returned wrong data")
+	}
+	if _, err := f.Pread(ctx, buf, off); err != syscall.EBADF {
+		t.Fatalf("pread after close: %v, want EBADF", err)
+	}
 }

--- a/pkg/vfs/reader.go
+++ b/pkg/vfs/reader.go
@@ -623,7 +623,66 @@ func (f *fileReader) waitForIO(ctx meta.Context, reqs []*req, buf []byte) (int, 
 	return n, 0
 }
 
+// readCached serves a random read from the local cache on the calling
+// goroutine. It returns false when the range is not fully cached, belongs to a
+// sequential session (readahead is left to the slice readers), or the reader is
+// stopping; the caller then takes the regular path. Skipping the slice reader
+// saves a goroutine hand-off per read, which is what makes cache hits expensive
+// when the caller is an OS thread pinned by a cgo call (Hadoop SDK).
+func (f *fileReader) readCached(ctx meta.Context, offset uint64, buf []byte) (int, bool) {
+	size := uint64(len(buf))
+	if size == 0 || offset == 0 || offset/meta.ChunkSize != (offset+size-1)/meta.ChunkSize {
+		return 0, false
+	}
+	f.Lock()
+	if f.shouldStop() || offset+size > f.length {
+		f.Unlock()
+		return 0, false
+	}
+	block := &frange{offset, size}
+	if f.need(block) {
+		f.Unlock()
+		return 0, false
+	}
+	// keep session tracking as checkReadahead would, minus the readahead
+	f.sessions[f.guessSession(block)].lastOffset = block.end()
+	f.Unlock()
+
+	var slices []meta.Slice
+	if st := f.r.m.Read(ctx, f.inode, uint32(offset/meta.ChunkSize), &slices); st != 0 {
+		return 0, false
+	}
+	coff := uint32(offset % meta.ChunkSize)
+	var read, pos uint32
+	for i := range slices {
+		s := &slices[i]
+		if uint64(read) < size && coff < pos+s.Len {
+			toread := min(uint32(size)-read, pos+s.Len-coff)
+			if s.Id == 0 {
+				clear(buf[read : read+toread])
+			} else {
+				r, ok := f.r.store.NewReader(s.Id, int(s.Size)).(chunk.CachedReader)
+				if !ok {
+					return 0, false
+				}
+				n, ok := r.ReadCachedAt(buf[read:read+toread], int(coff-pos)+int(s.Off))
+				if !ok || uint32(n) != toread {
+					return 0, false
+				}
+			}
+			read += toread
+			coff += toread
+		}
+		pos += s.Len
+	}
+	clear(buf[read:size]) // hole after the last slice
+	return int(size), true
+}
+
 func (f *fileReader) Read(ctx meta.Context, offset uint64, buf []byte) (int, syscall.Errno) {
+	if n, ok := f.readCached(ctx, offset, buf); ok {
+		return n, 0
+	}
 	if f.r.readBufferUsed() > f.r.bufferSize {
 		time.Sleep(time.Millisecond * 10)             // slow down
 		for f.r.readBufferUsed() > f.r.bufferSize*2 { // readahead uses 80% of buffer, stop here to avoid OOM

--- a/pkg/vfs/reader_test.go
+++ b/pkg/vfs/reader_test.go
@@ -1,0 +1,166 @@
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vfs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/juicedata/juicefs/pkg/chunk"
+	"github.com/juicedata/juicefs/pkg/meta"
+	"github.com/juicedata/juicefs/pkg/object"
+)
+
+type countingStorage struct {
+	object.ObjectStorage
+	gets atomic.Int32
+}
+
+func (s *countingStorage) Get(ctx context.Context, key string, off, limit int64, getters ...object.AttrGetter) (io.ReadCloser, error) {
+	s.gets.Add(1)
+	return s.ObjectStorage.Get(ctx, key, off, limit, getters...)
+}
+
+// createCachedTestReader writes data as one slice of a new file and returns a
+// data reader backed by a memory block cache that keeps full blocks.
+func createCachedTestReader(t *testing.T, blockSize int, data []byte) (*dataReader, *countingStorage, Ino) {
+	t.Helper()
+	metaConf := meta.DefaultConf()
+	metaConf.MountPoint = "/jfs"
+	m := meta.NewClient("memkv://", metaConf)
+	format := &meta.Format{
+		Name:        "test-" + uuid.New().String(),
+		UUID:        uuid.New().String(),
+		Storage:     "mem",
+		BlockSize:   blockSize >> 10,
+		Compression: "none",
+		DirStats:    true,
+	}
+	if err := m.Init(format, true); err != nil {
+		t.Fatalf("init meta: %v", err)
+	}
+	conf := &Config{
+		Meta:   metaConf,
+		Format: *format,
+		Chunk: &chunk.Config{
+			BlockSize:      blockSize,
+			MaxUpload:      2,
+			MaxDownload:    200,
+			BufferSize:     4 << 20,
+			Readahead:      1 << 20,
+			CacheSize:      10 << 20,
+			CacheDir:       "memory",
+			CacheFullBlock: true,
+		},
+		FuseOpts: &FuseOptions{},
+	}
+	base, _ := object.CreateStorage("mem", "", "", "", "")
+	blob := &countingStorage{ObjectStorage: base}
+	store := chunk.NewCachedStore(blob, *conf.Chunk, nil)
+
+	ctx := meta.Background()
+	var inode meta.Ino
+	var attr meta.Attr
+	if st := m.Create(ctx, meta.RootInode, "file", 0644, 0, 0, &inode, &attr); st != 0 {
+		t.Fatalf("create file: %s", st)
+	}
+	var sliceID uint64
+	if st := m.NewSlice(ctx, &sliceID); st != 0 {
+		t.Fatalf("new slice: %s", st)
+	}
+	w := store.NewWriter(sliceID, 0)
+	if _, err := w.WriteAt(data, 0); err != nil {
+		t.Fatalf("write slice: %s", err)
+	}
+	if err := w.Finish(len(data)); err != nil {
+		t.Fatalf("finish slice: %s", err)
+	}
+	if st := m.Write(ctx, inode, 0, 0, meta.Slice{Id: sliceID, Size: uint32(len(data)), Len: uint32(len(data))}, time.Now()); st != 0 {
+		t.Fatalf("write meta: %s", st)
+	}
+	if st := m.Open(ctx, inode, syscall.O_RDONLY, &attr); st != 0 {
+		t.Fatalf("open: %s", st)
+	}
+	return NewDataReader(conf, m, store).(*dataReader), blob, Ino(inode)
+}
+
+func hasSlices(fr FileReader) bool {
+	f := fr.(*fileReader)
+	f.Lock()
+	defer f.Unlock()
+	return f.slices != nil
+}
+
+func TestReadCached(t *testing.T) {
+	const blockSize = 64 << 10
+	// 6 blocks; reads stay away from block 0 and the last 32 KiB, where the
+	// reader starts readahead on its own.
+	data := make([]byte, 6*blockSize)
+	for i := range data {
+		data[i] = byte(i * 7)
+	}
+	dr, blob, inode := createCachedTestReader(t, blockSize, data)
+	ctx := meta.Background()
+	check := func(fr FileReader, off uint64, size int) {
+		t.Helper()
+		buf := make([]byte, size)
+		if n, st := fr.Read(ctx, off, buf); st != 0 || n != size {
+			t.Fatalf("read at %d: (%d,%s)", off, n, st)
+		}
+		if !bytes.Equal(buf, data[off:off+uint64(size)]) {
+			t.Fatalf("read at %d: data mismatch", off)
+		}
+	}
+
+	// cold: the slice reader fetches block 1 and caches it
+	fr := dr.Open(inode, uint64(len(data)))
+	check(fr, blockSize, 4096)
+	if !hasSlices(fr) {
+		t.Fatalf("uncached read should go through a slice reader")
+	}
+	if got := blob.gets.Load(); got == 0 {
+		t.Fatalf("uncached read should reach the object storage")
+	}
+	fr.Close(ctx)
+
+	// warm: served from the cache on the calling goroutine, no slice reader
+	fr = dr.Open(inode, uint64(len(data)))
+	defer fr.Close(ctx)
+	gets := blob.gets.Load()
+	check(fr, blockSize+1024, 4096)
+	if hasSlices(fr) {
+		t.Fatalf("cached read should not create a slice reader")
+	}
+	if got := blob.gets.Load(); got != gets {
+		t.Fatalf("cached read should not reach the object storage: %d -> %d", gets, got)
+	}
+
+	// partly cached (block 1 is, block 2 is not): falls back to the slice reader
+	check(fr, 2*blockSize-2048, 4096)
+	if !hasSlices(fr) {
+		t.Fatalf("partly cached read should fall back to a slice reader")
+	}
+	if got := blob.gets.Load(); got == gets {
+		t.Fatalf("partly cached read should fetch the missing block")
+	}
+}

--- a/pkg/vfs/reader_test.go
+++ b/pkg/vfs/reader_test.go
@@ -41,9 +41,10 @@ func (s *countingStorage) Get(ctx context.Context, key string, off, limit int64,
 	return s.ObjectStorage.Get(ctx, key, off, limit, getters...)
 }
 
-// createCachedTestReader writes data as one slice of a new file and returns a
-// data reader backed by a memory block cache that keeps full blocks.
-func createCachedTestReader(t *testing.T, blockSize int, data []byte) (*dataReader, *countingStorage, Ino) {
+// createCachedTestReader writes data as one slice at sliceOff of a new file
+// and returns a data reader backed by a memory block cache that keeps full
+// blocks.
+func createCachedTestReader(t *testing.T, blockSize int, sliceOff uint32, data []byte) (*dataReader, *countingStorage, Ino) {
 	t.Helper()
 	metaConf := meta.DefaultConf()
 	metaConf.MountPoint = "/jfs"
@@ -95,7 +96,7 @@ func createCachedTestReader(t *testing.T, blockSize int, data []byte) (*dataRead
 	if err := w.Finish(len(data)); err != nil {
 		t.Fatalf("finish slice: %s", err)
 	}
-	if st := m.Write(ctx, inode, 0, 0, meta.Slice{Id: sliceID, Size: uint32(len(data)), Len: uint32(len(data))}, time.Now()); st != 0 {
+	if st := m.Write(ctx, inode, 0, sliceOff, meta.Slice{Id: sliceID, Size: uint32(len(data)), Len: uint32(len(data))}, time.Now()); st != 0 {
 		t.Fatalf("write meta: %s", st)
 	}
 	if st := m.Open(ctx, inode, syscall.O_RDONLY, &attr); st != 0 {
@@ -119,7 +120,7 @@ func TestReadCached(t *testing.T) {
 	for i := range data {
 		data[i] = byte(i * 7)
 	}
-	dr, blob, inode := createCachedTestReader(t, blockSize, data)
+	dr, blob, inode := createCachedTestReader(t, blockSize, 0, data)
 	ctx := meta.Background()
 	check := func(fr FileReader, off uint64, size int) {
 		t.Helper()
@@ -162,5 +163,83 @@ func TestReadCached(t *testing.T) {
 	}
 	if got := blob.gets.Load(); got == gets {
 		t.Fatalf("partly cached read should fetch the missing block")
+	}
+}
+
+func TestReadCachedHole(t *testing.T) {
+	const blockSize = 64 << 10
+	// blocks 0-1 are a hole, blocks 2-3 hold data
+	data := make([]byte, 2*blockSize)
+	for i := range data {
+		data[i] = byte(i*7 + 1)
+	}
+	dr, blob, inode := createCachedTestReader(t, blockSize, 2*blockSize, data)
+	ctx := meta.Background()
+	fr := dr.Open(inode, 4*blockSize)
+	defer fr.Close(ctx)
+
+	// inside the hole: zeros, nothing to fetch, no slice reader
+	buf := make([]byte, 4096)
+	buf[0] = 1
+	if n, st := fr.Read(ctx, blockSize, buf); st != 0 || n != len(buf) {
+		t.Fatalf("read in hole: (%d,%s)", n, st)
+	}
+	if !bytes.Equal(buf, make([]byte, len(buf))) {
+		t.Fatalf("read in hole should return zeros")
+	}
+	if hasSlices(fr) || blob.gets.Load() != 0 {
+		t.Fatalf("read in hole should not need a slice reader or the object storage")
+	}
+
+	// hole plus uncached data: regular path
+	off := uint64(2*blockSize - 2048)
+	if n, st := fr.Read(ctx, off, buf); st != 0 || n != len(buf) {
+		t.Fatalf("read across hole: (%d,%s)", n, st)
+	}
+	if !bytes.Equal(buf[:2048], make([]byte, 2048)) || !bytes.Equal(buf[2048:], data[:2048]) {
+		t.Fatalf("read across hole: data mismatch")
+	}
+	if !hasSlices(fr) {
+		t.Fatalf("read of uncached data should go through a slice reader")
+	}
+}
+
+func TestReadCachedFallbacks(t *testing.T) {
+	const blockSize = 64 << 10
+	data := make([]byte, 6*blockSize)
+	dr, _, inode := createCachedTestReader(t, blockSize, 0, data)
+	ctx := meta.Background()
+	buf := make([]byte, 4096)
+
+	fr := dr.Open(inode, uint64(len(data))).(*fileReader)
+	if _, ok := fr.readCached(ctx, uint64(len(data))-2048, buf); ok {
+		t.Fatalf("read past the end should not take the fast path")
+	}
+	if _, ok := fr.readCached(ctx, 0, buf); ok {
+		t.Fatalf("read at offset 0 should not take the fast path")
+	}
+	fr.Close(ctx)
+	if _, ok := fr.readCached(ctx, blockSize, buf); ok {
+		t.Fatalf("read on a closed reader should not take the fast path")
+	}
+
+	// the inode does not exist: meta lookup fails
+	fr = dr.Open(inode+1000, uint64(len(data))).(*fileReader)
+	defer fr.Close(ctx)
+	if _, ok := fr.readCached(ctx, blockSize, buf); ok {
+		t.Fatalf("read of an unknown inode should not take the fast path")
+	}
+
+	// the chunk store cannot read from the cache alone
+	store := &blockingChunkStore{reader: &blockingChunkReader{
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}}
+	bdr, binode := createCancellationTestReader(t, store)
+	bfr := bdr.Open(binode, 4).(*fileReader)
+	defer bfr.Close(ctx)
+	if _, ok := bfr.readCached(ctx, 1, buf[:3]); ok {
+		t.Fatalf("store without CachedReader should not take the fast path")
 	}
 }

--- a/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
+++ b/sdk/java/src/main/java/io/juicefs/JuiceFileSystemImpl.java
@@ -72,6 +72,8 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1055,6 +1057,9 @@ public class JuiceFileSystemImpl extends FileSystem {
   class FileInputStream extends FSInputStream implements ByteBufferReadable {
     private int fd;
     private final Path path;
+    // Positioned reads run without the stream monitor so they can overlap each
+    // other; this lock only keeps close() from freeing fd under an in-flight one.
+    private final ReadWriteLock closeLock = new ReentrantReadWriteLock();
 
     private ByteBuffer buf;
     private long position;
@@ -1128,8 +1133,10 @@ public class JuiceFileSystemImpl extends FileSystem {
       return true;
     }
 
+    // Not synchronized: a positioned read touches only fd and path, and HBase
+    // issues many of them on one stream at once.
     @Override
-    public synchronized int read(long pos, byte[] b, int off, int len) throws IOException {
+    public int read(long pos, byte[] b, int off, int len) throws IOException {
       if (b == null || off < 0 || len < 0 || b.length - off < len) {
         throw new IllegalArgumentException("arguments: " + off + " " + len);
       }
@@ -1165,14 +1172,19 @@ public class JuiceFileSystemImpl extends FileSystem {
       return got + more;
     }
 
-    private synchronized int read(long pos, ByteBuffer b) throws IOException {
+    private int read(long pos, ByteBuffer b) throws IOException {
       if (pos < 0)
         throw new EOFException("position is negative");
       if (!b.hasRemaining())
         return 0;
       int got;
       int startPos = b.position();
-      got = lib.jfs_pread(Thread.currentThread().getId(), fd, b, b.remaining(), pos);
+      closeLock.readLock().lock();
+      try {
+        got = lib.jfs_pread(Thread.currentThread().getId(), fd, b, b.remaining(), pos);
+      } finally {
+        closeLock.readLock().unlock();
+      }
       if (got == EINVAL)
         throw new IOException("stream was closed");
       if (got < 0)
@@ -1235,8 +1247,14 @@ public class JuiceFileSystemImpl extends FileSystem {
       }
       directBufferPool.returnBuffer(buf);
       buf = null;
-      int r = lib.jfs_close(Thread.currentThread().getId(), fd);
-      fd = 0;
+      int r;
+      closeLock.writeLock().lock();
+      try {
+        r = lib.jfs_close(Thread.currentThread().getId(), fd);
+        fd = 0;
+      } finally {
+        closeLock.writeLock().unlock();
+      }
       if (r < 0)
         throw error(r, path);
     }

--- a/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
+++ b/sdk/java/src/test/java/io/juicefs/JuiceFileSystemTest.java
@@ -37,11 +37,14 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_CHECKPOINT_INTERVAL_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
@@ -1333,5 +1336,118 @@ public class JuiceFileSystemTest extends TestCase {
 
     // Cleanup
     newFS.close();
+  }
+
+  private byte[] writeRandomFile(Path p, int size, long seed) throws IOException {
+    byte[] data = new byte[size];
+    new Random(seed).nextBytes(data);
+    try (FSDataOutputStream out = fs.create(p, true)) {
+      out.write(data);
+    }
+    return data;
+  }
+
+  private static void preadFully(FSDataInputStream in, long pos, byte[] buf, int len) throws IOException {
+    int got = 0;
+    while (got < len) {
+      int n = in.read(pos + got, buf, got, len - got);
+      assertTrue("unexpected EOF at " + (pos + got), n > 0);
+      got += n;
+    }
+  }
+
+  // HBase issues positioned reads on one shared HFile stream from many handler
+  // threads. A pread must therefore not take the stream's monitor, otherwise
+  // every read of an uncached block waits for the previous one to finish.
+  public void testPositionedReadDoesNotHoldStreamLock() throws Exception {
+    Path p = new Path("/pread-lock");
+    byte[] data = writeRandomFile(p, 1 << 20, 0);
+    try (FSDataInputStream in = fs.open(p)) {
+      Object monitor = in.getWrappedStream();
+      byte[] buf = new byte[4096];
+      long pos = 512 * 1024;
+      CountDownLatch done = new CountDownLatch(1);
+      AtomicReference<Throwable> failure = new AtomicReference<>();
+      Thread reader = new Thread(() -> {
+        try {
+          preadFully(in, pos, buf, buf.length);
+        } catch (Throwable t) {
+          failure.set(t);
+        } finally {
+          done.countDown();
+        }
+      });
+      synchronized (monitor) {
+        reader.start();
+        assertTrue("positioned read blocked while another thread held the stream monitor",
+                done.await(5, TimeUnit.SECONDS));
+      }
+      reader.join();
+      assertNull(failure.get());
+      assertArrayEquals(Arrays.copyOfRange(data, (int) pos, (int) pos + buf.length), buf);
+    }
+  }
+
+  public void testConcurrentPositionedReads() throws Exception {
+    Path p = new Path("/pread-concurrent");
+    byte[] data = writeRandomFile(p, 4 << 20, 1);
+    int threads = 8;
+    int rounds = 200;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try (FSDataInputStream in = fs.open(p)) {
+      List<Future<?>> futures = new ArrayList<>();
+      for (int t = 0; t < threads; t++) {
+        long seed = t;
+        futures.add(pool.submit(() -> {
+          Random rnd = new Random(seed);
+          byte[] buf = new byte[8192];
+          for (int i = 0; i < rounds; i++) {
+            int len = 1 + rnd.nextInt(buf.length);
+            int pos = rnd.nextInt(data.length - len);
+            preadFully(in, pos, buf, len);
+            assertArrayEquals(Arrays.copyOfRange(data, pos, pos + len), Arrays.copyOf(buf, len));
+          }
+          return null;
+        }));
+      }
+      for (Future<?> f : futures) {
+        f.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  // close() racing with an in-flight pread must end in IOException("stream was
+  // closed") or a normal read; never a crash, a hang, or wrong bytes.
+  public void testCloseDuringPositionedRead() throws Exception {
+    Path p = new Path("/pread-close");
+    byte[] data = writeRandomFile(p, 1 << 20, 2);
+    ExecutorService pool = Executors.newSingleThreadExecutor();
+    try {
+      for (int round = 0; round < 20; round++) {
+        FSDataInputStream in = fs.open(p);
+        CountDownLatch started = new CountDownLatch(1);
+        Future<?> reader = pool.submit(() -> {
+          byte[] buf = new byte[4096];
+          started.countDown();
+          try {
+            for (int i = 0; i < 1000; i++) {
+              int pos = i * 512;
+              preadFully(in, pos, buf, buf.length);
+              assertArrayEquals(Arrays.copyOfRange(data, pos, pos + buf.length), buf);
+            }
+          } catch (IOException e) {
+            assertEquals("stream was closed", e.getMessage());
+          }
+          return null;
+        });
+        started.await();
+        in.close();
+        reader.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
   }
 }


### PR DESCRIPTION
close #7504

Positioned reads on one Hadoop stream were serialized by `synchronized` in `FileInputStream` and by the `fs.File` mutex held across the object storage wait in `File.Pread`, so a file with cache misses had at most one in-flight read.

The second commit keeps cache hits cheap once those reads overlap. Every random read used to start a sliceReader goroutine and park until it finished, even for a cached block; for a caller pinned to an OS thread by cgo (the Hadoop SDK) each park is a P hand-off and a futex wake-up, which adds up when several threads read one file.

`fileReader.Read` now copies a fully cached range on the calling goroutine and leaves everything else (cache misses, offset 0, sequential sessions with readahead) to the regular path.