### PR TITLE
meta: skip trash insert when rename overwrites a relinked hardlink

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -174,6 +174,7 @@ func testMeta(t *testing.T, m Meta) {
 	testMetaClient(t, m)
 	testTruncateAndDelete(t, m)
 	testTrash(t, m)
+	testRenameOverRelinkedHardlink(t, m)
 	testParents(t, m)
 	testRemove(t, m)
 	testResolve(t, m)
@@ -2756,6 +2757,61 @@ func testTrash(t *testing.T, m Meta) {
 	m.getBase().doCleanupTrash(Background(), format.TrashDays, true, nil)
 	if st := m.GetAttr(ctx2, TrashInode+1, attr); st != syscall.ENOENT {
 		t.Fatalf("getattr: %s", st)
+	}
+}
+
+func testRenameOverRelinkedHardlink(t *testing.T, m Meta) {
+	format := testFormat()
+	format.TrashDays = 1
+	if err := m.Init(format, false); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer func() {
+		if err := m.Init(testFormat(), false); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+	}()
+	ctx := Background()
+	var file1, file2, ino Ino
+	var attr Attr
+	if st := m.Create(ctx, RootInode, "rl_file1", 0644, 022, 0, &file1, &attr); st != 0 {
+		t.Fatalf("create rl_file1: %s", st)
+	}
+	if st := m.Link(ctx, file1, RootInode, "rl_link", &attr); st != 0 {
+		t.Fatalf("link rl_file1 -> rl_link: %s", st)
+	}
+	if st := m.Unlink(ctx, RootInode, "rl_link"); st != 0 {
+		t.Fatalf("unlink rl_link: %s", st)
+	}
+	if st := m.Create(ctx, RootInode, "rl_file2", 0644, 022, 0, &file2, &attr); st != 0 {
+		t.Fatalf("create rl_file2: %s", st)
+	}
+	if st := m.Link(ctx, file1, RootInode, "rl_link", &attr); st != 0 {
+		t.Fatalf("relink rl_file1 -> rl_link: %s", st)
+	}
+	if st := m.Rename(ctx, RootInode, "rl_file2", RootInode, "rl_link", 0, &ino, &attr); st != 0 {
+		t.Fatalf("rename rl_file2 -> rl_link: %s", st)
+	}
+	if st := m.Lookup(ctx, RootInode, "rl_link", &ino, &attr, true); st != 0 {
+		t.Fatalf("lookup rl_link: %s", st)
+	}
+	if ino != file2 {
+		t.Fatalf("rl_link inode: expect %d, got %d", file2, ino)
+	}
+	if st := m.Lookup(ctx, RootInode, "rl_file1", &ino, &attr, true); st != 0 {
+		t.Fatalf("lookup rl_file1: %s", st)
+	}
+	if ino != file1 {
+		t.Fatalf("rl_file1 inode: expect %d, got %d", file1, ino)
+	}
+	if attr.Nlink != 2 {
+		t.Fatalf("rl_file1 nlink: expect 2 (original + trash), got %d", attr.Nlink)
+	}
+	if st := m.Unlink(ctx, RootInode, "rl_file1"); st != 0 {
+		t.Fatalf("unlink rl_file1: %s", st)
+	}
+	if st := m.Unlink(ctx, RootInode, "rl_link"); st != 0 {
+		t.Fatalf("unlink rl_link: %s", st)
 	}
 }
 

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -2558,6 +2558,9 @@ func (m *redisMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentD
 			if (tattr.Flags & FlagSkipTrash) != 0 {
 				trash = 0
 			}
+			if !exchange && trash > 0 && tattr.Nlink > 1 && tx.HExists(ctx, m.entryKey(trash), m.trashEntry(parentDst, dino, nameDst)).Val() {
+				trash = 0
+			}
 			tattr.Ctime = now.Unix()
 			tattr.Ctimensec = uint32(now.Nanosecond())
 			if exchange {

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2418,6 +2418,11 @@ func (m *dbMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			if (dn.Flags & FlagSkipTrash) != 0 {
 				trash = 0
 			}
+			if !exchange && trash > 0 && dn.Nlink > 1 {
+				if o, e := s.Get(&edge{Parent: trash, Name: []byte(m.trashEntry(parentDst, dino, string(de.Name))), Inode: dino, Type: de.Type}); e == nil && o {
+					trash = 0
+				}
+			}
 			dn.setCtime(now)
 			if exchange {
 				if parentSrc != parentDst {

--- a/pkg/meta/sql_test.go
+++ b/pkg/meta/sql_test.go
@@ -36,6 +36,17 @@ func TestSQLiteClient(t *testing.T) {
 	testMeta(t, m)
 }
 
+func TestSQLiteRenameOverRelinkedHardlink(t *testing.T) {
+	m, err := newSQLMeta("sqlite3", path.Join(t.TempDir(), "jfs-rename-relink.db"), testConfig())
+	if err != nil || m.Name() != "sqlite3" {
+		t.Fatalf("create meta: %s", err)
+	}
+	if err := m.Reset(); err != nil {
+		t.Fatalf("reset meta: %s", err)
+	}
+	testRenameOverRelinkedHardlink(t, m)
+}
+
 type commitOnSQLiteBusyLogger struct {
 	xormlog.ContextLogger
 	commit    func() error

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -2237,6 +2237,9 @@ func (m *kvMeta) doRename(ctx Context, parentSrc Ino, nameSrc string, parentDst 
 			if (tattr.Flags & FlagSkipTrash) != 0 {
 				trash = 0
 			}
+			if !exchange && trash > 0 && tattr.Nlink > 1 && tx.get(m.entryKey(trash, m.trashEntry(parentDst, dino, nameDst))) != nil {
+				trash = 0
+			}
 			tattr.Ctime = now.Unix()
 			tattr.Ctimensec = uint32(now.Nanosecond())
 			if exchange {


### PR DESCRIPTION
## Summary
- `doRename` was missing the hardlink trash-collision check that `doUnlink` already had.
- With trash enabled, `unlink(link)` keeps `{parent}-{inode}-{name}` in trash; recreating the link and `rename(file2, link)` then UNIQUE-fails (EIO on SQL) or overwrites and leaks `nlink` on Redis/TKV.
- Mirror unlink across SQL/Redis/TKV: if that trash edge already exists, skip trash and decrement `nlink`.

Fixes #7502

## Test plan
- [x] `go test ./pkg/meta -run TestSQLiteRenameOverRelinkedHardlink -count=1`
- [x] `go test ./pkg/meta -run 'TestSQLiteClient|TestMemKVClient' -count=1`