### PR TITLE
store: prevent page overwrite when loadRange falls back to full read

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -733,7 +733,7 @@ func (store *cachedStore) loadRange(ctx context.Context, key string, page *Page,
 		res = tmp
 	}
 	logRequest("GET", key, fmt.Sprintf("RANGE(%d,%d) ", off, len(p)), res.reqID, err, used)
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, utils.ErrFuncTimeout) {
 		return 0, err
 	}
 	store.objectDataBytes.WithLabelValues("GET", res.sc).Add(float64(res.n))


### PR DESCRIPTION
TODO: For object storage Get implementations that don’t handle context cancellation, there is a small chance that the slice may be modified during a retry, causing a data race.