### PR TITLE
object: honor context cancellation in Get

### DIFF
--- a/pkg/object/bos.go
+++ b/pkg/object/bos.go
@@ -95,14 +95,17 @@ func (q *bosclient) Get(ctx context.Context, key string, off, limit int64, gette
 	var r *api.GetObjectResult
 	var needCheck bool
 	if limit > 0 {
-		r, err = q.c.GetObject(q.bucket, key, nil, off, off+limit-1)
+		r, err = q.c.GetObjectWithContext(ctx, q.bucket, key, nil, off, off+limit-1)
 	} else if off > 0 {
-		r, err = q.c.GetObject(q.bucket, key, nil, off)
+		r, err = q.c.GetObjectWithContext(ctx, q.bucket, key, nil, off)
 	} else {
-		r, err = q.c.GetObject(q.bucket, key, nil)
+		r, err = q.c.GetObjectWithContext(ctx, q.bucket, key, nil)
 		needCheck = true
 	}
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
 		return
 	}
 	if needCheck {

--- a/pkg/object/bos_context_cancellation_test.go
+++ b/pkg/object/bos_context_cancellation_test.go
@@ -1,0 +1,92 @@
+//go:build !nobos
+// +build !nobos
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/services/bos"
+)
+
+func TestBOSGet_ContextCanceled(t *testing.T) {
+	tests := []struct {
+		name      string
+		off       int64
+		limit     int64
+		wantRange string
+	}{
+		{name: "full", limit: -1},
+		{name: "offset", off: 3, limit: -1, wantRange: "bytes=3-"},
+		{name: "range", off: 3, limit: 2, wantRange: "bytes=3-4"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			started := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				started <- r.Header.Get("Range")
+				<-r.Context().Done()
+			}))
+			defer server.Close()
+
+			client, err := bos.NewClient("access-key", "secret-key", server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.Config.Retry = bce.NewNoRetryPolicy()
+			store := &bosclient{bucket: "bucket", c: client}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			result := make(chan error, 1)
+			go func() {
+				body, err := store.Get(ctx, "object", test.off, test.limit)
+				if body != nil {
+					_ = body.Close()
+				}
+				result <- err
+			}()
+
+			select {
+			case gotRange := <-started:
+				if gotRange != test.wantRange {
+					t.Errorf("Range header: got %q, want %q", gotRange, test.wantRange)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("BOS Get did not start")
+			}
+			cancel()
+
+			select {
+			case err := <-result:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected context.Canceled, got %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("BOS Get did not stop after context cancellation")
+			}
+		})
+	}
+}

--- a/pkg/object/qiniu.go
+++ b/pkg/object/qiniu.go
@@ -66,10 +66,10 @@ func (q *qiniu) Limits() Limits {
 	return Limits{}
 }
 
-func (q *qiniu) download(key string, off, limit int64) (io.ReadCloser, error) {
+func (q *qiniu) download(ctx context.Context, key string, off, limit int64) (io.ReadCloser, error) {
 	deadline := time.Now().Add(time.Second * 3600).Unix()
 	url := storage.MakePrivateURL(q.cred, os.Getenv("QINIU_DOMAIN"), key, deadline)
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (q *qiniu) Head(ctx context.Context, key string) (Object, error) {
 
 func (q *qiniu) Get(ctx context.Context, key string, off, limit int64, getters ...AttrGetter) (io.ReadCloser, error) {
 	if strings.HasPrefix(key, "/") && os.Getenv("QINIU_DOMAIN") != "" {
-		return q.download(key, off, limit)
+		return q.download(ctx, key, off, limit)
 	}
 	return q.s3client.Get(ctx, key, off, limit, getters...)
 }

--- a/pkg/object/qiniu_context_cancellation_test.go
+++ b/pkg/object/qiniu_context_cancellation_test.go
@@ -1,0 +1,75 @@
+//go:build !noqiniu && !nos3
+// +build !noqiniu,!nos3
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qiniu/go-sdk/v7/auth"
+)
+
+func TestQiniuPrivateGet_ContextCanceled(t *testing.T) {
+	started := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started <- r.Header.Get("Range")
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	oldClient := httpClient
+	httpClient = server.Client()
+	t.Cleanup(func() { httpClient = oldClient })
+	t.Setenv("QINIU_DOMAIN", server.URL)
+
+	store := &qiniu{cred: auth.New("access-key", "secret-key")}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		body, err := store.Get(ctx, "/object", 3, 2)
+		if body != nil {
+			_ = body.Close()
+		}
+		result <- err
+	}()
+
+	select {
+	case gotRange := <-started:
+		if gotRange != "bytes=3-4" {
+			t.Errorf("Range header: got %q, want %q", gotRange, "bytes=3-4")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Qiniu Get did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Qiniu Get did not stop after context cancellation")
+	}
+}

--- a/pkg/object/sql.go
+++ b/pkg/object/sql.go
@@ -62,7 +62,7 @@ func (s *sqlStore) String() string {
 func (s *sqlStore) Get(ctx context.Context, key string, off, limit int64, getters ...AttrGetter) (io.ReadCloser, error) {
 	var b = blob{Key: []byte(key)}
 	// TODO: range
-	ok, err := s.db.Get(&b)
+	ok, err := s.db.Context(ctx).Get(&b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/object/sql_context_cancellation_test.go
+++ b/pkg/object/sql_context_cancellation_test.go
@@ -1,0 +1,42 @@
+//go:build !nosqlite
+// +build !nosqlite
+
+/*
+ * JuiceFS, Copyright 2026 Juicedata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestSQLGet_ContextCanceled(t *testing.T) {
+	store, err := newSQLStore("sqlite3", filepath.Join(t.TempDir(), "teststore.db"), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = store.Get(ctx, "object", 0, -1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/pkg/object/user_agent_test.go
+++ b/pkg/object/user_agent_test.go
@@ -123,7 +123,7 @@ func TestQiniuPrivateDownloadSendsUserAgent(t *testing.T) {
 
 	userAgent := captureUserAgent(t, http.StatusOK, func() {
 		store := &qiniu{cred: auth.New("access-key", "secret-key")}
-		body, err := store.download("key", 0, -1)
+		body, err := store.download(context.Background(), "key", 0, -1)
 		require.NoError(t, err)
 		require.NoError(t, body.Close())
 	})


### PR DESCRIPTION
## What
ref: #7511 #7513

- propagate `Get` contexts through BOS, Qiniu private downloads, and SQL storage
- add cancellation and range regression tests

## Test

- `go test ./pkg/object -count=1`