### PR TITLE
chunk: synchronize staging cleanup after timeout

### DIFF
--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -410,19 +410,26 @@ func (s *wSlice) upload(indx int) {
 		}
 		ctx := context.WithValue(context.Background(), object.TierKey{}, s.tierID)
 		if s.writeback && blen < s.store.conf.WritebackThresholdSize {
+			const (
+				stagePending int32 = iota
+				stageSucceeded
+				stageAbandoned
+			)
 			stagingPath := "unknown"
-			stageFailed := false
+			var stageState atomic.Int32
 			block.Acquire()
 			err := utils.WithTimeout(context.TODO(), func(context.Context) (err error) { // In case it hangs for more than 5 minutes(see fileWriter.flush), fallback to uploading directly to avoid `EIO`
 				defer block.Release()
 				stagingPath, err = s.store.bcache.stage(key, block.Data, s.tierID)
-				if err == nil && stageFailed { // upload thread already marked me as failed because of timeout
+				if err == nil && !stageState.CompareAndSwap(stagePending, stageSucceeded) {
 					_ = s.store.bcache.removeStage(key)
 				}
 				return err
 			}, s.store.conf.PutTimeout)
 			if err != nil {
-				stageFailed = true
+				if !stageState.CompareAndSwap(stagePending, stageAbandoned) {
+					_ = s.store.bcache.removeStage(key)
+				}
 				if !errors.Is(err, errStageConcurrency) {
 					s.store.stageBlockErrors.Add(1)
 					logger.Warnf("write %s to disk: %s, upload it directly", key, err)

--- a/pkg/chunk/cached_store.go
+++ b/pkg/chunk/cached_store.go
@@ -410,6 +410,7 @@ func (s *wSlice) upload(indx int) {
 		}
 		ctx := context.WithValue(context.Background(), object.TierKey{}, s.tierID)
 		if s.writeback && blen < s.store.conf.WritebackThresholdSize {
+			block.Acquire()
 			const (
 				stagePending int32 = iota
 				stageSucceeded
@@ -417,14 +418,15 @@ func (s *wSlice) upload(indx int) {
 			)
 			stagingPath := "unknown"
 			var stageState atomic.Int32
-			block.Acquire()
+			stageState.Store(stagePending)
 			err := utils.WithTimeout(context.TODO(), func(context.Context) (err error) { // In case it hangs for more than 5 minutes(see fileWriter.flush), fallback to uploading directly to avoid `EIO`
 				defer block.Release()
-				stagingPath, err = s.store.bcache.stage(key, block.Data, s.tierID)
-				if err == nil && !stageState.CompareAndSwap(stagePending, stageSucceeded) {
+				var stageErr error
+				stagingPath, stageErr = s.store.bcache.stage(key, block.Data, s.tierID)
+				if stageErr == nil && !stageState.CompareAndSwap(stagePending, stageSucceeded) {
 					_ = s.store.bcache.removeStage(key)
 				}
-				return err
+				return stageErr
 			}, s.store.conf.PutTimeout)
 			if err != nil {
 				if !stageState.CompareAndSwap(stagePending, stageAbandoned) {

--- a/pkg/chunk/cached_store_test.go
+++ b/pkg/chunk/cached_store_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juicedata/juicefs/pkg/compress"
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,6 +180,77 @@ func TestStoreSmallBuffer(t *testing.T) {
 	conf.BufferSize = 1 << 20
 	store := NewCachedStore(mem, conf, nil)
 	testStore(t, store)
+}
+
+type blockingStageCache struct {
+	CacheManager
+	started chan struct{}
+	release chan struct{}
+	removed chan string
+}
+
+func (c *blockingStageCache) cache(string, *Page, bool, bool) {}
+
+func (c *blockingStageCache) stage(string, []byte, uint8) (string, error) {
+	close(c.started)
+	<-c.release
+	return "late-stage", nil
+}
+
+func (c *blockingStageCache) removeStage(key string) error {
+	c.removed <- key
+	return nil
+}
+
+func TestWritebackStageTimeoutRemovesLateStage(t *testing.T) {
+	mem, err := object.CreateStorage("mem", "", "", "", "")
+	require.NoError(t, err)
+	cache := &blockingStageCache{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		removed: make(chan string, 1),
+	}
+	conf := defaultConf
+	conf.Compress = "lz4"
+	conf.PutTimeout = 20 * time.Millisecond
+	conf.Writeback = true
+	conf.WritebackThresholdSize = conf.BlockSize + 1
+	store := &cachedStore{
+		storage:       mem,
+		conf:          conf,
+		bcache:        cache,
+		currentUpload: make(chan struct{}, 1),
+		compressor:    compress.NewCompressor(conf.Compress),
+	}
+	store.initMetrics()
+
+	writer := store.NewWriter(123, 0)
+	data := []byte("late")
+	_, err = writer.WriteAt(data, 0)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- writer.Finish(len(data)) }()
+
+	select {
+	case <-cache.started:
+	case <-time.After(time.Second):
+		t.Fatal("stage did not start")
+	}
+	timer := time.AfterFunc(5*conf.PutTimeout, func() { close(cache.release) })
+	defer timer.Stop()
+
+	select {
+	case err = <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("direct upload did not finish after stage timeout")
+	}
+	select {
+	case key := <-cache.removed:
+		require.Equal(t, "chunks/0/0/123_0_4", key)
+	case <-time.After(time.Second):
+		t.Fatal("late stage was not removed")
+	}
 }
 
 func TestStoreAsync(t *testing.T) {


### PR DESCRIPTION
## What

- Replace the unsynchronized `stageFailed` flag with an atomic three-state handoff.
- Ensure a successfully staged block is removed when either the timeout path or the stage callback loses the handoff race.
- Add a controlled regression test where direct upload wins the timeout and staging succeeds later.

## Why

`utils.WithTimeout` may return while the staging callback is still running. The previous shared boolean had a data race and could miss cleanup when staging checked the flag immediately before the timeout path marked failure.

## Testing

- `go test ./pkg/chunk -run ^TestWritebackStageTimeoutRemovesLateStage$ -count=1`
- `go test -race ./pkg/chunk -run ^TestWritebackStageTimeoutRemovesLateStage$ -count=1`
- `go test ./pkg/chunk -count=1`
- `make test.pkg` was attempted but the local environment lacks `pkg-config`, so packages built with the Gluster tag could not compile.