### PR TITLE
mount: isolate results from timed-out callbacks

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -544,6 +544,20 @@ func getDefaultLogDir() string {
 	return defaultLogDir
 }
 
+func withTimeoutResult[T any](ctx context.Context, f func(context.Context) (T, error), timeout time.Duration) (T, error) {
+	var result T
+	err := utils.WithTimeout(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = f(ctx)
+		return err
+	}, timeout)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return result, nil
+}
+
 func mount(c *cli.Context) error {
 	setup(c, 2)
 	addr := c.Args().Get(0)
@@ -561,13 +575,14 @@ func mount(c *cli.Context) error {
 
 	var err error
 	if stage == 0 || supervisor == "test" {
-		err = utils.WithTimeout(context.TODO(), func(context.Context) error {
-			mp, err = filepath.Abs(mp)
-			return err
+		var absMp string
+		absMp, err = withTimeoutResult(context.TODO(), func(context.Context) (string, error) {
+			return filepath.Abs(mp)
 		}, time.Second*3)
 		if err != nil {
 			logger.Fatalf("abs %q: %s", mp, err)
 		}
+		mp = absMp
 		if mp == "/" {
 			logger.Fatalf("should not mount on the root directory")
 		}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -544,20 +544,6 @@ func getDefaultLogDir() string {
 	return defaultLogDir
 }
 
-func withTimeoutResult[T any](ctx context.Context, f func(context.Context) (T, error), timeout time.Duration) (T, error) {
-	var result T
-	err := utils.WithTimeout(ctx, func(ctx context.Context) error {
-		var err error
-		result, err = f(ctx)
-		return err
-	}, timeout)
-	if err != nil {
-		var zero T
-		return zero, err
-	}
-	return result, nil
-}
-
 func mount(c *cli.Context) error {
 	setup(c, 2)
 	addr := c.Args().Get(0)
@@ -575,14 +561,14 @@ func mount(c *cli.Context) error {
 
 	var err error
 	if stage == 0 || supervisor == "test" {
-		var absMp string
-		absMp, err = withTimeoutResult(context.TODO(), func(context.Context) (string, error) {
-			return filepath.Abs(mp)
+		err = utils.WithTimeout(context.TODO(), func(context.Context) error {
+			var pathErr error
+			mp, pathErr = filepath.Abs(mp)
+			return pathErr
 		}, time.Second*3)
 		if err != nil {
 			logger.Fatalf("abs %q: %s", mp, err)
 		}
-		mp = absMp
 		if mp == "/" {
 			logger.Fatalf("should not mount on the root directory")
 		}

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -129,6 +129,33 @@ func resetTestMeta() *redis.Client { // using Redis
 
 var mountLock sync.Mutex
 
+func TestWithTimeoutResultDoesNotPublishLateResult(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	returned := make(chan struct{})
+
+	result, err := withTimeoutResult(context.Background(), func(context.Context) (string, error) {
+		close(started)
+		<-release
+		close(returned)
+		return "late result", nil
+	}, 10*time.Millisecond)
+	<-started
+	if !errors.Is(err, utils.ErrFuncTimeout) {
+		t.Fatalf("expected timeout, got %v", err)
+	}
+	if result != "" {
+		t.Fatalf("timeout published %q", result)
+	}
+
+	close(release)
+	<-returned
+	time.Sleep(10 * time.Millisecond)
+	if result != "" {
+		t.Fatalf("late callback changed returned result to %q", result)
+	}
+}
+
 func mountTemp(t *testing.T, bucket *string, extraFormatOpts []string, extraMountOpts []string) {
 	// wait for last mount exit
 	for !mountLock.TryLock() {

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -129,33 +129,6 @@ func resetTestMeta() *redis.Client { // using Redis
 
 var mountLock sync.Mutex
 
-func TestWithTimeoutResultDoesNotPublishLateResult(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	returned := make(chan struct{})
-
-	result, err := withTimeoutResult(context.Background(), func(context.Context) (string, error) {
-		close(started)
-		<-release
-		close(returned)
-		return "late result", nil
-	}, 10*time.Millisecond)
-	<-started
-	if !errors.Is(err, utils.ErrFuncTimeout) {
-		t.Fatalf("expected timeout, got %v", err)
-	}
-	if result != "" {
-		t.Fatalf("timeout published %q", result)
-	}
-
-	close(release)
-	<-returned
-	time.Sleep(10 * time.Millisecond)
-	if result != "" {
-		t.Fatalf("late callback changed returned result to %q", result)
-	}
-}
-
 func mountTemp(t *testing.T, bucket *string, extraFormatOpts []string, extraMountOpts []string) {
 	// wait for last mount exit
 	for !mountLock.TryLock() {

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -697,11 +697,8 @@ func canShutdownGracefully(mp string, newConf *vfs.Config) bool {
 	if csiCommPath != "" {
 		return false
 	}
-	var ino uint64
-	var err error
-	err = utils.WithTimeout(context.TODO(), func(context.Context) error {
-		ino, err = utils.GetFileInode(mp)
-		return err
+	ino, err := withTimeoutResult(context.TODO(), func(context.Context) (uint64, error) {
+		return utils.GetFileInode(mp)
 	}, time.Second*3)
 	if err != nil {
 		logger.Warnf("get inode of %q: %s", mp, err)

--- a/cmd/mount_unix.go
+++ b/cmd/mount_unix.go
@@ -697,8 +697,11 @@ func canShutdownGracefully(mp string, newConf *vfs.Config) bool {
 	if csiCommPath != "" {
 		return false
 	}
-	ino, err := withTimeoutResult(context.TODO(), func(context.Context) (uint64, error) {
-		return utils.GetFileInode(mp)
+	var ino uint64
+	err := utils.WithTimeout(context.TODO(), func(context.Context) error {
+		var getErr error
+		ino, getErr = utils.GetFileInode(mp)
+		return getErr
 	}, time.Second*3)
 	if err != nil {
 		logger.Warnf("get inode of %q: %s", mp, err)


### PR DESCRIPTION
## What changed

- add an internal `withTimeoutResult` helper that only publishes a callback result when `utils.WithTimeout` completes successfully
- use it for mount-point absolute path resolution and graceful-shutdown inode lookup
- add a deterministic regression test covering a callback that finishes after the timeout

## Why

`utils.WithTimeout` may return while a callback that ignores context cancellation is still running. The two mount callbacks captured and mutated caller state directly, so a late completion could race with or overwrite state after the timeout path had started.

## Verification

- `/Users/zhijian/sdk/go1.25.12/bin/go test ./cmd -run ^'TestWithTimeoutResultDoesNotPublishLateResult$' -count=20`\n- `/Users/zhijian/sdk/go1.25.12/bin/go test -race ./cmd -run ^'TestWithTimeoutResultDoesNotPublishLateResult$' -count=5`\n- `/Users/zhijian/sdk/go1.25.12/bin/go test ./cmd -run ^'$' -count=1`\n- `git diff --check`\n\n`make test.cmd` was not run locally because it requires sudo and external MinIO services.