### PR TITLE
meta: dedupe repeated names in BatchUnlink

### DIFF
--- a/pkg/meta/base_test.go
+++ b/pkg/meta/base_test.go
@@ -3410,6 +3410,85 @@ func testDirStat(t *testing.T, m Meta) {
 	}); err != nil {
 		t.Fatalf("test dir usage rmdir: %v", err)
 	}
+
+	// test BatchUnlink with duplicate hardlink names
+	dupFileName := "batch-dup-file"
+	dupLinkName := "batch-dup-link"
+	dupFileLength := uint64(4097)
+	var dupInode Ino
+	if st := m.Create(Background(), testInode, dupFileName, 0640, 022, 0, &dupInode, nil); st != 0 {
+		t.Fatalf("create duplicate batch file: %s", st)
+	}
+	if st := m.Fallocate(Background(), dupInode, 0, 0, dupFileLength, nil); st != 0 {
+		t.Fatalf("fallocate duplicate batch file: %s", st)
+	}
+	if st := m.Link(Background(), dupInode, testInode, dupLinkName, nil); st != 0 {
+		t.Fatalf("link duplicate batch file: %s", st)
+	}
+	if err := waitCheckResult(m, dirStat{2 * int64(dupFileLength), 2 * align4K(dupFileLength), 2}, func() (*dirStat, syscall.Errno) {
+		return m.GetDirStat(Background(), testInode)
+	}); err != nil {
+		t.Fatalf("test dir usage duplicate batch link: %v", err)
+	}
+
+	var dupLinkInode Ino
+	var dupLinkAttr Attr
+	if st := m.Lookup(Background(), testInode, dupLinkName, &dupLinkInode, &dupLinkAttr, false); st != 0 {
+		t.Fatalf("lookup duplicate batch link: %s", st)
+	}
+	if dupLinkInode != dupInode || dupLinkAttr.Nlink != 2 {
+		t.Fatalf("duplicate batch link attr: inode %d attr %+v", dupLinkInode, dupLinkAttr)
+	}
+	dupEntries := []*Entry{
+		{Inode: dupInode, Name: []byte(dupLinkName), Attr: &dupLinkAttr},
+		{Inode: dupInode, Name: []byte(dupLinkName), Attr: &dupLinkAttr},
+	}
+	var dupCount uint64
+	if st := m.getBase().BatchUnlink(Background(), testInode, dupEntries, &dupCount, true); st != 0 {
+		t.Fatalf("batch unlink duplicate hardlink: %s", st)
+	}
+	if dupCount != uint64(len(dupEntries)) {
+		t.Fatalf("batch unlink duplicate count: expect %d, got %d", len(dupEntries), dupCount)
+	}
+	if err := waitCheckResult(m, dirStat{int64(dupFileLength), align4K(dupFileLength), 1}, func() (*dirStat, syscall.Errno) {
+		return m.GetDirStat(Background(), testInode)
+	}); err != nil {
+		t.Fatalf("test dir usage duplicate batch unlink: %v", err)
+	}
+
+	var remainingInode Ino
+	var remainingAttr Attr
+	if st := m.Lookup(Background(), testInode, dupFileName, &remainingInode, &remainingAttr, false); st != 0 {
+		t.Fatalf("lookup remaining hardlink after duplicate batch unlink: %s", st)
+	}
+	if remainingInode != dupInode || remainingAttr.Nlink != 1 {
+		t.Fatalf("remaining hardlink attr: inode %d attr %+v", remainingInode, remainingAttr)
+	}
+	var removedInode Ino
+	var removedAttr Attr
+	if st := m.Lookup(Background(), testInode, dupLinkName, &removedInode, &removedAttr, false); st != syscall.ENOENT {
+		t.Fatalf("lookup removed duplicate hardlink: %s", st)
+	}
+	deleted := false
+	if err := m.ScanDeletedObject(Background(), nil, nil, nil, func(ino Ino, size uint64, ts int64) (bool, error) {
+		if ino == dupInode {
+			deleted = true
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("scan pending deleted files: %s", err)
+	}
+	if deleted {
+		t.Fatalf("inode %d was queued for deletion after duplicate batch unlink", dupInode)
+	}
+	if st := m.Unlink(Background(), testInode, dupFileName); st != 0 {
+		t.Fatalf("unlink duplicate batch file: %s", st)
+	}
+	if err := waitCheckResult(m, dirStat{0, 0, 0}, func() (*dirStat, syscall.Errno) {
+		return m.GetDirStat(Background(), testInode)
+	}); err != nil {
+		t.Fatalf("test dir usage duplicate batch cleanup: %v", err)
+	}
 }
 
 func testRenameDirStat(t *testing.T, m Meta) {

--- a/pkg/meta/redis.go
+++ b/pkg/meta/redis.go
@@ -1988,6 +1988,7 @@ func (m *redisMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, del
 			if err != nil {
 				return err
 			}
+			seenNames := make(map[string]struct{}, len(batch))
 			for idx, entry := range batch {
 				val := vals[idx]
 				if val == nil {
@@ -1998,8 +1999,13 @@ func (m *redisMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, del
 				if entry.Inode != ino || typ == TypeDirectory || (entry.Attr != nil && entry.Attr.Typ != typ) {
 					continue
 				}
+				name := string(entry.Name)
+				if _, ok := seenNames[name]; ok {
+					continue
+				}
+				seenNames[name] = struct{}{}
 				entryInfos = append(entryInfos, &entryInfo{
-					name:  string(entry.Name),
+					name:  name,
 					inode: ino,
 					typ:   typ,
 					trash: trash,

--- a/pkg/meta/sql.go
+++ b/pkg/meta/sql.go
@@ -2864,7 +2864,8 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 			inodes := make([]Ino, 0, len(batch))
 			inodeM := make(map[Ino]struct{}) // filter hardlinks
 			for _, entry := range batch {
-				e, ok := entryMap[string(entry.Name)]
+				name := string(entry.Name)
+				e, ok := entryMap[name]
 				if !ok {
 					continue
 				}
@@ -2872,6 +2873,7 @@ func (m *dbMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 					continue
 				}
 				entryInfos = append(entryInfos, &entryInfo{e: e, trash: trash})
+				delete(entryMap, name)
 				if _, exists := inodeM[entry.Inode]; !exists {
 					inodeM[entry.Inode] = struct{}{}
 					inodes = append(inodes, entry.Inode)

--- a/pkg/meta/tkv.go
+++ b/pkg/meta/tkv.go
@@ -1792,6 +1792,7 @@ func (m *kvMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 				keys = append(keys, m.entryKey(parent, string(entry.Name)))
 			}
 			vals := tx.gets(keys...)
+			seenNames := make(map[string]struct{}, len(batch))
 			for idx, entry := range batch {
 				if vals[idx] == nil {
 					continue
@@ -1800,8 +1801,13 @@ func (m *kvMeta) doBatchUnlink(ctx Context, parent Ino, entries []*Entry, delta 
 				if ino != entry.Inode || typ == TypeDirectory || (entry.Attr != nil && typ != entry.Attr.Typ) {
 					continue
 				}
+				name := string(entry.Name)
+				if _, ok := seenNames[name]; ok {
+					continue
+				}
+				seenNames[name] = struct{}{}
 				info := entryInfo{
-					name:  string(entry.Name),
+					name:  name,
 					inode: ino,
 					typ:   typ,
 					trash: trash,


### PR DESCRIPTION
Improve API fault tolerance to handle unexpected inputs from SDK usage or direct external API calls.

## Problem

A name repeated within a single `BatchUnlink` batch produced one `entryInfo` per occurrence, and those duplicates shared the same `*Attr` loaded from the inode map. The decrement loop then ran multiple times on that shared pointer:

```go
if info.trash == 0 && info.attr.Nlink > 0 {
    info.attr.Nlink--
}
```

For a file with `Nlink == 2` (a hard link) unlinked with trash skipped, `Nlink` went 2 → 0, so the inode was queued into `delfiles` and deleted while the other hard link still referenced it — a dangling entry plus data loss.

The same repeated iteration also double counted `batchDirInodes` / `batchDirLength` / `batchDirSpace`, corrupting directory stats and quota deltas.

All three metadata engines were affected.

## Fix

Skip duplicate names when building the entry list, so each name is processed at most once per batch:

| Engine | Change |
| --- | --- |
| SQL | `delete(entryMap, name)` after consuming an entry |
| Redis | new `seenNames` set |
| KV/TKV | new `seenNames` set |

Notes for reviewers:

- The dedupe set is per batch. `entries` is split into batches, each in its own transaction; if duplicates land in different batches the later one re-reads the edge, finds it already deleted, and skips it — so cross-batch dedupe is not needed.
- In SQL, `entryMap` is built **inside** the `m.txn` closure, so mutating it with `delete` is safe across transaction retries (it is rebuilt on every attempt).

## Tests

Regression added to the shared `testDirStat`, so all three engines exercise it. It builds an `Nlink == 2` hard link, calls `BatchUnlink` with a duplicated name and `skipCheckTrash=true` (so `info.trash == 0` does not short-circuit the decrement), then asserts the surviving link exists with `Nlink == 1`, the dir stat was decremented once, and the inode was not queued for deletion.

Verified by reverting only the engine changes and keeping the test:

- Without the fix: `TestSQLiteClient`, `TestMemKVClient`, `TestBadgerClient` all fail — dir stat drops from `{4097, 8192, 1}` to `{0, 0, 0}`.
- With the fix: `TestSQLiteClient`, `TestMemKVClient`, `TestBadgerClient`, `TestRedisClient` all pass.

`gofmt` and `go vet ./pkg/meta/` are clean. `TestLoadDump` in `make test.meta.core` fails locally for lack of TiKV/PD at `127.0.0.1:2379`, unrelated to this change; PostgreSQL/etcd/KeyDB were likewise not covered locally.