### PR TITLE
object: make findLen available without QingStor

### DIFF
--- a/pkg/object/object_storage.go
+++ b/pkg/object/object_storage.go
@@ -17,6 +17,7 @@
 package object
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -462,4 +463,39 @@ func isExists(err error) bool {
 func defaultPathStyle() bool {
 	v := os.Getenv("JFS_S3_VHOST_STYLE")
 	return v == "" || v == "0" || v == "false"
+}
+
+func findLen(in io.Reader) (io.Reader, int64, error) {
+	var vlen int64
+	switch v := in.(type) {
+	case *bytes.Buffer:
+		vlen = int64(v.Len())
+	case *bytes.Reader:
+		vlen = int64(v.Len())
+	case *strings.Reader:
+		vlen = int64(v.Len())
+	case *os.File:
+		st, err := v.Stat()
+		if err != nil {
+			return nil, 0, err
+		}
+		vlen = st.Size()
+	case io.ReadSeeker:
+		var err error
+		vlen, err = v.Seek(0, 2)
+		if err != nil {
+			return nil, 0, err
+		}
+		if _, err = v.Seek(0, 0); err != nil {
+			return nil, 0, err
+		}
+	default:
+		d, err := io.ReadAll(in)
+		if err != nil {
+			return nil, 0, err
+		}
+		vlen = int64(len(d))
+		in = bytes.NewBuffer(d)
+	}
+	return in, vlen, nil
 }

--- a/pkg/object/qingstor.go
+++ b/pkg/object/qingstor.go
@@ -111,41 +111,6 @@ func (q *qingstor) Restore(ctx context.Context, key string, days int32) error {
 	return notSupported
 }
 
-func findLen(in io.Reader) (io.Reader, int64, error) {
-	var vlen int64
-	switch v := in.(type) {
-	case *bytes.Buffer:
-		vlen = int64(v.Len())
-	case *bytes.Reader:
-		vlen = int64(v.Len())
-	case *strings.Reader:
-		vlen = int64(v.Len())
-	case *os.File:
-		st, err := v.Stat()
-		if err != nil {
-			return nil, 0, err
-		}
-		vlen = st.Size()
-	case io.ReadSeeker:
-		var err error
-		vlen, err = v.Seek(0, 2)
-		if err != nil {
-			return nil, 0, err
-		}
-		if _, err = v.Seek(0, 0); err != nil {
-			return nil, 0, err
-		}
-	default:
-		d, err := io.ReadAll(in)
-		if err != nil {
-			return nil, 0, err
-		}
-		vlen = int64(len(d))
-		in = bytes.NewBuffer(d)
-	}
-	return in, vlen, nil
-}
-
 func (q *qingstor) Put(ctx context.Context, key string, in io.Reader, getters ...AttrGetter) error {
 	body, vlen, err := findLen(in)
 	if err != nil {


### PR DESCRIPTION
## What changed

Move `findLen` from `qingstor.go` to the build-tag-independent `object_storage.go`.

This cherry-picks the fix merged into `ee-5.4` by #7527.

## Why

`findLen` is shared by QingStor, BOS, and Qiniu, but its previous definition lived in a file guarded by `!noqingstor`. Building with `-tags noqingstor` while retaining BOS or Qiniu therefore failed with `undefined: findLen`.

## Tests

- `go test ./pkg/object`
- `go build -tags noqingstor ./pkg/object`

Note: `go test -tags noqingstor ./pkg/object` is not currently supported because existing tests directly reference `newQingStor`.